### PR TITLE
Update ISO 8601 precision

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -311,7 +311,7 @@ var util = {
      */
     iso8601: function iso8601(date) {
       if (date === undefined) { date = util.date.getDate(); }
-      return date.toISOString();
+      return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
     },
 
     /**

--- a/test/fixtures/protocol/input/ec2.json
+++ b/test/fixtures/protocol/input/ec2.json
@@ -352,7 +352,7 @@
         },
         "serialized": {
           "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00.000Z"
+          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
         }
       }
     ]

--- a/test/fixtures/protocol/input/query.json
+++ b/test/fixtures/protocol/input/query.json
@@ -304,7 +304,7 @@
         },
         "serialized": {
           "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00.000Z"
+          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
         }
       }
     ]

--- a/test/fixtures/protocol/input/rest-xml.json
+++ b/test/fixtures/protocol/input/rest-xml.json
@@ -610,7 +610,7 @@
         },
         "serialized": {
           "method": "POST",
-          "body": "<OperationRequest xmlns=\"https://foo/\"><StructureParam><t>2015-01-25T08:00:00.000Z</t><b>Zm9v</b></StructureParam></OperationRequest>",
+          "body": "<OperationRequest xmlns=\"https://foo/\"><StructureParam><t>2015-01-25T08:00:00Z</t><b>Zm9v</b></StructureParam></OperationRequest>",
           "uri": "/2014-01-01/hostedzone",
           "headers": {}
         }

--- a/test/json/builder.spec.coffee
+++ b/test/json/builder.spec.coffee
@@ -104,7 +104,7 @@ describe 'AWS.JSON.Builder', ->
       now.setMilliseconds(100)
       params = Build: When: now
       formatted = AWS.util.date.iso8601(now).replace(/\.\d+Z$/, '')
-      expect(build(rules, params)).to.match(new RegExp('\\{"Build":\\{"When":"'+formatted+'\\.\\d+Z"\\}\\}'))
+      expect(build(rules, params)).to.match(new RegExp('\\{"Build":\\{"When":"'+formatted+'"\\}\\}'))
 
     it 'translates integers formatted as strings', ->
       rules =

--- a/test/model/shape.spec.coffee
+++ b/test/model/shape.spec.coffee
@@ -20,7 +20,7 @@ describe 'AWS.Model.Shape', ->
       it 'converts iso8601 timestamps', ->
         api = new AWS.Model.Api metadata: timestampFormat: 'iso8601'
         shape = AWS.Model.Shape.create { type: 'timestamp' }, { api: api }
-        date = shape.toType('1970-01-01T00:00:00.000Z')
+        date = shape.toType('1970-01-01T00:00:00Z')
         expect(date).to.eql(new Date(0))
 
       it 'converts rfc822 timestamps', ->
@@ -54,13 +54,13 @@ describe 'AWS.Model.Shape', ->
         api = new AWS.Model.Api metadata: protocol: 'rest-xml'
         shape = AWS.Model.Shape.create { type: 'timestamp' }, { api: api }
         date = shape.toWireFormat(new Date(12300000))
-        expect(date).to.equal('1970-01-01T03:25:00.000Z')
+        expect(date).to.equal('1970-01-01T03:25:00Z')
 
         # query
         api = new AWS.Model.Api metadata: protocol: 'query'
         shape = AWS.Model.Shape.create { type: 'timestamp' }, { api: api }
         date = shape.toWireFormat(new Date(12300000))
-        expect(date).to.equal('1970-01-01T03:25:00.000Z')
+        expect(date).to.equal('1970-01-01T03:25:00Z')
 
     describe 'BooleanShape', ->
       describe 'toType()', ->

--- a/test/signers/v2.spec.coffee
+++ b/test/signers/v2.spec.coffee
@@ -34,7 +34,7 @@ describe 'AWS.Signers.V2', ->
   describe 'addAuthorization', ->
 
     it 'adds a url encoded iso8601 timestamp param', ->
-      expect(stringify(request.params)).to.match(/Timestamp=2031-04-30T20%3A16%3A13.456Z/)
+      expect(stringify(request.params)).to.match(/Timestamp=2031-04-30T20%3A16%3A13Z/)
 
     it 'adds a SignatureVersion param', ->
       expect(stringify(request.params)).to.match(/SignatureVersion=2/)
@@ -54,15 +54,15 @@ describe 'AWS.Signers.V2', ->
       expect(stringify(request.params)).to.match(/SecurityToken=session/)
 
     it 'populates the body', ->
-      expect(request.body).to.equal('AWSAccessKeyId=akid&Signature=%2FrumhWptMPvyb4aaeOv5iGpl6%2FLfs5uVHu8k1d3NNfc%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2031-04-30T20%3A16%3A13.456Z')
+      expect(request.body).to.equal('AWSAccessKeyId=akid&Signature=6g8SME09kuR%2FVYtVhDoXRqXsZDb7%2FPcjEVDKHJB%2BZe8%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2031-04-30T20%3A16%3A13Z')
 
     it 'populates content-length header', ->
-      expect(request.headers['Content-Length']).to.equal(165)
+      expect(request.headers['Content-Length']).to.equal(163)
 
     it 'signs additional body params', ->
       request = buildRequest()
       request.params['Param.1'] = 'abc'
       request.params['Param.2'] = 'xyz'
       signRequest(request)
-      expect(request.body).to.equal('AWSAccessKeyId=akid&Param.1=abc&Param.2=xyz&Signature=3pcXIWw0eVd4wFmp%2Blo24L93UTMGcYSNE%2BFYNNqzDts%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2031-04-30T20%3A16%3A13.456Z')
+      expect(request.body).to.equal('AWSAccessKeyId=akid&Param.1=abc&Param.2=xyz&Signature=hoA%2F%2FTha7KYkewoZbCMC8NQIcixNQd5U6WNLk%2B%2BKl%2FU%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2031-04-30T20%3A16%3A13Z')
 

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -107,17 +107,17 @@ describe 'AWS.util.date', ->
         expect(util.getDate().getTime()).to.equal(0)
 
   describe 'iso8601', ->
-    it 'should return date formatted as YYYYMMDDTHHnnssZ', ->
+    it 'should return date formatted as YYYYMMDDTHHmmssZ', ->
       date = new Date(600000); date.setMilliseconds(0)
       helpers.spyOn(util, 'getDate').andCallFake -> date
-      expect(util.iso8601()).to.equal('1970-01-01T00:10:00.000Z')
+      expect(util.iso8601()).to.equal('1970-01-01T00:10:00Z')
 
     it 'should allow date parameter', ->
       date = new Date(660000); date.setMilliseconds(0)
-      expect(util.iso8601(date)).to.equal('1970-01-01T00:11:00.000Z')
+      expect(util.iso8601(date)).to.equal('1970-01-01T00:11:00Z')
 
   describe 'rfc822', ->
-    it 'should return date formatted as YYYYMMDDTHHnnssZ', ->
+    it 'should return date formatted as YYYYMMDDTHHmmssZ', ->
       date = new Date(600000); date.setMilliseconds(0)
       helpers.spyOn(util, 'getDate').andCallFake -> date
       expect(util.rfc822()).to.match(/^Thu, 0?1 Jan 1970 00:10:00 (GMT|UTC)$/)


### PR DESCRIPTION
Update ISO 8601 to omit millisecond precision.