### PR TITLE
When wrapping an error object, copy the original stack over to the ne…

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -618,6 +618,15 @@ var util = {
     if (typeof Object.defineProperty === 'function') {
       Object.defineProperty(err, 'name', {writable: true, enumerable: false});
       Object.defineProperty(err, 'message', {enumerable: true});
+      if (typeof options === 'object' && options.stack) {
+        var oldStack = err.stack;
+        Object.defineProperty(err, 'stack', {
+          enumerable: false,
+          get: function () {
+            return oldStack + '\nCaused by: ' + options.stack;
+          }
+        });
+      }
     }
 
     err.name = err.name || err.code || 'Error';


### PR DESCRIPTION
Fixes #639 by copying the stack object from the original error to the newly created error in util.error