### PR TITLE
S3 signature breaks for restoreObject

### DIFF
--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -35,7 +35,7 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
     'partNumber': 1,
     'policy': 1,
     'requestPayment': 1,
-    'restore': 1
+    'restore': 1,
     'tagging': 1,
     'torrent': 1,
     'uploadId': 1,


### PR DESCRIPTION
I kept getting a SignatureDoesNotMatch error when trying to use S3.restoreObject - I think I've narrowed this down to "?restore" not being included in the signature string because it's not included in the list of subresources. Simply adding it in made everything work for me.
