### PR TITLE
Ensure the cache is invalidated if the date has changed

### DIFF
--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -53,14 +53,15 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
 
   signature: function signature(credentials, datetime) {
     var cache = cachedSecret[this.serviceName];
-    if (!cache || cache.region !== this.request.region) {
+    var date = datetime.substr(0, 8);
+    if (!cache || cache.region !== this.request.region || cache.date !== date) {
       var kSecret = credentials.secretAccessKey;
-      var kDate = AWS.util.crypto.hmac('AWS4' + kSecret, datetime.substr(0, 8), 'buffer');
+      var kDate = AWS.util.crypto.hmac('AWS4' + kSecret, date, 'buffer');
       var kRegion = AWS.util.crypto.hmac(kDate, this.request.region, 'buffer');
       var kService = AWS.util.crypto.hmac(kRegion, this.serviceName, 'buffer');
       var kCredentials = AWS.util.crypto.hmac(kService, 'aws4_request', 'buffer');
       cachedSecret[this.serviceName] = {
-        region: this.request.region, key: kCredentials
+        region: this.request.region, date: date, key: kCredentials
       };
     }
 


### PR DESCRIPTION
This does involve an extra `substr` call, but should not have a noticeable impact on performance.

Should fix #168
