### PR TITLE
RestXMLClient include Content-Length header for empty bodies

### DIFF
--- a/lib/rest_xml_client.js
+++ b/lib/rest_xml_client.js
@@ -69,6 +69,8 @@ AWS.RESTXMLClient = inherit(AWS.RESTClient, {
     if (body) {
       req.body = body;
       req.headers['Content-Length'] = body.length;
+    } else {
+      req.headers['Content-Length'] = 0;
     }
 
   },

--- a/test/unit/rest_xml_client.spec.coffee
+++ b/test/unit/rest_xml_client.spec.coffee
@@ -65,6 +65,14 @@ describe 'AWS.RESTXMLClient', ->
         expect(req.path).toEqual('/abc')
         expect(req.headers['x-amz-acl']).toEqual('canned-acl')
 
+      it 'includes Content-Length header if body is empty', ->
+        operation.u = '/{Bucket}'
+        operation.i = {m:{Bucket:{l:'uri',r:1},Data:{t:'s',l:'body'}}}
+        params = { Bucket: 'bucket-name', Data: '' }
+        req = buildRequest(params)
+        expect(req.body).toEqual(null)
+        expect(req.headers['Content-Length']).toEqual(0)
+
     describe 'string bodies', ->
 
       it 'populates the body with string types directly', ->


### PR DESCRIPTION
Fixes #15
