### PR TITLE
Fix AWS.S3 to allow binary SSE keys

### DIFF
--- a/apis/s3-2006-03-01.min.json
+++ b/apis/s3-2006-03-01.min.json
@@ -2980,11 +2980,11 @@
       "value": {}
     },
     "S18": {
-      "type": "string",
+      "type": "blob",
       "sensitive": true
     },
     "S1b": {
-      "type": "string",
+      "type": "blob",
       "sensitive": true
     },
     "S2f": {

--- a/apis/s3-2006-03-01.normal.json
+++ b/apis/s3-2006-03-01.normal.json
@@ -1276,7 +1276,7 @@
     "CopySourceRange":{"type":"string"},
     "CopySourceSSECustomerAlgorithm":{"type":"string"},
     "CopySourceSSECustomerKey":{
-      "type":"string",
+      "type":"blob",
       "sensitive":true
     },
     "CopySourceSSECustomerKeyMD5":{"type":"string"},
@@ -4385,7 +4385,7 @@
     },
     "SSECustomerAlgorithm":{"type":"string"},
     "SSECustomerKey":{
-      "type":"string",
+      "type":"blob",
       "sensitive":true
     },
     "SSECustomerKeyMD5":{"type":"string"},

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -125,36 +125,6 @@ Feature: Working with Objects in S3
     And I access the URL via HTTP PUT with data "NOT CHECKSUMMED"
     Then the HTTP response should contain "SignatureDoesNotMatch"
 
-  @sse
-  Scenario: Server side encryption with string keys
-    Given I put "data" to the key "string_sse_object" with a string AES key
-    Then the encrypted object "string_sse_object" should exist
-    When I get the encrypted object "string_sse_object"
-    Then the object "string_sse_object" should contain "data"
-
-  @sse
-  Scenario: Server side encryption with blob keys
-    Given I put "data" to the key "blob_sse_object" with a blob AES key
-    Then the encrypted object "blob_sse_object" should exist
-    When I get the encrypted object "blob_sse_object"
-    Then the object "blob_sse_object" should contain "data"
-
-  @sse
-  Scenario: Server side encryption copy with string keys
-    Given I put "data" to the key "string_sse_object_source" with a string AES key
-    And I copy the encrypted object "string_sse_object_source" to the key "string_sse_object_copy" with a string AES key
-    Then the object "string_sse_object_copy" should exist
-    When I get the object "string_sse_object_copy"
-    Then the object "string_sse_object_copy" should contain "data"
-
-  @sse
-  Scenario: Server side encryption copy with blob keys
-    Given I put "data" to the key "blob_sse_object_source" with a string AES key
-    And I copy the encrypted object "blob_sse_object_source" to the key "blob_sse_object_copy" with a blob AES key
-    Then the object "blob_sse_object_copy" should exist
-    When I get the object "blob_sse_object_copy"
-    Then the object "blob_sse_object_copy" should contain "data"
-
   @streams
   Scenario: Streaming objects
     Given I put "STREAMING CONTENT" to the key "streaming_object"

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -125,6 +125,36 @@ Feature: Working with Objects in S3
     And I access the URL via HTTP PUT with data "NOT CHECKSUMMED"
     Then the HTTP response should contain "SignatureDoesNotMatch"
 
+  @sse
+  Scenario: Server side encryption with string keys
+    Given I put "data" to the key "string_sse_object" with a string AES key
+    Then the encrypted object "string_sse_object" should exist
+    When I get the encrypted object "string_sse_object"
+    Then the object "string_sse_object" should contain "data"
+
+  @sse
+  Scenario: Server side encryption with blob keys
+    Given I put "data" to the key "blob_sse_object" with a blob AES key
+    Then the encrypted object "blob_sse_object" should exist
+    When I get the encrypted object "blob_sse_object"
+    Then the object "blob_sse_object" should contain "data"
+
+  @sse
+  Scenario: Server side encryption copy with string keys
+    Given I put "data" to the key "string_sse_object_source" with a string AES key
+    And I copy the encrypted object "string_sse_object_source" to the key "string_sse_object_copy" with a string AES key
+    Then the object "string_sse_object_copy" should exist
+    When I get the object "string_sse_object_copy"
+    Then the object "string_sse_object_copy" should contain "data"
+
+  @sse
+  Scenario: Server side encryption copy with blob keys
+    Given I put "data" to the key "blob_sse_object_source" with a string AES key
+    And I copy the encrypted object "blob_sse_object_source" to the key "blob_sse_object_copy" with a blob AES key
+    Then the object "blob_sse_object_copy" should exist
+    When I get the object "blob_sse_object_copy"
+    Then the object "blob_sse_object_copy" should contain "data"
+
   @streams
   Scenario: Streaming objects
     Given I put "STREAMING CONTENT" to the key "streaming_object"

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -237,45 +237,6 @@ module.exports = function () {
     next();
   });
 
-  this.When(/^I put "([^"]*)" to the key "([^"]*)" with a (string|blob) AES key$/, function(data, key, type, next) {
-    var sse = 'abcdabcdabcdabcdabcdabcdabcdabcd';
-    this.sseKey = type === 'blob' ? new this.AWS.util.Buffer(sse) : sse;
-    var params = {Bucket: this.sharedBucket, Key: key, Body: data, SSECustomerKey: this.sseKey, SSECustomerAlgorithm: 'AES256'};
-    this.request('s3', 'putObject', params, next, false);
-  });
-
-  this.When(/^I copy the encrypted object "([^"]*)" to the key "([^"]*)" with a (string|blob) AES key$/, function(source, dest, type, next) {
-    var sse = 'abcdabcdabcdabcdabcdabcdabcdabcd';
-    this.sseKey = type === 'blob' ? new this.AWS.util.Buffer(sse) : sse;
-    var params = {
-      Bucket: this.sharedBucket,
-      CopySource: this.sharedBucket + '/' + source,
-      Key: dest,
-      CopySourceSSECustomerKey: this.sseKey,
-      CopySourceSSECustomerAlgorithm: 'AES256'
-    };
-    this.request('s3', 'copyObject', params, next, false);
-  });
-
-  this.Then(/^the encrypted object "([^"]*)" should (not )?exist$/, function(key, shouldNotExist, next) {
-    var params = { Bucket: this.sharedBucket, Key: key, SSECustomerKey: this.sseKey, SSECustomerAlgorithm: 'AES256'};
-    this.eventually(next, function (retry) {
-      retry.condition = function() {
-        if (shouldNotExist) {
-          return this.error && this.error.code === 'NotFound';
-        } else {
-          return !this.error;
-        }
-      };
-      this.request('s3', 'headObject', params, retry, false);
-    });
-  });
-
-  this.When(/^I get the encrypted object "([^"]*)"$/, function(key, next) {
-    var params = {Bucket: this.sharedBucket, Key: key, SSECustomerAlgorithm: 'AES256', SSECustomerKey: this.sseKey};
-    this.request('s3', 'getObject', params, next, false);
-  });
-
   this.Given(/^an empty bucket$/, function(next) {
     var self = this;
     var params = { Bucket: this.sharedBucket };

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -106,7 +106,7 @@ module.exports = function () {
     callback();
   });
 
-  this.When(/^I access the URL via HTTP GET$/, function(callback, verb) {
+  this.When(/^I access the URL via HTTP GET$/, function(callback) {
     var world = this;
     this.data = '';
     require('https').get(this.signedUrl, function (res) {
@@ -235,6 +235,45 @@ module.exports = function () {
     var receivedContentMD5 = this.AWS.util.crypto.md5(this.data.Body.toString(), 'base64');
     this.assert.equal(receivedContentMD5, this.sentContentMD5);
     next();
+  });
+
+  this.When(/^I put "([^"]*)" to the key "([^"]*)" with a (string|blob) AES key$/, function(data, key, type, next) {
+    var sse = 'abcdabcdabcdabcdabcdabcdabcdabcd';
+    this.sseKey = type === 'blob' ? new this.AWS.util.Buffer(sse) : sse;
+    var params = {Bucket: this.sharedBucket, Key: key, Body: data, SSECustomerKey: this.sseKey, SSECustomerAlgorithm: 'AES256'};
+    this.request('s3', 'putObject', params, next, false);
+  });
+
+  this.When(/^I copy the encrypted object "([^"]*)" to the key "([^"]*)" with a (string|blob) AES key$/, function(source, dest, type, next) {
+    var sse = 'abcdabcdabcdabcdabcdabcdabcdabcd';
+    this.sseKey = type === 'blob' ? new this.AWS.util.Buffer(sse) : sse;
+    var params = {
+      Bucket: this.sharedBucket,
+      CopySource: this.sharedBucket + '/' + source,
+      Key: dest,
+      CopySourceSSECustomerKey: this.sseKey,
+      CopySourceSSECustomerAlgorithm: 'AES256'
+    };
+    this.request('s3', 'copyObject', params, next, false);
+  });
+
+  this.Then(/^the encrypted object "([^"]*)" should (not )?exist$/, function(key, shouldNotExist, next) {
+    var params = { Bucket: this.sharedBucket, Key: key, SSECustomerKey: this.sseKey, SSECustomerAlgorithm: 'AES256'};
+    this.eventually(next, function (retry) {
+      retry.condition = function() {
+        if (shouldNotExist) {
+          return this.error && this.error.code === 'NotFound';
+        } else {
+          return !this.error;
+        }
+      };
+      this.request('s3', 'headObject', params, retry, false);
+    });
+  });
+
+  this.When(/^I get the encrypted object "([^"]*)"$/, function(key, next) {
+    var params = {Bucket: this.sharedBucket, Key: key, SSECustomerAlgorithm: 'AES256', SSECustomerKey: this.sseKey};
+    this.request('s3', 'getObject', params, next, false);
   });
 
   this.Given(/^an empty bucket$/, function(next) {

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -202,21 +202,14 @@ AWS.util.update(AWS.S3.prototype, {
    * @api private
    */
   computeSseCustomerKeyMd5: function computeSseCustomerKeyMd5(req) {
-    var headers = [
-      'x-amz-server-side-encryption-customer-key',
-      'x-amz-copy-source-server-side-encryption-customer-key'
-    ];
-    AWS.util.arrayEach(headers, function(header) {
-      if (req.httpRequest.headers[header]) {
-        var key = req.httpRequest.headers[header];
-        var md5header = header + '-MD5';
-
-        req.httpRequest.headers[header] = AWS.util.base64.encode(key);
-        if (!req.httpRequest.headers[md5header]) {
-          var value = AWS.util.crypto.md5(key, 'base64');
-          req.httpRequest.headers[md5header] = value;
-        }
-
+    var keys = {
+      SSECustomerKey: 'x-amz-server-side-encryption-customer-key-MD5',
+      CopySourceSSECustomerKey: 'x-amz-copy-source-server-side-encryption-customer-key-MD5'
+    };
+    AWS.util.each(keys, function(key, header) {
+      if (req.params[key]) {
+        var value = AWS.util.crypto.md5(req.params[key], 'base64');
+        req.httpRequest.headers[header] = value;
       }
     });
   },

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -230,25 +230,49 @@ describe 'AWS.S3', ->
       req.build()
       expect(req.response.error.code).to.equal('ConfigError')
 
-    it 'encodes SSECustomerKey and fills in MD5', ->
-      req = s3.putObject
-        Bucket: 'bucket', Key: 'key', Body: 'data'
-        SSECustomerKey: 'KEY', SSECustomerAlgorithm: 'AES256'
-      req.build()
-      expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key']).
-        to.equal('S0VZ')
-      expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key-MD5']).
-        to.equal('O1lJ4MJrh3Z6R1Kidt6VcA==')
+    describe 'SSECustomerKey', ->
+      it 'encodes strings keys and fills in MD5', ->
+        req = s3.putObject
+          Bucket: 'bucket', Key: 'key', Body: 'data'
+          SSECustomerKey: 'KEY', SSECustomerAlgorithm: 'AES256'
+        req.build()
+        expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key']).
+          to.equal('S0VZ')
+        expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key-MD5']).
+          to.equal('O1lJ4MJrh3Z6R1Kidt6VcA==')
 
-    it 'encodes CopySourceSSECustomerKey and fills in MD5', ->
-      req = s3.copyObject
-        Bucket: 'bucket', Key: 'key', CopySource: 'bucket/oldkey', Body: 'data'
-        CopySourceSSECustomerKey: 'KEY', CopySourceSSECustomerAlgorithm: 'AES256'
-      req.build()
-      expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key']).
-        to.equal('S0VZ')
-      expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key-MD5']).
-        to.equal('O1lJ4MJrh3Z6R1Kidt6VcA==')
+      it 'encodes blob keys and fills in MD5', ->
+        req = s3.putObject
+          Bucket: 'bucket', Key: 'key', Body: 'data'
+          SSECustomerKey: new AWS.util.Buffer('098f6bcd4621d373cade4e832627b4f6', 'hex')
+          SSECustomerAlgorithm: 'AES256'
+        req.build()
+        expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key']).
+          to.equal('CY9rzUYh03PK3k6DJie09g==')
+        expect(req.httpRequest.headers['x-amz-server-side-encryption-customer-key-MD5']).
+          to.equal('YM1UqSjLvLtue1WVurRqng==')
+
+    describe 'CopySourceSSECustomerKey', ->
+      it 'encodes string keys and fills in MD5', ->
+        req = s3.copyObject
+          Bucket: 'bucket', Key: 'key', CopySource: 'bucket/oldkey', Body: 'data'
+          CopySourceSSECustomerKey: 'KEY', CopySourceSSECustomerAlgorithm: 'AES256'
+        req.build()
+        expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key']).
+          to.equal('S0VZ')
+        expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key-MD5']).
+          to.equal('O1lJ4MJrh3Z6R1Kidt6VcA==')
+
+      it 'encodes blob keys and fills in MD5', ->
+        req = s3.copyObject
+          Bucket: 'bucket', Key: 'key', CopySource: 'bucket/oldkey', Body: 'data'
+          CopySourceSSECustomerKey: new AWS.util.Buffer('098f6bcd4621d373cade4e832627b4f6', 'hex')
+          CopySourceSSECustomerAlgorithm: 'AES256'
+        req.build()
+        expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key']).
+          to.equal('CY9rzUYh03PK3k6DJie09g==')
+        expect(req.httpRequest.headers['x-amz-copy-source-server-side-encryption-customer-key-MD5']).
+          to.equal('YM1UqSjLvLtue1WVurRqng==')
 
   describe 'retry behavior', ->
     it 'retries RequestTimeout errors', ->


### PR DESCRIPTION
`SSECustomerKey` and `CopySourceSSECustomerKey` can now be binary parameters.

Fixes #621