### PR TITLE
Disallow SSE keys to be sent over HTTP

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -35,9 +35,10 @@ AWS.util.update(AWS.S3.prototype, {
         scheme = req.httpRequest.endpoint.protocol,
         sensitive = params.SSECustomerKey || params.CopySourceSSECustomerKey;
     if (sensitive && scheme !== 'https:') {
-      var msg = 'Cannot send SSE keys over HTTP. Use HTTPS';
+      var msg = 'Cannot send SSE keys over HTTP. Set \'sslEnabled\'' +
+        'to \'true\' in your configuration';
       throw AWS.util.error(new Error(),
-        { name: 'ConfigError', message: msg });
+        { code: 'ConfigError', message: msg });
     }
   },
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -180,7 +180,7 @@ describe 'AWS.S3', ->
         SSECustomerKey: 'sse-key', SSECustomerAlgorithm: 'AES256'
       req.httpRequest.endpoint.protocol = 'http:'
       req.build()
-      expect(req.response.error.name).to.equal('ConfigError')
+      expect(req.response.error.code).to.equal('ConfigError')
 
     it 'fails if the scheme is not HTTPS: when CopySourceSSECustomerKey is provided', ->
       req = s3.putObject
@@ -188,7 +188,7 @@ describe 'AWS.S3', ->
         CopySourceSSECustomerKey: 'sse-key', CopySourceSSECustomerAlgorithm: 'AES256'
       req.httpRequest.endpoint.protocol = 'http:'
       req.build()
-      expect(req.response.error.name).to.equal('ConfigError')
+      expect(req.response.error.code).to.equal('ConfigError')
 
     it 'encodes SSECustomerKey and fills in MD5', ->
       req = s3.putObject


### PR DESCRIPTION
All unit tests are passing. Integration tests for S3 passing.
