### PR TITLE
With a lot of concurrent requests to metadata service, credentials can fail

### DIFF
--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -67,11 +67,18 @@ AWS.MetadataService = inherit({
     var httpRequest = new AWS.HttpRequest('http://' + this.host + path);
     httpRequest.method = 'GET';
 
-    http.handleRequest(httpRequest, this.httpOptions, function(httpResponse) {
-      httpResponse.on('data', function(chunk) { data += chunk.toString(); });
-      httpResponse.on('end', function() { callback(null, data); });
-    }, callback);
+    process.nextTick(function() {
+      http.handleRequest(httpRequest, this.httpOptions, function(httpResponse) {
+        httpResponse.on('data', function(chunk) { data += chunk.toString(); });
+        httpResponse.on('end', function() { callback(null, data); });
+      }, callback);
+    });
   },
+
+  /**
+  * @api private
+  */
+  loadCredentialsCallbacks: [],
 
   /**
    * Loads a set of credentials stored in the instance metadata service
@@ -86,18 +93,28 @@ AWS.MetadataService = inherit({
   loadCredentials: function loadCredentials(callback) {
     var self = this;
     var basePath = '/latest/meta-data/iam/security-credentials/';
+    self.loadCredentialsCallbacks.push(callback);
+    if (self.loadCredentialsCallbacks.length > 1) { return; }
+
+    function callbacks(err, creds) {
+      var cb;
+      while ((cb = self.loadCredentialsCallbacks.shift()) !== undefined) {
+        cb(err, creds);
+      }
+    }
+
     self.request(basePath, function (err, roleName) {
-      if (err) callback(err);
+      if (err) callbacks(err);
       else {
         roleName = roleName.split('\n')[0]; // grab first (and only) role
         self.request(basePath + roleName, function (credErr, credData) {
-          if (credErr) callback(credErr);
+          if (credErr) callbacks(credErr);
           else {
             try {
               var credentials = JSON.parse(credData);
-              callback(null, credentials);
+              callbacks(null, credentials);
             } catch (parseError) {
-              callback(parseError);
+              callbacks(parseError);
             }
           }
         });

--- a/test/metadata_service.spec.coffee
+++ b/test/metadata_service.spec.coffee
@@ -38,6 +38,21 @@ if AWS.util.isNode()
           expect(data.Token).to.equal('TOKEN')
           done()
 
+
+      it 'should load credentials from metadata service', (done) ->
+        concurrency = countdown = 10
+        for x in [1..concurrency]
+          service.loadCredentials (err, data) ->
+            expect(err).to.equal(null)
+            expect(data.Code).to.equal('Success')
+            expect(data.AccessKeyId).to.equal('KEY')
+            expect(data.SecretAccessKey).to.equal('SECRET')
+            expect(data.Token).to.equal('TOKEN')
+            countdown--
+            if countdown == 0
+              done()
+
+
       it 'should fail if server is not up', (done) ->
         server.close(); server = null
         service = new AWS.MetadataService(host: '255.255.255.255')


### PR DESCRIPTION
This is encountered as `CredentialsError: Missing credentials in config` because the request for IAM Role can timeout before all the requests are answered. fixes #445 

The fix:
 - add a locking so the metadata service isnt flooded with requests.
 - add setImmediate so IO can still be processed even with a lot of request to the metadata service being generated.

This is a bit hard to add a test for. I did [add a test](https://github.com/mick/aws-sdk-js/compare/aws:master...mick:creds_lock?expand=1#diff-c5a12adba23f3b82dcb6d33d6980c069R42) for multiple concurrent requests to `loadCredentials`.

On an ec2 of the same type and size: [This test case](https://gist.github.com/willwhite/6afe2d333a002c33413f) passed with these changes, even with increasing concurrency up to 10000.

cc: @lsegal @willwhite