### PR TITLE
Upgrade to 0.4.9 of xml2js in order to properly resolve xml entities.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
       "sax": "0.5.3",
-      "xml2js": "0.2.8",
+      "xml2js": "0.4.9",
       "xmlbuilder": "0.4.2"
     },
     "main": "lib/aws.js",

--- a/test/xml/parser.spec.coffee
+++ b/test/xml/parser.spec.coffee
@@ -46,6 +46,12 @@ describe 'AWS.XML.Parser', ->
       parse xml, rules, (data) ->
         expect(data).to.eql({Abc:'xyz'})
 
+    it 'converts hexadecimal xml entity to the correct unicode character', ->
+      xml = '<xml><Abc>&#x1f608;</Abc></xml>'
+      smilingFaceWithHornsEmoji = '\uD83D\uDE08'
+      parse xml, rules, (data) ->
+        expect(data).to.eql({Abc: smilingFaceWithHornsEmoji})
+
   describe 'structures', ->
 
     it 'returns empty objects as {}', ->


### PR DESCRIPTION
The previously used version (0.2.8) handles xml entities improperly.

This specifically affected the simpledb apis for retrieving attributes or selecting several items for a domain, but it might also affect other aws apis that use xml as the wire protocol.