### PR TITLE
Disable signature cache

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -390,7 +390,8 @@ AWS.Config = AWS.util.inherit({
     convertResponseTypes: true,
     dynamoDbCrc32: true,
     systemClockOffset: 0,
-    signatureVersion: null
+    signatureVersion: null,
+    signatureCache: true
   },
 
   /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,6 +95,11 @@ require('./credentials/credential_provider_chain');
  * @!attribute signatureVersion
  *   @return [String] the signature version to sign requests with (overriding
  *     the API configuration). Possible values are: 'v2', 'v3', 'v4'.
+ *
+ * @!attribute signatureCache
+ *   @return [Boolean] whether the signature to sign requests with (overriding
+ *     the API configuration) is cached. Only applies to the signature version 'v4'.
+ *     Defaults to `true`.
  */
 AWS.Config = AWS.util.inherit({
   /**
@@ -182,6 +187,9 @@ AWS.Config = AWS.util.inherit({
    * @option options signatureVersion [String] the signature version to sign
    *   requests with (overriding the API configuration). Possible values are:
    *   'v2', 'v3', 'v4'.
+   * @option options signatureCache [Boolean] whether the signature to sign
+   *   requests with (overriding the API configuration) is cached. Only applies
+   *   to the signature version 'v4'. Defaults to `true`.
    */
   constructor: function Config(options) {
     if (options === undefined) options = {};

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -147,7 +147,8 @@ AWS.EventListeners = {
           var date = AWS.util.date.getDate();
           var SignerClass = req.service.getSignerClass(req);
           var signer = new SignerClass(req.httpRequest,
-            req.service.api.signingName || req.service.api.endpointPrefix);
+            req.service.api.signingName || req.service.api.endpointPrefix,
+            req.service.config.signatureCache);
 
           // clear old authorization headers
           delete req.httpRequest.headers['Authorization'];

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -88,7 +88,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   },
 
   signature: function signature(credentials, datetime) {
-    var cache = null
+    var cache = null;
     if (this.signatureCache) {
       var cache = cachedSecret[this.serviceName];
     }

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -15,9 +15,10 @@ var expiresHeader = 'presigned-expires';
  * @api private
  */
 AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
-  constructor: function V4(request, serviceName) {
+  constructor: function V4(request, serviceName, signatureCache) {
     AWS.Signers.RequestSigner.call(this, request);
     this.serviceName = serviceName;
+    this.signatureCache = signatureCache;
   },
 
   algorithm: 'AWS4-HMAC-SHA256',
@@ -89,7 +90,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   signature: function signature(credentials, datetime) {
     var cache = cachedSecret[this.serviceName];
     var date = datetime.substr(0, 8);
-    if (!cache ||
+    if (!cache || !this.signatureCache ||
         cache.akid !== credentials.accessKeyId ||
         cache.region !== this.request.region ||
         cache.date !== date) {

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -88,17 +88,27 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   },
 
   signature: function signature(credentials, datetime) {
-    var cache = cachedSecret[this.serviceName];
-    var date = datetime.substr(0, 8);
-    if (!cache || !this.signatureCache ||
+    var cache = null
+    if (this.signatureCache) {
+      var cache = cachedSecret[this.serviceName];
+      var date = datetime.substr(0, 8);
+    }
+
+    if (!cache ||
         cache.akid !== credentials.accessKeyId ||
         cache.region !== this.request.region ||
         cache.date !== date) {
+
       var kSecret = credentials.secretAccessKey;
       var kDate = AWS.util.crypto.hmac('AWS4' + kSecret, date, 'buffer');
       var kRegion = AWS.util.crypto.hmac(kDate, this.request.region, 'buffer');
       var kService = AWS.util.crypto.hmac(kRegion, this.serviceName, 'buffer');
       var kCredentials = AWS.util.crypto.hmac(kService, 'aws4_request', 'buffer');
+
+      if (!this.signatureCache) {
+        return AWS.util.crypto.hmac(kCredentials, this.stringToSign(datetime), 'hex');
+      }
+
       cachedSecret[this.serviceName] = {
         region: this.request.region, date: date,
         key: kCredentials, akid: credentials.accessKeyId

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -91,8 +91,8 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     var cache = null
     if (this.signatureCache) {
       var cache = cachedSecret[this.serviceName];
-      var date = datetime.substr(0, 8);
     }
+    var date = datetime.substr(0, 8);
 
     if (!cache ||
         cache.akid !== credentials.accessKeyId ||

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -11,8 +11,8 @@ buildRequest = ->
   req.httpRequest.headers['X-Amz-User-Agent'] = 'aws-sdk-js/0.1'
   req.httpRequest
 
-buildSigner = (request) ->
-  return new AWS.Signers.V4(request || buildRequest(), 'dynamodb')
+buildSigner = (request, signatureCache) ->
+  return new AWS.Signers.V4(request || buildRequest(), 'dynamodb', signatureCache || true)
 
 describe 'AWS.Signers.V4', ->
   date = new Date(1935346573456)
@@ -80,6 +80,12 @@ describe 'AWS.Signers.V4', ->
         expect(calls.length).to.equal(callCount + 1)
         signer.signature(creds, datetime)
         expect(calls.length).to.equal(callCount + 2)
+
+      it 'busts cache if caching is disabled', ->
+        signer = buildSigner(null, false)
+        callCount = calls.length
+        signer.signature(creds, datetime)
+        expect(calls.length).to.equal(callCount + 5)
 
       it 'busts cache if region changes', ->
         signer.request.region = 'new-region'


### PR DESCRIPTION
We use the AWS SDK both for our own purposes and for requests of users. In the former case, it is good that the v4 signatures are cached. In the latter, however, the Access Key Id is mostly different between subsequent requests, making caching unnecessary.

What's even more important, when users make a request with an invalid secret access key, the signature is cached as well.

Therefore, this pull requests allows one to disable caching of the signature for a specific configuration.