### PR TITLE
allowing scalar params to be null and still validate if they're not required

### DIFF
--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -83,6 +83,7 @@ AWS.ParamValidator = AWS.util.inherit({
 
   validateScalar: function validateScalar(rules, value, context) {
     /*jshint maxcomplexity:12*/
+    if(value === null && !rules.required) return;
     switch (rules.type) {
       case null:
       case undefined:


### PR DESCRIPTION
this is important as e.g. AWS.config.credentials needs ProviderId to be null for google+ provider, as per current JS SDK docs.
I'm not 100% certain this is exactly how you'd make such a change but there definitely seems to be the need to enhance validation with instructions that deal with null values! Definitely for scalars, absolutely not sure about whether the other (composite) types need that at all.
