### PR TITLE
URL-decode subresource values as well as other query parameters

### DIFF
--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -127,11 +127,7 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
         if (this.subResources[name] || this.responseHeaders[name]) {
           var subresource = { name: name };
           if (value !== undefined) {
-            if (this.subResources[name]) {
-              subresource.value = value;
-            } else {
-              subresource.value = decodeURIComponent(value);
-            }
+            subresource.value = decodeURIComponent(value);
           }
           resources.push(subresource);
         }

--- a/test/signers/s3.spec.coffee
+++ b/test/signers/s3.spec.coffee
@@ -273,7 +273,7 @@ describe 'AWS.Signers.S3', ->
 
 
       x-amz-date:DATE-STRING
-      /?versionId=a%2Bb
+      /?versionId=a+b
       """)
 
     it 'includes the non-encoded query string get header overrides', ->


### PR DESCRIPTION
In signing request to S3, current implementation does not URL-decode subresource values in query parameters. Other query parameters are properly URL-decoded in creating canonicalResource.

For example, another client implementation, s3curl, perform URL-decode for subresource values [1].

[1] https://github.com/rtdp/s3curl/blob/master/s3curl.pl#L192-L199
