### PR TITLE
Support empty root payload elements in REST-XML.

### DIFF
--- a/lib/protocol/rest_xml.js
+++ b/lib/protocol/rest_xml.js
@@ -15,7 +15,7 @@ function populateBody(req) {
 
     if (payloadMember.type === 'structure') {
       var rootElement = payloadMember.name;
-      req.httpRequest.body = builder.toXML(params, payloadMember, rootElement);
+      req.httpRequest.body = builder.toXML(params, payloadMember, rootElement, true);
     } else { // non-xml payload
       req.httpRequest.body = params;
     }

--- a/lib/xml/builder.js
+++ b/lib/xml/builder.js
@@ -3,11 +3,11 @@ var builder = require('xmlbuilder');
 
 function XmlBuilder() { }
 
-XmlBuilder.prototype.toXML = function(params, shape, rootElement) {
+XmlBuilder.prototype.toXML = function(params, shape, rootElement, noEmpty) {
   var xml = builder.create(rootElement);
   applyNamespaces(xml, shape);
   serialize(xml, params, shape);
-  return xml.children.length === 0 ? '' : xml.root().toString();
+  return xml.children.length > 0 || noEmpty ? xml.root().toString() : '';
 };
 
 function serialize(xml, value, shape) {

--- a/test/fixtures/protocol/input/rest-xml.json
+++ b/test/fixtures/protocol/input/rest-xml.json
@@ -849,6 +849,28 @@
           },
           "name": "OperationName"
         },
+        "params": {
+          "foo": {
+          }
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "<foo/>",
+          "uri": "/"
+        }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/"
+          },
+          "input": {
+            "shape": "InputShape",
+            "payload": "foo"
+          },
+          "name": "OperationName"
+        },
         "params": {},
         "serialized": {
           "method": "POST",


### PR DESCRIPTION
This change ensures that an XML string is generated when an
empty object is passed to a payload structure member.

Fixes #598