### PR TITLE
Refactor parameter validator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "quotes": [2, "single"],
     "strict": 0,
     "curly": 0,
+    "no-empty": 0,
     "no-underscore-dangle": 0,
     "new-cap": 0,
     "dot-notation": 0,

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -85,7 +85,9 @@ AWS.EventListeners = {
 
     add('VALIDATE_PARAMETERS', 'validate', function VALIDATE_PARAMETERS(req) {
       var rules = req.service.api.operations[req.operation].input;
-      new AWS.ParamValidator().validate(rules, req.params);
+      new AWS.ParamValidator().validate(rules, req.params, function(err) {
+        if (err) req.response.error = err;
+      });
     });
 
     add('SET_CONTENT_LENGTH', 'afterBuild', function SET_CONTENT_LENGTH(req) {

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -4,22 +4,28 @@ var AWS = require('./core');
  * @api private
  */
 AWS.ParamValidator = AWS.util.inherit({
-  validate: function validate(shape, params, context) {
+  validate: function validate(shape, params, context, callback) {
     this.errors = [];
-    this.validateMember(shape, params || {}, context || 'params');
+
+    if (typeof context === 'function' && typeof callback === 'undefined') {
+      callback = context;
+      context = 'params';
+    }
+
+    this.validateMember(shape, params || {}, context);
 
     if (this.errors.length > 1) {
       var msg = this.errors.join('\n* ');
       if (this.errors.length > 1) {
         msg = 'There were ' + this.errors.length +
               ' validation errors:\n* ' + msg;
-        throw AWS.util.error(new Error(msg),
-          {code: 'MultipleValidationErrors', errors: this.errors});
+        callback(AWS.util.error(new Error(msg),
+          {code: 'MultipleValidationErrors', errors: this.errors}));
       }
     } else if (this.errors.length === 1) {
-      throw this.errors[0];
+      callback(this.errors[0]);
     } else {
-      return true;
+      callback();
     }
   },
 

--- a/test/param_validator.spec.coffee
+++ b/test/param_validator.spec.coffee
@@ -5,19 +5,23 @@ Buffer = AWS.util.Buffer
 describe 'AWS.ParamValidator', ->
   [members, input] = [{}, {}]
 
-  validate = (params) ->
+  validate = (params, callback) ->
     r = input
     if r && !r.xml && !r.payload
       r = AWS.Model.Shape.create(input, {api: {}})
-    new AWS.ParamValidator().validate(r, params)
+    new AWS.ParamValidator().validate r, params, callback
 
   expectValid = (params) ->
-    expect(validate(params)).to.equal(true)
+    callback = (err) ->
+      expect(err).not.to.exist
+    validate params, callback
 
   expectError = (message, params) ->
     if params == undefined
       [message, params] = [undefined, message]
-    expect(-> validate(params)).to.throw(message)
+    callback = (err) ->
+      expect(err).to.exist
+    validate params, callback
 
   # empty input (nil or {}) means no arguments are accepted
   describe 'empty input', ->


### PR DESCRIPTION
The `AWS.ParameterValidator.validate()` should not throw an error. This interferes with the way the SDK distinguishes between SDK errors and programmer errors. 

The `AWS.ParameterValidator.validate()` now accepts a callback and passes in any errors as an argument to the callback.