### PR TITLE
Test against node@0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.8"
+  - "0.10"
 
 branches:
   only:


### PR DESCRIPTION
The latest stable release of node is now 0.10.  As such, the travis build should test against that too.  Since many people haven't upgraded yet, the old version should still be tested.
