### PR TITLE
XML parsing was causing off-by-one errors in javascript dates

### DIFF
--- a/lib/xml/parser_xml2js.js
+++ b/lib/xml/parser_xml2js.js
@@ -148,7 +148,7 @@ AWS.XML.Parser = inherit({
 
       var parts = value.split(/-|:|\.|T|Z/);
       var date = new Date(parts[0], 0, 1);
-      if (parts[1]) { date.setUTCMonth(parts[1]); }
+      if (parts[1]) { date.setUTCMonth(parts[1] - 1); }
       if (parts[2]) { date.setUTCDate(parts[2]); }
       if (parts[3]) { date.setUTCHours(parts[3]); }
       if (parts[4]) { date.setUTCMinutes(parts[4]); }


### PR DESCRIPTION
The xml feed uses 1-based months (1=jan, 2=feb, etc).  Javascript uses 0-based months (0=jan, 1=feb, etc).  The XML date parser needs a small tweak to make the conversion correct.
