### PR TITLE
Fix minor typo in temporary_credentials.js

### DIFF
--- a/lib/credentials/temporary_credentials.js
+++ b/lib/credentials/temporary_credentials.js
@@ -41,7 +41,7 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
    *   {AWS.STS.assumeRole} or {AWS.STS.getSessionToken} operations.
    *   If a `RoleArn` parameter is passed in, credentials will be based on the
    *   IAM role.
-   * @example Creating a new credenials object for generic temporary credentials
+   * @example Creating a new credentials object for generic temporary credentials
    *   AWS.config.credentials = new AWS.TemporaryCredentials();
    * @example Creating a new credentials object for an IAM role
    *   AWS.config.credentials = new AWS.TemporaryCredentials({


### PR DESCRIPTION
'credenials' -> 'credentials'