### PR TITLE
S3 Encrypted Client

### DIFF
--- a/lib/s3/encryption.js
+++ b/lib/s3/encryption.js
@@ -1,0 +1,20 @@
+var AWS = require('../core');
+
+AWS.S3.Encryption = AWS.util.inherit({
+});
+
+/* sub-modules */
+require('./encryption/client');
+require('./encryption/decrypt_handler');
+require('./encryption/default_cipher_provider');
+require('./encryption/key_provider');
+require('./encryption/default_key_provider');
+require('./encryption/encrypt_handler');
+require('./encryption/errors');
+require('./encryption/io_decrypter');
+require('./encryption/io_encrypter');
+require('./encryption/kms_cipher_provider');
+require('./encryption/materials');
+require('./encryption/utils');
+
+module.exports = AWS.S3.Encryption;

--- a/lib/s3/encryption/client.js
+++ b/lib/s3/encryption/client.js
@@ -38,16 +38,16 @@ var AWS = require('../../core');
  *     key = OpenSSL::PKey::RSA.new(1024)
  *
  *     // encryption client
- *     s3 = Aws::S3::Encryption::Client.new(encryption_key: key)
+ *     s3 = new Aws.S3.Encryption.Client(encryption_key: key)
  *
  *     // round-trip an object, encrypted/decrypted locally
- *     s3.put_object(bucket:'aws-sdk', key:'secret', body:'handshake')
- *     s3.get_object(bucket:'aws-sdk', key:'secret').body.read
+ *     s3.putObject(bucket:'aws-sdk', key:'secret', body:'handshake')
+ *     s3.getObject(bucket:'aws-sdk', key:'secret')
  *     #=> 'handshake'
  *
  *     // reading encrypted object without the encryption client
  *     // results in the getting the cipher text
- *     Aws::S3::Client.new.get_object(bucket:'aws-sdk', key:'secret').body.read
+ *     (new Aws.S3.Client(bucket:'aws-sdk', key:'secret')).getObject()
  *     #=> "... cipher text ..."
  *
  * ## Keys
@@ -79,10 +79,11 @@ var AWS = require('../../core');
  * then KMS will be used to generate, encrypt and decrypt object keys.
  *
  *     // keep track of the kms key id
- *     kms = Aws::KMS::Client.new
- *     key_id = kms.create_key.key_metadata.key_id
- *
- *     Aws::S3::Encryption::Client.new(
+ *     kms = new Aws.KMS()
+ *     kms.createKey(function(err, metadata){
+ *        key_id = metadata.key_id;
+ *     });
+ *     new Aws.S3.Encryption.Client(
  *       kms_key_id: key_id,
  *       kms_client: kms,
  *     )
@@ -252,40 +253,45 @@ var AWS = require('../../core');
   //attr_reader :instruction_file_suffix,
 
   /* Uploads an object to Amazon S3, encrypting data client-side.
-   * See {S3::Client#put_object} for documentation on accepted
+   * See {S3::Client#putObject} for documentation on accepted
    * request parameters.
-   * @option (see S3::Client#put_object)
-   * @return (see S3::Client#put_object)
-   * @see S3::Client#put_object
+   * @option (see S3::Client#putObject)
+   * @return (see S3::Client#putObject)
+   * @see S3::Client#putObject
    */
-  putObject: function( params ) {
+  putObject: function( params, callback ) {
+    // fallbacks
     params = params || {};
-    // create request
-    req = this.client.makeRequest('putObject', params );
+    callback = callback || function() {};
+    params = this.normalParams(params);
+    // classes
+    var EncryptHandler = AWS.S3.Encryption.EncryptHandler;
     //req.handlers.add(EncryptHandler, { priority: 95 });
+    // always update cipher ?
+    var cipher_provider = this.cipherProvider(params);
+    // create request
+    var req = this.client.makeRequest('putObject', this.filterParams(params) );
     // encryption meta
-    req.encryption = {
-      cipher_provider: this.cipher_provider,
+    req['encryption'] = {
+      cipher_provider: cipher_provider,
       envelope_location: this.envelope_location,
       instruction_file_suffix: this.instruction_file_suffix,
     }
     // add event listeners
-    AWS.S3.Encryption.EncryptHandler.call( req );
-    // process request
-    req.send(function(err, res) {
-      console.log(err, res);
-      // wait for the message to get decrypted before returning to the callback
-      //DecryptHandler.on('decrypted', function( decrypted ) {
-      //  res.Body = decrypted;
-      //  callback(err, res);
-      //});
+    EncryptHandler.call( req );
+    EncryptHandler.on('encrypted', function() {
+      // process request
+      req.send(callback);
+    });
+    EncryptHandler.on('error', function( err ) {
+      callback(err);
     });
     return req;
   },
 
   /*
    * Gets an object from Amazon S3, decrypting  data locally.
-   * See {S3::Client#get_object} for documentation on accepted
+   * See {S3::Client#getObject} for documentation on accepted
    * request parameters.
    * @option params [String] :instruction_file_suffix The suffix
    *   used to find the instruction file containing the encryption
@@ -293,25 +299,26 @@ var AWS = require('../../core');
    *   is stored in the object metadata. Defaults to
    *   {#instruction_file_suffix}.
    * @option params [String] :instruction_file_suffix
-   * @option (see S3::Client#get_object)
-   * @return (see S3::Client#get_object)
-   * @see S3::Client#get_object
+   * @option (see S3::Client#getObject)
+   * @return (see S3::Client#getObject)
+   * @see S3::Client#getObject
    * @note The `:range` request parameter is not yet supported.
    */
   getObject: function( params, callback ) {
     // fallbacks
     params = params || {};
     callback = callback || function() {};
+    params = this.normalParams(params);
     // prerequisites
     if ( params['range'] ) {
-      //raise NotImplementedError, '#get_object with :range not supported yet'
+      //raise NotImplementedError, '#getObject with :range not supported yet'
     }
     var self = this;
     var DecryptHandler = AWS.S3.Encryption.DecryptHandler;
     var envelope_location,
       instruction_file_suffix = this.envelope_options(params);
     // create request
-    var req = this.client.makeRequest('getObject', params );
+    var req = this.client.makeRequest('getObject', this.filterParams(params) );
     // encryption meta
     req['encryption'] = {
       cipher_provider: this.cipher_provider,
@@ -322,6 +329,7 @@ var AWS = require('../../core');
     // add event listeners
     //req.handlers.add(DecryptHandler)
     DecryptHandler.call( req );
+
     // events
     var decrypt_body, decrypt_error, response;
     DecryptHandler.on('error', function( err ) {
@@ -355,6 +363,8 @@ var AWS = require('../../core');
     delete opt['encryption_key'];
     delete opt['envelope_location'];
     delete opt['instruction_file_suffix'];
+    delete opt['metadata'];
+    delete opt['body'];
     return new AWS.S3( opt );
   },
 
@@ -364,10 +374,12 @@ var AWS = require('../../core');
     // create new KMS client
     // find region from the options / fallback to the store config
     var region = this.client.config.region;
-    if ( options['kms_cmk_id'] ) {
-      region = options['kms_cmk_id'].replace('arn:aws:kms:', '');
+    var id = options['kms_cmk_id'] || options['kms_key_id'] || false;
+    if ( id ) {
+      region = id.replace('arn:aws:kms:', '');
       region = region.substr(0, region.indexOf(':') );
     }
+
     return new AWS.KMS({
         apiVersion: '2014-11-01',
         region: region,
@@ -381,12 +393,13 @@ var AWS = require('../../core');
     var DefaultCipherProvider = AWS.S3.Encryption.DefaultCipherProvider;
     //
     var self = this;
-    var key = options['kms_key_id'] || options['kms_cmk_id'] || false;
+    var id = options['kms_key_id'] || options['kms_cmk_id'] || false;
     //
-    if ( key ) {
+    if ( id ) {
       return new KmsCipherProvider({
-        kms_key_id: key,
+        kms_key_id: id,
         kms_client: self.kms_client(options),
+        encryption_key: options['encryption_key'] || null
       });
     } else {
       // kept here for backwards compatability, {#key_provider} is deprecated
@@ -451,6 +464,43 @@ var AWS = require('../../core');
         message: msg
       });
     }
+  },
+
+  // converting camel case variables to normal underscore vars
+  normalParams: function( params ){
+    // normalize kms id
+    if( params['KMSKeyId'] ){
+      params['kms_key_id'] = params['KMSKeyId'];
+      delete params['KMSKeyId'];
+    }
+    if( params['KMSClient'] ){
+      params['kms_client'] = params['KMSClient'];
+      delete params['KMSClient'];
+    }
+    if( params['EncryptionKey'] ){
+      params['encryption_key'] = params['EncryptionKey'];
+      delete params['EncryptionKey'];
+    }
+    if( params['Body'] ){
+      params['body'] = params['Body'];
+      delete params['Body'];
+    }
+    return params;
+  },
+
+  // remove params before sending API requests
+  filterParams: function( params ){
+    // clone object
+    var filtered = JSON.parse( JSON.stringify( params ) );
+    delete filtered['kms_key_id'];
+    delete filtered['metadata'];
+    delete filtered['encryption_key'];
+    if( filtered['body'] ){
+      filtered['Body'] = filtered['body'];
+      delete filtered['body'];
+    }
+    return filtered;
+
   }
 
 });

--- a/lib/s3/encryption/client.js
+++ b/lib/s3/encryption/client.js
@@ -1,0 +1,444 @@
+var AWS = require('../../core');
+
+/* Provides an encryption client that encrypts and decrypts data client-side,
+ * storing the encrypted data in Amazon S3.
+ *
+ * This client uses a process called "envelope encryption". Your private
+ * encryption keys and plain-text of your data are **never** sent to
+ * Amazon S3. **If you loose your encryption keys, you will not be able to
+ * un-encrypt your data.**
+ *
+ * ## Envelope Encryption Overview
+ *
+ * The goal of envelope encryption is to combine the performance of
+ * fast symmetric encryption while maintaining the secure key management
+ * that asymmetric keys provide.
+ *
+ * A one-time-use symmetric key (envelope key) is generated client-side.
+ * This is used to encrypt the data client-side. This key is then
+ * encrypted by your master key and stored alongside your data in Amazon
+ * S3.
+ *
+ * When accessing your encrypted data with the encryption client,
+ * the encrypted envelope key is retrieved and decrypted client-side
+ * with your master key. The envelope key is then used to decrypt the
+ * data client-side.
+ *
+ * One of the benefits of envelope encryption is that if your master key
+ * is compromised, you have the option of jut re-encrypting the stored
+ * envelope symmetric keys, instead of re-encrypting all of the
+ * data in your account.
+ *
+ * ## Basic Usage
+ *
+ * The encryption client requires an {Aws::S3::Client}. If you do not
+ * provide a `:client`, then a client will be constructed for you.
+ *
+ *     require 'openssl'
+ *     key = OpenSSL::PKey::RSA.new(1024)
+ *
+ *     // encryption client
+ *     s3 = Aws::S3::Encryption::Client.new(encryption_key: key)
+ *
+ *     // round-trip an object, encrypted/decrypted locally
+ *     s3.put_object(bucket:'aws-sdk', key:'secret', body:'handshake')
+ *     s3.get_object(bucket:'aws-sdk', key:'secret').body.read
+ *     #=> 'handshake'
+ *
+ *     // reading encrypted object without the encryption client
+ *     // results in the getting the cipher text
+ *     Aws::S3::Client.new.get_object(bucket:'aws-sdk', key:'secret').body.read
+ *     #=> "... cipher text ..."
+ *
+ * ## Keys
+ *
+ * For client-side encryption to work, you must provide one of the following:
+ *
+ * * An encryption key
+ * * A {KeyProvider}
+ * * A KMS encryption key id
+ *
+ * ### An Encryption Key
+ *
+ * You can pass a single encryption key. This is used as a master key
+ * encrypting and decrypting all object keys.
+ *
+ *     key = OpenSSL::Cipher.new("AES-256-ECB").random_key // symmetric key
+ *     key = OpenSSL::PKey::RSA.new(1024) // asymmetric key pair
+ *
+ *     s3 = Aws::S3::Encryption::Client.new(encryption_key: key)
+ *
+ * ### Key Provider
+ *
+ * Alternatively, you can use a {KeyProvider}. A key provider makes
+ * it easy to work with multiple keys and simplifies key rotation.
+ *
+ * ### KMS Encryption Key Id
+ *
+ * If you pass the id to an AWS Key Management Service (KMS) key,
+ * then KMS will be used to generate, encrypt and decrypt object keys.
+ *
+ *     // keep track of the kms key id
+ *     kms = Aws::KMS::Client.new
+ *     key_id = kms.create_key.key_metadata.key_id
+ *
+ *     Aws::S3::Encryption::Client.new(
+ *       kms_key_id: key_id,
+ *       kms_client: kms,
+ *     )
+ *
+ * ## Custom Key Providers
+ *
+ * A {KeyProvider} is any object that responds to:
+ *
+ * * `#encryption_materials`
+ * * `#key_for(materials_description)`
+ *
+ * Here is a trivial implementation of an in-memory key provider.
+ * This is provided as a demonstration of the key provider interface,
+ * and should not be used in production:
+ *
+ *     KeyProvider: AWS.util.inherit({
+ *
+ *       initialize: function(default_key_name, keys){
+ *         this.keys = keys
+ *         this.encryption_materials = new AWS.S3.Encryption.Materials({
+ *           key: this.keys[default_key_name],
+ *           description: JSON.stringify({ key: default_key_name }),
+ *         })
+ *       },
+ *
+ *       key_for: function(matdesc){
+ *         key_name = JSON.parse(matdesc)['key']
+ *         if( key == @keys[key_name] ){
+ *           return key;
+ *         } else {
+ *           console.log("encryption key not found for: "+ matdesc);
+ *         }
+ *       }
+ *     });
+ *
+ * Given the above key provider, you can create an encryption client that
+ * chooses the key to use based on the materials description stored with
+ * the encrypted object. This makes it possible to use multiple keys
+ * and simplifies key rotation.
+ *
+ *     // uses "new-key" for encrypting objects, uses either for decrypting
+ *     keys = new AWS.S3.Encryption.KeyProvider('new-key', {
+ *       "old-key" => new Buffer("kM5UVbhE/4rtMZJfsadYEdm2vaKFsmV2f5+URSeUCV4=", 'base64' , 'utf8'),
+ *       "new-key" => new Buffer("w1WLio3agRWRTSJK/Ouh8NHoqRQ6fn5WbSXDTHjXMSo=", 'base64' , 'utf8'),
+ *     })
+ *
+ *     // chooses the key based on the materials description stored
+ *     // with the encrypted object
+ *     s3 = new AWS.S3.Encryption.Client({ key_provider: keys })
+ *
+ * ## Materials Description
+ *
+ * A materials description is a JSON document string that is stored
+ * in the metadata (or instruction file) of an encrypted object.
+ * The {DefaultKeyProvider} uses the empty JSON document `"{}"`.
+ *
+ * When building a key provider, you are free to store whatever
+ * information you need to identify the master key that was used
+ * to encrypt the object.
+ *
+ * ## Envelope Location
+ *
+ * By default, the encryption client store the encryption envelope
+ * with the object, as metadata. You can choose to have the envelope
+ * stored in a separate "instruction file". An instruction file
+ * is an object, with the key of the encrypted object, suffixed with
+ * `".instruction"`.
+ *
+ * Specify the `:envelope_location` option as `:instruction_file` to
+ * use an instruction file for storing the envelope.
+ *
+ *     // default behavior
+ *     s3 = new AWS.S3.Encryption.Client({
+ *       key_provider: ...,
+ *       envelope_location: :metadata,
+ *     })
+ *
+ *     // store envelope in a separate object
+ *     s3 = new Aws::S3::Encryption::Client.new(
+ *       key_provider: ...,
+ *       envelope_location: :instruction_file,
+ *       instruction_file_suffix: '.instruction' // default
+ *     )
+ *
+ * When using an instruction file, multiple requests are made when
+ * putting and getting the object. **This may cause issues if you are
+ * issuing concurrent PUT and GET requests to an encrypted object.**
+ */
+
+ AWS.S3.Encryption.Client = AWS.util.inherit({
+  //extend Deprecations
+
+  /* Creates a new encryption client. You must provide on of the following
+   * options:
+   *
+   * * `:encryption_key`
+   * * `:kms_key_id`
+   * * `:key_provider`
+   *
+   * You may also pass any other options accepted by {S3::Client#initialize}.
+   *
+   * @option options [S3::Client] :client A basic S3 client that is used
+   *   to make api calls. If a `:client` is not provided, a new {S3::Client}
+   *   will be constructed.
+   *
+   * @option options [OpenSSL::PKey::RSA, String] :encryption_key The master
+   *   key to use for encrypting/decrypting all objects.
+   *
+   * @option options [String] :kms_key_id When you provide a `:kms_key_id`,
+   *   then AWS Key Management Service (KMS) will be used to manage the
+   *   object encryption keys. By default a {KMS::Client} will be
+   *   constructed for KMS API calls. Alternatively, you can provide
+   *   your own via `:kms_client`.
+   *
+   * @option options [#key_for] :key_provider Any object that responds
+   *   to `#key_for`. This method should accept a materials description
+   *   JSON document string and return return an encryption key.
+   *
+   * @option options [Symbol] :envelope_location (:metadata) Where to
+   *   store the envelope encryption keys. By default, the envelope is
+   *   stored with the encrypted object. If you pass `:instruction_file`,
+   *   then the envelope is stored in a separate object in Amazon S3.
+   *
+   * @option options [String] :instruction_file_suffix ('.instruction')
+   *   When `:envelope_location` is `:instruction_file` then the
+   *   instruction file uses the object key with this suffix appended.
+   *
+   * @option options [KMS::Client] :kms_client A default {KMS::Client}
+   *   is constructed when using KMS to manage encryption keys.
+   */
+  constructor: function(options) {
+    var self = this;
+    //AWS.SequentialExecutor.call(self);
+    //if (!this.loadServiceClass) {
+    //  throw AWS.util.error(new Error(),
+    //    'Service must be constructed with `new\' operator');
+    //}
+    //var ServiceClass = this.loadServiceClass(options || {});
+    //if (ServiceClass) return new ServiceClass(options);
+    this.initialize(options);
+
+    //self.configure(options);
+  },
+
+  initialize: function( options ) {
+    options = options || {};
+    this.client = this.extract_client(options);
+    this.cipher_provider = this.cipherProvider(options);
+    this.envelope_location = this.extract_location(options);
+    this.instruction_file_suffix = this.extract_suffix(options);
+    return this;
+  },
+
+  // @return [S3::Client]
+  //attr_reader: client,
+
+  // @return [KeyProvider, nil] Returns `nil` if you are using
+  //   AWS Key Management Service (KMS).
+  //attr_reader: key_provider,
+
+  // @return [Symbol<:encryption_key, :instruction_file>]
+  //attr_reader: envelope_location,
+
+  // @return [String] When {#envelope_location} is `:instruction_file`,
+  //   the envelope is stored in the object with the object key suffixed
+  //   by this string.
+  //attr_reader :instruction_file_suffix,
+
+  /* Uploads an object to Amazon S3, encrypting data client-side.
+   * See {S3::Client#put_object} for documentation on accepted
+   * request parameters.
+   * @option (see S3::Client#put_object)
+   * @return (see S3::Client#put_object)
+   * @see S3::Client#put_object
+   */
+  putObject: function( params ) {
+    params = params || {};
+    // create request
+    req = this.client.makeRequest('putObject', params );
+    //req.handlers.add(EncryptHandler, { priority: 95 });
+    // encryption meta
+    req.encryption = {
+      cipher_provider: this.cipher_provider,
+      envelope_location: this.envelope_location,
+      instruction_file_suffix: this.instruction_file_suffix,
+    }
+    // add event listeners
+    AWS.S3.Encryption.EncryptHandler.call( req );
+    // process request
+    req.send();
+    return req;
+  },
+
+  /*
+   * Gets an object from Amazon S3, decrypting  data locally.
+   * See {S3::Client#get_object} for documentation on accepted
+   * request parameters.
+   * @option params [String] :instruction_file_suffix The suffix
+   *   used to find the instruction file containing the encryption
+   *   envelope. You should not set this option when the envelope
+   *   is stored in the object metadata. Defaults to
+   *   {#instruction_file_suffix}.
+   * @option params [String] :instruction_file_suffix
+   * @option (see S3::Client#get_object)
+   * @return (see S3::Client#get_object)
+   * @see S3::Client#get_object
+   * @note The `:range` request parameter is not yet supported.
+   */
+  getObject: function( params, callback ) {
+    // fallbacks
+    params = params || {};
+    callback = callback || function() {};
+    // prerequisites
+    if ( params['range'] ) {
+      //raise NotImplementedError, '#get_object with :range not supported yet'
+    }
+    var self = this;
+    var DecryptHandler = AWS.S3.Encryption.DecryptHandler;
+    var envelope_location,
+      instruction_file_suffix = this.envelope_options(params);
+    // create request
+    var req = this.client.makeRequest('getObject', params );
+    // encryption meta
+    req['encryption'] = {
+      cipher_provider: this.cipher_provider,
+      envelope_location: envelope_location,
+      instruction_file_suffix: instruction_file_suffix,
+      cipherProvider: this.cipherProvider.bind(self)
+    }
+    // add event listeners
+    //req.handlers.add(DecryptHandler)
+    DecryptHandler.call( req );
+    // process request
+    req.send(function(err, res) {
+      // wait for the message to get decrypted before returning to the callback
+      DecryptHandler.on('decrypted', function( decrypted ) {
+        res.Body = decrypted;
+        callback(err, res);
+      });
+    });
+    return req;
+  },
+
+  /**
+   * @api private
+   */
+  extract_client: function( options ) {
+    if ( options['client'] ) return options['client'];
+    // duplicate options (better way?)
+    var opt = JSON.parse( JSON.stringify( options ) );
+    // remove unwanted options
+    delete opt['kms_key_id'];
+    delete opt['kms_client'];
+    delete opt['key_provider'];
+    delete opt['encryption_key'];
+    delete opt['envelope_location'];
+    delete opt['instruction_file_suffix'];
+    return new AWS.S3( opt );
+  },
+
+  kms_client: function( options ) {
+    // exit now if we passed a client as part of the (init) options
+    if ( options['kms_client'] ) return options['kms_client'];
+    // create new KMS client
+    // find region from the options / fallback to the store config
+    var region = this.client.config.region;
+    if ( options['kms_cmk_id'] ) {
+      region = options['kms_cmk_id'].replace('arn:aws:kms:', '');
+      region = region.substr(0, region.indexOf(':') );
+    }
+    return new AWS.KMS({
+        apiVersion: '2014-11-01',
+        region: region,
+        credentials: this.client.config.credentials,
+    });
+  },
+
+  cipherProvider: function( options ) {
+    // classes
+    var KmsCipherProvider = AWS.S3.Encryption.KmsCipherProvider;
+    var DefaultCipherProvider = AWS.S3.Encryption.DefaultCipherProvider;
+    //
+    var self = this;
+    var key = options['kms_key_id'] || options['kms_cmk_id'] || false;
+    //
+    if ( key ) {
+      return new KmsCipherProvider({
+        kms_key_id: key,
+        kms_client: self.kms_client(options),
+      });
+    } else {
+      // kept here for backwards compatability, {#key_provider} is deprecated
+      this.key_provider = this.extract_key_provider(options);
+      return new DefaultCipherProvider({ key_provider: this.key_provider });
+    }
+  },
+
+  extract_key_provider: function(options) {
+    if ( options['key_provider'] ) {
+      return options['key_provider'];
+    //} else if ( options['encryption_key'] || options['kms_key_id'] ) {
+    } else {
+      // classes
+      var DefaultKeyProvider = AWS.S3.Encryption.DefaultKeyProvider;
+      return new DefaultKeyProvider(options);
+    } /* else {
+      var msg = 'you must pass a :kms_key_id, :key_provider, or :encryption_key';
+      //raise ArgumentError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+
+    }*/
+  },
+
+  envelope_options: function( params ) {
+    var location = params['envelope_location'] || this.envelope_location;
+    var suffix = params['instruction_file_suffix'];
+    // delete used params
+    delete params['envelope_location'];
+    delete params['instruction_file_suffix'];
+    if ( suffix ) {
+      return ['instruction_file', suffix];
+    } else {
+      return [location, this.instruction_file_suffix];
+    }
+  },
+
+  extract_location: function(options) {
+    location = options['envelope_location'] || this.metadata;
+    if ( ['metadata', 'instruction_file'].indexOf( location ) > -1 ) {
+      return location;
+    } else {
+      var msg = ':envelope_location must be :metadata or :instruction_file';
+      //msg << "got "+ location.toString()
+      //raise ArgumentError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+    }
+  },
+
+  extract_suffix: function(options) {
+    suffix = options['instruction_file_suffix'] || '.instruction';
+    if ( typeof suffix == 'string') {
+      return suffix;
+    } else {
+      var msg = ':instruction_file_suffix must be a String';
+      //raise ArgumentError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+    }
+  }
+
+});
+
+
+module.exports = AWS.S3.Encryption.Client;

--- a/lib/s3/encryption/client.js
+++ b/lib/s3/encryption/client.js
@@ -272,7 +272,14 @@ var AWS = require('../../core');
     // add event listeners
     AWS.S3.Encryption.EncryptHandler.call( req );
     // process request
-    req.send();
+    req.send(function(err, res) {
+      console.log(err, res);
+      // wait for the message to get decrypted before returning to the callback
+      //DecryptHandler.on('decrypted', function( decrypted ) {
+      //  res.Body = decrypted;
+      //  callback(err, res);
+      //});
+    });
     return req;
   },
 
@@ -315,13 +322,21 @@ var AWS = require('../../core');
     // add event listeners
     //req.handlers.add(DecryptHandler)
     DecryptHandler.call( req );
+    // events
+    var decrypt_body, decrypt_error, response;
+    DecryptHandler.on('error', function( err ) {
+      decrypt_error = err;
+    });
+    DecryptHandler.on('decrypted', function( decrypt_body ) {
+      response.Body = decrypt_body;
+      callback(null, response);
+    });
     // process request
     req.send(function(err, res) {
+      err = err || decrypt_error || false;
+      if( err ) return callback(err, res);
       // wait for the message to get decrypted before returning to the callback
-      DecryptHandler.on('decrypted', function( decrypted ) {
-        res.Body = decrypted;
-        callback(err, res);
-      });
+      response = res;
     });
     return req;
   },

--- a/lib/s3/encryption/client.js
+++ b/lib/s3/encryption/client.js
@@ -331,7 +331,7 @@ var AWS = require('../../core');
     DecryptHandler.call( req );
 
     // events
-    var decrypt_body, decrypt_error, response;
+    var decrypt_body, decrypt_error, response = {};
     DecryptHandler.on('error', function( err ) {
       decrypt_error = err;
     });

--- a/lib/s3/encryption/decrypt_handler.js
+++ b/lib/s3/encryption/decrypt_handler.js
@@ -1,0 +1,234 @@
+var AWS = require('../../core');
+
+var V1_ENVELOPE_KEYS = [
+  'x-amz-key',
+  'x-amz-iv',
+  'x-amz-matdesc'
+];
+
+var V2_ENVELOPE_KEYS = [
+  'x-amz-key-v2',
+  'x-amz-iv',
+  'x-amz-cek-alg',
+  'x-amz-wrap-alg',
+  'x-amz-matdesc'
+];
+
+var POSSIBLE_ENVELOPE_KEYS = V1_ENVELOPE_KEYS.concat( V2_ENVELOPE_KEYS.filter(function (item) {
+    return V1_ENVELOPE_KEYS.indexOf(item) < 0;
+}));
+
+var POSSIBLE_ENCRYPTION_FORMATS = [
+  'AES/CBC/PKCS5Padding',
+  'AES/GCM/NoPadding'
+]
+// possible to support
+//   RSA/ECB/OAEPWithSHA-256AndMGF1Padding
+
+AWS.S3.Encryption.DecryptHandler = AWS.util.update({
+  //< Seahorse::Client::Handler
+
+  /**
+   * @api private
+   */
+  call: function( context ) {
+    this.attach_http_event_listeners(context);
+    //this.handler.call(context);
+  },
+
+  /**
+   * @api private
+   */
+  attach_http_event_listeners: function(context) {
+    var self = this;
+    var req = context;
+    var headers, cipher, body;
+
+    context.on('httpHeaders', function(err, response) {
+      if ( err !== 200 ) return; // display error
+      headers = response;
+
+    });
+
+    //context.on('success', function(err, res) {
+    context.on('success', function(res) {
+      //if ( err !== 200  ) return; // display error
+      body = res.httpResponse.body;
+      // decrypt cipher
+      self.decryption_cipher(req, headers, function( err, response ) {
+        if ( err ) return; // error
+        cipher = response;
+        // optionally authenticate cipher
+        if ( headers['x-amz-meta-x-amz-unencrypted-content-length'] && (headers['content-length'] !== headers['x-amz-meta-x-amz-unencrypted-content-length']) ) {
+          var auth = body.slice( headers['x-amz-meta-x-amz-unencrypted-content-length'] );
+          body = body.slice( 0, headers['x-amz-meta-x-amz-unencrypted-content-length'] );
+          cipher.setAuthTag( auth );
+        }
+        // decrypt text
+        var text = self.decrypt_message(cipher, body);
+        res.httpResponse.body = text;
+        //res.httpResponse.decrypted = true;
+        self.trigger('decrypted', res.httpResponse.body);
+      });
+
+    });
+
+    context.on('error', function(err, res) {
+      console.log(err);
+      if ( res.httpResponse.body instanceof AWS.S3.Encryption.IODecrypter ) {
+        res.httpResponse.body = res.httpResponse.body.finalize();
+      }
+    });
+  },
+
+  // Helpers
+  // - events
+  on: function(e, callback) {
+    this._events = this._events || [];
+    this._events[e] = this._events[e] ||[];
+    this._events[e].push(callback);
+  },
+
+  trigger: function(e, params) {
+    var events = this._events[e] || false;
+    if ( !events ) return;
+    for (var i in events ) {
+      events[i](params);
+    }
+    // reset?
+    //delete this._events[trigger];
+  },
+
+  // - decryption
+  decryption_cipher: function(req, res, callback) {
+    var envelope = this.get_encryption_envelope(req, res);
+    if ( envelope ) {
+      // FIX: reset cipher_provider if not the right instance
+      if ( (envelope['x-amz-wrap-alg'] == 'kms') && !( req['encryption']['cipher_provider'] instanceof AWS.S3.Encryption.KmsCipherProvider ) ) {
+        var metadata = JSON.parse( envelope['x-amz-matdesc'] );
+        req['encryption']['cipher_provider'] = req['encryption'].cipherProvider(metadata);
+      }
+      req['encryption']['cipher_provider'].decryption_cipher(envelope, callback);
+    } else {
+      //raise Errors::DecryptionError,
+      var msg = 'unable to locate encyrption envelope';
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+    }
+  },
+
+  get_encryption_envelope: function(req, res) {
+    var metadata = ( typeof req['encryption']['envelope_location'] == 'undefined' );
+    if ( metadata ) {
+      return this.envelope_from_metadata(res) || this.envelope_from_instr_file(req);
+    } else {
+      return this.envelope_from_instr_file(req) || this.envelope_from_metadata(res);
+    }
+  },
+
+  envelope_from_metadata: function( headers ) {
+    var possible_envelope = {};
+    for ( var i in POSSIBLE_ENVELOPE_KEYS ) {
+      var suffix = POSSIBLE_ENVELOPE_KEYS[i];
+      //var value = context.httpResponse.headers['x-amz-meta-'+ suffix];
+      var value = headers['x-amz-meta-'+ suffix];
+      if ( value ) {
+        possible_envelope[suffix] = value;
+      }
+    }
+    return this.extract_envelope(possible_envelope);
+  },
+
+  // NOT WORKING
+  envelope_from_instr_file: function(context) {
+    return null;
+    suffix = context['encryption']['instruction_file_suffix'];
+    context.client.getObject({
+      bucket: context.params['bucket'],
+      key: context.params['key'] + suffix
+    }, function( err, response ) {
+      possible_envelope = JSON.parse( response );
+    });
+    return this.extract_envelope(possible_envelope);
+    //rescue S3::Errors::ServiceError, Json::ParseError
+    AWS.util.error(new Error(), {
+      message: 'Json::ParseError'
+    });
+    return null;
+  },
+
+  extract_envelope: function(hash) {
+    if ( hash['x-amz-key'] ) return this.v1_envelope(hash);
+    if ( hash['x-amz-key-v2'] ) return this.v2_envelope(hash);
+    var keys = Object.keys(hash);
+    if ( keys.match(/^x-amz-key-(.+)$/).length ) {
+      var msg = 'unsupported envelope encryption version #{$1}';
+      //raise Errors::DecryptionError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+      return false;
+    } else {
+      // no envelope found
+      return null;
+    }
+  },
+
+  decrypt_message: function(cipher, body) {
+    var IODecrypter = AWS.S3.Encryption.IODecrypter;
+    var decrypter= new IODecrypter(cipher, body);
+    var output = decrypter.finalize();
+    //if( decrypter.io.respond_to?(:rewind) ) decrypter.io.rewind;  // what's this?
+    //res.httpResponse = decrypter.io
+    return output;
+  },
+
+  v1_envelope: function(envelope) {
+    return envelope;
+  },
+
+  v2_envelope: function(envelope) {
+    if ( POSSIBLE_ENCRYPTION_FORMATS.indexOf( envelope['x-amz-cek-alg'] ) == -1 ) {
+      var alg = envelope['x-amz-cek-alg'].toString();
+      var msg = 'unsupported content encrypting key (cek) format: '+ alg;
+      //raise Errors::DecryptionError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+      return null;
+    }
+    if ( envelope['x-amz-wrap-alg'] !== 'kms' ) {
+      var alg = envelope['x-amz-wrap-alg'].toString();
+      var msg = 'unsupported key wrapping algorithm: '+ alg;
+      //raise Errors::DecryptionError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+      return null;
+    }
+
+    var keys = Object.keys(envelope).sort();
+    V2_ENVELOPE_KEYS = V2_ENVELOPE_KEYS.sort();
+    var keys_match = (V2_ENVELOPE_KEYS.length == keys.length) && keys.every(function(element, index) {
+        return element === V2_ENVELOPE_KEYS[index];
+    });
+
+    if ( !keys_match ) {
+      var msg = 'incomplete v2 encryption envelope:\n';
+      msg += '  expected: '+ V2_ENVELOPE_KEYS.join(',');
+      msg += '  got: '+ keys.join(',');
+      //raise Errors::DecryptionError, msg
+      AWS.util.error(new Error(), {
+        message: msg
+      });
+      return null;
+    }
+
+    return envelope;
+  }
+
+});
+
+
+module.exports = AWS.S3.Encryption.DecryptHandler;

--- a/lib/s3/encryption/decrypt_handler.js
+++ b/lib/s3/encryption/decrypt_handler.js
@@ -179,7 +179,7 @@ AWS.S3.Encryption.DecryptHandler = AWS.util.update({
 
   decrypt_message: function(cipher, body) {
     var IODecrypter = AWS.S3.Encryption.IODecrypter;
-    var decrypter= new IODecrypter(cipher, body);
+    var decrypter = new IODecrypter(cipher, body);
     var output = decrypter.finalize();
     //if( decrypter.io.respond_to?(:rewind) ) decrypter.io.rewind;  // what's this?
     //res.httpResponse = decrypter.io

--- a/lib/s3/encryption/decrypt_handler.js
+++ b/lib/s3/encryption/decrypt_handler.js
@@ -56,7 +56,7 @@ AWS.S3.Encryption.DecryptHandler = AWS.util.update({
       body = res.httpResponse.body;
       // decrypt cipher
       self.decryption_cipher(req, headers, function( err, response ) {
-        if ( err ) return; // error
+        if ( err ) return self.trigger('error', err); // error
         cipher = response;
         // optionally authenticate cipher
         if ( headers['x-amz-meta-x-amz-unencrypted-content-length'] && (headers['content-length'] !== headers['x-amz-meta-x-amz-unencrypted-content-length']) ) {
@@ -111,10 +111,11 @@ AWS.S3.Encryption.DecryptHandler = AWS.util.update({
       req['encryption']['cipher_provider'].decryption_cipher(envelope, callback);
     } else {
       //raise Errors::DecryptionError,
-      var msg = 'unable to locate encyrption envelope';
+      var msg = 'unable to locate encryption envelope';
       AWS.util.error(new Error(), {
         message: msg
       });
+      callback(msg);
     }
   },
 
@@ -162,7 +163,8 @@ AWS.S3.Encryption.DecryptHandler = AWS.util.update({
     if ( hash['x-amz-key'] ) return this.v1_envelope(hash);
     if ( hash['x-amz-key-v2'] ) return this.v2_envelope(hash);
     var keys = Object.keys(hash);
-    if ( keys.match(/^x-amz-key-(.+)$/).length ) {
+    var encryptions = keys.filter(function(value){ return (value.indexOf('x-amz-key-') == 0) });
+    if ( encryptions.length ){
       var msg = 'unsupported envelope encryption version #{$1}';
       //raise Errors::DecryptionError, msg
       AWS.util.error(new Error(), {

--- a/lib/s3/encryption/default_cipher_provider.js
+++ b/lib/s3/encryption/default_cipher_provider.js
@@ -1,0 +1,66 @@
+var AWS = require('../../core'),
+    crypto = require('crypto');
+
+AWS.S3.Encryption.DefaultCipherProvider = AWS.util.inherit({
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+  /**
+   * @api private
+   */
+  initialize: function( options ) {
+    options = options || {};
+    this.key_provider = options['key_provider'];
+  },
+
+  // @return [Array<Hash,Cipher>] Creates an returns a new encryption
+  //   envelope and encryption cipher.
+  encryption_cipher: function() {
+    var envelope = {
+      'x-amz-key': Utils.encode64(encrypt(envelope_key(cipher))),
+      'x-amz-iv': Utils.encode64(envelope_iv(cipher)),
+      'x-amz-matdesc': this.materials_description(),
+    };
+    var cipher = crypto.createCipheriv('aes-256-cbc', envelope['x-amz-key'], envelope['x-amz-iv'] );
+    return [envelope, cipher];
+  },
+
+  // @return [Cipher] Given an encryption envelope, returns a
+  //   decryption cipher.
+  decryption_cipher: function(envelope) {
+    var Utils = AWS.S3.Encryption.Utils;
+    // variables
+    var master_key = this.key_provider.key_for(envelope['x-amz-matdesc']),
+        key = Utils.decrypt(master_key, Utils.decode64( envelope['x-amz-key'] || envelope['x-amz-key-v2'] ));
+    // cipher
+    var cipher = Utils.createDecipher(key, envelope);
+    return cipher;
+  },
+
+
+  /**
+   * @api private
+   */
+  envelope_key: function(cipher) {
+    cipher.key = cipher.random_key;
+  },
+
+  envelope_iv: function(cipher) {
+    cipher.iv = cipher.random_iv;
+  },
+
+  encrypt: function(data) {
+    var Utils = AWS.S3.Encryption.Utils;
+    return Utils.encrypt( this.key_provider.encryption_materials.key, data);
+  },
+
+  materials_description: function() {
+    return this.key_provider.encryption_materials.description;
+  }
+
+});
+
+
+
+module.exports = AWS.S3.Encryption.DefaultCipherProvider;

--- a/lib/s3/encryption/default_cipher_provider.js
+++ b/lib/s3/encryption/default_cipher_provider.js
@@ -17,6 +17,7 @@ AWS.S3.Encryption.DefaultCipherProvider = AWS.util.inherit({
   // @return [Array<Hash,Cipher>] Creates an returns a new encryption
   //   envelope and encryption cipher.
   encryption_cipher: function() {
+    var Utils = AWS.S3.Encryption.Utils;
     var envelope = {
       'x-amz-key': Utils.encode64(encrypt(envelope_key(cipher))),
       'x-amz-iv': Utils.encode64(envelope_iv(cipher)),

--- a/lib/s3/encryption/default_key_provider.js
+++ b/lib/s3/encryption/default_key_provider.js
@@ -1,0 +1,44 @@
+var AWS = require('../../core');
+/*
+ * The default key provider is constructed with a single key
+ * that is used for both encryption and decryption, ignoring
+ * the possible per-object envelope encryption materials description.
+ */
+AWS.S3.Encryption.DefaultKeyProvider = AWS.util.inherit(AWS.S3.Encryption.KeyProvider, {
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+
+  /**
+    * @api private
+    */
+  // @option options [required, OpenSSL::PKey::RSA, String] :encryption_key
+  //   The master key to use for encrypting objects.
+  // @option options [String<JSON>] :materials_description ('{}')
+  //   A description of the encryption key.
+  initialize: function( options ) {
+    options = options || {};
+    // classes
+    var Materials = AWS.S3.Encryption.Materials;
+    this.encryption_materials = new Materials({
+      key: options['encryption_key'],
+      description: options['materials_description'] || '{}'
+    });
+  },
+  /*
+  // @return [Materials]
+  function encryption_materials(){
+    @encryption_materials
+  },
+  */
+  // @param [String<JSON>] materials_description
+  // @return Returns the key given in the constructor.
+  key_for: function( materials_description ) {
+    //return this.encryption_materials.key;
+    return materials_description['kms_cmk_id'];
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.DefaultKeyProvider;

--- a/lib/s3/encryption/encrypt_handler.js
+++ b/lib/s3/encryption/encrypt_handler.js
@@ -1,16 +1,20 @@
 var AWS = require('../../core');
 
-AWS.S3.Encryption.EncryptHandler = AWS.util.inherit({
-
-  constructor: function(options) {
-    this.initialize(options);
-  },
+AWS.S3.Encryption.EncryptHandler = AWS.util.update({
 
   call: function(context) {
-    var envelope, cipher = context['encryption']['cipher_provider'].encryption_cipher;
-    this.apply_encryption_envelope(context, envelope, cipher);
-    this.apply_encryption_cipher(context, cipher);
-    //this.handler.call(context);
+    var self = this,
+        envelope, cipher;
+    // callback to separate method?
+    context['encryption']['cipher_provider'].encryption_cipher(function(err, response){
+      if( err ) return self.trigger('error', err);
+      envelope = response.envelope;
+      cipher = response.cipher;
+      // condition?
+      self.apply_encryption_envelope(context, envelope, cipher);
+      self.apply_encryption_cipher(context, cipher);
+      self.trigger('encrypted', context);
+    });
   },
 
   /**
@@ -18,33 +22,60 @@ AWS.S3.Encryption.EncryptHandler = AWS.util.inherit({
    */
   apply_encryption_envelope: function(context, envelope, cipher) {
     context['encryption']['cipher'] = cipher;
-    if ( context['encryption']['envelope_location'] == this.metadata ) {
-      context.params['metadata'] = context.params['metadata'] || {};
-      context.params['metadata'].update(envelope);
+    var metadata = context['encryption']['envelope_location'];
+    if ( metadata ) {
+      context.params['Metadata'] = context.params['Metadata'] || context.params['metadata'] || {};
+      context.params['Metadata'] = AWS.util.update(envelope);
     } else {
       // :instruction_file
       var suffix = context['encryption']['instruction_file_suffix'];
-      context.client.put_object({
+      // NOT WORKING
+      /*
+      context.client.putObject({
         bucket: context.params['bucket'],
         key: context.params['key'] + suffix,
         body: JSON.stringify(envelope)
       });
+      */
     }
   },
 
   apply_encryption_cipher: function(context, cipher) {
-    var io = context.params['body'] || '';
-    if ( typeof io === 'string' ) io = StringIO.new(io);
-    context.params['body'] = new AWS.S3.Encryption.IOEncrypter(cipher, io);
-    context.params['metadata'] = context.params['metadata'] || {};
-    context.params['metadata']['x-amz-unencrypted-content-length'] = io.size;
-    if ( md5 = context.params['content_md5'] ) {
+    var io = context.params['Body'] || '';
+    //if ( typeof io === 'string' ) io = StringIO.new(io);
+    var encrypter = new AWS.S3.Encryption.IOEncrypter(cipher, io);
+    // no delay?
+    context.params['Body'] = encrypter.body;
+    context.params['Metadata'] = context.params['Metadata'] || {};
+    context.params['Metadata']['x-amz-unencrypted-content-length'] = (io.length).toString();
+    var md5 = context.params['content_md5'];
+    if ( md5 ) {
       delete context.params['content_md5'];
-      context.params['metadata']['x-amz-unencrypted-content-md5'] = md5
+      context.params['Metadata']['x-amz-unencrypted-content-md5'] = md5;
     }
+    /*
     context.http_response.on('httpHeaders', function() {
         context.params['body'].close;
     });
+    */
+  },
+
+  // Helpers
+  // - events
+  on: function(e, callback) {
+    this._events = this._events || [];
+    this._events[e] = this._events[e] ||[];
+    this._events[e].push(callback);
+  },
+
+  trigger: function(e, params) {
+    var events = this._events[e] || false;
+    if ( !events ) return;
+    for (var i in events ) {
+      events[i](params);
+    }
+    // reset?
+    //delete this._events[trigger];
   }
 
 });

--- a/lib/s3/encryption/encrypt_handler.js
+++ b/lib/s3/encryption/encrypt_handler.js
@@ -1,0 +1,52 @@
+var AWS = require('../../core');
+
+AWS.S3.Encryption.EncryptHandler = AWS.util.inherit({
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+
+  call: function(context) {
+    var envelope, cipher = context['encryption']['cipher_provider'].encryption_cipher;
+    this.apply_encryption_envelope(context, envelope, cipher);
+    this.apply_encryption_cipher(context, cipher);
+    //this.handler.call(context);
+  },
+
+  /**
+   * @api private
+   */
+  apply_encryption_envelope: function(context, envelope, cipher) {
+    context['encryption']['cipher'] = cipher;
+    if ( context['encryption']['envelope_location'] == this.metadata ) {
+      context.params['metadata'] = context.params['metadata'] || {};
+      context.params['metadata'].update(envelope);
+    } else {
+      // :instruction_file
+      var suffix = context['encryption']['instruction_file_suffix'];
+      context.client.put_object({
+        bucket: context.params['bucket'],
+        key: context.params['key'] + suffix,
+        body: JSON.stringify(envelope)
+      });
+    }
+  },
+
+  apply_encryption_cipher: function(context, cipher) {
+    var io = context.params['body'] || '';
+    if ( typeof io === 'string' ) io = StringIO.new(io);
+    context.params['body'] = new AWS.S3.Encryption.IOEncrypter(cipher, io);
+    context.params['metadata'] = context.params['metadata'] || {};
+    context.params['metadata']['x-amz-unencrypted-content-length'] = io.size;
+    if ( md5 = context.params['content_md5'] ) {
+      delete context.params['content_md5'];
+      context.params['metadata']['x-amz-unencrypted-content-md5'] = md5
+    }
+    context.http_response.on('httpHeaders', function() {
+        context.params['body'].close;
+    });
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.EncryptHandler;

--- a/lib/s3/encryption/errors.js
+++ b/lib/s3/encryption/errors.js
@@ -1,0 +1,12 @@
+var AWS = require('../../core');
+
+//AWS.S3.Encryption.Errors =
+AWS.S3.Encryption.Errors = AWS.util.update({
+
+  DecryptionError: AWS.util.error,
+
+  EncryptionError: AWS.util.error
+
+});
+
+module.exports = AWS.S3.Encryption.Errors;

--- a/lib/s3/encryption/io_decrypter.js
+++ b/lib/s3/encryption/io_decrypter.js
@@ -28,7 +28,14 @@ AWS.S3.Encryption.IODecrypter = AWS.util.inherit({
   },
 
   finalize: function() {
-    this.io += this.cipher.final('utf8');
+    // sometimes this fails with most common error:
+    // Unsupported state or unable to authenticate data
+    try {
+      this.io += this.cipher.final('utf8');
+    } catch( e ){
+      console.log( e );
+      // what to do?
+    }
     return this.io;
   },
 

--- a/lib/s3/encryption/io_decrypter.js
+++ b/lib/s3/encryption/io_decrypter.js
@@ -1,0 +1,45 @@
+var AWS = require('../../core');
+
+//AWS.S3.Encryption.IODecrypter = ;
+AWS.S3.Encryption.IODecrypter = AWS.util.inherit({
+
+  constructor: function(cipher, io) {
+    this.initialize(cipher, io);
+  },
+
+  /**
+   * @api private
+   */
+  // @param [OpenSSL::Cipher] cipher
+  // @param [#write] io An IO-like object that responds to {#write}.
+  initialize: function(cipher, io) {
+    this.orig_cipher = cipher; //clone?
+    this.cipher = cipher;
+    this.io = '';
+    this.write(io);
+    //this.reset_cipher()
+  },
+
+  // @return [#write]
+  //attr_reader :io,
+
+  write: function(chunk) {
+    this.io += this.cipher.update(chunk, 'binary', 'utf8');
+  },
+
+  finalize: function() {
+    this.io += this.cipher.final('utf8');
+    return this.io;
+  },
+
+
+  /**
+   * @api private
+   */
+  reset_cipher: function() {
+    this.cipher = this.orig_cipher.clone;
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.IODecrypter;

--- a/lib/s3/encryption/io_encrypter.js
+++ b/lib/s3/encryption/io_encrypter.js
@@ -20,10 +20,11 @@ AWS.S3.Encryption.IOEncrypter =  AWS.util.inherit({
    * @api private
    */
   initialize: function(cipher, io) {
-    this.encrypted = ( io.size <= ONE_MEGABYTE )
-      ? encrypt_to_stringio(cipher, io.read)
-      : encrypt_to_tempfile(cipher, io);
-    this.size = this.encrypted.size;
+    this.encrypted = ( io.length <= ONE_MEGABYTE )
+      ? this.encrypt_to_stringio(cipher, io)
+      : this.encrypt_to_tempfile(cipher, io);
+    this.size = this.encrypted.length;
+    this.body = this.encrypted;
   },
 
   // @return [Integer]
@@ -53,11 +54,11 @@ AWS.S3.Encryption.IOEncrypter =  AWS.util.inherit({
    * @api private
    */
   encrypt_to_stringio: function(cipher, plain_text) {
-    if ( plain_text.empty ) {
-      cipher.final('utf-8');
+    if ( typeof plain_text == "undefined" ) {
+      return cipher.final('binary'); // when is this called?
     } else {
       //if ( cipher_size(key) < cipher_size(data) ) console.log(UNSAFE_MSG);
-      cipher.update(plain_text, 'utf-8') + cipher.final('utf-8');
+      return cipher.update(plain_text, 'utf-8', 'binary') + cipher.final('binary');
     }
   },
 
@@ -65,7 +66,7 @@ AWS.S3.Encryption.IOEncrypter =  AWS.util.inherit({
     var os = require('os');
     encrypted = os.tmpdir() + Math.random().toString(36).substr(4); //.new(self.object_id.to_s)
     //encrypted.binmode();
-    var output = cipher.finalize();
+    var output = cipher.final('binary');
 
     fs.writeFile(encrypted, output, function(err) {
       if (err) return console.log(err);

--- a/lib/s3/encryption/io_encrypter.js
+++ b/lib/s3/encryption/io_encrypter.js
@@ -1,0 +1,80 @@
+var AWS = require('../../core');
+
+var ONE_MEGABYTE = 1024 * 1024;
+
+var UNSAFE_MSG = 'unsafe encryption, data is longer than key length';
+
+/*
+ * Provides an IO wrapper encrpyting a stream of data.
+ * It is possible to use this same object for decrypting. You must
+ * initialize it with a decryptiion cipher in that case and the
+ * IO object must contain cipher text instead of plain text.
+ */
+AWS.S3.Encryption.IOEncrypter =  AWS.util.inherit({
+
+  constructor: function(cipher, io) {
+    this.initialize(cipher, io);
+  },
+
+  /**
+   * @api private
+   */
+  initialize: function(cipher, io) {
+    this.encrypted = ( io.size <= ONE_MEGABYTE )
+      ? encrypt_to_stringio(cipher, io.read)
+      : encrypt_to_tempfile(cipher, io);
+    this.size = this.encrypted.size;
+  },
+
+  // @return [Integer]
+  //attr_reader :size,
+  read: function(bytes, output_buffer) {
+    bytes = bytes || null;
+    output_buffer = output_buffer || null;
+    if ( Tempfile === this.encrypted && this.encrypted.closed ) {
+      this.encrypted.open();
+      this.encrypted.binmode();
+    }
+    this.encrypted.read(bytes, output_buffer);
+  },
+
+  rewind: function() {
+    this.encrypted.rewind()
+  },
+
+  /**
+   * @api private
+   */
+  close: function() {
+    if ( Tempfile === this.encrypted ) this.encrypted.close();
+  },
+
+  /**
+   * @api private
+   */
+  encrypt_to_stringio: function(cipher, plain_text) {
+    if ( plain_text.empty ) {
+      cipher.final('utf-8');
+    } else {
+      //if ( cipher_size(key) < cipher_size(data) ) console.log(UNSAFE_MSG);
+      cipher.update(plain_text, 'utf-8') + cipher.final('utf-8');
+    }
+  },
+
+  encrypt_to_tempfile: function(cipher, io) {
+    var os = require('os');
+    encrypted = os.tmpdir() + Math.random().toString(36).substr(4); //.new(self.object_id.to_s)
+    //encrypted.binmode();
+    var output = cipher.finalize();
+
+    fs.writeFile(encrypted, output, function(err) {
+      if (err) return console.log(err);
+    });
+    //encrypted.write(cipher.final);
+    //encrypted.rewind();
+    return encrypted;
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.IOEncrypter;

--- a/lib/s3/encryption/key_provider.js
+++ b/lib/s3/encryption/key_provider.js
@@ -1,0 +1,32 @@
+var AWS = require('../../core');
+
+/*
+ * This module defines the interface required for a {Client#key_provider}.
+ * A key provider is any object that:
+ *
+ * * Responds to {#encryption_materials} with an {Materials} object.
+ *
+ * * Responds to {#key_for}, receiving a JSON document String,
+ *   returning an encryption key. The returned encryption key
+ *   must be one of:
+ *
+ *   * `OpenSSL::PKey::RSA` - for asymmetric encryption
+ *   * `String` - 32, 24, or 16 bytes long, for symmetric encryption
+ */
+
+AWS.S3.Encryption.KeyProvider = AWS.util.inherit({
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+
+  // @return [Materials]
+  encryption_materials: function() {},
+
+  // @param [String<JSON>] materials_description
+  // @return [OpenSSL::PKey::RSA, String] encryption_key
+  key_for: function( materials_description ) {}
+
+});
+
+module.exports = AWS.S3.Encryption.KeyProvider;

--- a/lib/s3/encryption/kms_cipher_provider.js
+++ b/lib/s3/encryption/kms_cipher_provider.js
@@ -1,5 +1,4 @@
-var AWS = require('../../core'),
-    crypto = require('crypto');
+var AWS = require('../../core');
 
 AWS.S3.Encryption.KmsCipherProvider = AWS.util.inherit({
 
@@ -13,31 +12,54 @@ AWS.S3.Encryption.KmsCipherProvider = AWS.util.inherit({
     options = options || {};
     this.kms_key_id = options['kms_key_id'];
     this.kms_client = options['kms_client'];
+    this.encryption_key = options['encryption_key'];
   },
 
   // @return [Array<Hash,Cipher>] Creates an returns a new encryption
   //   envelope and encryption cipher.
-  encryption_cipher: function() {
+  encryption_cipher: function(callback) {
     // classes
     var Utils = AWS.S3.Encryption.Utils;
     var encryption_context = { kms_cmk_id: this.kms_key_id };
-    key_data = this.kms_client.generate_data_key({
-      key_id: this.kms_key_id,
-      encryption_context: encryption_context,
-      key_spec: 'AES_256',
-    });
-    var cipher = crypto.createCipheriv('aes-256-cbc', key_data.ciphertext_blob, cipher.random_iv );
-    cipher.key = key_data.plaintext;
+    var iv = Utils.randomIV(),
+        key, cipher;
+
     var envelope = {
-      'x-amz-key-v2': Utils.encode64(key_data.ciphertext_blob),
-      'x-amz-iv': Utils.encode64(cipher.iv),
-      'x-amz-cek-alg': 'AES/CBC/PKCS5Padding',
+      'x-amz-iv': Utils.encode64(iv),
+      'x-amz-cek-alg': 'AES/CBC/PKCS5Padding', // variable?
       'x-amz-wrap-alg': 'kms',
       'x-amz-matdesc': JSON.stringify(encryption_context)
     };
-    var cipher = Utils.createCipher( key, envelope );
 
-    return [envelope, cipher];
+    if ( this.encryption_key ) {
+      // assume this is right?
+      envelope['x-amz-key-v2'] = (typeof this.encryption_key == 'string') ? Utils.encode64( this.encryption_key ) : this.encryption_key;
+      //key = key_data.ciphertext_blob;
+      // decrypt encryption key
+      this.kms_client.decrypt({
+        CiphertextBlob: this.encryption_key,
+        EncryptionContext: encryption_context,
+      }, function(err, response) {
+        if ( err ) return callback( err );
+        key = Utils.decode64(response.Plaintext);
+        cipher = Utils.createDecipher( key, envelope );
+        return callback(null, { envelope: envelope, cipher: cipher });
+      });
+    } else {
+      // generate a new encryption key
+      this.kms_client.generateDataKey({
+        KeyId: this.kms_key_id,
+        EncryptionContext: encryption_context,
+        KeySpec: 'AES_256',
+      }, function(err, key_data){
+        if ( err ) return callback( err );
+        key = key_data.Plaintext;
+        envelope['x-amz-key-v2'] = Utils.encode64(key_data.CiphertextBlob);
+        cipher = Utils.createCipher( key, envelope );
+        return callback(null, { envelope: envelope, cipher: cipher });
+      });
+    }
+
   },
 
   // @return [Cipher] Given an encryption envelope, returns a

--- a/lib/s3/encryption/kms_cipher_provider.js
+++ b/lib/s3/encryption/kms_cipher_provider.js
@@ -1,0 +1,64 @@
+var AWS = require('../../core'),
+    crypto = require('crypto');
+
+AWS.S3.Encryption.KmsCipherProvider = AWS.util.inherit({
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+  /**
+   * @api private
+   */
+  initialize: function( options ) {
+    options = options || {};
+    this.kms_key_id = options['kms_key_id'];
+    this.kms_client = options['kms_client'];
+  },
+
+  // @return [Array<Hash,Cipher>] Creates an returns a new encryption
+  //   envelope and encryption cipher.
+  encryption_cipher: function() {
+    // classes
+    var Utils = AWS.S3.Encryption.Utils;
+    var encryption_context = { kms_cmk_id: this.kms_key_id };
+    key_data = this.kms_client.generate_data_key({
+      key_id: this.kms_key_id,
+      encryption_context: encryption_context,
+      key_spec: 'AES_256',
+    });
+    var cipher = crypto.createCipheriv('aes-256-cbc', key_data.ciphertext_blob, cipher.random_iv );
+    cipher.key = key_data.plaintext;
+    var envelope = {
+      'x-amz-key-v2': Utils.encode64(key_data.ciphertext_blob),
+      'x-amz-iv': Utils.encode64(cipher.iv),
+      'x-amz-cek-alg': 'AES/CBC/PKCS5Padding',
+      'x-amz-wrap-alg': 'kms',
+      'x-amz-matdesc': JSON.stringify(encryption_context)
+    };
+    var cipher = Utils.createCipher( key, envelope );
+
+    return [envelope, cipher];
+  },
+
+  // @return [Cipher] Given an encryption envelope, returns a
+  //   decryption cipher.
+  decryption_cipher: function(envelope, callback) {
+    // classes
+    var Utils = AWS.S3.Encryption.Utils;
+    var encryption_context = JSON.parse(envelope['x-amz-matdesc']);
+    this.kms_client.decrypt({
+      CiphertextBlob: Utils.decode64( envelope['x-amz-key-v2'] ),
+      EncryptionContext: encryption_context,
+    }, function(err, response) {
+      if ( err ) return callback( err );
+      var key = Utils.decode64(response.Plaintext);
+      var cipher = Utils.createDecipher( key, envelope );
+
+      return callback(null, cipher);
+    });
+
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.KmsCipherProvider;

--- a/lib/s3/encryption/materials.js
+++ b/lib/s3/encryption/materials.js
@@ -1,0 +1,73 @@
+var AWS = require('../../core');
+
+AWS.S3.Encryption.Materials = AWS.util.inherit({
+
+  constructor: function(options) {
+    this.initialize(options);
+  },
+  /*
+   * @option options [required, OpenSSL::PKey::RSA, String] :key
+   *   The master key to use for encrypting/decrypting all objects.
+   *
+   * @option options [String<JSON>] :description ('{}')
+   *   The encryption materials description. This is must be
+   *   a JSON document string.
+   */
+  initialize: function( options  ) {
+    options = options || {};
+    this.key = this.validate_key(options['key']);
+    this.description = this.validate_desc(options['description']);
+  },
+
+  // @return [OpenSSL::PKey::RSA, String]
+  //attr_reader: key,
+
+  // @return [String<JSON>]
+  //attr_reader: description,
+
+  /**
+   * @api private
+   */
+  validate_key: function( key ) {
+    var type = (typeof key);
+    switch ( type ) {
+      case 'OpenSSL::PKey::RSA':
+        return key;
+      break;
+      case 'string':
+        if ( [32, 24, 16].indexOf( key.length ) > -1 ) {
+          return key;
+        } else {
+          var msg = 'invalid key, symmetric key required to be 16, 24, or ';
+          //msg << "32 bytes in length, saw length 31"
+          //raise ArgumentError, msg
+          AWS.util.error(new Error(), {
+            message: msg
+          });
+        }
+      break;
+      default:
+        var msg = 'invalid encryption key, expected an OpenSSL::PKey::RSA key';
+        //msg << "(for asymmetric encryption) or a String (for symmetric "
+        //msg << "encryption)."
+        //raise ArgumentError, msg
+        AWS.util.error(new Error(), {
+          message: msg
+        });
+    }
+  },
+
+  validate_desc: function(description) {
+    var description = JSON.parse(description);
+
+    //rescue Json::ParseError
+    var msg = 'expected description to be a valid JSON document string';
+    //raise ArgumentError, msg
+    AWS.util.error(new Error(), {
+      message: msg
+    });
+  }
+
+});
+
+module.exports = AWS.S3.Encryption.Materials;

--- a/lib/s3/encryption/utils.js
+++ b/lib/s3/encryption/utils.js
@@ -28,7 +28,7 @@ AWS.util.update(AWS.S3.Encryption, {
       // prerequisites
       var iv = ( envelope['x-amz-iv'] ) ? this.decode64( envelope['x-amz-iv'] ) : null; // or random bytes?
 
-      var type = data['x-amz-cek-alg'] || false;
+      var type = envelope['x-amz-cek-alg'] || false;
       switch ( type ) {
         case 'AES/CBC/PKCS5Padding':
           cipher = aes_encryption_cipher('CBC', key, iv);
@@ -80,6 +80,11 @@ AWS.util.update(AWS.S3.Encryption, {
 
     decode64: function(str) {
       return new Buffer( str, 'base64' , 'utf8');
+    },
+
+    randomIV: function( size ){
+      size = size || 16;
+      return crypto.pseudoRandomBytes( size );
     }
   }
 

--- a/lib/s3/encryption/utils.js
+++ b/lib/s3/encryption/utils.js
@@ -1,0 +1,146 @@
+var AWS = require('../../core'),
+    crypto = require('crypto');
+
+AWS.util.update(AWS.S3.Encryption, {
+
+  Utils: {
+    //class << self
+
+    // encrypts a key
+    encrypt: function(key, data) {
+      // todo
+      // asymmetric encryption
+      //return key.public_encrypt(data);
+      // symmetric encryption
+      //return cipher.update(data) + cipher.final;
+      return key;
+    },
+
+    // decrypts a key
+    decrypt: function(key, data) {
+      // todo
+      //key.private_decrypt(data);
+      return key;
+    },
+
+    // creates a cipher for encryption
+    createCipher: function(key, envelope) {
+      // prerequisites
+      var iv = ( envelope['x-amz-iv'] ) ? this.decode64( envelope['x-amz-iv'] ) : null; // or random bytes?
+
+      var type = data['x-amz-cek-alg'] || false;
+      switch ( type ) {
+        case 'AES/CBC/PKCS5Padding':
+          cipher = aes_encryption_cipher('CBC', key, iv);
+        break;
+        case 'AES/GCM/NoPadding':
+          cipher = aes_encryption_cipher('GCM', key, iv);
+        break;
+        case 'AES/ECB/PKCS5Padding':
+          cipher = aes_encryption_cipher('ECB', key, iv);
+        break;
+        default:
+          // encode to CBC by default
+          cipher = aes_encryption_cipher('CBC', key, iv);
+        break;
+      }
+
+      return cipher;
+    },
+
+    // creates a cipher for decryption
+    createDecipher: function(key, envelope) {
+      //
+      var type = envelope['x-amz-cek-alg'] || false;
+      var iv = ( envelope['x-amz-iv'] ) ? this.decode64( envelope['x-amz-iv'] ) : null;
+
+      switch ( type ) {
+        case 'AES/CBC/PKCS5Padding':
+          return aes_decryption_cipher('CBC', key, iv);
+        break;
+        case 'AES/GCM/NoPadding':
+          return aes_decryption_cipher('GCM', key, iv);
+        break;
+        case 'AES/ECB/PKCS5Padding':
+          return aes_decryption_cipher('ECB', key, iv);
+        break;
+      }
+      // no valid type, output error
+      var msg = 'decryption failed, possible incorrect key';
+      //raise Errors::DecryptionError, msg
+      AWS.util.error(new Error(), {
+        code: 'OpenSSL::Cipher::CipherError',
+        message: msg
+      });
+    },
+
+    encode64: function(str) {
+      return new Buffer( str, 'utf8', 'base64');
+    },
+
+    decode64: function(str) {
+      return new Buffer( str, 'base64' , 'utf8');
+    }
+  }
+
+});
+
+// Internal
+
+/*
+ * @param [String] block_mode "CBC" or "ECB"
+ * @param [OpenSSL::PKey::RSA, String, nil] key
+ * @param [String, nil] iv The initialization vector
+ */
+function aes_encryption_cipher(block_mode, key, iv) {
+  key = key || null,
+  iv = iv || null;
+  return aes_cipher('encrypt', block_mode, key, iv);
+}
+/*
+ * @param [String] block_mode "CBC" or "ECB"
+ * @param [OpenSSL::PKey::RSA, String, nil] key
+ * @param [String, nil] iv The initialization vector
+ */
+function aes_decryption_cipher(block_mode, key, iv) {
+  key = key || null,
+  iv = iv || null;
+  return aes_cipher('decrypt', block_mode, key, iv);
+}
+/*
+ * @param [String] mode "encrypt" or "decrypt"
+ * @param [String] block_mode "CBC" or "ECB"
+ * @param [OpenSSL::PKey::RSA, String, nil] key
+ * @param [String, nil] iv The initialization vector
+ */
+function aes_cipher(mode, block_mode, key, iv) {
+  var cipher;
+  block_mode = block_mode.toString().toLowerCase();
+  var algorithm = ( key )
+    ? 'aes-'+ cipher_size(key) +'-'+ block_mode
+    : 'aes-256-'+ block_mode;
+
+  switch ( mode ) {
+    case 'encrypt':
+      cipher = ( iv )
+        ? crypto.createCipheriv(algorithm, key, iv)
+        : crypto.createCipher(algorithm, key);
+    break;
+    case 'decrypt':
+      cipher = ( iv )
+        ? crypto.createDecipheriv(algorithm, key, iv)
+        : crypto.createDecipheriv(algorithm, key);
+    break;
+  }
+  return cipher;
+}
+/*
+ * @param [String] key
+ * @return [Integer]
+ * @raise ArgumentError
+ */
+function cipher_size(key) {
+  return key.length * 8;
+}
+
+//module.exports = AWS.S3.Encryption.Utils;

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -2,6 +2,8 @@ var AWS = require('../core');
 
 // Pull in managed upload extension
 require('../s3/managed_upload');
+// encrypted client
+require('../s3/encryption');
 
 AWS.util.update(AWS.S3.prototype, {
   /**

--- a/test/s3/encryption/client.spec.coffee
+++ b/test/s3/encryption/client.spec.coffee
@@ -1,0 +1,443 @@
+helpers = require('../../helpers')
+AWS = helpers.AWS
+
+describe 'AWS.S3.Encryption.Client', ->
+
+  master_key = new Buffer('kM5UVbhE/4rtMZJfsadYEdm2vaKFsmV2f5+URSeUCV4=', 'base64' , 'utf8')
+
+  api_client = new AWS.S3(
+      accessKeyId: 'akid',
+      secretAccessKey: 'secret',
+      region: 'us-west-1',
+      maxRetries: 0 # disable failed request retries
+    )
+
+  options = { client: api_client, encryption_key: master_key }
+
+  client = new AWS.S3.Encryption.Client(options)
+
+  request = (operation, params) -> client.makeRequest(operation, params)
+
+  double = ( obj ) ->
+    if (obj == null || (typeof obj != 'object'))
+      return obj;
+
+    clone = obj.constructor(); # give clone the original obj's constructor
+    for key in obj
+      clone[key] = double(obj[key]);
+
+    return clone;
+
+  describe 'configuration', ->
+
+    it 'constructs a default s3 client when one is not given', (done) ->
+      #api_client = double(client)
+      # expect(S3.Client).to receive(:new).andReturn(api_client)
+      #expect(-> new AWS.S3()).to.be(api_client)
+      client = new AWS.S3.Encryption.Client({ encryption_key: master_key })
+      #expect(client.client).to.be(api_client)
+      done()
+
+    it 'accepts vanilla client options', (done) ->
+      opts = {
+        region: 'us-west-2',
+        credentials: new AWS.Credentials(accessKeyId: 'akid', secretAccessKey: 'secret'),
+        encryption_key: '.' * 32,
+      }
+      enc_client = new AWS.S3.Encryption.Client(opts)
+      expect(enc_client.client.config.region).to.equal('us-west-2')
+      expect(enc_client.client.config.credentials.accessKeyId).to.equal('akid')
+      # this fails because secretAccessKey is hidden
+      #expect(enc_client.client.config.credentials.secretAccessKey).to.equal('secret')
+      done()
+
+    it 'requires an encryption key or provider', (done) ->
+      expect ->
+        delete options['encryption_key']
+        new AWS.S3.Encryption.Client(options)
+      .to.throw(':kms_key_id, :key_provider, or :encryption_key')
+
+      expect ->
+        console.log( Object.assign(options, { encryption_key: master_key }) );
+        new AWS.S3.Encryption.Client( Object.assign(options, { encryption_key: master_key }) )
+      .not.to.equal(error)
+
+      expect ->
+        #key_provider = double('key-provider')
+        new AWS.S3.Encryption.Client( Object.assign(options, { key_provider: key_provider }) )
+      .not.to.equal(error)
+      done()
+
+    it 'consturcts a key provider from a master key', (done) ->
+      options['encryption_key'] = master_key
+      console.log( client.key_provider );
+      expect(client.key_provider.key_for('')).to.equal(master_key)
+      expect(client.key_provider.key_for('{}')).to.equal(master_key)
+      expect(client.key_provider.key_for('{"foo":"bar"}')).to.equal(master_key)
+      done()
+
+    it 'defaults :envelope_location to :metadata', (done) ->
+      expect(client.envelope_location).to.equal(metadata)
+      done()
+
+    it 'requires :envelope_location to be :metadata or :instruction_file', (done) ->
+      expect ->
+        new AWS.S3.Encryption.Client( Object.assign(options, { envelope_location: bad }) )
+      .to.throw(':metadata or :instruction_file')
+
+      expect ->
+        new AWS.S3.Encryption.Client( Object.assign(options, { envelope_location: metadata }) )
+        new AWS.S3.Encryption.Client( Object.assign(options, { envelope_location: instruction_file }) )
+      .not.to.equal(error)
+      done()
+
+    it 'requires :materials_description to be a valid JSON document', (done) ->
+      options['materials_description'] = '?!'
+      expect ->
+        client
+      .to.throw('JSON document')
+      done()
+
+    it 'defaults :instruction_file_suffix to ".instruction"', (done) ->
+      expect(client.instruction_file_suffix).to.equal('.instruction')
+      done()
+
+    it 'requires :instruction_file_suffix to be a string', (done) ->
+      options['instruction_file_suffix'] = true
+      expect ->
+        client
+      .to.throw('must be a string')
+      done()
+
+
+  describe 'encryption methods', ->
+
+    # this is the encrypted string "secret" using the fixed envelope
+    # keys defined below in the beforeEach block
+    encrypted_body = new Buffer('JIgXCTXpeQerPLiU6dVL4Q==', 'base64' , 'utf8')
+
+    beforeEach ->
+      key = new Buffer('uSwsRlIMhY1klVYrgqceqjmQMmARcNl7rEKWW+7HVvA=', 'base64' , 'utf8')
+      iv = new Buffer('TO5mQgtOzWkTfoX4RE5tsA==', 'base64' , 'utf8')
+      #allow_any_instance_of(OpenSSL.Cipher).to receive(random_key).andReturn(key)
+      #allow_any_instance_of(OpenSSL.Cipher).to receive(random_iv).andReturn(iv)
+
+    describe '#put_object', ->
+
+      it 'encrypts the data client-side', (done) ->
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+        client.putObject(bucket:'bucket', key:'key', body:'secret')
+        expect(
+          a_request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key').with(
+            body: encrypted_body,
+            headers: {
+              'Content-Length': '16',
+              'Content-Md5': 'l0B7VfMeJ/9UqZlxWo2uEw==',
+              # key is encrypted here with the master encryption key,
+              # then base64 encoded
+              'X-Amz-Meta-X-Amz-Key': 'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
+              'X-Amz-Meta-X-Amz-Iv': 'TO5mQgtOzWkTfoX4RE5tsA==',
+              'X-Amz-Meta-X-Amz-Matdesc': '{}',
+              'X-Amz-Meta-X-Amz-Unencrypted-Content-Length': '6'
+            }
+          )
+        ).to have_been_made.once
+        done()
+
+      it 'encrypts an empty or missing body', (done) ->
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+        client.putObject(bucket:'bucket', key:'key') # body not set
+        expect(
+          a_request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key').
+            with(body: /.{16}/)
+        ).to have_been_made.once
+        done()
+
+      it 'can store the encryption envelope in a separate object', (done) ->
+
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key.instruction')
+
+        options['envelope_location'] = instruction_file
+        client.putObject(bucket:'bucket', key:'key', body:'secret')
+
+        # first request stores the encryption materials in the instruction file
+        expect(
+          a_request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key.instruction').with(
+            body: JSON.stringify(
+              'x-amz-key': 'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
+              'x-amz-iv': 'TO5mQgtOzWkTfoX4RE5tsA==',
+              'x-amz-matdesc': '{}',
+            )
+          )
+        ).to have_been_made.once
+
+        # second request stores teh encrypted object
+        expect(
+          a_request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key').with(
+            body: encrypted_body,
+            headers: {
+              'Content-Length': '16',
+              'X-Amz-Meta-X-Amz-Unencrypted-Content-Length': '6'
+            }
+          )
+        ).to have_been_made.once
+        done()
+
+      it 'accpets a custom instruction file suffix', (done) ->
+        req1 = request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key.envelope')
+        req2 = request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+
+        options['envelope_location'] = instruction_file
+        options['instruction_file_suffix'] = '.envelope'
+        client.putObject(bucket:'bucket', key:'key', body:'secret')
+
+        expect(req1).to have_been_made.once
+        expect(req2).to have_been_made.once
+        done()
+
+      it 'moves the un-encrypted md5 to a new header', (done) ->
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+        client.putObject(bucket:'bucket', key:'key', body:'secret', content_md5: 'MD5')
+        expect(
+          a_request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key').with(
+            body: encrypted_body,
+            headers: {
+              'X-Amz-Meta-X-Amz-Unencrypted-Content-Md5': 'MD5'
+            }
+          )
+        ).to have_been_made.once
+        done()
+
+      it 'supports encryption with an asymmetric key pair', (done) ->
+        request('PUT', 'https://bucket.s3-us-west-1.amazonaws.com/key')
+        options['encryption_key'] = OpenSSL.PKey.RSA.generate(1024)
+        resp = client.putObject(bucket:'bucket', key:'key', body:'secret')
+        expect(resp.context.http_request.body_contents).not_to.equal('secret')
+        done()
+
+      it 'raises an error on an invalid encryption key', (done) ->
+        options['encryption_key'] = 123
+        expect ->
+          client.putObject(bucket:'bucket', key:'key', body:'secret')
+        .to.throw('invalid encryption key')
+        done()
+
+
+    describe '#get_object', ->
+
+      stub_encrypted_get = (matdesc) ->
+        request('GET', 'https://bucket.s3-us-west-1.amazonaws.com/key').
+          to.eql(
+            body: encrypted_body,
+            headers: {
+              'X-Amz-Meta-X-Amz-Key': 'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
+              'X-Amz-Meta-X-Amz-Iv': 'TO5mQgtOzWkTfoX4RE5tsA==',
+              'X-Amz-Meta-X-Amz-Matdesc': matdesc,
+            }
+          )
+
+      stub_encrypted_get_with_instruction_file = () ->
+        request('GET', 'https://bucket.s3-us-west-1.amazonaws.com/key').
+          to.eql(body: encrypted_body)
+        request('GET', 'https://bucket.s3-us-west-1.amazonaws.com/key.instruction').
+          to.eql(
+            body: JSON.stringify(
+              'x-amz-key': 'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
+              'x-amz-iv': 'TO5mQgtOzWkTfoX4RE5tsA==',
+              'x-amz-matdesc': '{}',
+            )
+          )
+
+      it 'decrypts the object', (done) ->
+        stub_encrypted_get()
+        #helpers.mockHttpResponse 200, {'body': 'secret'}, """{"body": "secret" }"""
+        #request = dynamo.listTables()
+        #request.send (err, data) ->
+        resp = client.getObject(bucket:'bucket', key:'key')
+        console.log(resp)
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'supports #getObject with a block', (done) ->
+        stub_encrypted_get()
+        data = ''
+        client.getObject (bucket:'bucket', key:'key'), (chunk) ->
+          data << chunk
+
+        expect(data).to.equal('secret')
+        done()
+
+      it 'does not attempt to decrypt failed responses', (done) ->
+        request('GET', 'https://bucket.s3-us-west-1.amazonaws.com/key').
+          to.eql(status: 500)
+        expect ->
+          client.getObject(bucket:'bucket', key:'key')
+        .to.throw(AWS.S3.Errors.ServiceError)
+        done()
+
+      it 'loads envelope from instruction file when not found in metadata', (done) ->
+        stub_encrypted_get_with_instruction_file()
+        resp = client.getObject(bucket:'bucket', key:'key')
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'users the configured instruction file suffix', (done) ->
+        stub_encrypted_get_with_instruction_file('.envelope')
+        options['instruction_file_suffix'] = '.envelope'
+        resp = client.getObject(bucket:'bucket', key:'key')
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'gets the instruction file first with loc :instruction_file', (done) ->
+        stub_encrypted_get_with_instruction_file()
+        options['envelope_location'] = instruction_file
+        resp = client.getObject(bucket:'bucket', key:'key')
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'accepts :envelope_location, overriding the default location', (done) ->
+        stub_encrypted_get_with_instruction_file()
+        resp = client.getObject(bucket:'bucket', key:'key', envelope_location: instruction_file)
+        expect(resp.body.read).to.equal('secret')
+        expect(resp.context['encryption']['envelope_location']).to.equal(instruction_file)
+        expect(resp.context['encryption']['instruction_file_suffix']).to.equal('.instruction')
+        done()
+
+      it 'accepts :instruction_file_suffix, overriding the default location', (done) ->
+        stub_encrypted_get_with_instruction_file('.envelope')
+        resp = client.getObject(bucket:'bucket', key:'key', instruction_file_suffix: '.envelope')
+        expect(resp.body.read).to.equal('secret')
+        expect(resp.context['encryption']['envelope_location']).to.equal(instruction_file)
+        expect(resp.context['encryption']['instruction_file_suffix']).to.equal('.envelope')
+        done()
+
+      it 'supports multiple master keys with a key provider', (done) ->
+        stub_encrypted_get('MATERIALS-DESC')
+        #key_provider = double('key-provider')
+        expect(key_provider).to receive(key_for).
+          with('MATERIALS-DESC').andReturn(master_key)
+        options['key_provider'] = key_provider
+        resp = client.getObject(bucket:'bucket', key:'key')
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'raises an error when materials can not be found', (done) ->
+        stub_encrypted_get_with_instruction_file()
+        request('GET', 'https://bucket.s3-us-west-1.amazonaws.com/key.instruction').
+          to.eql(status: 404)
+        expect ->
+          client.getObject(bucket:'bucket', key:'key')
+        .to.throw('unable to locate encyrption envelope')
+        done()
+
+      it 'resets the cipher during decryption on error', (done) ->
+        data = encrypted_body
+        api_client.handle (step: send), (context) ->
+          http_resp = context.http_response
+          headers = {
+            'X-Amz-Meta-X-Amz-Key': 'gX+a4JQYj7FP0y5TAAvxTz4e2l0DvOItbXByml/NPtKQcUlsoGHoYR/T0TuYHcNj',
+            'X-Amz-Meta-X-Amz-Iv': 'TO5mQgtOzWkTfoX4RE5tsA==',
+            'X-Amz-Meta-X-Amz-Matdesc': '{}',
+          }
+          # fail first attempt, succeed second time
+          if context['already_failed']
+            http_resp.signal_headers(200, headers)
+            http_resp.signal_data(data)
+            http_resp.signal_done
+          else
+            context['already_failed'] = true
+            http_resp.signal_headers(200, headers)
+            http_resp.signal_data(data)
+            http_resp.signal_error(
+              new Seahorse.Client.NetworkingError( new RuntimeError('oops'))
+            )
+
+          new Seahorse.Client.Response({ context: context })
+
+        resp = client.getObject({ bucket:'bucket', key:'key' })
+        expect(resp.body.read).to.equal('secret')
+        done()
+
+      it 'raises an error when it is unable to decrypt the envelope', (done) ->
+        stub_encrypted_get()
+        options['encryption_key'] = '.' * 32
+        expect ->
+          client.getObject(bucket:'bucket', key:'key')
+        .to.throw('decryption failed, possible incorrect key')
+        done()
+
+      it 'validates the key length', (done) ->
+        stub_encrypted_get()
+        options['encryption_key'] = '.' * 31
+        msg = 'invalid key, symmetric key required to be 16, 24, or 32 bytes in length, saw length 31'
+        expect ->
+          client.getObject(bucket:'bucket', key:'key')
+        .to.throw(msg)
+        done()
+
+      it 'supports asymmetric keys', (done) ->
+        stub_encrypted_get()
+        options['encryption_key'] = OpenSSL.PKey.RSA.generate(1024)
+        expect ->
+          client.getObject(bucket:'bucket', key:'key')
+        .to.throw(StandardError)
+        done()
+
+      it 'does not support get with range', (done) ->
+        expect ->
+          client.getObject(bucket:'bucket', key:'key', range: 'BYTE-RANGE')
+        .to.throw('range not supported')
+        done()
+
+
+  describe 'kms', ->
+
+    kms_client = new AWS.KMS({ stub_responses:true })
+
+    client = new AWS.S3.Encryption.Client(
+        kms_key_id: 'kms-key-id',
+        kms_client: kms_client,
+        stub_responses: true,
+      )
+
+    envelope = {
+      'x-amz-wrap-alg': 'kms',
+      'x-amz-cek-alg': 'AES/CBC/PKCS5Padding',
+      'x-amz-iv': 'rVucSqIJvenVa7HliO+oIw==',
+      'x-amz-key-v2': new Buffer('encrypted-object-key', 'utf8', 'base64'),
+      'x-amz-matdesc': '{"kms_cmk_id":"kms-key-id"}',
+    }
+
+    plaintext_object_key = '\xE4^\xE3\xE0v@\x8Aq\xAF\xE7y\x10\x18\xD4X\xC2\xDC&\xF6\xDB\xCCM\x03\xAF3DD\xFF\xDA\x0Flj'
+
+    encrypted_object_key = 'encrypted-object-key'
+
+    random_iv = new Buffer('rVucSqIJvenVa7HliO+oIw==', 'base64', 'utf8')
+
+    #beforeEach -> allow_any_instance_of(OpenSSL.Cipher).to.receive(random_iv).andReturn(random_iv)
+
+    it 'supports encryption via KMS', (done) ->
+      kms_client.generateDataKey ({
+        plaintext: plaintext_object_key,
+        ciphertext_blob: encrypted_object_key,
+      }), (err, response) ->
+        #console.log("err, response", err, response);
+      resp = client.putObject(bucket:'aws-sdk', key:'foo', body:'plain-text')
+      console.log("resp.context.http_request.headers", resp.context.http_request.headers);
+      headers = resp.context.http_request.headers
+      AWS.util.each envelope (key, value) ->
+        expect(headers['x-amz-meta-#{key}']).to.equal(value)
+
+      expect( new Buffer(resp.context.http_request.body_contents, 'utf8', 'base64') ).to.equal('4FAj3kTOIisQ+9b8/kia8g==\n')
+      done()
+
+    it 'supports decryption via KMS', (done) ->
+      kms_client.decrypt(plaintext: plaintext_object_key)
+      client.client.getObject({
+        body: new Buffer('4FAj3kTOIisQ+9b8/kia8g==\n', 'base64', 'utf8'),
+        metadata: envelope
+      })
+      resp = client.getObject(bucket:'aws-sdk', key:'foo')
+      expect(resp.body.read).to.equal('plain-text')
+      done()

--- a/test/s3/encryption/io_encrypter.spec.coffee
+++ b/test/s3/encryption/io_encrypter.spec.coffee
@@ -16,6 +16,10 @@ describe 'AWS.S3.Encryption.IOEncrypter', ->
   #cipher.key = key
   #cipher.iv = iv
 
+  double = ( obj ) ->
+    if (obj == null || (typeof obj != 'object'))
+      return obj;
+
   it 'encrypts an IO object', (done) ->
     io = new AWS.S3.Encryption.IOEncrypter(cipher, plain_text)
     expect(io.read).to eq(cipher_text)
@@ -31,7 +35,7 @@ describe 'AWS.S3.Encryption.IOEncrypter', ->
     done()
 
   it 'caches the cipher-text of large objects to disk', (done) ->
-    tempfile = double('tempfile').as_null_object
+    tempfile = double('tempfile') #.as_null_object
     expect(tempfile).to.receive(write)
     expect(tempfile).to.receive(binmode)
     #allow(Tempfile).to.receive(new).andReturn(tempfile)

--- a/test/s3/encryption/io_encrypter.spec.coffee
+++ b/test/s3/encryption/io_encrypter.spec.coffee
@@ -1,0 +1,53 @@
+helpers = require('../../helpers')
+AWS = helpers.AWS
+
+describe 'AWS.S3.Encryption.IOEncrypter', ->
+
+  key = new Buffer( 'kM5UVbhE/4rtMZJfsadYEdm2vaKFsmV2f5+URSeUCV4=', 'base64', 'utf8')
+
+  iv = new Buffer( 'k8n8oF8ZNPRKAYY0RFqN2Q==', 'base64', 'utf8')
+
+  plain_text = 'The quick brown fox jumps over the lazy dog.'
+
+  cipher_text = new Buffer( 'MUeGuvB6IcjFo5VBWET659nWwx3+YH21HyVhF2Jf8bQ++2wvmtpXaGMJC2fae4j/', 'base64', 'utf8')
+
+  cipher = require('crypto').createCipheriv('aes-256-cbc', key, iv )
+  # cipher.encrypt
+  #cipher.key = key
+  #cipher.iv = iv
+
+  it 'encrypts an IO object', (done) ->
+    io = new AWS.S3.Encryption.IOEncrypter(cipher, plain_text)
+    expect(io.read).to eq(cipher_text)
+    done()
+
+  it 'supports partial reads', (done) ->
+    io = new AWS.S3.Encryption.IOEncrypter(cipher, plain_text)
+    parts = []
+    while part = io.read(3)
+      parts << part
+    end
+    expect(parts.join).to.equal(cipher_text)
+    done()
+
+  it 'caches the cipher-text of large objects to disk', (done) ->
+    tempfile = double('tempfile').as_null_object
+    expect(tempfile).to.receive(write)
+    expect(tempfile).to.receive(binmode)
+    #allow(Tempfile).to.receive(new).andReturn(tempfile)
+
+    large_io = double('large-io-object', size: 10 * 1024 * 1024, read: nil)
+    allow(large_io).to receive(read).
+      and_return('data').
+      and_return(nil)
+
+    new AWS.S3.Encryption.IOEncrypter(cipher, large_io)
+    done()
+
+  it 'supports re-reading from the cache file to enable retries', (done) ->
+    data = '.' * (2 * 1024 * 1024) # 2MB file
+    io = new AWS.S3.Encryption.IOEncrypter(cipher, data)
+    cipher_text = io.read();
+    io.close()
+    expect(io.read).to eq(cipher_text) # automatically re-opens the file
+    done()


### PR DESCRIPTION
This request is a direct follow-up to the issue #800 , raised a few days ago.

As previously mentioned, I used the Ruby lib as a basis to reconstruct the logic for the JavaScript lib. Certain liberties were taken, some related with the JavaScript syntax and some with the existing conventions of the AWS SDK; the linting script was responsible for a few tweaks as well.

Please note, the new code relates with the ability to automatically encrypt/decrypt S3 objects from the client-side. It is not currently addressing SSE (Server-side Encryption), which I'm not sure if it's under the `AWS.S3` domain. 

At the current state my main objective, to read KMS encrypted SES messages is fulfilled. This can be easily done like this:

```
var params = {
  Bucket: '{{BUCKET_NAME}}',
  Key: '{{BUCKET_ADDRESS}}',
};

var store = new AWS.S3.Encryption.Client({
  accessKeyId: '...',
  secretAccessKey: '...',
  region: '...', 
  sslEnabled: true,
  signatureVersion: 'v4',
});

var downloader = store.getObject(params, function(err, response ){
  // output...
  res.end( response.Body );
});
```

I'm also satisfied that the logic is laid out so it can grow. Additional abilities are in place, but not fully tested:
### putObject
- Encrypt and upload content using a `KMSKeyId` and `EncryptionKey`.
- Encrypt and upload content using only a `KMSKeyId`, with the ``EncryptionKey` automatically generated.
- Encrypt content using a custom `kms_client`, passed with the options of  `AWS.S3.Encryption.Client`.
### getObject
- Decrypt and download content using a `KMSKeyId` and `EncryptionKey`.
- Decrypt and download content using only a `KMSKeyId`, with the ``EncryptionKey` resourced from the file headers (as _'x-amz-key-v2'_).
- Decrypt content using a custom `kms_client`, passed with the options of  `AWS.S3.Encryption.Client`.

There is also scaffolding for allowing an instruction file, which will contain the encryption context of an encrypted file, but that functionality is at present disabled. 

Some of these features I didn't want to complete by introducing my own conventions. For example, arbitrary including the `x-amz-key-v2` key in the putObject response (to allow the user to save that info).

In addition, I tried to incorporate the unit tests from the Ruby lib, although they are failing, mostly because the stub requests for the KMS and S3 services aren't setup properly. I'm sure this can be easily amended by someone more familiar with the inner workings of the API/SDK. 

I understand that further adjustments may be required before this code can be integrated to the main lib. That's why I'm committing it as a separate branch. Frankly, I feel it is a significant component that shouldn't be addressed by just one contributor anyway. 

On a positive note, everything is contained under the `AWS.S3.Encryption` namespace and should not interfere with any of the existing functionality. I can use my branch to decrypt SES messages and there's an open invitation for anyone that wants to work on the other features. 

Let me know if you have any questions. 
