### PR TITLE
Validate MD5 checksums in SQS operations.

### DIFF
--- a/lib/services/sqs.js
+++ b/lib/services/sqs.js
@@ -39,7 +39,8 @@ AWS.SQS = AWS.Service.defineService('sqs', ['2012-11-05'], {
     if (calculatedMd5 !== md5) {
       var msg = 'Got "' + response.data.MD5OfMessageBody +
         '", expecting "' + calculatedMd5 + '".';
-      this.service.throwInvalidChecksumError(response, undefined, msg);
+      this.service.throwInvalidChecksumError(response,
+        [response.data.MessageId], msg);
     }
   },
 

--- a/test/services/sqs.spec.coffee
+++ b/test/services/sqs.spec.coffee
@@ -41,6 +41,7 @@ describe 'AWS.SQS', ->
       """
       <SendMessageResponse><SendMessageResult>
         <MD5OfMessageBody>#{md5}</MD5OfMessageBody>
+        <MessageId>MSGID</MessageId>
       </SendMessageResult></SendMessageResponse>
       """
 
@@ -51,6 +52,7 @@ describe 'AWS.SQS', ->
     it 'raises InvalidChecksum if MD5 does not match message input', ->
       checksumValidate 'sendMessage', input, payload('000'), false, (err) ->
         expect(err.message).toMatch('Got "000", expecting "acbd18db4cc2f85cedef654fccc4a4d8"')
+        expect(err.messageIds).toEqual(['MSGID'])
 
     it 'ignores checksum errors if computeChecksums is false', ->
       sqs.config.computeChecksums = false


### PR DESCRIPTION
This feature can be disabled by passing `computeChecksums: false`
to the SQS service object constructor.

Affected operations are:
- sendMessage
- sendMessageBatch
- receiveMessage

If any messages sent or received in these operations fail the MD5
check, an error will be raised for the affected message.
