### PR TITLE
Lowercase the key when setting mapped httpRequest headers

### DIFF
--- a/lib/protocol/rest.js
+++ b/lib/protocol/rest.js
@@ -68,7 +68,7 @@ function populateHeaders(req) {
 
     if (member.location === 'headers' && member.type === 'map') {
       util.each(value, function(key, memberValue) {
-        req.httpRequest.headers[member.name + key] = memberValue;
+        req.httpRequest.headers[member.name + key.toLowerCase()] = memberValue;
       });
     } else if (member.location === 'header') {
       value = member.toWireFormat(value).toString();

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -642,6 +642,10 @@ describe 'AWS.S3', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=J%2BnWZ0lPUfLV0kio8ONhJmAttGc%3D&x-amz-security-token=session')
 
+    it 'gets a signed URL for putObject with Metadata', ->
+      url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key', Metadata: {someKey: 'someValue'})
+      expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=5Lcbv0WLGWseQhtmNQ8WwIpX6Kw%3D&x-amz-meta-somekey=someValue&x-amz-security-token=session')
+
     it 'gets a signed URL for putObject with special characters', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: '!@#$%^&*();\':"{}[],./?`~')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/%21%40%23%24%25%5E%26%2A%28%29%3B%27%3A%22%7B%7D%5B%5D%2C./%3F%60~?AWSAccessKeyId=akid&Expires=900&Signature=9nEltJACZKsriZqU2cmRel6g8LQ%3D&x-amz-security-token=session')


### PR DESCRIPTION
This ensures that a metadata property like "someVal" will correctly
get mapped to an all-lowercased header "x-amz-meta-someval".

Fixes #747 

This will lowercase all mapped header keys which may not be ideal. I'm not sure what other important cases there may be, but none of the tests failed after making this change. If there is a way to explicitly target lowercasing only the Metadata keys that may be a better fix. Happy to change this PR if that is warranted.