### PR TITLE
Return empty map when XML map is empty

### DIFF
--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -79,6 +79,8 @@ function parseStructure(xml, shape) {
 
 function parseMap(xml, shape) {
   var data = {};
+  if (xml === null) return data;
+
   var xmlKey = shape.key.name || 'key';
   var xmlValue = shape.value.name || 'value';
   var iterable = shape.flattened ? xml : xml.entry;

--- a/test/xml/parser.spec.coffee
+++ b/test/xml/parser.spec.coffee
@@ -272,6 +272,22 @@ describe 'AWS.XML.Parser', ->
   describe 'maps', ->
 
     describe 'non-flattened', ->
+      it 'returns empty maps as {}', ->
+        xml = """
+        <xml>
+          <DomainMap/>
+        </xml>
+        """
+        rules =
+          type: 'structure'
+          members:
+            DomainMap:
+              type: 'map'
+              value:
+                type: 'string'
+        parse xml, rules, (data) ->
+          expect(data).to.eql(DomainMap: {})
+
       it 'expects entry, key, and value elements by default', ->
         # example from IAM GetAccountSummary (output)
         xml = """


### PR DESCRIPTION
Came across a `Cannot access property 'entry' of 'null'` exception when testing `AWS.CloudSearch.listDomainNames()` when no domain names are present.