### PR TITLE
Cache Cognito ID on a per-identity-pool basis.

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -113,17 +113,17 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
                 self.data = self.webIdentityCredentials.data;
                 self.sts.credentialsFrom(self.data, self);
               } else {
-                //self.clearCachedId();
+                self.clearCachedId();
               }
               callback(webErr);
             });
           } else {
-            //self.clearCachedId();
+            self.clearCachedId();
             callback(cogErr);
           }
         });
       } else {
-        //self.clearCachedId();
+        self.clearCachedId();
         callback(err);
       }
     });

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -588,6 +588,28 @@ describe 'AWS.CognitoIdentityCredentials', ->
       expect(creds.cacheId.calls.length).to.equal(0)
       expect(creds.getStorage('id')).not.to.exist
 
+    it 'clears cache if getId fails', ->
+      creds.setStorage('id', 'MYID')
+      helpers.mockResponses creds.cognito, [
+        {data: {IdentityId: 'IDENTITY-ID'}, error: null},
+        {data: null, error: new Error('INVALID SERVICE')}
+      ]
+      helpers.spyOn(creds.webIdentityCredentials, 'refresh').andCallFake(->)
+      creds.refresh (err) -> expect(err.message).to.equal('INVALID SERVICE')
+      expect(creds.cacheId.calls.length).to.equal(0)
+      expect(creds.getStorage('id')).not.to.exist
+
+    it 'clears cache if getOpenIdToken fails', ->
+      creds.setStorage('id', 'MYID')
+      helpers.mockResponses creds.cognito, [
+        {data: {IdentityId: 'IDENTITY-ID'}, error: null},
+        {data: null, error: new Error('INVALID SERVICE')}
+      ]
+      helpers.spyOn(creds.webIdentityCredentials, 'refresh').andCallFake(->)
+      creds.refresh (err) -> expect(err.message).to.equal('INVALID SERVICE')
+      expect(creds.cacheId.calls.length).to.equal(0)
+      expect(creds.getStorage('id')).not.to.exist
+
     it 'does try to load creds second time if service request failed', ->
       helpers.mockResponses creds.cognito, [
         {data: {IdentityId: 'IDENTITY-ID'}, error: null},


### PR DESCRIPTION
Also adds `CognitoIdentityCredentials.clearCachedId()` to manually clear cache for a given IdentityPoolId.
