### PR TITLE
Allow global configuration to include service-specific settings.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -178,7 +178,10 @@ AWS.Config = AWS.util.inherit({
     allowUnknownKeys = allowUnknownKeys || false;
     options = this.extractCredentials(options);
     AWS.util.each.call(this, options, function (key, value) {
-      if (allowUnknownKeys || this.keys.hasOwnProperty(key)) this[key] = value;
+      if (allowUnknownKeys || this.keys.hasOwnProperty(key) ||
+          AWS.Service.hasService(key)) {
+        this[key] = value;
+      }
     });
   },
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -32,7 +32,10 @@ AWS.Service = inherit({
    * @api private
    */
   initialize: function initialize(config) {
+    var svcConfig = AWS.config[this.serviceIdentifier];
+
     this.config = new AWS.Config(AWS.config);
+    if (svcConfig) this.config.update(svcConfig, true);
     if (config) this.config.update(config, true);
 
     this.validateService();
@@ -403,6 +406,7 @@ AWS.util.update(AWS.Service, {
    * @return [Class<Service>] the service class defined by this function.
    */
   defineService: function defineService(serviceIdentifier, versions, features) {
+    AWS.Service._serviceMap[serviceIdentifier] = true;
     if (!Array.isArray(versions)) {
       features = versions;
       versions = [];
@@ -478,5 +482,17 @@ AWS.util.update(AWS.Service, {
 
     AWS.Service.defineMethods(svc);
     return svc;
-  }
+  },
+
+  /**
+   * @api private
+   */
+  hasService: function(identifier) {
+    return AWS.Service._serviceMap.hasOwnProperty(identifier);
+  },
+
+  /**
+   * @api private
+   */
+  _serviceMap: {}
 });

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -120,6 +120,11 @@ describe 'AWS.Config', ->
       config.update(foo: 10)
       expect(config.foo).to.equal(undefined)
 
+    it 'should allow service identifiers to be set', ->
+      config = new AWS.Config()
+      config.update(s3: {endpoint: 'localhost'})
+      expect(config.s3).to.eql(endpoint: 'localhost')
+
     it 'allows unknown keys if allowUnknownKeys is set', ->
       config = new AWS.Config()
       config.update(foo: 10, true)

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -28,6 +28,26 @@ describe 'AWS.Service', ->
       expect(service.config.sslEnabled).to.equal(true)
       expect(service.config.maxRetries).to.equal(5)
 
+    it 'merges service-specific configuration from global config', ->
+      AWS.config.update(s3: endpoint: 'localhost')
+      s3 = new AWS.S3
+      expect(s3.endpoint.host).to.equal('localhost')
+      delete AWS.config.s3
+
+    it 'service-specific global config overrides global config', ->
+      region = AWS.config.region
+      AWS.config.update(region: 'us-west-2', s3: region: 'eu-west-1')
+      s3 = new AWS.S3
+      expect(s3.config.region).to.equal('eu-west-1')
+      AWS.config.region = region
+      delete AWS.config.s3
+
+    it 'service-specific local config overrides service-specific global config', ->
+      AWS.config.update(s3: region: 'us-west-2')
+      s3 = new AWS.S3 region: 'eu-west-1'
+      expect(s3.config.region).to.equal('eu-west-1')
+      delete AWS.config.s3
+
     it 'merges credential data into config', ->
       service = new AWS.Service(accessKeyId: 'foo', secretAccessKey: 'bar')
       expect(service.config.credentials.accessKeyId).to.equal('foo')


### PR DESCRIPTION
Example:

```
AWS.config.update({s3: {endpoint: 'localhost'}});
var s3 = new AWS.S3(); // will hit the localhost endpoint
var other_s3 = new AWS.S3(); // this one too
```
