### PR TITLE
S3 putBucketWebsite API rules

### DIFF
--- a/lib/services/api/s3-2006-03-01.js
+++ b/lib/services/api/s3-2006-03-01.js
@@ -2593,7 +2593,6 @@ module.exports = {
                       required: true,
                       members: {
                         HostName: {
-                          required: true
                         },
                         HttpRedirectCode: {
                         },


### PR DESCRIPTION
HostName is not required in a RoutingRule Redirect per http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html
