### PR TITLE
Fixed being able to specify availabilityZone

### DIFF
--- a/lib/services/ec2.api.js
+++ b/lib/services/ec2.api.js
@@ -8208,8 +8208,8 @@ AWS.EC2.Client.prototype.api = {
           Placement: {
             t: 'o',
             m: {
-              AvailabilityZone: {
-                n: 'availabilityZone'
+              availabilityZone: {
+                n: 'AvailabilityZone'
               },
               groupName: {
               },


### PR DESCRIPTION
Fixed being able to specify availabilityZone 
when issuing a runInstances call.

It seems there are other places where this may
also be an issue (L6603 for example) but this
one is the one I was testing and my changes fixed
the problem.
