### PR TITLE
Send ArrayBufferView objects by default.

### DIFF
--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -66,10 +66,14 @@ AWS.XHRClient = AWS.util.inherit({
       xhr.withCredentials = true;
     }
 
-    if (httpRequest.body && typeof httpRequest.body.buffer === 'object') {
-      xhr.send(httpRequest.body.buffer); // typed arrays sent as ArrayBuffer
-    } else {
+    try {
       xhr.send(httpRequest.body);
+    } catch (err) {
+      if (httpRequest.body && typeof httpRequest.body.buffer === 'object') {
+        xhr.send(httpRequest.body.buffer); // send ArrayBuffer directly
+      } else {
+        throw err;
+      }
     }
 
     return emitter;


### PR DESCRIPTION
Only fallback to sending ArrayBuffers when sending of body fails
(for legacy browser support).

Fixes #391
