### PR TITLE
Default to empty object if localStorage is not accessible.

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -231,14 +231,12 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   storage: (function() {
-      var hasStorage = typeof(Storage) !== void(0);
+      var hasStorage = false;
 
       try {
           window.localStorage['foo'] = 'bar';
           hasStorage = delete window.localStorage['foo'];
-      } catch (e) {
-          hasStorage = false;
-      }
+      } catch (e) { }
 
       return AWS.util.isBrowser() && hasStorage ? window.localStorage : {};
   })()


### PR DESCRIPTION
Add try and catch block to account for instances when the localStorage exists but is not accessible. For example if the user has their browser set to block cookies and site data.
