### PR TITLE
Fix typo in document client example

### DIFF
--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -331,7 +331,7 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    *  var docClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.updateItem(params, function(err, data) {
+   *  docClient.update(params, function(err, data) {
    *     if (err) console.log(err);
    *     else console.log(data);
    *  });


### PR DESCRIPTION
Fix example documentation in DynamoDB document client.

CC  @chrisradek 