### PR TITLE
Adds ability to specifiy a custom user agent to be appended to user a…

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -54,6 +54,9 @@ require('./credentials/credential_provider_chain');
  *     requests that fail because of an skewed client clock. Defaults to
  *     `false`.
  *
+ * @!attribute customUserAgent
+ *   @return [String] a custom identifier to append to user agent headers.
+ *
  * @!attribute sslEnabled
  *   @return [Boolean] whether SSL is enabled for requests
  *
@@ -150,6 +153,8 @@ AWS.Config = AWS.util.inherit({
    * @option options correctClockSkew [Boolean] whether to apply a clock skew
    *     correction and retry requests that fail because of an skewed client
    *     clock. Defaults to `false`.
+   * @option options customUserAgent [String] A custom identifier to append to
+   *     user agent headers.
    * @option options s3ForcePathStyle [Boolean] whether to force path
    *   style URLs for S3 objects.
    * @option options s3BucketEndpoint [Boolean] whether the provided endpoint
@@ -405,6 +410,7 @@ AWS.Config = AWS.util.inherit({
     computeChecksums: true,
     convertResponseTypes: true,
     correctClockSkew: false,
+    customUserAgent: null,
     dynamoDbCrc32: true,
     systemClockOffset: 0,
     signatureVersion: null,

--- a/lib/config.js
+++ b/lib/config.js
@@ -54,9 +54,6 @@ require('./credentials/credential_provider_chain');
  *     requests that fail because of an skewed client clock. Defaults to
  *     `false`.
  *
- * @!attribute customUserAgent
- *   @return [String] a custom identifier to append to user agent headers.
- *
  * @!attribute sslEnabled
  *   @return [Boolean] whether SSL is enabled for requests
  *
@@ -153,8 +150,6 @@ AWS.Config = AWS.util.inherit({
    * @option options correctClockSkew [Boolean] whether to apply a clock skew
    *     correction and retry requests that fail because of an skewed client
    *     clock. Defaults to `false`.
-   * @option options customUserAgent [String] A custom identifier to append to
-   *     user agent headers.
    * @option options s3ForcePathStyle [Boolean] whether to force path
    *   style URLs for S3 objects.
    * @option options s3BucketEndpoint [Boolean] whether the provided endpoint

--- a/lib/http.js
+++ b/lib/http.js
@@ -108,7 +108,12 @@ AWS.HttpRequest = inherit({
    */
   setUserAgent: function setUserAgent(customUserAgent) {
     var prefix = AWS.util.isBrowser() ? 'X-Amz-' : '';
-    var customSuffix = (typeof customUserAgent === 'string' && customUserAgent) ? '/' + customUserAgent : '';
+    var customSuffix = '';
+    if (Array.isArray(customUserAgent) && customUserAgent.length) {
+      customSuffix += ' ' + customUserAgent.join('/');
+    } else if (typeof customUserAgent === 'string' && customUserAgent) {
+      customSuffix += ' ' + customUserAgent;
+    }
     this.headers[prefix + 'User-Agent'] = AWS.util.userAgent() + customSuffix;
   },
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -92,7 +92,7 @@ AWS.HttpRequest = inherit({
   /**
    * @api private
    */
-  constructor: function HttpRequest(endpoint, region) {
+  constructor: function HttpRequest(endpoint, region, customUserAgent) {
     endpoint = new AWS.Endpoint(endpoint);
     this.method = 'POST';
     this.path = endpoint.path || '/';
@@ -100,15 +100,16 @@ AWS.HttpRequest = inherit({
     this.body = '';
     this.endpoint = endpoint;
     this.region = region;
-    this.setUserAgent();
+    this.setUserAgent(customUserAgent);
   },
 
   /**
    * @api private
    */
-  setUserAgent: function setUserAgent() {
+  setUserAgent: function setUserAgent(customUserAgent) {
     var prefix = AWS.util.isBrowser() ? 'X-Amz-' : '';
-    this.headers[prefix + 'User-Agent'] = AWS.util.userAgent();
+    var customSuffix = (typeof customUserAgent === 'string' && customUserAgent) ? '/' + customUserAgent : '';
+    this.headers[prefix + 'User-Agent'] = AWS.util.userAgent() + customSuffix;
   },
 
   /**

--- a/lib/http.js
+++ b/lib/http.js
@@ -109,9 +109,7 @@ AWS.HttpRequest = inherit({
   setUserAgent: function setUserAgent(customUserAgent) {
     var prefix = AWS.util.isBrowser() ? 'X-Amz-' : '';
     var customSuffix = '';
-    if (Array.isArray(customUserAgent) && customUserAgent.length) {
-      customSuffix += ' ' + customUserAgent.join('/');
-    } else if (typeof customUserAgent === 'string' && customUserAgent) {
+    if (typeof customUserAgent === 'string' && customUserAgent) {
       customSuffix += ' ' + customUserAgent;
     }
     this.headers[prefix + 'User-Agent'] = AWS.util.userAgent() + customSuffix;

--- a/lib/request.js
+++ b/lib/request.js
@@ -304,6 +304,7 @@ AWS.Request = inherit({
   constructor: function Request(service, operation, params) {
     var endpoint = service.endpoint;
     var region = service.config.region;
+    var customUserAgent = service.config.customUserAgent;
 
     // global endpoints sign as us-east-1
     if (service.isGlobalEndpoint) region = 'us-east-1';
@@ -312,7 +313,7 @@ AWS.Request = inherit({
     this.service = service;
     this.operation = operation;
     this.params = params || {};
-    this.httpRequest = new AWS.HttpRequest(endpoint, region);
+    this.httpRequest = new AWS.HttpRequest(endpoint, region, customUserAgent);
     this.startTime = AWS.util.date.getDate();
 
     this.response = new AWS.Response(this);

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -84,6 +84,10 @@ describe 'AWS.Config', ->
     it 'defaults to false', ->
       expect(configure().correctClockSkew).to.equal(false)
 
+  describe 'customUserAgent', ->
+    it 'defaults to null', ->
+      expect(configure().customUserAgent).to.equal(null)
+
   describe 'set', ->
     it 'should set a default value for a key', ->
       config = new AWS.Config()

--- a/test/http_request.spec.coffee
+++ b/test/http_request.spec.coffee
@@ -25,10 +25,16 @@ describe 'AWS.HttpRequest', ->
       headers[agentHeader] = AWS.util.userAgent()
       expect(request.headers).to.eql(headers)
 
-    it 'adds the customUserAgent to the user agent header if provided', ->
+    it 'adds the customUserAgent to the user agent header if provided as string', ->
       headers = {}
-      headers[agentHeader] = AWS.util.userAgent() + '/custom'
+      headers[agentHeader] = AWS.util.userAgent() + ' custom'
       request = new AWS.HttpRequest('http://domain.com', '', 'custom')
+      expect(request.headers).to.eql(headers)
+
+      it 'adds the customUserAgent to the user agent header if provided as array', ->
+      headers = {}
+      headers[agentHeader] = AWS.util.userAgent() + ' custom/1'
+      request = new AWS.HttpRequest('http://domain.com', '', ['custom', 1])
       expect(request.headers).to.eql(headers)
 
     it 'defaults body to empty string', ->

--- a/test/http_request.spec.coffee
+++ b/test/http_request.spec.coffee
@@ -31,7 +31,7 @@ describe 'AWS.HttpRequest', ->
       request = new AWS.HttpRequest('http://domain.com', '', 'custom')
       expect(request.headers).to.eql(headers)
 
-      it 'adds the customUserAgent to the user agent header if provided as array', ->
+    it 'adds the customUserAgent to the user agent header if provided as array', ->
       headers = {}
       headers[agentHeader] = AWS.util.userAgent() + ' custom/1'
       request = new AWS.HttpRequest('http://domain.com', '', ['custom', 1])

--- a/test/http_request.spec.coffee
+++ b/test/http_request.spec.coffee
@@ -25,6 +25,12 @@ describe 'AWS.HttpRequest', ->
       headers[agentHeader] = AWS.util.userAgent()
       expect(request.headers).to.eql(headers)
 
+    it 'adds the customUserAgent to the user agent header if provided', ->
+      headers = {}
+      headers[agentHeader] = AWS.util.userAgent() + '/custom'
+      request = new AWS.HttpRequest('http://domain.com', '', 'custom')
+      expect(request.headers).to.eql(headers)
+
     it 'defaults body to empty string', ->
       expect(request.body).to.equal('')
 

--- a/test/http_request.spec.coffee
+++ b/test/http_request.spec.coffee
@@ -31,12 +31,6 @@ describe 'AWS.HttpRequest', ->
       request = new AWS.HttpRequest('http://domain.com', '', 'custom')
       expect(request.headers).to.eql(headers)
 
-    it 'adds the customUserAgent to the user agent header if provided as array', ->
-      headers = {}
-      headers[agentHeader] = AWS.util.userAgent() + ' custom/1'
-      request = new AWS.HttpRequest('http://domain.com', '', ['custom', 1])
-      expect(request.headers).to.eql(headers)
-
     it 'defaults body to empty string', ->
       expect(request.body).to.equal('')
 


### PR DESCRIPTION
…gent headers.

Added `customUserAgent` to the AWS.config object so that it can be set globally or at the service level.

/cc @jeskew 