### PR TITLE
Add Expect: 100-continue for large payloads in S3 by default.

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -9,6 +9,7 @@ require('../http');
  */
 AWS.NodeHttpClient = AWS.util.inherit({
   handleRequest: function handleRequest(httpRequest, httpOptions, callback, errCallback) {
+    var self = this;
     var cbAlreadyCalled = false;
     var endpoint = httpRequest.endpoint;
     var pathPrefix = '';
@@ -61,7 +62,15 @@ AWS.NodeHttpClient = AWS.util.inherit({
       errCallback.apply(this, arguments);
     });
 
-    this.writeBody(stream, httpRequest);
+    var expect = httpRequest.headers.Expect || httpRequest.headers.expect;
+    if (expect === '100-continue') {
+      stream.on('continue', function() {
+        self.writeBody(stream, httpRequest);
+      });
+    } else {
+      this.writeBody(stream, httpRequest);
+    }
+
     return stream;
   },
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -30,6 +30,7 @@ AWS.util.update(AWS.S3.prototype, {
     request.addListener('build', this.computeContentMd5);
     request.onAsync('build', this.computeSha256);
     request.addListener('build', this.computeSseCustomerKeyMd5);
+    request.addListener('afterBuild', this.addExpect100Continue);
     request.removeListener('validate',
       AWS.EventListeners.Core.VALIDATE_REGION);
     request.addListener('extractError', this.extractError);
@@ -98,6 +99,17 @@ AWS.util.update(AWS.S3.prototype, {
           httpRequest.path = '/' + httpRequest.path;
         }
       }
+    }
+  },
+
+  /**
+   * Adds Expect: 100-continue header if payload is greater-or-equal 1MB
+   * @api private
+   */
+  addExpect100Continue: function addExpect100Continue(req) {
+    var len = req.httpRequest.headers['Content-Length'];
+    if (AWS.util.isNode() && len >= 1024 * 1024) {
+      req.httpRequest.headers['Expect'] = '100-continue';
     }
   },
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -114,6 +114,23 @@ describe 'AWS.S3', ->
         req = build('listObjects', { Bucket: 'bucket', MaxKeys:123 })
         expect(req.path).to.equal('/?max-keys=123')
 
+    describe 'adding Expect: 100-continue', ->
+      if AWS.util.isNode()
+        it 'does not add expect header to payloads less than 1MB', ->
+          req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024 * 1024 - 1))
+          expect(req.headers['Expect']).not.to.exist
+
+        it 'adds expect header to payloads greater than 1MB', ->
+          req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024 * 1024 + 1))
+          expect(req.headers['Expect']).to.equal('100-continue')
+
+      if AWS.util.isBrowser()
+        beforeEach -> helpers.spyOn(AWS.util, 'isBrowser').andReturn(true)
+
+        it 'does not add expect header in the browser', ->
+          req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024 * 1024 + 1))
+          expect(req.headers['Expect']).not.to.exist
+
     describe 'adding Content-Type', ->
       beforeEach -> helpers.spyOn(AWS.util, 'isBrowser').andReturn(true)
 


### PR DESCRIPTION
Payloads larger than 1MB will now send an Expect: 100-continue header, which is correctly handled by the underlying Node.js HTTP client.

Fixes #135 in conjunction with the managed uploader (AWS.S3.upload). 

Also verified that S3 integration tests now use Expect headers successfully.
