### PR TITLE
Android Users have localStorage as null

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -297,7 +297,7 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   storage: (function() {
     try {
-      return AWS.util.isBrowser() && typeof window.localStorage === 'object' ?
+      return AWS.util.isBrowser() && window.localStorage !== null && typeof window.localStorage === 'object' ?
              window.localStorage : {};
     } catch (_) {
       return {};


### PR DESCRIPTION
On android phones, we have seen that there are times when `window.localStorage` is null. Since it's an object, we're actually using `null` as our storage. This should not be the case.