### PR TITLE
fix. http/endpoint.constructor

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -16,6 +16,7 @@
 var AWS = require('./core');
 var Stream = require('stream').Stream;
 var inherit = AWS.util.inherit;
+var _ = require('underscore');
 
 /**
  * The endpoint that a service will talk to, for example,
@@ -56,9 +57,11 @@ AWS.Endpoint = inherit({
    */
   constructor: function Endpoint(endpoint, config) {
     if (!endpoint.match(/^http/)) {
-      var useSSL = config && config.sslEnabled !== undefined ?
-        config.sslEnabled : AWS.config.sslEnabled;
-      endpoint = (useSSL ? 'https' : 'http') + '://' + endpoint;
+      if(config && _.isBoolean(config.sslEnabled)){
+        endpoint = (config.sslEnabled ? 'https' : 'http') + '://' + endpoint;
+      }else{
+        endpoint = (AWS.config.sslEnabled ? 'https' : 'http') + '://' + endpoint;
+      }
     }
 
     AWS.util.update(this, AWS.util.urlParse(endpoint));

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     },
     "dependencies": {
       "xml2js": "latest",
-      "xmlbuilder": "latest"
+      "xmlbuilder": "latest",
+      "underscore":"~1.4.4"
     },
     "optionalDependencies": {
       "libxmljs": "latest"

--- a/test/unit/endpoint.spec.coffee
+++ b/test/unit/endpoint.spec.coffee
@@ -73,9 +73,54 @@ describe 'AWS.Endpoint', ->
     expect(endpoint.hostname).toEqual('domain.com')
     expect(endpoint.port).toEqual(443)
 
-  it 'accepts a configuration object that specifies the mode', ->
+  it 'accepts a configuration object that specifies the mode as false', ->
     expect(AWS.config.sslEnabled).toEqual(true)
     endpoint = new AWS.Endpoint('domain.com', { sslEnabled: false })
+    expect(endpoint.href).toEqual('http://domain.com/')
+    expect(endpoint.protocol).toEqual('http:')
+    expect(endpoint.host).toEqual('domain.com')
+    expect(endpoint.hostname).toEqual('domain.com')
+    expect(endpoint.port).toEqual(80)
+
+  it 'accepts a configuration object that specifies the mode as true', ->
+    AWS.config.sslEnabled = false;
+    endpoint = new AWS.Endpoint('domain.com', { sslEnabled: true })
+    expect(endpoint.href).toEqual('https://domain.com/')
+    expect(endpoint.protocol).toEqual('https:')
+    expect(endpoint.host).toEqual('domain.com')
+    expect(endpoint.hostname).toEqual('domain.com')
+    expect(endpoint.port).toEqual(443)
+
+  it 'accepts a configuration object that specifies the mode as null, defaulting to AWS.config truthy', ->
+    AWS.config.sslEnabled = true;
+    endpoint = new AWS.Endpoint('domain.com', { sslEnabled: null })
+    expect(endpoint.href).toEqual('https://domain.com/')
+    expect(endpoint.protocol).toEqual('https:')
+    expect(endpoint.host).toEqual('domain.com')
+    expect(endpoint.hostname).toEqual('domain.com')
+    expect(endpoint.port).toEqual(443)
+
+  it 'accepts a configuration object that specifies the mode as null, defaulting to AWS.config falsey', ->
+    AWS.config.sslEnabled = false;
+    endpoint = new AWS.Endpoint('domain.com', { sslEnabled: null })
+    expect(endpoint.href).toEqual('http://domain.com/')
+    expect(endpoint.protocol).toEqual('http:')
+    expect(endpoint.host).toEqual('domain.com')
+    expect(endpoint.hostname).toEqual('domain.com')
+    expect(endpoint.port).toEqual(80)
+
+  it 'accepts a configuration object that specifies the mode as undefined, defaulting to AWS.config truthy', ->
+    AWS.config.sslEnabled = true;
+    endpoint = new AWS.Endpoint('domain.com', { sslEnabled: undefined })
+    expect(endpoint.href).toEqual('https://domain.com/')
+    expect(endpoint.protocol).toEqual('https:')
+    expect(endpoint.host).toEqual('domain.com')
+    expect(endpoint.hostname).toEqual('domain.com')
+    expect(endpoint.port).toEqual(443)
+
+  it 'accepts a configuration object that specifies the mode as undefined, defaulting to AWS.config falsey', ->
+    AWS.config.sslEnabled = false;
+    endpoint = new AWS.Endpoint('domain.com', { sslEnabled: undefined })
     expect(endpoint.href).toEqual('http://domain.com/')
     expect(endpoint.protocol).toEqual('http:')
     expect(endpoint.host).toEqual('domain.com')


### PR DESCRIPTION
was letting null fall through to the ternary operation.
