### PR TITLE
Setting home to env.USERPROFILE instead of env.HOMEPATH

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -88,7 +88,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   loadDefaultFilename: function loadDefaultFilename() {
-    var env = process.env, home = env.HOME || env.HOMEPATH || env.USERPROFILE;
+    var env = process.env, home = env.USERPROFILE || env.HOME;
     if (!home) {
       throw AWS.util.error(
         new Error('Cannot load credentials, HOME path not set'));


### PR DESCRIPTION
On Windows, env.HOMEPATH does not include the drive, which causes the SDK to fail to find the default credentials file when run from another drive.
