### PR TITLE
Managed Upload: Allow readable streams in any environment

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -158,20 +158,17 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     var runFill = true;
     if (self.sliceFn) {
       self.fillQueue = self.fillBuffer;
-    } else if (AWS.util.isNode()) {
-      var Stream = AWS.util.nodeRequire('stream').Stream;
-      if (self.body instanceof Stream) {
-        runFill = false;
-        self.fillQueue = self.fillStream;
-        self.partBuffers = [];
-        self.body.
-          on('readable', function() { self.fillQueue(); }).
-          on('end', function() {
-            self.isDoneChunking = true;
-            self.numParts = self.totalPartNumbers;
-            self.fillQueue.call(self);
-          });
-      }
+    } else if (AWS.util.isReadableStream(self.body)) {
+      runFill = false;
+      self.fillQueue = self.fillStream;
+      self.partBuffers = [];
+      self.body.
+        on('readable', function() { self.fillQueue(); }).
+        on('end', function() {
+          self.isDoneChunking = true;
+          self.numParts = self.totalPartNumbers;
+          self.fillQueue.call(self);
+        });
     }
 
     if (runFill) self.fillQueue.call(self);

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,6 +43,12 @@ var util = {
     return require(util.isNode() ? module1 : module2);
   },
 
+  isReadableStream: function isReadableStream(obj) {
+    return typeof obj.read === 'function' &&
+      typeof obj._read === 'function' &&
+      typeof obj.on === 'function';
+  },
+
   uriEscape: function uriEscape(string) {
     var output = encodeURIComponent(string);
     output = output.replace(/[^A-Za-z0-9_.~\-%]+/g, escape);


### PR DESCRIPTION
This patch will allow any object that implements the ReadableStream
interface to be passed to the Body of a Managed Upload.

For example, one may create streams for the browser by using the
`stream` module with browserify.

addresses https://github.com/aws/aws-sdk-js/issues/771
