### PR TITLE
Adjust version string for node 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
       "istanbul": "*"
     },
     "dependencies": {
-      "aws-sdk-apis": "^3.1",
+      "aws-sdk-apis": "~3.1",
       "xml2js": "0.2.6",
       "xmlbuilder": "0.4.2"
     },


### PR DESCRIPTION
Hi! I'm having trouble building the project on node 0.8.x because of the way the version string is written in `package.json`. 

It is confusing that:
- `engines.node` advertises that aws-sdk runs on node >= 0.6.0
- `.travis.yml` does not test on any node version other than 0.10.x
- some of the `devDependencies` are explicitly >= 0.10.x (e.g. [eslint](https://github.com/eslint/eslint/blob/master/package.json#L77))

cc @yhahn 
