### PR TITLE
Fix readableStream unexpected end while waiting response

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -308,6 +308,7 @@ AWS.Request = inherit({
           while (data = httpStream.read()) {
             stream.push(data);
           }
+          stream.push('');
         };
 
         var events = ['end', 'error', (legacyStreams ? 'data' : 'readable')];

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -67,7 +67,11 @@ mockHttpSuccessfulResponse = (status, headers, data, cb) ->
   httpResp.headers = headers
   httpResp.read = ->
     if data.length > 0
-      new Buffer(data.shift())
+      chunk = data.shift()
+      if chunk is null
+        null
+      else
+        new Buffer(chunk)
     else
       null
 

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -56,6 +56,29 @@ describe 'AWS.Request', ->
       runs ->
         expect(data).toEqual('FOOBARBAZQUX')
 
+    it 'streams2 data does not hang out while waiting response', ->
+      if AWS.HttpClient.streamsApiVersion < 2
+        return
+
+      data = ''; done = false
+      helpers.mockHttpResponse 200, {}, ['FOO', 'BAR', null, null, 'BAZ', 'QUX']
+
+      runs ->
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'end', -> done = true
+        s.on 'readable', ->
+          try
+            chunk = s.read()
+            if chunk
+              data += chunk
+          catch e
+            console.log(e.stack)
+
+      waitsFor -> done == true
+      runs ->
+        expect(data).toEqual('FOOBARBAZQUX')
+
     it 'does not stream data on failures', ->
       data = ''; error = null; done = false
       helpers.mockHttpResponse 404, {}, ['No such file']


### PR DESCRIPTION
Hello,

recently while using createReadStream() to pipe response in AWS.S3, under Node v0.10.1
I found the stream will hangout unexpected and only return partial result:

```
var buffers = [];
var s3 = new AWS.S3();
var stream = s3.getObject(params).createReadStream();
stream.on('readable', function(){
  var data;
  while (data = stream.read()){
    buffers.push(data);
  };
});
stream.on('end', function(){
  fs.writeFileSync('./test.jpg', Buffer.concat(buffers));
}); // result in partial image
```

After checking the source of createReadStream(), 
I found the stream._read method is missing a push method when httpStream.read() return false values, which result to the unexpected end:

```
stream._read = function() {
  var data;
  /*jshint boss:true*/
  while (data = httpStream.read()) {
    stream.push(data);
  }
};
```

What happened here, is because when the read method on stream is called, it will set a reading flag to true, until the stream.push is called, it will block next read call until the previous read finished. Therefore when httpStream is still waiting for response, the readStream will block itself because of the missing push call.

Further details is in the source of [issac/readable-stream](https://github.com/issac/readable-stream)
[https://github.com/isaacs/readable-stream/blob/master/lib/_stream_readable.js#L286](https://github.com/isaacs/readable-stream/blob/master/lib/_stream_readable.js#L286)

So the pipe is also working now under 0.10.x, 

```
var out = fs.createWriteStream('./nyancat.jpg');
s3.getObject(params).createReadStream().pipe(out);
```

Let me know is this solves the problem, also I made some hack on helper to emulate empty read call. Probably will have better way to emulate it.
