### PR TITLE
Lazy load SAML and Cognito Clients

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -90,7 +90,6 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
     this.params = params;
     this.data = null;
     this.identityId = null;
-    this.hasClients = false;
     this.loadCachedId();
   },
 
@@ -107,7 +106,7 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
-    if (!self.hasClients) self.createClients();
+    self.createClients();
     self.data = null;
     self.identityId = null;
     self.getId(function(err) {
@@ -250,13 +249,11 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   createClients: function() {
-    var self = this;
-    self.webIdentityCredentials = self.webIdentityCredentials ||
-      new AWS.WebIdentityCredentials(self.params);
-    self.cognito = self.cognito ||
-      new AWS.CognitoIdentity({params: self.params});
-    self.sts = self.sts || new AWS.STS();
-    self.hasClients = true;
+    this.webIdentityCredentials = this.webIdentityCredentials ||
+      new AWS.WebIdentityCredentials(this.params);
+    this.cognito = this.cognito ||
+      new AWS.CognitoIdentity({params: this.params});
+    this.sts = this.sts || new AWS.STS();
   },
 
   /**

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -87,12 +87,10 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
   constructor: function CognitoIdentityCredentials(params) {
     AWS.Credentials.call(this);
     this.expired = true;
-    this.webIdentityCredentials = new AWS.WebIdentityCredentials(params);
-    this.cognito = new AWS.CognitoIdentity({params: params});
-    this.sts = new AWS.STS();
     this.params = params;
     this.data = null;
     this.identityId = null;
+    this.hasClients = false;
     this.loadCachedId();
   },
 
@@ -109,6 +107,7 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
+    if (!self.hasClients) self.createClients();
     self.data = null;
     self.identityId = null;
     self.getId(function(err) {
@@ -245,6 +244,19 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
         self.params.IdentityId = id;
       }
     }
+  },
+
+  /**
+   * @api private
+   */
+  createClients: function() {
+    var self = this;
+    self.webIdentityCredentials = self.webIdentityCredentials ||
+      new AWS.WebIdentityCredentials(self.params);
+    self.cognito = self.cognito ||
+      new AWS.CognitoIdentity({params: self.params});
+    self.sts = self.sts || new AWS.STS();
+    self.hasClients = true;
   },
 
   /**

--- a/lib/credentials/saml_credentials.js
+++ b/lib/credentials/saml_credentials.js
@@ -52,7 +52,6 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
     AWS.Credentials.call(this);
     this.expired = true;
     this.params = params;
-    this.hasClients = false;
   },
 
   /**
@@ -68,7 +67,7 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
-    if (!self.hasClients) self.createClients();
+    self.createClients();
     if (!callback) callback = function(err) { if (err) throw err; };
 
     self.service.assumeRoleWithSAML(function (err, data) {
@@ -83,9 +82,7 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   createClients: function() {
-    this.service = this.service ||
-      new AWS.STS({params: this.params});
-    this.hasClients = true;
+    this.service = this.service || new AWS.STS({params: this.params});
   }
 
 });

--- a/lib/credentials/saml_credentials.js
+++ b/lib/credentials/saml_credentials.js
@@ -52,7 +52,7 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
     AWS.Credentials.call(this);
     this.expired = true;
     this.params = params;
-    this.service = new AWS.STS({params: this.params});
+    this.hasClients = false;
   },
 
   /**
@@ -68,6 +68,7 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
+    if (!self.hasClients) self.createClients();
     if (!callback) callback = function(err) { if (err) throw err; };
 
     self.service.assumeRoleWithSAML(function (err, data) {
@@ -76,5 +77,15 @@ AWS.SAMLCredentials = AWS.util.inherit(AWS.Credentials, {
       }
       callback(err);
     });
+  },
+
+  /**
+   * @api private
+   */
+  createClients: function() {
+    this.service = this.service ||
+      new AWS.STS({params: this.params});
+    this.hasClients = true;
   }
+
 });

--- a/lib/credentials/temporary_credentials.js
+++ b/lib/credentials/temporary_credentials.js
@@ -60,7 +60,6 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
       this.params.RoleSessionName =
         this.params.RoleSessionName || 'temporary-credentials';
     }
-    this.service = new AWS.STS({params: this.params});
   },
 
   /**
@@ -78,6 +77,7 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
+    self.createClients();
     if (!callback) callback = function(err) { if (err) throw err; };
 
     self.service.config.credentials = self.masterCredentials;
@@ -99,5 +99,13 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
     while (this.masterCredentials.masterCredentials) {
       this.masterCredentials = this.masterCredentials.masterCredentials;
     }
+  },
+
+  /**
+   * @api private
+   */
+  createClients: function() {
+    this.service = this.service || new AWS.STS({params: this.params});
   }
+
 });

--- a/lib/credentials/web_identity_credentials.js
+++ b/lib/credentials/web_identity_credentials.js
@@ -56,7 +56,6 @@ AWS.WebIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
     this.expired = true;
     this.params = params;
     this.params.RoleSessionName = this.params.RoleSessionName || 'web-identity';
-    this.service = new AWS.STS({params: this.params});
     this.data = null;
   },
 
@@ -73,6 +72,7 @@ AWS.WebIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
+    self.createClients();
     if (!callback) callback = function(err) { if (err) throw err; };
 
     self.service.assumeRoleWithWebIdentity(function (err, data) {
@@ -83,5 +83,13 @@ AWS.WebIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
       }
       callback(err);
     });
+  },
+
+  /**
+   * @api private
+   */
+  createClients: function() {
+    this.service = this.service || new AWS.STS({params: this.params});
   }
+
 });


### PR DESCRIPTION
Lazily construct service clients in credential classes. Now credential providers can be constructed before a region is set. The service clients are only created when the credentials are refreshed.

Example:
```javascript
// This will now work
AWS.config.update({
  region: 'us-east-1',
  credentials: new AWS.CognitoIdentityCredentials({
    IndentityPoolId: 'us-east-1: foo-bar-baz'
  })
```
