### PR TITLE
Fixes AWS.util.uriEscape incorrectly encoding utf8 characters.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -42,9 +42,7 @@ AWS.util = {
 
   uriEscape: function uriEscape(string) {
     /*jshint undef:false */
-    var uri = escape(string).replace(/\+/g, '%2B').replace(/\//g, '%2F');
-    uri = uri.replace(/%7E/g, '~').replace(/\=/g, '%3D');
-    return uri;
+    return encodeURIComponent(string).replace(/[^A-Za-z0-9_.~\-%]+/g, escape);
   },
 
   uriEscapePath: function uriEscapePath(string) {

--- a/test/unit/util.spec.coffee
+++ b/test/unit/util.spec.coffee
@@ -29,6 +29,9 @@ describe 'uriEscape', ->
   it 'does not escape ~', ->
     expect(e('a~b')).toEqual('a~b')
 
+  it 'encodes utf8 characters', ->
+    expect(e('ёŝ')).toEqual('%D1%91%C5%9D')
+
 describe 'uriEscapePath', ->
 
   e = AWS.util.uriEscapePath


### PR DESCRIPTION
`AWS.util.uriEscape` uses the `escape` function which is not utf8 friendly.

Example:

``` javascript
AWS.util.uriEscapePath('example/key/path/Ťёŝтĭńġ.zip');
```

Current method's return value:

```
example/key/path/%u0164%u0451%u015D%u0442%u012D%u0144%u0121.zip
```

Pull request method's return value:

```
example/key/path/%C5%A4%D1%91%C5%9D%D1%82%C4%AD%C5%84%C4%A1.zip
```
