### PR TITLE
Respect the global agent maxSocket property

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -82,9 +82,16 @@ AWS.NodeHttpClient = AWS.util.inherit({
 
   sslAgent: function sslAgent(http) {
     if (!AWS.NodeHttpClient.sslAgent) {
+      var numMaxSockets = 5;
+      if (typeof http != 'undefined') {
+        numMaxSockets = http.globalAgent.maxSockets;
+      }
+      if (typeof https != 'undefined') {
+        numMaxSockets = https.globalAgent.maxSockets;
+      }
       AWS.NodeHttpClient.sslAgent = new http.Agent({
         rejectUnauthorized: true,
-        maxSockets: https.globalAgent.maxSockets
+        maxSockets: numMaxSockets
       });
       AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
     }


### PR DESCRIPTION
Currently if someone uses an AWS service and they use SSL, `http(s).globalAgent.maxSockets` is ignored entirely when this new agent is created. You also can't configure `maxSockets` by passing in config, as that is also ignored in this case.

By default, node pools its connections. That means if you have a shared agent, and you have more than 5 connections open (because the default `maxSockets` is 5), you're going to block until a connection is available for use. This is particularly bad when you're trying to rapidly pull and push from something like SQS.

The simplest test is to make a queue consumer for SQS. Create 10 workers that will continually try eating off the queue, and then try sending a message with the current library. The response will take a very long time to return.

See https://gist.github.com/nscott/8735628 for an example in CoffeeScript. Run it with the current aws-sdk, and then run it with this revision. You'll see that sendMessage()'s callback hits very quickly, as opposed to waiting a very long time. receiveMessage() can also pick up on those messages faster.

A temporary, injectable solution is to overwrite the prototype. See the coffescript at https://gist.github.com/nscott/8735708. 
