### PR TITLE
pass error to callback early in finishSinglePart

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -62,6 +62,7 @@ function ManagedUpload(svc, options) {
   function finishSinglePart(err, data) {
     var httpReq = this.request.httpRequest;
     var url = AWS.util.urlFormat(httpReq.endpoint);
+    if (err) return callback(err);
     data.Location = url.substr(0, url.length - 1) + httpReq.path;
     callback(err, data);
   }


### PR DESCRIPTION
Access violations or non-existant buckets seem to only manifest in finishSinglePart().
This trivial PR checks for errors and passes them up to the callback, before trying to manipulate `data`, which in these cases is undefined.
