### PR TITLE
Move default timeout from MetadataService to EC2 cred provider

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,7 @@ require('./credentials/credential_provider_chain');
  *       peer certificate verification. This feature is only supported in the
  *       Node.js environment.
  *     * **timeout** [Integer] &mdash; The number of milliseconds to wait before
- *       giving up on a connection attempt. Defaults to no timeout.
+ *       giving up on a connection attempt. Defaults to no timeout (0).
  *     * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
  *       HTTP requests. Used in the browser environment only. Set to false to
  *       send requests synchronously. Defaults to true (async on).

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -9,14 +9,35 @@ require('../metadata_service');
  * can connect, and credentials are available, these will be used with zero
  * configuration.
  *
+ * This credentials class will timeout after 1 second of inactivity by default.
+ * If your requests to the EC2 metadata service are timing out, you can increase
+ * the value by configuring them directly:
+ *
+ * ```javascript
+ * AWS.config.credentials = new AWS.EC2MetadataCredentials({
+ *   httpOptions: { timeout: 5000 } // 5 second timeout
+ * });
+ * ```
+ *
  * @!macro nobrowser
  */
 AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
   constructor: function EC2MetadataCredentials(options) {
     AWS.Credentials.call(this);
+
+    options = options ? AWS.util.copy(options) : {};
+    if (!options.httpOptions) options.httpOptions = {};
+    options.httpOptions = AWS.util.merge(
+      {timeout: this.defaultTimeout}, options.httpOptions);
+
     this.metadataService = new AWS.MetadataService(options);
     this.metadata = {};
   },
+
+  /**
+   * @api private
+   */
+  defaultTimeout: 1000,
 
   /**
    * Loads the credentials from the instance metadata service

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -8,7 +8,11 @@ var inherit = AWS.util.inherit;
  * on the metadata service.
  *
  * @!attribute [r] httpOptions
- *   @return [map] a map of options to pass to the underlying HTTP request
+ *   @return [map] a map of options to pass to the underlying HTTP request:
+ *
+ *     * **timeout** (Number) &mdash; a timeout value in milliseconds to wait
+ *       before aborting the connection. Set to 0 for no timeout.
+ *
  * @!macro nobrowser
  */
 AWS.MetadataService = inherit({
@@ -22,9 +26,13 @@ AWS.MetadataService = inherit({
    */
 
   /**
-   * Options
+   * Default HTTP options. By default, the metadata service is set to not
+   * timeout on long requests. This means that on non-EC2 machines, this
+   * request will never return. If you are calling this operation from an
+   * environment that may not always run on EC2, set a `timeout` value so
+   * the SDK will abort the request after a given number of milliseconds.
    */
-  httpOptions: { timeout: 1000 },
+  httpOptions: { timeout: 0 },
 
   /**
    * Creates a new MetadataService object with a given set of options.
@@ -32,7 +40,10 @@ AWS.MetadataService = inherit({
    * @option options host [String] the hostname of the instance metadata
    *   service
    * @option options httpOptions [map] a map of options to pass to the
-   *   underlying HTTP request
+   *   underlying HTTP request:
+   *
+   *   * **timeout** (Number) &mdash; a timeout value in milliseconds to wait
+   *     before aborting the connection. Set to 0 for no timeout.
    */
   constructor: function MetadataService(options) {
     AWS.util.update(this, options);

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -282,6 +282,16 @@ if AWS.util.isNode()
       it 'allows passing of AWS.MetadataService options', ->
         expect(creds.metadataService.host).to.equal('host')
 
+      it 'does not modify options object', ->
+        opts = {}
+        creds = new AWS.EC2MetadataCredentials(opts)
+        expect(opts).to.eql({})
+
+      it 'allows setting timeout', ->
+        opts = httpOptions: timeout: 5000
+        creds = new AWS.EC2MetadataCredentials(opts)
+        expect(creds.metadataService.httpOptions.timeout).to.equal(5000)
+
     describe 'needsRefresh', ->
       it 'can be expired based on expire time from EC2 Metadata service', ->
         mockMetadataService(new Date(0))


### PR DESCRIPTION
The AWS.EC2MetadataCredentials now has a 1000ms timeout.
The AWS.MetadataService does not timeout by default.

Also updated documentation to reflect these changes and provide more
information on how to change timeout values.

References #366
