### PR TITLE
Do not ignore bower.json itself

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "ignore": [
     "doc-src", "dist-tools", "eslint-rules", "features", "lib", 
     "scripts", "tasks", "test", "Gemfile*", "configuration*",
-    "Rakefile", "*.json", ".*"
+    "Rakefile", "package.json", "testem.json", ".*"
   ],
   "main": "dist/aws-sdk.js"
 }


### PR DESCRIPTION
In order to allow webpack and other build tools that rely on a properly defined `"main"` section in `bower.json` to work with this SDK without using any aliases or other workarounds, the bower.json itself should not be excluded from the installed bower package. 