### PR TITLE
fully unroll params in log message, don’t include hidden props

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -374,7 +374,7 @@ AWS.EventListeners = {
         var delta = (time - req.startTime.getTime()) / 1000;
         var ansi = logger.isTTY ? true : false;
         var status = resp.httpResponse.statusCode;
-        var params = require('util').inspect(req.params, false, null);
+        var params = require('util').inspect(req.params, true, null);
 
         var message = '';
         if (ansi) message += '\x1B[33m';


### PR DESCRIPTION
The current log messages do not include values for some nested structures because of the arguments chosen for util.inspect limit the depth.
In the case of DynamoDB.updateItem this leads to ExpressionAttributeValues being masked by `[Object]`, for instance.

This PR changes the call to util.inspect to not include shadow properties (arg2 false, why would we want this?) and also set the depth to unlimited (arg3 null).
