### PR TITLE
Adding of Node.JS Domains to Error Handling Broke Simpleworkflow

### DIFF
--- a/lib/sequential_executor.js
+++ b/lib/sequential_executor.js
@@ -29,10 +29,10 @@ var domain;
 AWS.SequentialExecutor = AWS.util.inherit({
 
   constructor: function SequentialExecutor() {
-    this.domain = null;
+    this._domain = null;
     if (require('events').usingDomains) {
       domain = require('domain');
-      if (domain.active) this.domain = domain.active;
+      if (domain.active) this._domain = domain.active;
     }
     this._events = {};
   },
@@ -92,8 +92,8 @@ AWS.SequentialExecutor = AWS.util.inherit({
    */
   emit: function emit(eventName, eventArgs, doneCallback) {
     if (!doneCallback) doneCallback = this.unhandledErrorCallback;
-    if (this.domain && (this.domain instanceof require('domain').Domain))
-      this.domain.enter();
+    if (this._domain && (this._domain instanceof require('domain').Domain))
+      this._domain.enter();
 
     var listeners = this.listeners(eventName);
     var count = listeners.length;
@@ -107,8 +107,8 @@ AWS.SequentialExecutor = AWS.util.inherit({
   callListeners: function callListeners(listeners, args, doneCallback) {
     if (listeners.length === 0) {
       doneCallback.call(this);
-      if (this.domain && (this.domain instanceof require('domain').Domain))
-        this.domain.exit();
+      if (this._domain && (this._domain instanceof require('domain').Domain))
+        this._domain.exit();
     } else {
       var listener = listeners.shift();
       if (listener.async) {
@@ -117,8 +117,8 @@ AWS.SequentialExecutor = AWS.util.inherit({
         var callNextListener = function(err) {
           if (err) {
             doneCallback.call(this, err);
-            if (this.domain && (this.domain instanceof require('domain').Domain))
-              this.domain.exit();
+            if (this._domain && (this._domain instanceof require('domain').Domain))
+              this._domain.exit();
           } else {
             this.callListeners(listeners, args, doneCallback);
           }
@@ -133,8 +133,8 @@ AWS.SequentialExecutor = AWS.util.inherit({
           this.callListeners(listeners, args, doneCallback);
         } catch (err) {
           doneCallback.call(this, err);
-          if (this.domain && (this.domain instanceof require('domain').Domain))
-            this.domain.exit();
+          if (this._domain && (this._domain instanceof require('domain').Domain))
+            this._domain.exit();
         }
 
       }
@@ -252,11 +252,11 @@ AWS.SequentialExecutor = AWS.util.inherit({
    */
   unhandledErrorCallback: function unhandledErrorCallback(err) {
     if (err) {
-      if (this.domain && (this.domain instanceof require('domain').Domain)) {
+      if (this._domain && (this._domain instanceof require('domain').Domain)) {
         err.domainEmitter = this;
-        err.domain = this.domain;
+        err.domain = this._domain;
         err.domainThrown = false;
-        this.domain.emit('error', err);
+        this._domain.emit('error', err);
       } else {
         throw err;
       }


### PR DESCRIPTION
It was in https://github.com/aws/aws-sdk-js/issues/74 that domains were added to exception handling.  The existence of a domain is tested by checking the running context (this.domain) in the sequential_executor, however calls are regularly made into the AWS.SequentialExecutor object in which the context is not of the proper object (a problem all to itself), coincidentally the SimpleWorkflow often has a `domain` object attached to the request.  When exceptions are thrown it is not uncommon for it to find this string.  Therefore all if statements `if (this.domain)` have had type-checking added.  Since the require('domain') was included in this file on a context-only basis, the same notation was used throughout.
