### PR TITLE
Clear `AWS.CognitoIdentityCredentials` instance information alongside the cached ID.

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -129,6 +129,9 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    * the identity pool ID was deleted.
    */
   clearCachedId: function clearCache() {
+    this.identityId = null;
+    delete this.params.IdentityId;
+
     var poolId = this.params.IdentityPoolId;
     delete this.storage[this.localStorageKey.id + poolId];
     delete this.storage[this.localStorageKey.providers + poolId];

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -619,6 +619,13 @@ describe 'AWS.CognitoIdentityCredentials', ->
       expect(creds.getStorage('id')).not.to.exist
       expect(creds.getStorage('providers')).not.to.exist
 
+    it 'should clear instance information', ->
+      creds.identityId = 'foo'
+      creds.params.IdentityId = 'foo'
+      creds.clearCachedId()
+      expect(creds.identityId).not.to.exist
+      expect(creds.params.IdentityId).not.to.exist
+
   describe 'createClients', ->
     beforeEach -> setupCreds()
 


### PR DESCRIPTION
Without this change, an instance will keep using the cached information even after the
cache is cleared.