### PR TITLE
Query string request authentication

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -248,4 +248,112 @@ AWS.S3.prototype.createBucket = function createBucket(params, callback) {
   return this.makeRequest('createBucket', params, callback);
 };
 
+/**
+ * Returns a signed URL that can be used to retrieve an object from Amazon S3.
+ * @param params [Object] a map of parameter keys and values
+ * @param callback [Function] the listener callback function
+ */
+AWS.S3.prototype.getSignedUrl = function getSignedUrl(params, callback) {
+    function validate(req) {
+        new AWS.ParamValidator().validate({
+            type: 'structure',
+            members: {
+                Bucket: {
+                    required: true,
+                    location: 'uri'
+                },
+                Expires: {
+                    required: true,
+                    location: 'uri'
+                },
+                Key: {
+                    required: true,
+                    location: 'uri'
+                }
+            }
+        }, req.params);
+    }
+
+    // The method in stringToSign will be GET.
+    function afterBuild(req) {
+        req.httpRequest.method = 'GET';
+    }
+
+    // This sign is asynchronous because it calls getCredentials().
+    sign.async = true;
+    function sign(req, next) {
+        req.service.config.getCredentials(function (err, credentials) {
+            try {
+                if (err) return next(err);
+
+                // Query String Request Authentication uses Expires in place of Date
+                req.httpRequest.headers['Date'] = req.params.Expires;
+
+                var sigVersion = req.service.api.signatureVersion;
+                var SignerClass = AWS.Signers.RequestSigner.getVersion(sigVersion);
+                var signer = new SignerClass(req.httpRequest, req.service.api.signingName || req.service.api.endpointPrefix);
+                var signature = signer.sign(credentials.secretAccessKey, signer.stringToSign());
+                var query = AWS.util.queryParamsToString({
+                    AWSAccessKeyId: credentials.accessKeyId,
+                    Expires: req.params.Expires,
+                    Signature: signature
+                });
+                req.httpRequest.path += '?' + query;
+                next();
+            }
+            catch (e) {
+                next(e);
+            }
+        });
+    }
+
+    // We do not need to talk to the service to sign the object URL.
+    function send(res) {
+        // this will emit the response phase events
+        this.completeRequest(res);
+    }
+
+    // Here we build the data that getSignedUrl will return -
+    // an object with one field, Url, that holds the full signed URL.
+    function extractData(res) {
+        res.data = {
+            Url: [
+                res.request.httpRequest.endpoint.protocol,
+                '//',
+                res.request.httpRequest.endpoint.hostname, // <-- populateURI does not update .host
+                res.request.httpRequest.path
+            ].join('')
+        };
+    }
+
+    // Change the event listeners of a getObject() request
+    // to those we use for getSignedUrl().
+    function swapListeners(req)
+    {
+        req.removeListener('validate', AWS.EventListeners.Core.VALIDATE_PARAMETERS);
+        req.removeAllListeners('sign');
+        req.removeAllListeners('send');
+        req.removeAllListeners('retry');
+        req.removeAllListeners('extractData');
+        req.removeAllListeners('extractError');
+        req.addListener('validate', validate);
+        req.addListener('afterBuild', afterBuild);
+        req.addListener('sign', sign);
+        req.addListener('send', send);
+        req.addListener('extractData', extractData);
+    }
+
+    var req = this.getObject(params);
+    swapListeners(req);
+
+    if (callback) {
+        req.on('complete', function (res) {
+            callback.call(res, res.err, res.data);
+        });
+        req.send();
+    }
+
+    return req;
+};
+
 module.exports = AWS.S3;


### PR DESCRIPTION
Looks like there is no query string request authentication method in the SDK. Knox has one. I'm not sure where it should live, since it's not part of the across-the-wire API, but I took a stab at it anyway. Feel free to ignore if you don't think it belongs.
