### PR TITLE
Adds retry logic to dynamodb crc32 checksum errors

### DIFF
--- a/lib/services/dynamodb.js
+++ b/lib/services/dynamodb.js
@@ -7,7 +7,9 @@ AWS.util.update(AWS.DynamoDB.prototype, {
    */
   setupRequestListeners: function setupRequestListeners(request) {
     if (request.service.config.dynamoDbCrc32) {
+      request.removeListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
       request.addListener('extractData', this.checkCrc32);
+      request.addListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
     }
   },
 
@@ -21,6 +23,8 @@ AWS.util.update(AWS.DynamoDB.prototype, {
         message: 'CRC32 integrity check failed',
         retryable: true
       });
+      resp.request.haltHandlersOnError();
+      throw (resp.error);
     }
   },
 

--- a/test/services/dynamodb.spec.coffee
+++ b/test/services/dynamodb.spec.coffee
@@ -65,3 +65,9 @@ describe 'AWS.DynamoDB', ->
       request = dynamo.listTables()
       request.send (err, data) ->
         expect(err.code).to.eql('CRC32CheckFailed')
+
+    it 'retries request when response checksum does not match', ->
+      helpers.mockHttpResponse 200, {'x-amz-crc32': '0'}, """{"TableNames":["mock-table"]}"""
+      request = dynamo.listTables()
+      request.send (err, data) ->
+        expect(this.retryCount).to.eql(10)


### PR DESCRIPTION
This moves the CRC32 check to occur prior to parsing a JSON response body. Additionally, the SDK will retry a request when a crc32 checksum mismatch is encountered.

/cc @jeskew 