### PR TITLE
Do not use ternary in a require call

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -40,7 +40,13 @@ var util = {
     if (util.isNode()) return require(module);
   },
   multiRequire: function multiRequire(module1, module2) {
-    return require(util.isNode() ? module1 : module2);
+    var module;
+    if (util.isNode()) {
+      module = module1;
+    } else {
+      module = module2;
+    }
+    return require(module);
   },
 
   uriEscape: function uriEscape(string) {


### PR DESCRIPTION
Webpack has trouble with this: https://github.com/webpack/webpack/issues/627

This could be seen as a bug in webpack, but a fix here would be very helpful.
