### PR TITLE
Added route53domains endpoint to region_config.json

### DIFF
--- a/lib/region_config.json
+++ b/lib/region_config.json
@@ -27,6 +27,13 @@
           "endpoint": "https://{service}.amazonaws.com"
         },
         "globalEndpoint": true
+      },
+      {
+        "services": ["route53domains"],
+        "config": {
+          "endpoint": "{service}.us-east-1.amazonaws.com"
+        },
+        "globalEndpoint": true
       }
     ]
   },


### PR DESCRIPTION
route53domains actions fail if you are configured to use any region other than us-east-1.

It appears to be because there is no global endpoint configured for this service and the local dns entries don't exit (route53domains.eu-west-1.amazonaws.com, etc).

There also isn't an endpoint that matches the pattern the other global endpoints have ({service}.amazonaws.com).

This commit allows route53domains queries to work but I'm not sure it's exactly right - I suspect adding route53domains.amazonaws.com to the dns would be preferable to the SDK hardcoding us-east-1 and I wasn't sure about the https prefix in front of the endpoint (some have it, some don't.)

Thanks,

Daniel
