### PR TITLE
A very simple example of how to use modules

### DIFF
--- a/lib/services/cloudformation.js
+++ b/lib/services/cloudformation.js
@@ -13,8 +13,8 @@
  * language governing permissions and limitations under the License.
  */
 
-var AWS = require('../core');
+// import a dependency
+var service = require('../service');
 
-AWS.CloudFormation = AWS.Service.defineService('cloudformation', ['2010-05-15']);
-
-module.exports = AWS.CloudFormation;
+// export something useful
+module.exports = service.defineService('cloudformation', ['2010-05-15']);


### PR DESCRIPTION
This code is no longer using the CommonJS equivalent of a global namespace (`var AWS = require("../core");`).  

This anti-pattern is causing unnecessary circular dependencies  (throughout the project), but -- more importantly -- allows developers to use deep objects on its hierarchy.  This is the root of "dependency hell" caused by globals.  You've just recreated it in CommonJS.

I also removed an implicit dependency on one such deep object: `AWS.Service.defineService`.  There's no `require` specifying this dependency.  It's just magically available somehow.  This is an example of "dependency hell" in action.  There's no way a human or machine could easily know what the requirements of this module were before I made it explicit.

I'm not 100% sure, but I don't think the previous code will transpile to ES6 format.  The code I wrote will.
