### PR TITLE
Fixes issue where S3 would reject presigned URLs that contained mixed-case Metadata

### DIFF
--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -49,6 +49,9 @@ function signedUrlSigner(request) {
 
   AWS.util.each(request.httpRequest.headers, function (key, value) {
     if (key === expiresHeader) key = 'Expires';
+    if (key.indexOf('x-amz-') === 0) {
+      key = key.toLowerCase();
+    }
     queryParams[key] = value;
   });
   delete request.httpRequest.headers[expiresHeader];

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -644,6 +644,10 @@ describe 'AWS.S3', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=J%2BnWZ0lPUfLV0kio8ONhJmAttGc%3D&x-amz-security-token=session')
 
+    it 'gets a signed URL for putObject with Metadata', ->
+      url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key', Metadata: {someKey: 'someValue'})
+      expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=5Lcbv0WLGWseQhtmNQ8WwIpX6Kw%3D&x-amz-meta-somekey=someValue&x-amz-security-token=session')
+
     it 'gets a signed URL for putObject with special characters', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: '!@#$%^&*();\':"{}[],./?`~')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/%21%40%23%24%25%5E%26%2A%28%29%3B%27%3A%22%7B%7D%5B%5D%2C./%3F%60~?AWSAccessKeyId=akid&Expires=900&Signature=9nEltJACZKsriZqU2cmRel6g8LQ%3D&x-amz-security-token=session')


### PR DESCRIPTION
Fixes issue where S3 would reject presigned URLs that contained mixed-case Metadata

Includes tests from pull request #748 by @bantic
Fixes #747 

cc @jeskew @trevorrowe 