### PR TITLE
Reverted back signature version

### DIFF
--- a/lib/services/api/elb-2012-06-01.js
+++ b/lib/services/api/elb-2012-06-01.js
@@ -19,7 +19,7 @@ module.exports = {
   endpointPrefix: 'elasticloadbalancing',
   resultWrapped: true,
   serviceFullName: 'Elastic Load Balancing',
-  signatureVersion: 'v4',
+  signatureVersion: 'v2',
   timestampFormat: 'iso8601',
   operations: {
     applySecurityGroupsToLoadBalancer: {


### PR DESCRIPTION
Signature version v2 fails to authenticate against the ELB api

err:  { [SignatureDoesNotMatch: Signature not yet current: 20130730T204752Z is still later than 20130730T204123Z (20130730T203623Z + 5 min.)]
  message: 'Signature not yet current: 20130730T204752Z is still later than 20130730T204123Z (20130730T203623Z + 5 min.)',
  code: 'SignatureDoesNotMatch',
  name: 'SignatureDoesNotMatch',
  statusCode: 403,
  retryable: false }
