### PR TITLE
fixed hard error state lookup

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -33,7 +33,7 @@ fsm.setupStates = function() {
       if (this._hardError) {
         throw e;
       }
-      else if (hardErrorStates.indexOf(this._asm.currentState) >= 0) {
+      else if (hardErrorStates.hasOwnProperty(this._asm.currentState)) {
         this._hardError = true;
       }
       done(e);


### PR DESCRIPTION
This error was posted when using aws-sdk in nock:
https://github.com/pgte/nock/issues/184

It looks like there is a problem in the error lookup code:
A JavaScript object does not have a `.indexOf` method. Instead the lookup can be done using the universal `.hasOwnProperty` method.

Also, it looks like this part of the code has no test coverage, that's probably why it slipped.
