### PR TITLE
Use `getCredentialsForIdentity()` when a `RoleArn` is not passed in as a parameter

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -104,30 +104,19 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
     self.identityId = null;
     self.getId(function(err) {
       if (!err) {
-        self.cognito.getOpenIdToken(function(cogErr, data) {
-          if (!cogErr) {
-            self.cacheId(data);
-            self.params.WebIdentityToken = data.Token;
-            self.webIdentityCredentials.refresh(function(webErr) {
-              if (!webErr) {
-                self.data = self.webIdentityCredentials.data;
-                self.sts.credentialsFrom(self.data, self);
-              } else {
-                self.clearCachedId();
-              }
-              callback(webErr);
-            });
-          } else {
-            self.clearCachedId();
-            callback(cogErr);
-          }
-        });
+        if (!self.params.RoleArn) {
+          self.getCredentialsForIdentity(callback);
+        } else {
+          self.getCredentialsFromSTS(callback);
+        }
       } else {
         self.clearCachedId();
         callback(err);
       }
     });
   },
+      /*
+        }*/
 
   /**
    * Clears the cached Cognito ID associated with the currently configured
@@ -164,6 +153,61 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
         self.params.IdentityId = data.IdentityId;
         callback(null, data.IdentityId);
       } else {
+        callback(err);
+      }
+    });
+  },
+
+
+  /**
+   * @api private
+   */
+  loadCredentials: function loadCredentials(data, credentials) {
+    if (!data || !credentials) return;
+    credentials.expired = false;
+    credentials.accessKeyId = data.Credentials.AccessKeyId;
+    credentials.secretAccessKey = data.Credentials.SecretKey;
+    credentials.sessionToken = data.Credentials.SessionToken;
+    credentials.expireTime = data.Credentials.Expiration;
+  },
+
+  /**
+   * @api private
+   */
+  getCredentialsForIdentity: function getCredentialsForIdentity(callback) {
+    var self = this;
+    self.cognito.getCredentialsForIdentity(function(err, data){
+      if (!err){
+        self.cacheId(data);
+        self.data = data;
+        self.loadCredentials(self.data, self);
+      } else {
+        self.clearCachedId();
+      }
+      callback(err);
+    });
+  },
+
+  /**
+   *
+   */
+  getCredentialsFromSTS: function getCredentialsFromSTS(callback) {
+    var self = this;
+    self.cognito.getOpenIdToken(function(err, data) {
+      if (!err) {
+        self.cacheId(data);
+        self.params.WebIdentityToken = data.Token;
+        self.webIdentityCredentials.refresh(function(webErr) {
+          if (!webErr) {
+            self.data = self.webIdentityCredentials.data;
+            self.sts.credentialsFrom(self.data, self);
+          } else {
+            self.clearCachedId();
+          }
+          callback(webErr);
+        });
+      } else {
+        self.clearCachedId();
         callback(err);
       }
     });

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -187,7 +187,7 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
   },
 
   /**
-   *
+   * @api private
    */
   getCredentialsFromSTS: function getCredentialsFromSTS(callback) {
     var self = this;

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -115,8 +115,6 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
       }
     });
   },
-      /*
-        }*/
 
   /**
    * Clears the cached Cognito ID associated with the currently configured

--- a/lib/services/cognitoidentity.js
+++ b/lib/services/cognitoidentity.js
@@ -7,5 +7,9 @@ AWS.util.update(AWS.CognitoIdentity.prototype, {
 
   getId: function getId(params, callback) {
     return this.makeUnauthenticatedRequest('getId', params, callback);
+  },
+
+  getCredentialsForIdentity: function getCredentialsForIdentity(params, callback) {
+    return this.makeUnauthenticatedRequest('getCredentialsForIdentity', params, callback);
   }
 });


### PR DESCRIPTION
Use `getCredentialsForIdentity()` when a `RoleArn` is not passed in as a parameter to `AWS.CognitoIdentityCredentials`