### PR TITLE
Add error handling layer to request construction

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -209,9 +209,13 @@ AWS.EventListeners = {
       function executeSend() {
         var http = AWS.HttpClient.getInstance();
         var httpOptions = resp.request.service.config.httpOptions || {};
-        var stream = http.handleRequest(resp.request.httpRequest, httpOptions,
-                                        callback, error);
-        progress(stream);
+        try {
+          var stream = http.handleRequest(resp.request.httpRequest, httpOptions,
+                                          callback, error);
+          progress(stream);
+        } catch (err) {
+          error(err);
+        } 
       }
 
       var timeDiff = (AWS.util.date.getDate() - this.signedAt) / 1000;

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -36,6 +36,15 @@ describe 'AWS.Request', ->
       ).not.to.throw('error')
       expect(err.message).to.equal('error')
 
+    it 'propagates request creation errors into response', ->
+      helpers.spyOn(AWS.HttpClient, 'getInstance')
+      AWS.HttpClient.getInstance.andReturn handleRequest: (req, opts, cb, errCb) ->
+        throw new Error('XHR error')
+      db = new AWS.DynamoDB
+      req = db.listTables()
+      req.send()
+      expect(req.response.error.message).to.equal('XHR error')
+
   describe 'isPageable', ->
     beforeEach ->
       service = new AWS.Service apiConfig: new AWS.Model.Api


### PR DESCRIPTION
Add error handling layer to request construction. Exceptions in request construction now correctly set the error status on the response.
