### PR TITLE
Fix incorrectly named Attribute member in SQS API definition

### DIFF
--- a/lib/services/api/sqs-2012-11-05.js
+++ b/lib/services/api/sqs-2012-11-05.js
@@ -300,7 +300,7 @@ module.exports = {
       output: {
         type: 'structure',
         members: {
-          Value: {
+          Attribute: {
             type: 'map',
             keys: {
               name: 'Name'
@@ -399,7 +399,7 @@ module.exports = {
                 },
                 Body: {
                 },
-                Value: {
+                Attribute: {
                   type: 'map',
                   keys: {
                     name: 'Name'


### PR DESCRIPTION
This fixes https://github.com/aws/aws-sdk-js/issues/93
