### PR TITLE
Added a check when Function's prototype have the 'async' property

### DIFF
--- a/lib/sequential_executor.js
+++ b/lib/sequential_executor.js
@@ -111,7 +111,7 @@ AWS.SequentialExecutor = AWS.util.inherit({
         this.domain.exit();
     } else {
       var listener = listeners.shift();
-      if (listener.async) {
+      if (listener.hasOwnProperty('async') && listener.async) {
 
         // asynchronous listener
         var callNextListener = function(err) {


### PR DESCRIPTION
SDK fails to send requests when used with some control-flow libraries e.g. [fibrous](https://github.com/goodeggs/fibrous), [node-sync](https://github.com/0ctave/node-sync).
That libraries extends Function's prototype to add 'async' function. 
In SequentialExecutor, I think that is better to check listener's async flag is the own property.
