### PR TITLE
Make configurable authentication scheme

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -382,10 +382,12 @@ AWS.Credentials = inherit({
       this.accessKeyId = creds.accessKeyId;
       this.secretAccessKey = creds.secretAccessKey;
       this.sessionToken = creds.sessionToken;
+      this.authScheme = creds.authScheme;
     } else {
       this.accessKeyId = arguments[0];
       this.secretAccessKey = arguments[1];
       this.sessionToken = arguments[2];
+      this.authScheme = arguments[3];
     }
   },
 

--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -67,7 +67,8 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
     }
 
     var signature = this.sign(credentials.secretAccessKey, this.stringToSign());
-    var auth = 'AWS ' + credentials.accessKeyId + ':' + signature;
+    var auth = (credentials.authScheme || 'AWS') + ' ' +
+          credentials.accessKeyId + ':' + signature;
 
     this.request.headers['Authorization'] = auth;
   },

--- a/lib/signers/v3.js
+++ b/lib/signers/v3.js
@@ -37,7 +37,7 @@ AWS.Signers.V3 = inherit(AWS.Signers.RequestSigner, {
   },
 
   authorization: function authorization(credentials) {
-    return 'AWS3 ' +
+    return (credentials.authScheme || 'AWS3') + ' ' +
       'AWSAccessKeyId=' + credentials.accessKeyId + ',' +
       'Algorithm=HmacSHA256,' +
       'SignedHeaders=' + this.signedHeaders() + ',' +

--- a/lib/signers/v3https.js
+++ b/lib/signers/v3https.js
@@ -23,7 +23,7 @@ require('./v3');
  */
 AWS.Signers.V3Https = inherit(AWS.Signers.V3, {
   authorization: function authorization(credentials) {
-    return 'AWS3-HTTPS ' +
+    return (credentials.authScheme || 'AWS3-HTTPS') + ' ' +
       'AWSAccessKeyId=' + credentials.accessKeyId + ',' +
       'Algorithm=HmacSHA256,' +
       'Signature=' + this.signature(credentials);

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -43,8 +43,8 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   authorization: function authorization(credentials, datetime) {
     var parts = [];
     var credString = this.credentialString(datetime);
-    parts.push('AWS4-HMAC-SHA256 Credential=' +
-      credentials.accessKeyId + '/' + credString);
+    parts.push((credentials.authScheme || 'AWS4-HMAC-SHA256') +
+      ' Credential=' + credentials.accessKeyId + '/' + credString);
     parts.push('SignedHeaders=' + this.signedHeaders());
     parts.push('Signature=' + this.signature(credentials, datetime));
     return parts.join(', ');
@@ -56,12 +56,13 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     var kRegion = AWS.util.crypto.hmac(kDate, this.request.region);
     var kService = AWS.util.crypto.hmac(kRegion, this.serviceName);
     var kCredentials = AWS.util.crypto.hmac(kService, 'aws4_request');
-    return AWS.util.crypto.hmac(kCredentials, this.stringToSign(datetime), 'hex');
+    return AWS.util.crypto.hmac(kCredentials,
+      this.stringToSign(credentials, datetime), 'hex');
   },
 
-  stringToSign: function stringToSign(datetime) {
+  stringToSign: function stringToSign(credentials, datetime) {
     var parts = [];
-    parts.push('AWS4-HMAC-SHA256');
+    parts.push(credentials.authScheme || 'AWS4-HMAC-SHA256');
     parts.push(datetime);
     parts.push(this.credentialString(datetime));
     parts.push(this.hexEncodedHash(this.canonicalString()));

--- a/test/signers/s3.spec.coffee
+++ b/test/signers/s3.spec.coffee
@@ -100,6 +100,20 @@ describe 'AWS.Signers.S3', ->
 
       expect(req.headers['Authorization']).toEqual('AWS AKID:Gg5WLabTOvH0WMd15wv7lWe4zK0=')
 
+    it 'adds an Authorization header which contains akid, signature and authentication scheme', ->
+
+      creds = { accessKeyId: 'AKID', secretAccessKey: 'secret', authScheme: 'AMAZON' }
+
+      req = buildRequest()
+
+      signer = new AWS.Signers.S3(req)
+
+      spyOn(signer, 'stringToSign')
+      signer.stringToSign.andReturn('string-to-sign')
+      signer.addAuthorization(creds, date)
+
+      expect(req.headers['Authorization']).toEqual('AMAZON AKID:Gg5WLabTOvH0WMd15wv7lWe4zK0=')
+
   describe 'stringToSign', ->
 
     beforeEach ->

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -77,7 +77,15 @@ describe 'AWS.Signers.V4', ->
 
   describe 'stringToSign', ->
     it 'should sign correctly generated input string', ->
-      expect(signer.stringToSign(datetime)).toEqual 'AWS4-HMAC-SHA256\n' +
+      expect(signer.stringToSign(creds, datetime)).toEqual 'AWS4-HMAC-SHA256\n' +
+        datetime + '\n' +
+        '20310430/region/dynamodb/aws4_request\n' +
+        signer.hexEncodedHash(signer.canonicalString())
+
+  describe 'stringToSign with specific authentication scheme', ->
+    it 'should sign correctly generated input string', ->
+      creds.authScheme = 'AWS4-HMAC-SHA1'
+      expect(signer.stringToSign(creds, datetime)).toEqual 'AWS4-HMAC-SHA1\n' +
         datetime + '\n' +
         '20310430/region/dynamodb/aws4_request\n' +
         signer.hexEncodedHash(signer.canonicalString())


### PR DESCRIPTION
In current sdk, authentication scheme is hard coded

in s3, AWS
in v4, AWS4-HMAC-SHA256

Hardcoding should be avoid.
