### PR TITLE
Proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc
 test/browser/build
 test/browser/sample/appinfo.js
 dist/aws-sdk-all.js
+.idea/

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -36,9 +36,8 @@ AWS.NodeHttpClient = AWS.util.inherit({
       options.agent = this.sslAgent();
     }
 
-    if (httpOptions.proxy) {
-        options.headers['Proxy-Authorization'] = 'BASIC ' +new Buffer(endpoint.auth).toString('base64');
-        console.log('headers: ' +JSON.stringify(options.headers));
+    if (httpOptions.proxy && endpoint.auth !== undefined) {
+      options.headers['Proxy-Authorization'] = 'BASIC ' +new Buffer(endpoint.auth).toString('base64');
     }
 
     AWS.util.update(options, httpOptions);

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -36,6 +36,11 @@ AWS.NodeHttpClient = AWS.util.inherit({
       options.agent = this.sslAgent();
     }
 
+    if (httpOptions.proxy) {
+        options.headers['Proxy-Authorization'] = 'BASIC ' +new Buffer(endpoint.auth).toString('base64');
+        console.log('headers: ' +JSON.stringify(options.headers));
+    }
+
     AWS.util.update(options, httpOptions);
     delete options.proxy; // proxy isn't an HTTP option
     delete options.timeout; // timeout isn't an HTTP option

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -37,7 +37,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
     }
 
     if (httpOptions.proxy && endpoint.auth !== undefined) {
-      options.headers['Proxy-Authorization'] = 'BASIC ' +new Buffer(endpoint.auth).toString('base64');
+      options.headers['Proxy-Authorization'] = 'BASIC ' + new Buffer(endpoint.auth).toString('base64');
     }
 
     AWS.util.update(options, httpOptions);


### PR DESCRIPTION
Had some problems with using a proxy while uploading code through the grunt-aws-s3 module, apparently the proxy at our company was trying to use the aws secret in the Authorization header as the proxy credentials which of course always fails and results in a http 407. This seems to be fixed if the Proxy-Authorization header is set with the actual proxy credentials. Not entirely sure but it could be that these issues are related and possibly fixed:

https://github.com/aws/aws-sdk-js/issues/108
https://github.com/aws/aws-sdk-js/issues/26