### PR TITLE
Fix for #196 - Update config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -128,8 +128,8 @@ AWS.Config = AWS.util.inherit({
    *     SSL connections, a special Agent object is used in order to enable
    *     peer certificate verification. This feature is only available in the
    *     Node.js environment.
-   *   * **timeout** [Integer] &mdash; The number of milliseconds to wait before
-   *     giving up on a connection attempt. Defaults to no timeout.
+   *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
+   *     milliseconds of inactivity on the socket. Defaults to no timeout.
    * @option options apiVersion [String, Date] a String in YYYY-MM-DD format
    *   (or a date) that represents the latest possible API version that can be
    *   used in all services (unless overridden by `apiVersions`). Specify


### PR DESCRIPTION
Fix for #196.

Updated doc for `httpOptions.timeout` to reflect documentation from  http://nodejs.org/api/net.html#net_socket_settimeout_timeout_callback which is used internally to set the timeout.
