### PR TITLE
Open XMLHTTPRequest before setting properties

### DIFF
--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -19,14 +19,6 @@ AWS.XHRClient = AWS.util.inherit({
     var xhr = new XMLHttpRequest(), headersEmitted = false;
     httpRequest.stream = xhr;
 
-    if (httpOptions.timeout) {
-      xhr.timeout = httpOptions.timeout;
-    }
-
-    if (httpOptions.xhrWithCredentials) {
-      xhr.withCredentials = true;
-    }
-
     xhr.addEventListener('readystatechange', function() {
       try {
         if (xhr.status === 0) return; // 0 code is invalid
@@ -65,6 +57,14 @@ AWS.XHRClient = AWS.util.inherit({
         xhr.setRequestHeader(key, value);
       }
     });
+
+    if (httpOptions.timeout) {
+      xhr.timeout = httpOptions.timeout;
+    }
+
+    if (httpOptions.xhrWithCredentials) {
+      xhr.withCredentials = true;
+    }
 
     if (httpRequest.body && typeof httpRequest.body.buffer === 'object') {
       xhr.send(httpRequest.body.buffer); // typed arrays sent as ArrayBuffer


### PR DESCRIPTION
Execute the  <code>.open()</code> operation on the <code>XMLHttpRequest</code> object before setting the <code>timeout</code> and <code>withCredentials</code> property
