### PR TITLE
Add tagging to s3 signer for getBucketTagging to work.

### DIFF
--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -35,6 +35,7 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
     'partNumber': 1,
     'policy': 1,
     'requestPayment': 1,
+    'tagging': 1,
     'torrent': 1,
     'uploadId': 1,
     'uploads': 1,


### PR DESCRIPTION
The generated signature is invalid without this.
