### PR TITLE
Fixed docs reference to client objects.

### DIFF
--- a/doc-src/guide/Examples.md
+++ b/doc-src/guide/Examples.md
@@ -21,7 +21,7 @@ The following example lists all buckets associated with your AWS account:
 
 ```js
 var s3 = new AWS.S3();
-s3.listBuckets(function(err, data) {
+s3.client.listBuckets(function(err, data) {
   for (var index in data.Buckets) {
     var bucket = data.Buckets[index];
     console.log("Bucket: ", bucket.Name, ' : ', bucket.CreationDate);
@@ -36,8 +36,8 @@ object 'myKey' of bucket 'myBucket':
 
 ```js
 var s3 = new AWS.S3({params: {Bucket: 'myBucket', Key: 'myKey'}});
-s3.createBucket(function() {
-  s3.putObject({Body: 'Hello!'}, function() {
+s3.client.createBucket(function() {
+  s3.client.putObject({Body: 'Hello!'}, function() {
     console.log("Successfully uploaded data to myBucket/myKey");
   });
 });
@@ -56,7 +56,7 @@ on disk:
 var s3 = new AWS.S3();
 var params = {Bucket: 'myBucket', Key: 'myImageFile.jpg'};
 var file = require('fs').createWriteStream('/path/to/file.jpg');
-s3.getObject(params).createReadStream().pipe(file);
+s3.client.getObject(params).createReadStream().pipe(file);
 ```
 
 Alternatively, you can register an 'httpData' event listener on
@@ -68,7 +68,7 @@ var s3 = new AWS.S3();
 var params = {Bucket: 'myBucket', Key: 'myImageFile.jpg'};
 var file = require('fs').createWriteStream('/path/to/file.jpg');
 
-s3.getObject(params).
+s3.client.getObject(params).
 on('httpData', function(chunk) { file.write(chunk); }).
 on('httpDone', function() { file.end(); }).
 send();
@@ -95,7 +95,7 @@ The following example creates a vault named "YOUR_VAULT_NAME":
 
 ```js
 var glacier = new AWS.Glacier();
-glacier.createVault({vaultName: 'YOUR_VAULT_NAME'}, function(err) {
+glacier.client.createVault({vaultName: 'YOUR_VAULT_NAME'}, function(err) {
   if (!err) console.log("Created vault!")
 });
 ```
@@ -115,7 +115,7 @@ var glacier = new AWS.Glacier(),
     buffer = new Buffer(2.5 * 1024 * 1024); // 2.5MB buffer
 
 var params = {vaultName: vaultName, body: buffer};
-glacier.uploadArchive(params, function(err, data) {
+glacier.client.uploadArchive(params, function(err, data) {
   if (err) console.log("Error uploading archive!", err);
   else console.log("Archive ID", data.archiveId);
 });
@@ -141,11 +141,11 @@ var glacier = new AWS.Glacier(),
 
 // Compute the complete SHA-256 tree hash so we can pass it
 // to completeMultipartUpload request at the end
-var treeHash = glacier.computeChecksums(buffer).treeHash;
+var treeHash = glacier.client.computeChecksums(buffer).treeHash;
 
 // Initiate the multi-part upload
 console.log('Initiating upload to', vaultName);
-glacier.initiateMultipartUpload(params, function (mpErr, multipart) {
+glacier.client.initiateMultipartUpload(params, function (mpErr, multipart) {
   if (mpErr) { console.log('Error!', mpErr.stack); return; }
   console.log("Got upload ID", multipart.uploadId);
 
@@ -161,7 +161,7 @@ glacier.initiateMultipartUpload(params, function (mpErr, multipart) {
 
     // Send a single part
     console.log('Uploading part', i, '=', partParams.range);
-    glacier.uploadMultipartPart(partParams, function(multiErr, mData) {
+    glacier.client.uploadMultipartPart(partParams, function(multiErr, mData) {
       if (multiErr) return;
       console.log("Completed part", this.request.params.range);
       if (--numPartsLeft > 0) return; // complete only when all parts uploaded
@@ -174,7 +174,7 @@ glacier.initiateMultipartUpload(params, function (mpErr, multipart) {
       };
 
       console.log("Completing upload...");
-      glacier.completeMultipartUpload(doneParams, function(err, data) {
+      glacier.client.completeMultipartUpload(doneParams, function(err, data) {
         if (err) {
           console.log("An error occurred while uploading the archive");
           console.log(err);
@@ -207,7 +207,7 @@ AWS.config.update({
 });
 
 var s3 = new AWS.S3();
-s3.getObject({Bucket: 'bucket', Key: 'key'}, function (err, data) {
+s3.client.getObject({Bucket: 'bucket', Key: 'key'}, function (err, data) {
   console.log(err, data);
 });
 ```
@@ -219,7 +219,7 @@ same configuration option to the service constructor:
 
 ```js
 var s3 = new AWS.S3({httpOptions: {proxy: 'http://localhost:8080'}});
-s3.getObject({Bucket: 'bucket', Key: 'key'}, function (err, data) {
+s3.client.getObject({Bucket: 'bucket', Key: 'key'}, function (err, data) {
   console.log(err, data);
 });
 ```


### PR DESCRIPTION
Methods are bound to service object's client fields, not the service objects themselves.  Updated docs to reflect implementation.

e.g. 'listTables' does not exist on a new AWS.DynamoDB(), but instead exists on the (new AWS.DynamoDB()).client object.
