### PR TITLE
Add highwatermark to readable in buffer.tostream

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -120,7 +120,7 @@ var util = {
     toStream: function toStream(buffer) {
       if (!util.Buffer.isBuffer(buffer)) buffer = new util.Buffer(buffer);
 
-      var readable = new (util.nodeRequire('stream').Readable)();
+      var readable = new (util.nodeRequire('stream').Readable)({ highWaterMark: 5 * Math.pow(1024, 2) });
       var pos = 0;
       readable._read = function(size) {
         if (pos >= buffer.length) return readable.push(null);


### PR DESCRIPTION
I ran into this issue with recursive `nextTick` calls again and thought I'd just throw in a PR that helps: see https://github.com/aws/aws-sdk-js/issues/158#issuecomment-58612464. Again, while this problem does represent a problem in the node.js stream api, adding this is a very simple workaround.

p.s. this time I encountered the error when uploading a ~25MB zip file to lambda.