### PR TITLE
Fix `AWS.S3.ManagedUpload.fillBuffer()` to use correct buffer indices.

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -324,7 +324,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     var self = this;
     var bodyLen = byteLength(self.body);
     while (self.activeParts < self.queueSize && self.partPos < bodyLen) {
-      var endPos = self.partPos + self.partSize;
+      var endPos = Math.min(self.partPos + self.partSize, bodyLen);
       var buf = self.sliceFn.call(self.body, self.partPos, endPos);
       self.partPos += self.partSize;
 


### PR DESCRIPTION
Fixes #470