### PR TITLE
Fixed issue with optional Expires param failing validation

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -274,10 +274,12 @@ AWS.S3 = AWS.Service.defineService('s3', ['2006-03-01'], {
    *   console.log('The URL is', url); // expires in 60 seconds
    */
   getSignedUrl: function getSignedUrl(operation, params, callback) {
+    var expires = params.Expires || 900;
+    delete params.Expires; // we can't validate this
     var url = require('url');
     var events = ['validate', 'build', 'sign'];
     var request = this.makeRequest(operation, params);
-    var expires = params.Expires || 900;
+
     var expiresHeader = 'presigned-expires';
 
     function signedUrlBuilder() {
@@ -315,7 +317,6 @@ AWS.S3 = AWS.Service.defineService('s3', ['2006-03-01'], {
     if (!params.Body) { // no Content-MD5 signing if body is not provided
       request.removeListener('build', this.computeContentMd5);
     }
-    delete params.Expires; // we can't validate this
 
     if (callback) {
       request.emitEvents(events, new AWS.Response(request), function (err) {


### PR DESCRIPTION
I suspect that makeRequest is making a copy of the params object,
and the delete happens too late in the process. Then validation fails
because Expires is not a valid param.
