### PR TITLE
Fix wrong rowspan in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The SDK currently supports the following services:
     <th>API Version</th>
   </thead>
   <tbody>
-    <tr><td rowspan="2">Amazon CloudFront</td><td rowspan="3">AWS.CloudFront</td><td>2012-05-05</td></tr>
+    <tr><td rowspan="3">Amazon CloudFront</td><td rowspan="3">AWS.CloudFront</td><td>2012-05-05</td></tr>
     <tr><td>2013-05-12</td></tr>
     <tr><td>2013-08-26</td></tr>
     <tr><td>Amazon CloudSearch</td><td>AWS.CloudSearch</td><td>2011-02-01</td></tr>


### PR DESCRIPTION
The rowspan was wrong, breaking the "Supported Services"'s table layout.
