### PR TITLE
Updated .npmignore to ignore .gitignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 .yard*
 .eslintrc
 .travis.yml
+.gitignore
 apis/source
 configuration
 configuration.sample


### PR DESCRIPTION
Keeping .gitignore in a published npm package causes severe headaches for projects that include their dependencies in their Git index. This patch adds .gitignore to .npmignore so that all dependencies can be added to a Git index without issue
