### PR TITLE
Fix retry after ThrottlingException

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -341,6 +341,7 @@ AWS.Service = inherit({
     // this logic varies between services
     switch (error.code) {
       case 'ProvisionedThroughputExceededException':
+      case 'Throttling':
       case 'ThrottlingException':
         return true;
       default:

--- a/lib/service.js
+++ b/lib/service.js
@@ -341,7 +341,7 @@ AWS.Service = inherit({
     // this logic varies between services
     switch (error.code) {
       case 'ProvisionedThroughputExceededException':
-      case 'Throttling':
+      case 'ThrottlingException':
         return true;
       default:
         return false;

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -226,7 +226,7 @@ describe 'AWS.Service', ->
 
     it 'should retry on throttle error', ->
       retryableError({code: 'ProvisionedThroughputExceededException', statusCode:400}, true)
-      retryableError({code: 'ThrottlingException', statusCode:400}, true)
+      retryableError({code: 'Throttling', statusCode:400}, true)
 
     it 'should retry on expired credentials error', ->
       retryableError({code: 'ExpiredTokenException', statusCode:400}, true)

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -226,7 +226,7 @@ describe 'AWS.Service', ->
 
     it 'should retry on throttle error', ->
       retryableError({code: 'ProvisionedThroughputExceededException', statusCode:400}, true)
-      retryableError({code: 'Throttling', statusCode:400}, true)
+      retryableError({code: 'ThrottlingException', statusCode:400}, true)
 
     it 'should retry on expired credentials error', ->
       retryableError({code: 'ExpiredTokenException', statusCode:400}, true)


### PR DESCRIPTION
This is an additional fix for #412.  The patch by @lsegal (3677cd57de1c89dadb909d2f9029dc498a9e267f) checks for `err.code == 'Throttling'`, but some AWS services return `ThrottlingException`.