### PR TITLE
Clean up createReadStream logic to use a PassThrough stream.

### DIFF
--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -69,9 +69,12 @@ module.exports = function () {
     var params = {Bucket: this.sharedBucket, Key: key};
     var world = this;
     this.result = '';
-    this.service.getObject(params).createReadStream().
-      on('end', function() { callback(); }).
-      on('data', function(d) { world.result += d.toString(); });
+    var s = this.service.getObject(params).createReadStream();
+
+    setTimeout(function() {
+      s.on('end', function() { callback(); });
+      s.on('data', function(d) { world.result += d.toString(); });
+    }, 2000); // delay streaming to ensure it is buffered
   });
 
   this.When(/^I stream2 key "([^"]*)"$/, function(key, callback) {
@@ -80,10 +83,12 @@ module.exports = function () {
     var world = this;
     this.result = '';
     var stream = this.service.getObject(params).createReadStream();
-    stream.on('end', function() { callback(); });
-    stream.on('readable', function() {
-      var v = stream.read(); if (v) world.result += v;
-    });
+    setTimeout(function() {
+      stream.on('end', function() { callback(); });
+      stream.on('readable', function() {
+        var v = stream.read(); if (v) world.result += v;
+      });
+    }, 2000); // delay streaming to ensure it is buffered
   });
 
   this.Then(/^the streamed data should contain "([^"]*)"$/, function(data, callback) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -527,24 +527,22 @@ AWS.Request = inherit({
     var streams = AWS.util.nodeRequire('stream');
     var req = this;
     var stream = null;
-    var legacyStreams = false;
 
     if (AWS.HttpClient.streamsApiVersion === 2) {
-      stream = new streams.Readable();
-      stream._read = function() {};
+      stream = new streams.PassThrough();
+      req.send();
     } else {
       stream = new streams.Stream();
       stream.readable = true;
-    }
 
-    stream.sent = false;
-    stream.on('newListener', function(event) {
-      if (!stream.sent && (event === 'data' || event === 'readable')) {
-        if (event === 'data') legacyStreams = true;
-        stream.sent = true;
-        process.nextTick(function() { req.send(function() { }); });
-      }
-    });
+      stream.sent = false;
+      stream.on('newListener', function(event) {
+        if (!stream.sent && event === 'data') {
+          stream.sent = true;
+          process.nextTick(function() { req.send(); });
+        }
+      });
+    }
 
     this.on('httpHeaders', function streamHeaders(statusCode, headers, resp) {
       if (statusCode < 300) {
@@ -556,24 +554,14 @@ AWS.Request = inherit({
         });
 
         var httpStream = resp.httpResponse.createUnbufferedStream();
-        if (legacyStreams) {
+        if (AWS.HttpClient.streamsApiVersion === 2) {
+          httpStream.pipe(stream);
+        } else {
           httpStream.on('data', function(arg) {
             stream.emit('data', arg);
           });
           httpStream.on('end', function() {
             stream.emit('end');
-          });
-        } else {
-          httpStream.on('readable', function() {
-            var chunk;
-            do {
-              chunk = httpStream.read();
-              if (chunk !== null) stream.push(chunk);
-            } while (chunk !== null);
-            stream.read(0);
-          });
-          httpStream.on('end', function() {
-            stream.push(null);
           });
         }
 


### PR DESCRIPTION
Also fixes incorrect detection of streaming API in Node 0.12.x and
resolves a memory leak when not using pipe.

Fixes #605 

Ran against new S3 integration tests and all updated tests pass with these changes.