### PR TITLE
Expose reponse.requestId for query protocol requests

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -339,8 +339,11 @@ AWS.EventListeners = {
 
   CorePost: new SequentialExecutor().addNamedListeners(function(add) {
     add('EXTRACT_REQUEST_ID', 'extractData', function EXTRACT_REQUEST_ID(resp) {
-      resp.requestId = resp.httpResponse.headers['x-amz-request-id'] ||
-                       resp.httpResponse.headers['x-amzn-requestid'];
+
+      if (!resp.requestId) {
+        resp.requestId = resp.httpResponse.headers['x-amz-request-id'] ||
+                          resp.httpResponse.headers['x-amzn-requestid'];
+      }
 
       if (!resp.requestId && resp.data && resp.data.ResponseMetadata) {
         resp.requestId = resp.data.ResponseMetadata.RequestId;

--- a/lib/protocol/query.js
+++ b/lib/protocol/query.js
@@ -33,6 +33,7 @@ function extractError(resp) {
     data = new AWS.XML.Parser().parse(body);
   }
 
+  if (data.requestId && !resp.requestId) resp.requestId = data.requestId;
   if (data.Errors) data = data.Errors;
   if (data.Error) data = data.Error;
   if (data.Code) {
@@ -63,21 +64,25 @@ function extractData(resp) {
   }
 
   var parser = new AWS.XML.Parser();
-  var requestIdShape = Shape.create(
-    { type: 'string' },
-    { api: { protocol: 'query' } },
-    'requestId'
-  );
 
-  if (shape && shape.members) shape.members.RequestId = requestIdShape;
+  if (shape && shape.members && !shape.members.RequestId) {
+    var requestIdShape = Shape.create(
+      { type: 'string' },
+      { api: { protocol: 'query' } },
+      'requestId'
+    );
+    requestIdShape.augmentedMember = true;
+    shape.members.RequestId = requestIdShape;
+  }
 
   var data = parser.parse(resp.httpResponse.body.toString(), shape);
+  var requestId = data.RequestId || data.requestId;
 
-  if (data.RequestId) {
-    resp.requestId = data.RequestId;
+  if (requestId && !resp.requestId) resp.requestId = requestId;
+
+  if (shape && shape.members && shape.members.RequestId.augmentedMember)
     delete data.RequestId;
-    delete shape.members.RequestId;
-  }
+  if (shape && !shape.members) delete data.requestId;
 
   if (origRules.resultWrapper) {
     if (data[origRules.resultWrapper]) {

--- a/lib/protocol/query.js
+++ b/lib/protocol/query.js
@@ -63,7 +63,21 @@ function extractData(resp) {
   }
 
   var parser = new AWS.XML.Parser();
+  var requestIdShape = Shape.create(
+    { type: 'string' },
+    { api: { protocol: 'query' } },
+    'requestId'
+  );
+
+  if (shape && shape.members) shape.members.RequestId = requestIdShape;
+
   var data = parser.parse(resp.httpResponse.body.toString(), shape);
+
+  if (data.RequestId) {
+    resp.requestId = data.RequestId;
+    delete data.RequestId;
+    delete shape.members.RequestId;
+  }
 
   if (origRules.resultWrapper) {
     if (data[origRules.resultWrapper]) {

--- a/lib/protocol/query.js
+++ b/lib/protocol/query.js
@@ -65,24 +65,19 @@ function extractData(resp) {
 
   var parser = new AWS.XML.Parser();
 
-  if (shape && shape.members && !shape.members.RequestId) {
+  if (shape && shape.members && !shape.members._XAMZRequestId) {
     var requestIdShape = Shape.create(
       { type: 'string' },
       { api: { protocol: 'query' } },
       'requestId'
     );
-    requestIdShape.augmentedMember = true;
-    shape.members.RequestId = requestIdShape;
+    shape.members._XAMZRequestId = requestIdShape;
   }
 
   var data = parser.parse(resp.httpResponse.body.toString(), shape);
-  var requestId = data.RequestId || data.requestId;
+  resp.requestId = data._XAMZRequestId || data.requestId || '';
 
-  if (requestId && !resp.requestId) resp.requestId = requestId;
-
-  if (shape && shape.members && shape.members.RequestId.augmentedMember)
-    delete data.RequestId;
-  if (shape && !shape.members) delete data.requestId;
+  if (data._XAMZRequestId) delete data._XAMZRequestId;
 
   if (origRules.resultWrapper) {
     if (data[origRules.resultWrapper]) {

--- a/lib/protocol/query.js
+++ b/lib/protocol/query.js
@@ -65,6 +65,7 @@ function extractData(resp) {
 
   var parser = new AWS.XML.Parser();
 
+  // TODO: Refactor XML Parser to parse RequestId from response.
   if (shape && shape.members && !shape.members._XAMZRequestId) {
     var requestIdShape = Shape.create(
       { type: 'string' },

--- a/lib/protocol/query.js
+++ b/lib/protocol/query.js
@@ -75,7 +75,7 @@ function extractData(resp) {
   }
 
   var data = parser.parse(resp.httpResponse.body.toString(), shape);
-  resp.requestId = data._XAMZRequestId || data.requestId || '';
+  resp.requestId = data._XAMZRequestId || data.requestId;
 
   if (data._XAMZRequestId) delete data._XAMZRequestId;
 

--- a/test/protocol/query.spec.coffee
+++ b/test/protocol/query.spec.coffee
@@ -189,3 +189,16 @@ describe 'AWS.Protocol.Query', ->
       """
       expect(response.error).to.equal(null)
       expect(response.data).to.eql({Data:{Name:'abc',Count:12345.5}})
+
+    it 'extracts requestId from the response', ->
+      extractData """
+      <xml>
+        <requestId>12345-abcde</requestId>
+        <Data>
+          <Name>abc</Name>
+          <Count>123</Count>
+        </Data>
+      </xml>
+      """
+      expect(response.requestId).to.equal('12345-abcde')
+      expect(response.data).to.eql({Data:{Name:'abc',Count:123}})

--- a/test/protocol/query.spec.coffee
+++ b/test/protocol/query.spec.coffee
@@ -211,22 +211,40 @@ describe 'AWS.Protocol.Query', ->
       </xml>
       """
       expect(response.requestId).to.equal('12345-abcde')
-      expect(response.data).to.eql({})
+      expect(response.data).to.eql({requestId: '12345-abcde'})
 
-    it 'retains data.RequestId if RequestId is a modeled output', ->
+    it 'does not override RequestId if it is modeled', ->
       shape = AWS.Model.Shape.create(
         { type: 'string' },
         { api: {protocol: 'query'}},
-        'requestId')
+        'foo')
       service.api.operations.operationName.output.members.RequestId = shape
       extractData """
       <xml>
         <requestId>12345-abcde</requestId>
+        <foo>foo-bar</foo>
         <Data>
           <Name>abc</Name>
           <Count>123</Count>
         </Data>
       </xml>
       """
-      expect(response.requestId).to.equal('12345-abcde')
-      expect(response.data).to.eql({Data:{Name:'abc',Count:123},RequestId:'12345-abcde'})
+      expect(response.data).to.eql({Data:{Name:'abc',Count:123},RequestId:'foo-bar'})
+
+    it 'does not override requestId if it is modeled', ->
+      shape = AWS.Model.Shape.create(
+        { type: 'string' },
+        { api: {protocol: 'query'}},
+        'foo')
+      service.api.operations.operationName.output.members.requestId = shape
+      extractData """
+      <xml>
+        <requestId>12345-abcde</requestId>
+        <foo>foo-bar</foo>
+        <Data>
+          <Name>abc</Name>
+          <Count>123</Count>
+        </Data>
+      </xml>
+      """
+      expect(response.data).to.eql({Data:{Name:'abc',Count:123},requestId:'foo-bar'})


### PR DESCRIPTION
I augmented the rule passed in to the parser. This was to avoid parsing the response more than once.