### PR TITLE
Allowing use of bare objects to be passed in to utils.each

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -533,7 +533,7 @@ var util = {
 
   each: function each(object, iterFunction) {
     for (var key in object) {
-      if (object.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(object, key)) {
         var ret = iterFunction.call(this, key, object[key]);
         if (ret === util.abort) break;
       }


### PR DESCRIPTION
Resolves #844. Allows consumers to pass bare key/value pair objects into service constructors (or elsewhere in the codebase) and for the services to pull configs or the default version numbers