### PR TITLE
Add/error request ids

### DIFF
--- a/lib/services/ec2.js
+++ b/lib/services/ec2.js
@@ -57,5 +57,6 @@ AWS.util.update(AWS.EC2.prototype, {
         message: null
       });
     }
+    resp.error.requestId = data.RequestID || null;
   }
 });

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -317,6 +317,8 @@ AWS.util.update(AWS.S3.prototype, {
 
     var code = resp.httpResponse.statusCode;
     var body = resp.httpResponse.body || '';
+    var requestId = resp.requestId;
+    var extendedRequestId = resp.httpResponse.headers ? resp.httpResponse.headers['x-amz-id-2'] : null;
     if (codes[code] && body.length === 0) {
       resp.error = AWS.util.error(new Error(), {
         code: codes[resp.httpResponse.statusCode],
@@ -330,6 +332,8 @@ AWS.util.update(AWS.S3.prototype, {
         region: data.Region || null
       });
     }
+    resp.error.requestId = requestId || null;
+    resp.error.extendedRequestId = extendedRequestId || null;
   },
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -801,6 +801,10 @@ var util = {
     if (requestId) {
       resp.requestId = requestId;
     }
+
+    if (resp.error) {
+      resp.error.requestId = requestId;
+    }
   }
 };
 

--- a/test/services/ec2.spec.coffee
+++ b/test/services/ec2.spec.coffee
@@ -86,3 +86,6 @@ describe 'AWS.EC2', ->
           expect(error.message).to.equal(null)
           expect(data).to.equal(null)
 
+      it 'extracts the request id', ->
+        expect(error.requestId).to.equal('ab123mno-6432-dceb-asdf-123mno543123')
+

--- a/test/services/ec2.spec.coffee
+++ b/test/services/ec2.spec.coffee
@@ -87,5 +87,7 @@ describe 'AWS.EC2', ->
           expect(data).to.equal(null)
 
       it 'extracts the request id', ->
-        expect(error.requestId).to.equal('ab123mno-6432-dceb-asdf-123mno543123')
+        parse (error, data) ->
+          expect(error.requestId).to.equal('ab123mno-6432-dceb-asdf-123mno543123')
+          expect(data).to.equal(null)
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -307,6 +307,7 @@ describe 'AWS.S3', ->
       resp = new AWS.Response(req)
       resp.httpResponse.body = new Buffer(body || '')
       resp.httpResponse.statusCode = statusCode
+      resp.httpResponse.headers = {'x-amz-request-id': 'RequestId', 'x-amz-id-2': 'ExtendedRequestId'}
       req.emit('extractError', [resp])
       resp.error
 
@@ -340,6 +341,11 @@ describe 'AWS.S3', ->
         """
       error = extractError(400, body)
       expect(error.region).to.equal('eu-west-1')
+
+    it 'extracts the request ids', ->
+      error = extractError(400)
+      expect(error.requestId).to.equal('RequestId')
+      expect(error.extendedRequestId).to.equal('ExtendedRequestId')
 
     it 'misc errors not known to return an empty body', ->
       error = extractError(412) # made up

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -682,3 +682,10 @@ describe 'AWS.util.extractRequestId', ->
     req.send()
     AWS.util.extractRequestId(req.response)
     expect(req.response.requestId).to.equal('RequestId1')
+
+  it 'sets requestId on the error on error status codes', ->
+    helpers.mockHttpResponse 403, {'x-amz-request-id': 'RequestId1'}
+    req = service.sample()
+    req.send()
+    AWS.util.extractRequestId(req.response)
+    expect(req.response.error.requestId).to.equal('RequestId1')


### PR DESCRIPTION
This pr will update errors that come back from service calls to include request ids for easier access.  Currently, `requestIds` are available on the `response` object that is bound to the callback passed into service operation calls.  However, in some high-level abstractions, like `s3.upload`, the response isn't bound to the callback and if an error is returned by the service, there isn't a way to access the `requestId`.

This also exposes the `x-amz-id-2` header value provided by S3 as `extendedRequestId` for S3 errors.

/cc @jeskew 