### PR TITLE
Removing EventEmitter dependency.

### DIFF
--- a/lib/event_emitter.js
+++ b/lib/event_emitter.js
@@ -14,7 +14,6 @@
  */
 
 var AWS = require('./core');
-var EventEmitter = require('events').EventEmitter;
 
 /**
  * @!method on(eventName, callback)
@@ -26,7 +25,111 @@ var EventEmitter = require('events').EventEmitter;
  *   @param callback [Function] the listener callback function
  *   @return [AWS.EventEmitter] the same object for chaining
  */
-AWS.EventEmitter = AWS.util.inherit(EventEmitter, {
+AWS.EventEmitter = AWS.util.inherit({
+
+  constructor: function EventEmitter() {
+    this._events = {};
+  },
+
+  /**
+   * @api private
+   */
+  listeners: function listeners(eventName) {
+    return this._events[eventName] ? this._events[eventName].slice(0) : [];
+  },
+
+  on: function on(eventName, listener) {
+    if (this._events[eventName]) {
+      this._events[eventName].push(listener);
+    } else {
+      this._events[eventName] = [listener];
+    }
+    return this;
+  },
+
+  /**
+   * @api private
+   */
+  onAsync: function onAsync(eventName, listener) {
+    listener.async = true;
+    return this.on(eventName, listener);
+  },
+
+  removeListener: function removeListener(eventName, listener) {
+    var listeners = this._events[eventName];
+    if (listeners) {
+      var length = listeners.length;
+      var position = -1;
+      for (var i = 0; i < length; ++i) {
+        if (listeners[i] === listener) {
+          position = i;
+        }
+      }
+      if (position > -1) {
+        listeners.splice(position, 1);
+      }
+    }
+    return this;
+  },
+
+  removeAllListeners: function removeAllListeners(eventName) {
+    if (eventName) {
+      delete this._events[eventName];
+    } else {
+      this._events = {};
+    }
+    return this;
+  },
+
+  /**
+   * @api private
+   */
+  emit: function emit(eventName, eventArgs, doneCallback) {
+    if (!doneCallback) doneCallback = function() {};
+    var listeners = this.listeners(eventName);
+    if (listeners.length == 0) {
+      doneCallback.call(this);
+      return false;
+    } else {
+      this.callListeners(listeners, eventArgs, doneCallback);
+      return true;
+    }
+  },
+
+  /**
+   * @api private
+   */
+  callListeners: function callListeners(listeners, args, doneCallback) {
+    if (listeners.length == 0) {
+      doneCallback.call(this);
+    } else {
+      var listener = listeners.shift();
+      if (listener.async) {
+
+        // asynchronous listener
+        var callNextListener = function(err) {
+          if (err) {
+            doneCallback.call(this, err);
+          } else {
+            this.callListeners(listeners, args, doneCallback);
+          }
+        };
+        listener.apply(this, args.concat([callNextListener]))
+
+      } else {
+
+        // synchronous listener
+        try {
+          listener.apply(this, args);
+          this.callListeners(listeners, args, doneCallback);
+        } catch (err) {
+          doneCallback.call(this, err);
+        }
+
+      }
+    }
+  },
+
   /**
    * Adds or copies a set of listeners from another list of
    * listeners or EventEmitter object.
@@ -90,6 +193,14 @@ AWS.EventEmitter = AWS.util.inherit(EventEmitter, {
   },
 
   /**
+   * @api private
+   */
+  addNamedAsyncListener: function addNamedAsyncListener(name, eventName, callback) {
+    callback.async = true;
+    return this.addNamedListener(name, eventName, callback);
+  },
+
+  /**
    * Helper method to add a set of named listeners using
    * {addNamedListener}. The callback contains a parameter
    * with a handle to the `addNamedListener` method.
@@ -114,9 +225,21 @@ AWS.EventEmitter = AWS.util.inherit(EventEmitter, {
    */
   addNamedListeners: function addNamedListeners(callback) {
     var self = this;
-    callback(function() {
-      self.addNamedListener.apply(self, arguments);
-    });
+    callback(
+      function() {
+        self.addNamedListener.apply(self, arguments);
+      },
+      function() {
+        self.addNamedAsyncListener.apply(self, arguments);
+      }
+    );
     return this;
   }
+
 });
+
+/**
+ * {on} is the prefered method.
+ * @api private
+ */
+AWS.EventEmitter.prototype.addListener = AWS.EventEmitter.prototype.on;

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -83,7 +83,7 @@ AWS.EventListeners = {
 };
 
 AWS.EventListeners = {
-  Core: new AWS.EventEmitter().addNamedListeners(function(add) {
+  Core: new AWS.EventEmitter().addNamedListeners(function(add, addAsync) {
     add('VALIDATE_CREDENTIALS', 'validate', function VALIDATE_CREDENTIALS(req) {
       if (!req.client.config.credentials.accessKeyId ||
           !req.client.config.credentials.secretAccessKey) {
@@ -203,12 +203,13 @@ AWS.EventListeners = {
       }
     });
 
-    add('RETRY_SIGN', 'retry', function RETRY_SIGN(resp) {
-      this.emitEvents(resp, 'sign');
+    addAsync('RETRY_SIGN', 'retry', function RETRY_SIGN(resp, doneCallback) {
+      this.emitEvent('sign', resp, doneCallback);
     });
 
-    add('RETRY_DELAY_SEND', 'retry', function RETRY_DELAY_SEND(resp) {
+    addAsync('RETRY_DELAY_SEND', 'retry', function RETRY_DELAY_SEND(resp, doneCallback) {
       var delay = 0;
+      // why should we ever be emitting retry without an error?
       if (resp.error) {
         delay = this.client.retryDelays()[resp.retryCount-1] || 0;
       }
@@ -216,8 +217,12 @@ AWS.EventListeners = {
       resp.error = null;
       resp.data = null;
 
-      setTimeout(function() { resp.request.emitEvents(resp, 'send'); }, delay);
+      setTimeout(function() {
+        resp.request.emitEvent('send', resp, doneCallback);
+      }, delay);
+
     });
+
   }),
 
   Json: new AWS.EventEmitter().addNamedListeners(function(add) {

--- a/lib/http.js
+++ b/lib/http.js
@@ -193,21 +193,21 @@ AWS.NodeHttpClient = inherit({
 
   setupEvents: function setupEvents(client, options, request, response) {
     var stream = client.request(options, function onResponse(httpResponse) {
-      request.emitEvent('httpHeaders', response, httpResponse.statusCode,
-                        httpResponse.headers, response);
+      request.emitEvent('httpHeaders', [httpResponse.statusCode,
+                        httpResponse.headers, response]);
 
       httpResponse.on('data', function onData(data) {
-        request.emitEvent('httpData', response, data, response);
+        request.emitEvent('httpData', [data, response]);
       });
 
       httpResponse.on('end', function onEnd() {
-        request.emitEvents(response, 'httpDone');
+        request.emitEvent('httpDone', [response]);
       });
     });
 
     stream.on('error', function (err) {
-      request.emitEvent('httpError', response, AWS.util.error(err,
-        {code: 'NetworkingError', retryable: true}), response);
+      var error = AWS.util.error(err, {code: 'NetworkingError', retryable: true});
+      request.emitEvent('httpError', [error, response]);
     });
 
     return stream;

--- a/lib/request.js
+++ b/lib/request.js
@@ -201,7 +201,7 @@ var Stream = require('stream').Stream;
  *
  * @see AWS.Response
  */
-AWS.Request = inherit({
+AWS.Request = inherit(AWS.EventEmitter, {
 
   /**
    * Creates a request for an operation on a given client with
@@ -223,6 +223,8 @@ AWS.Request = inherit({
     this.operation = operation;
     this.params = params || {};
     this.httpRequest = new AWS.HttpRequest(endpoint, region);
+
+    AWS.EventEmitter.call(this);
   },
 
   /**
@@ -239,9 +241,16 @@ AWS.Request = inherit({
    *     request.send();
    */
   send: function send(response) {
-    response = response || new AWS.Response(this);
-    this.emitEvents(response, 'validate', 'build', 'afterBuild', 'sign', 'send');
-    if (response.error) this.completeRequest(response);
+    if (!response) response = new AWS.Response(this);
+    var eventNames = ['validate', 'build', 'afterBuild', 'sign', 'send'];
+    this.emitEvents(eventNames, response, function(err) {
+      if (err) {
+        // calling failRequest instead of completeRequest because errors
+        // raised before we have finished sending the request should never
+        // get retried
+        this.failRequest(response);
+      }
+    });
     return response;
   },
 
@@ -306,64 +315,69 @@ AWS.Request = inherit({
    * @api private
    */
   completeRequest: function completeRequest(response) {
-    this.emitEvents(response, 'extractError', 'extractData');
-
-    if (response.error) {
-      this.emitEventsAlways(response, 'retry');
-      if (!response.error) return;
-      if (this.listeners('error').length > 0) {
-        this.emitEvent('error', response);
-      }
-    } else {
-      this.emitEvents(response, 'success');
-    }
-    this.emitEventsAlways(response, 'complete');
-  },
-
-  /**
-   * @api private
-   */
-  emitEventsAlways: function emitEventsAlways() {
-    var response = arguments[0];
-    for (var i = 1; i < arguments.length; i++) {
-      var eventName = arguments[i];
-      if (this.listeners(eventName).length > 0) {
-        this.emitEvent(eventName, response);
-      }
-    }
-  },
-
-  /**
-   * @api private
-   */
-  emitEvents: function emitEvents() {
-    var response = arguments[0];
-    if (response.error) return;
-    for (var i = 1; i < arguments.length; i++) {
-      var eventName = arguments[i];
-      if (response.error) return AWS.util.abort;
-      if (this.listeners(eventName).length > 0) {
-        this.emitEvent(eventName, response);
-      }
-    }
-  },
-
-  /**
-   * @api private
-   */
-  emitEvent: function emitEvent(eventName, response) {
-    try {
-      var args;
-      if (arguments.length > 2) {
-        // TODO: accept any amount of arguments
-        args = [eventName, arguments[2], arguments[3], arguments[4], arguments[5]];
+    this.emitEvents(['extractError', 'extractData'], response, function(err) {
+      if (err) {
+        this.emitEvent('retry', response, function(retryError) {
+          if (retryError) this.failRequest(response);
+        });
       } else {
-        args = this.eventParameters(eventName, response);
+        this.emitEvent('success', [response]);
+        this.emitEvent('complete', [response]);
       }
-      this.emit.apply(this, args);
-    } catch (err) {
-      response.error = err;
+    });
+  },
+
+  /**
+   * @api private
+   */
+   failRequest: function failRequest(response) {
+      this.emitEvent('error', [response.error, response]);
+      this.emitEvent('complete', [response]);
+   },
+
+  /**
+   * @private
+   */
+  emitEvents: function emitEvents(eventNames, response, doneCallback) {
+    if (!doneCallback) doneCallback = function() {};
+    if (response.error) {
+      doneCallback.call(this, response.error);
+    } else if (eventNames.length == 0) {
+      doneCallback.call(this);
+    } else {
+      this.emitEvent(eventNames[0], response, function(err) {
+        if (err) {
+          doneCallback.call(this, err);
+        } else {
+          // next event (eventNames is a reducing set)
+          this.emitEvents(eventNames.slice(1), response, doneCallback);
+        }
+      });
     }
+  },
+
+  /**
+   * @param [Array,Response] args This should be the response object,
+   *   or an array of args to send to the event.
+   * @api private
+   */
+  emitEvent: function emitEvent(eventName, args, doneCallback) {
+    if (!doneCallback) doneCallback = function() {};
+
+    var response = null;
+    if (AWS.util.isType(args, Array)) {
+      response = args[args.length - 1];
+    } else {
+      response = args;
+      args = this.eventParameters(eventName, response);
+    }
+
+    this.emit(eventName, args, function (err) {
+      if (err) {
+        response.error = err;
+      }
+      doneCallback.call(this, err);
+    });
   },
 
   /**
@@ -372,18 +386,16 @@ AWS.Request = inherit({
   eventParameters: function eventParameters(eventName, response) {
     /*jshint maxcomplexity:8*/
     switch (eventName) {
-      case 'validate': case 'sign':
-      case 'build': case 'afterBuild':
-        return [eventName, this];
-      case 'error':
-        return [eventName, response.error, response];
+      case 'validate':
+      case 'sign':
+      case 'build':
+      case 'afterBuild':
+        return [this];
       default:
-        return [eventName, response];
+        return [response];
     }
   }
 });
-
-AWS.util.mixin(AWS.Request, AWS.EventEmitter);
 
 /**
  * This class encapsulates the the response information

--- a/test/event_emitter.spec.coffee
+++ b/test/event_emitter.spec.coffee
@@ -58,7 +58,7 @@ describe 'AWS.EventEmitter', ->
       expect(@emitter.CONSTNAME).toBe(spy)
 
       # also verify that event is hooked up like normal
-      @emitter.emit('eventName', 'argument')
+      @emitter.emit('eventName', ['argument'])
       expect(spy).toHaveBeenCalledWith('argument')
 
     it 'is chainable', ->
@@ -79,8 +79,8 @@ describe 'AWS.EventEmitter', ->
       expect(@emitter.CONST1).toBe(spy1)
       expect(@emitter.CONST2).toBe(spy2)
 
-      @emitter.emit('event1', 'arg1')
-      @emitter.emit('event2', 'arg2')
+      @emitter.emit('event1', ['arg1'])
+      @emitter.emit('event2', ['arg2'])
 
       expect(spy1).toHaveBeenCalledWith('arg1')
       expect(spy2).toHaveBeenCalledWith('arg2')

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -59,25 +59,25 @@ mockHttpResponse = (status, headers, data) ->
   spyOn(AWS.HttpClient, 'getInstance')
   AWS.HttpClient.getInstance.andReturn handleRequest: (req, resp) ->
     if typeof status == 'number'
-      req.emit('httpHeaders', status, headers, resp)
+      req.emit('httpHeaders', [status, headers, resp])
       str = str instanceof Array ? str : [str]
       AWS.util.arrayEach data, (str) ->
-        req.emit('httpData', new Buffer(str), resp)
-      req.emit('httpDone', resp)
+        req.emit('httpData', [new Buffer(str), resp])
+      req.emit('httpDone', [resp])
     else
-      req.emit('httpError', status, resp)
+      req.emit('httpError', [status, resp])
 
 mockIntermittentFailureResponse = (numFailures, status, headers, data) ->
   spyOn(AWS.HttpClient, 'getInstance')
   AWS.HttpClient.getInstance.andReturn handleRequest: (req, resp) ->
     if resp.retryCount < numFailures
-      req.emit('httpError', {code: 'NetworkingError', message: 'FAIL!'}, resp)
+      req.emit('httpError', [{code: 'NetworkingError', message: 'FAIL!'}, resp])
     else
-      req.emit('httpHeaders', (resp.retryCount < numFailures ? 500 : status), headers, resp)
+      req.emit('httpHeaders', [(resp.retryCount < numFailures ? 500 : status), headers, resp])
       str = str instanceof Array ? str : [str]
       AWS.util.arrayEach data, (str) ->
-        req.emit('httpData', new Buffer(str), resp)
-      req.emit('httpDone', resp)
+        req.emit('httpData', [new Buffer(str), resp])
+      req.emit('httpDone', [resp])
 
 module.exports =
   AWS: AWS

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -66,10 +66,10 @@ describe 'AWS.Request', ->
       data = ''; error = null; reqError = null; done = false
       spyOn(AWS.HttpClient, 'getInstance')
       AWS.HttpClient.getInstance.andReturn handleRequest: (req, resp) ->
-        req.emit('httpHeaders', 200, {}, resp)
+        req.emit('httpHeaders', [200, {}, resp])
         AWS.util.arrayEach ['FOO', 'BAR', 'BAZ'], (str) ->
-          req.emit('httpData', new Buffer(str), resp)
-        req.emit('httpError', new Error('fail'), resp)
+          req.emit('httpData', [new Buffer(str), resp])
+        req.emit('httpError', [new Error('fail'), resp])
 
       runs ->
         request = client.makeRequest('mockMethod')
@@ -89,18 +89,18 @@ describe 'AWS.Request', ->
       spyOn(AWS.HttpClient, 'getInstance')
       AWS.HttpClient.getInstance.andReturn handleRequest: (req, resp) ->
         process.nextTick ->
-            req.emit('httpHeaders', 200, {}, resp)
+            req.emit('httpHeaders', [200, {}, resp])
           AWS.util.arrayEach ['FOO', 'BAR', 'BAZ', 'QUX'], (str) ->
             if str == 'BAZ' and resp.retryCount < 1
               process.nextTick ->
-                req.emit('httpError', code: 'NetworkingError', message: 'FAIL!', retryable: true, resp)
+                req.emit('httpError', [{code: 'NetworkingError', message: 'FAIL!', retryable: true}, resp])
               return AWS.util.abort
             else
               process.nextTick ->
-                req.emit('httpData', new Buffer(str), resp)
+                req.emit('httpData', [new Buffer(str), resp])
           if resp.retryCount >= 1
             process.nextTick ->
-              req.emit('httpDone', resp)
+              req.emit('httpDone', [resp])
 
       runs ->
         request = client.makeRequest('mockMethod')

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -80,7 +80,7 @@ describe 'AWS.S3.Client', ->
     build = (operation, params) ->
       req = request(operation, params)
       resp = new AWS.Response(req)
-      req.emitEvents(resp, 'build')
+      req.emitEvents(['build'], resp)
       return req.httpRequest
 
     it 'obeys the configuration for s3ForcePathStyle', ->
@@ -175,7 +175,7 @@ describe 'AWS.S3.Client', ->
       resp = new AWS.Response(req)
       resp.httpResponse.body = new Buffer(body || '')
       resp.httpResponse.statusCode = statusCode
-      req.emit('extractError', resp, req)
+      req.emit('extractError', [resp])
       resp.error
 
     it 'handles 304 errors', ->

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -22,7 +22,7 @@ buildRequest = ->
   ddb = new AWS.DynamoDB.Client({region: 'region', endpoint: 'localhost'})
   req = ddb.makeRequest('listTables', {foo: 'bår'})
   resp = new AWS.Response(req)
-  req.emitEvents(resp, 'validate', 'build', 'afterBuild')
+  req.emitEvents(['validate', 'build', 'afterBuild'], resp)
   return req.httpRequest
 
 buildSigner = (request) ->


### PR DESCRIPTION
AWS.Request was previously extending EventEmitter, but this
proved to be limiting.  It was not possible to invoke listeners
asynchronously and sequentially.  It becomes an bigger issue when
the request needs to transition to the next state but needs to know
that all of the listeners (that may mutate the request) are complete.

The new implementation can provide a callback to listeners that is
called once copmlete (with optional error).  This should allow things
like asynchronously refreshing expired credentials from the
instance metadata service, asynchronous xml parsing, etc.
