### PR TITLE
add more details to 'httpUploadProgress' event emitter to support tra…

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -555,7 +555,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       info = {
         loaded: upload.totalUploadedBytes,
         total: upload.totalBytes,
-        part: this.params.PartNumber
+        part: this.params.PartNumber,
+        key: this.params.key,
+        name: upload.body.name
       };
     }
     upload.emit('httpUploadProgress', [info]);


### PR DESCRIPTION
when trying to upload multiple files in parallel, you get progress by listening on 'httpUploadProgess' event. but the payload you get is like:

**{loaded: 147456, total: 13566183, part: 1}**
**{loaded: 114688, total: 415560925, part: 1}**

so you don't know which object is for which file.

we added file name and key to the event emitter payload to be like this:
**{loaded: 147456, total: 415560925, part: 1, name: "12.mp4", key: "idOn4M86"}**
**{loaded: 180224, total: 13566183, part: 1, name: "122345.mp4", key: "ShMOAxJN"}**

so you can easily track the progress of each file.