### PR TITLE
set ENOTFOUND_ERROR errors to be retryable

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -359,7 +359,7 @@ AWS.EventListeners = {
           code: 'UnknownEndpoint',
           region: err.region,
           hostname: err.hostname,
-          retryable: false,
+          retryable: true,
           originalError: err
         });
       }


### PR DESCRIPTION
Retries on dns related errors.  Sometimes it wont be worth retrying in the case of invalid dns names, but it will in the case of intermittent dns / network issues.

fixes: #528 