### PR TITLE
fix issue when output is configured to return list

### DIFF
--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -56,7 +56,9 @@ function extractData(resp) {
   } else {
     var data = resp.data;
     Json.extractData(resp);
-    resp.data = util.merge(data, resp.data);
+    resp.data = Array.isArray(resp.data) ?
+      resp.data :
+      util.merge(data, resp.data);
   }
 }
 


### PR DESCRIPTION
configure output as list 
example
```json
"Search": {
      "http":{
        "method":"POST",
        "requestUri":"/account/search"
      },
      "name":"Search",
      "input":{"shape":"SearchAccountRequest"},
      "output":{"shape":"AccountList"}
    },

"AccountList":{
      "type":"list",
      "member":{"shape":"Account"}
    }
```

use protocol rest-json
when it is returned in method extractData line 57 rep.data is {}

after parsing rep.data will be array (returned as body from server)
but  util.merge(data, resp.data); will merge ({}, [a,b])
as result it will be { '0': a, '1':b}
instead of array