### PR TITLE
Fix AWS.S3.ManagedUpload tests to run async

### DIFF
--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -3,7 +3,7 @@ AWS = helpers.AWS
 
 body = (size) ->
   try
-    return new Blob((0 for i in [0..size]))
+    return new Blob((0 for i in [0...size]))
   catch e
     return new AWS.util.Buffer(size)
 
@@ -54,7 +54,7 @@ describe 'AWS.S3.ManagedUpload', ->
     it 'uses a default service object if none provided', ->
       expect(-> new AWS.S3.ManagedUpload()).to.throw('params.Body is required')
 
-    it 'uploads a single part if size is less than min multipart size', ->
+    it 'uploads a single part if size is less than min multipart size', (done) ->
       reqs = helpers.mockResponses [
         data: ETag: 'ETAG'
       ]
@@ -65,6 +65,7 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/key')
         expect(helpers.operationsForRequests(reqs)).to.eql ['s3.putObject']
         expect(reqs[0].params.ContentEncoding).to.equal('encoding')
+        done()
 
     it 'can fail a single part', ->
       reqs = helpers.mockResponses [
@@ -75,7 +76,7 @@ describe 'AWS.S3.ManagedUpload', ->
       expect(data).not.to.exist
       expect(err.message).to.equal('ERROR')
 
-    it 'uploads multipart if size is greater than min multipart size', ->
+    it 'uploads multipart if size is greater than min multipart size', (done) ->
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
         { data: ETag: 'ETAG1' }
@@ -113,8 +114,9 @@ describe 'AWS.S3.ManagedUpload', ->
           { ETag: 'ETAG3', PartNumber: 3 }
           { ETag: 'ETAG4', PartNumber: 4 }
         ]
+        done()
 
-    it 'aborts if ETag is not in response', ->
+    it 'aborts if ETag is not in response', (done) ->
       helpers.spyOn(AWS.util, 'isBrowser').andReturn true
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
@@ -130,8 +132,9 @@ describe 'AWS.S3.ManagedUpload', ->
         ]
         expect(err).to.exist
         expect(err.message).to.equal('No access to ETag property on response. Check CORS configuration to expose ETag header.')
+        done()
 
-    it 'allows changing part size', ->
+    it 'allows changing part size', (done) ->
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
         { data: ETag: 'ETAG1' }
@@ -154,19 +157,21 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(data.Location).to.equal('FINAL_LOCATION')
         expect(reqs[1].params.ContentLength).to.equal(size)
         expect(reqs[2].params.ContentLength).to.equal(size)
+        done()
 
-    it 'supports zero-byte body buffers', ->
+    it 'supports zero-byte body buffers', (done) ->
       reqs = helpers.mockResponses [data: ETag: 'ETAG']
       upload = new AWS.S3.ManagedUpload params: { Body: zerobody }
       upload.send ->
         expect(helpers.operationsForRequests(reqs)).to.eql ['s3.putObject']
         expect(err).not.to.exist
+        done()
 
     it 'errors if partSize is smaller than minPartSize', ->
       expect(-> new AWS.S3.ManagedUpload(partSize: 5)).to.throw(
         'partSize must be greater than 10')
 
-    it 'aborts if uploadPart fails', ->
+    it 'aborts if uploadPart fails', (done) ->
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
         { data: ETag: 'ETAG1' }
@@ -185,8 +190,9 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(err).to.exist
         expect(data).not.to.exist
         expect(reqs[3].params.UploadId).to.equal('uploadId')
+        done()
 
-    it 'aborts if complete call fails', ->
+    it 'aborts if complete call fails', (done) ->
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
         { data: ETag: 'ETAG1' }
@@ -209,8 +215,9 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(err).to.exist
         expect(err.code).to.equal('CompleteFailed')
         expect(data).not.to.exist
+        done()
 
-    it 'leaves parts if leavePartsOnError is set', ->
+    it 'leaves parts if leavePartsOnError is set', (done) ->
       reqs = helpers.mockResponses [
         { data: UploadId: 'uploadId' }
         { data: ETag: 'ETAG1' }
@@ -231,6 +238,7 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(err).to.exist
         expect(err.code).to.equal('UploadPartFailed')
         expect(data).not.to.exist
+        done()
 
     if AWS.util.isNode()
       describe 'streaming', ->


### PR DESCRIPTION
This patch changes ManagedUpload specs to run asynchronously and fixes build failures with PhantomJS 2.0.
