### PR TITLE
Detach SHA_256 handler for AWS.Glacier

### DIFF
--- a/lib/services/glacier.js
+++ b/lib/services/glacier.js
@@ -10,7 +10,8 @@ AWS.util.update(AWS.Glacier.prototype, {
     } else {
       request.on('validate', this.validateAccountId);
     }
-
+    request.removeListener('afterBuild',
+      AWS.EventListeners.Core.COMPUTE_SHA256);
     request.on('build', this.addGlacierApiVersion);
     request.on('build', this.addTreeHashHeaders);
   },

--- a/lib/services/glacier.js
+++ b/lib/services/glacier.js
@@ -40,7 +40,7 @@ AWS.util.update(AWS.Glacier.prototype, {
     if (request.params.body === undefined) return;
 
     var hashes = request.service.computeChecksums(request.params.body);
-    request.httpRequest.headers['x-amz-content-sha256'] = hashes.linearHash;
+    request.httpRequest.headers['X-Amz-Content-Sha256'] = hashes.linearHash;
 
     if (!request.httpRequest.headers['x-amz-sha256-tree-hash']) {
       request.httpRequest.headers['x-amz-sha256-tree-hash'] = hashes.treeHash;

--- a/test/services/glacier.spec.coffee
+++ b/test/services/glacier.spec.coffee
@@ -6,6 +6,12 @@ if AWS.util.isNode()
   describe 'AWS.Glacier', ->
 
     glacier = null
+    agentHeader = null
+    if AWS.util.isBrowser()
+      agentHeader = 'X-Amz-User-Agent'
+    else
+      agentHeader = 'User-Agent'
+
     beforeEach ->
       glacier = new AWS.Glacier()
 
@@ -21,6 +27,19 @@ if AWS.util.isNode()
         req.emit('validate', [req])
         req.emit('build', [req])
         expect(req.httpRequest.path).to.equal('/ABC123/vaults')
+
+      it 'adds linear and tree hash headers to payload requests', ->
+        headers =
+          'x-amz-glacier-version': '2012-06-01'
+          'x-amz-content-sha256': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
+          'x-amz-sha256-tree-hash': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
+          'Content-Length': 3
+          Host: 'glacier.mock-region.amazonaws.com'
+        headers[agentHeader] = AWS.util.userAgent()
+        req = glacier.uploadArchive(vaultName: 'foo', body: 'bar')
+        req.removeAllListeners('sign')
+        req.build()
+        expect(req.httpRequest.headers).to.eql(headers)
 
     describe 'computeChecksums', ->
       it 'returns correct linear and tree hash for buffer data', ->

--- a/test/services/glacier.spec.coffee
+++ b/test/services/glacier.spec.coffee
@@ -28,10 +28,19 @@ if AWS.util.isNode()
         req.emit('build', [req])
         expect(req.httpRequest.path).to.equal('/ABC123/vaults')
 
+      it 'computes the SHA 256 checksum header only once', ->
+        spy = helpers.spyOn(AWS.util.crypto, 'sha256').andCallThrough()
+        # Compute checksum of <= 1 megabyte buffer
+        # This will invoke AWS.util.crypto.sha256() only once
+        req = glacier.uploadArchive(vaultName: 'foo', body: 'bar')
+        req.removeAllListeners('sign')
+        req.build()
+        expect(spy.calls.length).to.eql(1)
+
       it 'adds linear and tree hash headers to payload requests', ->
         headers =
           'x-amz-glacier-version': '2012-06-01'
-          'x-amz-content-sha256': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
+          'X-Amz-Content-Sha256': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
           'x-amz-sha256-tree-hash': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9'
           'Content-Length': 3
           Host: 'glacier.mock-region.amazonaws.com'

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -60,6 +60,11 @@ describe 'AWS.Signers.V4', ->
     it 'should generate proper signature', ->
       expect(signer.signature(creds, datetime)).to.equal(signature)
 
+    it 'should not compute SHA 256 checksum more than once', ->
+      spy = helpers.spyOn(AWS.util.crypto, 'sha256').andCallThrough()
+      signer.signature(creds, datetime)
+      expect(spy.calls.length).to.eql(1)
+
     describe 'caching', ->
       callCount = null
       calls = null


### PR DESCRIPTION
CC: @lsegal 

The `AWS.Glacier` client was adding the `X-Amz-Content-Sha256` header twice.
Unit tests pass
Glacier integ tests pass 