### PR TITLE
Support multiple send's with leavePartsOnError

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -148,6 +148,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    */
   send: function(callback) {
     var self = this;
+    self.failed = false;
     self.callback = callback || function(err) { if (err) throw err; };
 
     var runFill = true;
@@ -411,6 +412,10 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       return null;
     }
 
+    if (self.completeInfo[partNumber] && self.completeInfo[partNumber].ETag !== null) {
+      return null; // Already uploaded this part.
+    }
+
     self.activeParts++;
     if (!self.service.config.params.UploadId) {
 
@@ -438,6 +443,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    */
   uploadPart: function uploadPart(chunk, partNumber) {
     var self = this;
+
     var partParams = {
       Body: chunk,
       ContentLength: AWS.util.string.byteLength(chunk),
@@ -445,7 +451,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     };
 
     var partInfo = {ETag: null, PartNumber: partNumber};
-    self.completeInfo.push(partInfo);
+    self.completeInfo[partNumber] = partInfo;
 
     var req = self.service.uploadPart(partParams);
     self.parts[partNumber] = req;
@@ -512,6 +518,10 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       part.abort();
     });
 
+    self.activeParts = 0;
+    self.partPos = 0;
+    self.numParts = 0;
+    self.totalPartNumbers = 0;
     self.parts = {};
     self.callback(err);
     self.failed = true;
@@ -522,7 +532,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    */
   finishMultiPart: function finishMultiPart() {
     var self = this;
-    var completeParams = { MultipartUpload: { Parts: self.completeInfo } };
+    var completeParams = { MultipartUpload: { Parts: self.completeInfo.slice(1) } };
     self.service.completeMultipartUpload(completeParams, function(err, data) {
       if (err) return self.cleanup(err);
       else self.callback(err, data);


### PR DESCRIPTION
Track which parts have been uploaded and if we have an `ETag` for them, don't try to upload them again. This works well with `leavePartsOnError`, so that you can restart a failed upload and only upload the missing parts.

This passes existing sdk tests and works well with buffer/file-type uploads. I don't think this is a use case for uploading streams, but it doesn't conflict with that case.

Fixes #633