### PR TITLE
Format timestamp headers correctly

### DIFF
--- a/lib/service_interface/rest.js
+++ b/lib/service_interface/rest.js
@@ -128,7 +128,12 @@ AWS.ServiceInterface.Rest = {
             req.httpRequest.headers[rule.name + key] = value;
           });
         } else {
-          req.httpRequest.headers[rule.name || name] = req.params[name];
+          var value = req.params[name];
+          if (rule.type === 'timestamp') {
+            var timestampFormat = rule.format || req.service.api.timestampFormat;
+            value = AWS.util.date.format(value, timestampFormat);
+          }
+          req.httpRequest.headers[rule.name || name] = value;
         }
       }
     });

--- a/test/service_interface/rest.spec.coffee
+++ b/test/service_interface/rest.spec.coffee
@@ -22,6 +22,7 @@ describe 'AWS.ServiceInterface.Rest', ->
   operation = null
   request = null
   response = null
+  service = null
   svc = eval(@description)
 
   beforeEach ->
@@ -33,6 +34,7 @@ describe 'AWS.ServiceInterface.Rest', ->
             uri: '/'
           input: null
           output: null
+ 
 
     AWS.Service.defineMethods(MockRESTService)
 
@@ -145,6 +147,63 @@ describe 'AWS.ServiceInterface.Rest', ->
               abc: 'xyz'
         expect(request.httpRequest.headers['x-amz-meta-foo']).toEqual('bar')
         expect(request.httpRequest.headers['x-amz-meta-abc']).toEqual('xyz')
+
+    describe 'timestamp header with format', ->
+      it 'populates the header with correct timestamp formatting', ->
+        date = new Date(Date.now());
+        buildRequest ->
+          operation.input =
+            members:
+              IfModifiedSince:
+                location: 'header'
+                name: 'If-Modified-Since'
+                type: 'timestamp'
+                format: 'rfc822'
+          request.params = IfModifiedSince: date
+        expect(request.httpRequest.headers['If-Modified-Since']).toEqual(date.toUTCString())
+
+    describe 'timestamp header without format', ->
+      it 'populates the header using the api formatting', ->
+        date = new Date(Date.now());
+        buildRequest ->
+          service.api.timestampFormat = 'rfc822'
+          operation.input =
+            members:
+              IfModifiedSince:
+                location: 'header'
+                name: 'If-Modified-Since'
+                type: 'timestamp'
+          request.params = IfModifiedSince: date
+        expect(request.httpRequest.headers['If-Modified-Since']).toEqual(date.toUTCString())
+
+    describe 'timestamp header with api formatting and parameter formatting', ->
+      it 'populates the header using the parameter formatting', ->
+        date = new Date(Date.now());
+        buildRequest ->
+          service.api.timestampFormat = 'invalid'
+          operation.input =
+            members:
+              IfModifiedSince:
+                location: 'header'
+                name: 'If-Modified-Since'
+                type: 'timestamp'
+                format: 'rfc822'
+          request.params = IfModifiedSince: date
+        expect(request.httpRequest.headers['If-Modified-Since']).toEqual(date.toUTCString())
+
+    describe 'timestamp header with iso formatting', ->
+      it 'populates the header using the parameter formatting', ->
+        date = new Date(Date.now());
+        buildRequest ->
+          operation.input =
+            members:
+              IfModifiedSince:
+                location: 'header'
+                name: 'If-Modified-Since'
+                type: 'timestamp'
+                format: 'iso8601'
+          request.params = IfModifiedSince: date
+        expect(request.httpRequest.headers['If-Modified-Since']).toEqual(date.toISOString())
 
   describe 'extractData', ->
     extractData = (callback) ->


### PR DESCRIPTION
HTTP header fields with timestamps do not use the formatting specified in the api definition, but use formatting with the local timezone.
This breaks the ifModifiedSince parameter for AWS.S3.getObject for me, because it sets If-Modified-Since to "Jul 09 2013 14:01:46 GMT+0200 (CEST)" (which the server apparently cannot parse) instead of using the required rfc822 formatting ("Tue, 09 Jul 2013 12:04:26 GMT")
