### PR TITLE
add error handling to list buckets example

### DIFF
--- a/doc-src/guide/node-examples.md
+++ b/doc-src/guide/node-examples.md
@@ -4,7 +4,7 @@
 
 All of these examples assume that the AWS library is required,
 credentials are loaded via environment variables (`AWS_ACCESS_KEY_ID`
-and `AWS_SECRET_ACCESS_KEY`), and the region is set via 
+and `AWS_SECRET_ACCESS_KEY`), and the region is set via
 `AWS.config.update({region: 'us-west-2'});` or the `AWS_REGION` environment
 variable.
 
@@ -97,6 +97,8 @@ The following example lists all buckets associated with your AWS account:
 ```javascript
 var s3 = new AWS.S3();
 s3.listBuckets(function(err, data) {
+  if (err) { return console.log(err); }
+  else if (!data) { return console.log('no buckets'); }
   for (var index in data.Buckets) {
     var bucket = data.Buckets[index];
     console.log("Bucket: ", bucket.Name, ' : ', bucket.CreationDate);

--- a/doc-src/guide/node-examples.md
+++ b/doc-src/guide/node-examples.md
@@ -98,10 +98,12 @@ The following example lists all buckets associated with your AWS account:
 var s3 = new AWS.S3();
 s3.listBuckets(function(err, data) {
   if (err) { return console.log(err); }
-  else if (!data) { return console.log('no buckets'); }
-  for (var index in data.Buckets) {
-    var bucket = data.Buckets[index];
-    console.log("Bucket: ", bucket.Name, ' : ', bucket.CreationDate);
+
+  else {
+    for (var index in data.Buckets) {
+      var bucket = data.Buckets[index];
+      console.log("Bucket: ", bucket.Name, ' : ', bucket.CreationDate);
+    }
   }
 });
 ```


### PR DESCRIPTION
Hey great work on the library, loving it so far, just one minor change. I ran the example of listing all buckets off of http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-examples.html#Amazon_S3__List_All_of_Your_Buckets__listBuckets_ and noticed if you don't have any buckets it will throw a type error because buckets will return as null, so I added some simple error checking to the documentation so that it will handle a situation with no buckets.
I didn't see a pattern in the way you formatted the control flow, so if there's a problem with inline if-statements let me know and I'll be happy to fix it. 

Also cleared a trailing whitespace.