### PR TITLE
Updated how AWS.S3.Client handles errors with empty HTTP response body.

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -155,19 +155,21 @@ AWS.S3 = AWS.Service.defineService('./services/s3.api', {
       var codes = {
         304: 'NotModified',
         403: 'Forbidden',
+        400: 'BadRequest',
         404: 'NotFound'
       };
 
-      if (codes[resp.httpResponse.statusCode]) {
+      var code = resp.httpResponse.statusCode;
+      var body = resp.httpResponse.body;
+      if (codes[code] && body.length === 0) {
         resp.error = AWS.util.error(new Error(), {
           code: codes[resp.httpResponse.statusCode],
           message: null
         });
       } else {
-        var data = new AWS.XML.Parser({}).parse(resp.httpResponse.body.toString());
-
+        var data = new AWS.XML.Parser({}).parse(body.toString());
         resp.error = AWS.util.error(new Error(), {
-          code: data.Code || resp.httpResponse.statusCode,
+          code: data.Code || code,
           message: data.Message || null
         });
       }


### PR DESCRIPTION
No longer using the canned errors when the body is present.  Also
added support for 400 (BadRequest) responses.
