### PR TITLE
Generate shared examples

### DIFF
--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -93,12 +93,9 @@ class MethodDocumentor
     @lines += shapes(api, operation['input']).map {|line| "  " + line }
 
     ## @example tag
-    @lines << "@example Calling the #{method_name(operation_name)} operation"
-    @lines << generate_example(api, klass, method_name(operation_name),
-                operation['input']).split("\n").map {|line| "  " + line }
     if examples
       examples.each do |example|
-        @lines << "@example Example: #{example['title']}"
+        @lines << "@example #{example['title']}"
         @lines << ""
         @lines << "  /* #{example['description']} */"
         @lines << ""
@@ -106,6 +103,9 @@ class MethodDocumentor
                 method_name(operation_name)).split("\n").map {|line| "  " + line }
       end
     end
+    @lines << "@example Calling the #{method_name(operation_name)} operation"
+    @lines << generate_example(api, klass, method_name(operation_name),
+                operation['input']).split("\n").map {|line| "  " + line }
 
     ## @callback tag
 

--- a/doc-src/templates/api-versions/plugin.rb
+++ b/doc-src/templates/api-versions/plugin.rb
@@ -142,9 +142,10 @@ eof
   end
 
   def add_methods(service, klass, model)
+    examples = load_examples(klass.downcase) || {}
     model['operations'].each_pair do |name, operation|
       meth = YARDJS::CodeObjects::PropertyObject.new(service, name[0].downcase + name[1..-1])
-      docs = MethodDocumentor.new(name, operation, model, klass).lines.join("\n")
+      docs = MethodDocumentor.new(name, operation, model, klass, examples[name]).lines.join("\n")
       meth.property_type = :function
       meth.parameters = [['params', '{}'], ['callback', nil]]
       meth.signature = "#{name}(params = {}, [callback])"
@@ -246,5 +247,13 @@ eof
     end
 
     raise "Unknown class name for #{prefix}"
+  end
+
+  def load_examples(name)
+    paths = Dir[File.join($APIS_DIR, "#{name}-*.examples.json")]
+    unless paths.empty?
+      json = JSON.parse(File.read(paths[0]))
+      json['examples']
+    end
   end
 end


### PR DESCRIPTION
Adds functionality and tests for generating shared documentation examples from the language-agnostic JSON format. These new examples will live alongside the JSON apis.

The code in this PR loads the examples from the plugin.rb, which passes them into the model_documentor.rb. From there the SharedExampleVisitor class parses the JSON and creates a JS example immediately after the automatically generated examples in the documentation.