### PR TITLE
Managed Upload: Support resuming streams

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -155,6 +155,8 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     self.failed = false;
     self.callback = callback || function(err) { if (err) throw err; };
 
+    self.resumeUploads();
+
     var runFill = true;
     if (self.sliceFn) {
       self.fillQueue = self.fillBuffer;
@@ -163,7 +165,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       if (self.body instanceof Stream) {
         runFill = false;
         self.fillQueue = self.fillStream;
-        self.partBuffers = [];
+        if (!self.partBuffers) self.partBuffers = [];
         self.body.
           on('readable', function() { self.fillQueue(); }).
           on('end', function() {
@@ -271,6 +273,11 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    * @api private
    */
   totalUploadedBytes: 0,
+
+  /**
+   * @api private
+   */
+  totalSuccessfullyUploadedBytes: 0,
 
   /**
    * @api private
@@ -423,29 +430,18 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       return null;
     }
 
-    if (self.completeInfo[partNumber] && self.completeInfo[partNumber].ETag !== null) {
-      return null; // Already uploaded this part.
-    }
-
+    self.parts[partNumber] = {
+      chunk: chunk,
+      partNumber: partNumber,
+      request: null,
+      status: 'queued'
+    };
     self.activeParts++;
-    if (!self.service.config.params.UploadId) {
 
-      if (!self.multipartReq) { // create multipart
-        self.multipartReq = self.service.createMultipartUpload();
-        self.multipartReq.on('success', function(resp) {
-          self.service.config.params.UploadId = resp.data.UploadId;
-          self.multipartReq = null;
-        });
-        self.queueChunks(chunk, partNumber);
-        self.multipartReq.on('error', function(err) {
-          self.cleanup(err);
-        });
-        self.multipartReq.send();
-      } else {
-        self.queueChunks(chunk, partNumber);
-      }
-    } else { // multipart is created, just send
+    if (self.service.config.params.UploadId) {
       self.uploadPart(chunk, partNumber);
+    } else {
+      self.createMultipartUpload();
     }
   },
 
@@ -465,14 +461,13 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     self.completeInfo[partNumber] = partInfo;
 
     var req = self.service.uploadPart(partParams);
-    self.parts[partNumber] = req;
+    var part = self.parts[partNumber];
+    part.request = req;
+    part.status = 'uploading';
     req._lastUploadedBytes = 0;
     req._managedUpload = self;
     req.on('httpUploadProgress', self.progress);
     req.send(function(err, data) {
-      delete self.parts[partParams.PartNumber];
-      self.activeParts--;
-
       if (!err && (!data || !data.ETag)) {
         var message = 'No access to ETag property on response.';
         if (AWS.util.isBrowser()) {
@@ -485,8 +480,14 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       }
       if (err) return self.cleanup(err);
 
+
       partInfo.ETag = data.ETag;
       self.doneParts++;
+
+      self.totalSuccessfullyUploadedBytes += chunk.length;
+      delete self.parts[partParams.PartNumber];
+      self.activeParts--;
+
       if (self.isDoneChunking && self.doneParts === self.numParts) {
         self.finishMultiPart();
       } else {
@@ -498,11 +499,41 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   /**
    * @api private
    */
-  queueChunks: function queueChunks(chunk, partNumber) {
+  createMultipartUpload: function createMultipartUpload() {
     var self = this;
-    self.multipartReq.on('success', function() {
-      self.uploadPart(chunk, partNumber);
+
+    if (self.multipartReq) return;
+
+    self.multipartReq = self.service.createMultipartUpload();
+    self.multipartReq.on('success', function(resp) {
+      self.service.config.params.UploadId = resp.data.UploadId;
+      self.multipartReq = null;
+      self.resumeUploads();
     });
+
+    self.multipartReq.on('error', function(err) {
+      self.multipartReq = null;
+      self.cleanup(err);
+    });
+
+    self.multipartReq.send();
+  },
+
+  /**
+   * @api private
+   */
+  resumeUploads: function resumeUploads() {
+    var self = this;
+
+    if (self.service.config.params.UploadId) {
+      AWS.util.each(self.parts, function(_, part) {
+        if (part.status !== 'uploading') {
+          self.uploadPart(part.chunk, part.partNumber);
+        }
+      });
+    } else {
+      self.createMultipartUpload();
+    }
   },
 
   /**
@@ -513,11 +544,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     if (self.failed) return;
 
     // clean up stream
-    if (typeof self.body.removeAllListeners === 'function' &&
-        typeof self.body.resume === 'function') {
+    if (typeof self.body.removeAllListeners === 'function') {
       self.body.removeAllListeners('readable');
       self.body.removeAllListeners('end');
-      self.body.resume();
     }
 
     if (self.service.config.params.UploadId && !self.leavePartsOnError) {
@@ -525,15 +554,23 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     }
 
     AWS.util.each(self.parts, function(partNumber, part) {
-      part.removeAllListeners('complete');
-      part.abort();
+      if (part.request) {
+        part.request.removeAllListeners('complete');
+        part.request.removeAllListeners('httpUploadProgress');
+        part.request.abort();
+      }
+      part.status = 'failed';
     });
 
-    self.activeParts = 0;
-    self.partPos = 0;
-    self.numParts = 0;
-    self.totalPartNumbers = 0;
-    self.parts = {};
+    if (!self.leavePartsOnError) {
+      self.activeParts = 0;
+      self.partPos = 0;
+      self.numParts = 0;
+      self.totalPartNumbers = 0;
+      self.parts = {};
+    }
+
+    self.totalUploadedBytes = self.totalSuccessfullyUploadedBytes;
     self.failed = true;
     self.callback(err);
   },


### PR DESCRIPTION
Previously we would discard the read chunks of a stream on success or
failure of a part upload. This patch will make it discard the chunk
only on success so that when `leavePartsOnError` is set to `true`, these
parts can be reuploaded with the saved chunks still in memory.

There are also changes with how parts are queued when waiting for the
`createMultipartUpload` request. They're queued using the `self.parts`
object instead of via event handlers. This makes retry possible if the
`createMultipartUpload` request fails.

We also have to make sure not to discard the `partBuffers` from a
previous `send` when calling `send` again. Otherwise there will be lost
data.

This patch also fixes an inaccuracy with `totalUploadedBytes` when
uploads are aborted and resumed. Since we're retrying parts that have
failed, `totalUploadedBytes` should be reset to the last known
successfully uploaded bytes. We track that in the
`totalSuccessfullyUploadedBytes` property.

Also I am not sure why we call `stream.resume()` in the cleanup step.
This will drain the stream and will make it unreadable when the upload
is resumed.
addresses https://github.com/aws/aws-sdk-js/issues/777

This patch also probably fixes https://github.com/aws/aws-sdk-js/issues/778
