### PR TITLE
Fix CloudSearchDomain signing on EC2 instance

### DIFF
--- a/lib/services/cloudsearchdomain.js
+++ b/lib/services/cloudsearchdomain.js
@@ -71,14 +71,21 @@ AWS.util.update(AWS.CloudSearchDomain.prototype, {
    * @api private
    */
   setupRequestListeners: function setupRequestListeners(request) {
-    if (!request.service.config.credentials) {
-      request.removeListener('validate',
-                             AWS.EventListeners.Core.VALIDATE_CREDENTIALS
-                            );
-      request.removeListener('sign', AWS.EventListeners.Core.SIGN);
-    } else {
-      request.addListener('validate', this.updateRegion);
-    }
+    request.removeListener('validate',
+      AWS.EventListeners.Core.VALIDATE_CREDENTIALS
+    );
+    request.onAsync('validate', this.validateCredentials);
+    request.addListener('validate', this.updateRegion);
+  },
+
+  validateCredentials: function(req, done) {
+    if (!req.service.api.signatureVersion) return done(); // none
+    req.service.config.getCredentials(function(err) {
+      if (err) {
+        req.removeListener('sign', AWS.EventListeners.Core.SIGN);
+      }
+      done();
+    });
   },
 
   /**

--- a/test/credential_provider_chain.spec.coffee
+++ b/test/credential_provider_chain.spec.coffee
@@ -16,6 +16,7 @@ if AWS.util.isNode()
 
       afterEach ->
         AWS.CredentialProviderChain.defaultProviders = defaultProviders
+        process.env = {}
 
       it 'returns an error by default', ->
         chain.resolve (err) ->

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -91,6 +91,9 @@ if AWS.util.isNode()
     beforeEach ->
       process.env = {}
 
+    afterEach ->
+      process.env = {}
+
     describe 'constructor', ->
       it 'should be able to read credentials from env with a prefix', ->
         process.env.AWS_ACCESS_KEY_ID = 'akid'


### PR DESCRIPTION
CloudSearchDomain requests are not signed if there are no credentials. Simply checking for `service.config.credentials` does not suffice, because this fails if the code is using EC2 metadata credentials. 

This is now fixed to detach the signer asynchronously if `config.getCredentials` returns an err (no credentials found).

I also fixed a couple of tests that were polluting process state.

This is a high priority fix, so please review and merge as soon as possible.
