### PR TITLE
Adding the ability to perform strict validation.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,6 +40,12 @@ require('./credentials/credential_provider_chain');
  *   @return [Boolean] whether input parameters should be validated against
  *     the operation description before sending the request. Defaults to true.
  *
+ * @!attribute strictParamValidation
+ *   @return [Boolean] whether input parameters should be validated more
+ *     strictly using validation traits such as enum, pattern, min, max, etc.
+ *     This option only takes effect if paramValidation is set to true.
+ *     Defaults to false.
+ *
  * @!attribute computeChecksums
  *   @return [Boolean] whether to compute checksums for payload bodies when
  *     the service accepts it (currently supported in S3 only).
@@ -140,6 +146,8 @@ AWS.Config = AWS.util.inherit({
    *   requests.
    * @option options paramValidation [Boolean] whether parameter validation
    *   is on.
+   * @option options strictParamValidation [Boolean] whether strict parameter
+   *   validation is on.
    * @option options computeChecksums [Boolean] whether to compute checksums
    *   for payload bodies when the service accepts it (currently supported
    *   in S3 only)
@@ -399,6 +407,7 @@ AWS.Config = AWS.util.inherit({
     maxRetries: undefined,
     maxRedirects: 10,
     paramValidation: true,
+    strictParamValidation: false,
     sslEnabled: true,
     s3ForcePathStyle: false,
     s3BucketEndpoint: false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,14 +37,19 @@ require('./credentials/credential_provider_chain');
  *     service request. Defaults to 10.
  *
  * @!attribute paramValidation
- *   @return [Boolean] whether input parameters should be validated against
+ *   @return [Boolean|map] whether input parameters should be validated against
  *     the operation description before sending the request. Defaults to true.
+ *     Pass a map to enable any of the following specific validation features:
  *
- * @!attribute strictParamValidation
- *   @return [Boolean] whether input parameters should be validated more
- *     strictly using validation traits such as enum, pattern, min, max, etc.
- *     This option only takes effect if paramValidation is set to true.
- *     Defaults to false.
+ *     * **min** [Boolean] &mdash; Validates that a value meets the min
+ *       constraint. This is enabled by default when paramValidation is set
+ *       to `true`.
+ *     * **max** [Boolean] &mdash; Validates that a value meets the max
+ *       constraint.
+ *     * **pattern** [Boolean] &mdash; Validates that a string value matches a
+ *       regular expression.
+ *     * **enum** [Boolean] &mdash; Validates that a string value matches one
+ *       of the allowable enum values.
  *
  * @!attribute computeChecksums
  *   @return [Boolean] whether to compute checksums for payload bodies when
@@ -144,10 +149,20 @@ AWS.Config = AWS.util.inherit({
    *   follow with a request. See {maxRedirects} for more information.
    * @option options sslEnabled [Boolean] whether to enable SSL for
    *   requests.
-   * @option options paramValidation [Boolean] whether parameter validation
-   *   is on.
-   * @option options strictParamValidation [Boolean] whether strict parameter
-   *   validation is on.
+   * @option options paramValidation [Boolean|map] whether input parameters
+   *   should be validated against the operation description before sending
+   *   the request. Defaults to true. Pass a map to enable any of the
+   *   following specific validation features:
+   *
+   *   * **min** [Boolean] &mdash; Validates that a value meets the min
+   *     constraint. This is enabled by default when paramValidation is set
+   *     to `true`.
+   *   * **max** [Boolean] &mdash; Validates that a value meets the max
+   *     constraint.
+   *   * **pattern** [Boolean] &mdash; Validates that a string value matches a
+   *     regular expression.
+   *   * **enum** [Boolean] &mdash; Validates that a string value matches one
+   *     of the allowable enum values.
    * @option options computeChecksums [Boolean] whether to compute checksums
    *   for payload bodies when the service accepts it (currently supported
    *   in S3 only)
@@ -407,7 +422,6 @@ AWS.Config = AWS.util.inherit({
     maxRetries: undefined,
     maxRedirects: 10,
     paramValidation: true,
-    strictParamValidation: false,
     sslEnabled: true,
     s3ForcePathStyle: false,
     s3BucketEndpoint: false,

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -85,8 +85,8 @@ AWS.EventListeners = {
 
     add('VALIDATE_PARAMETERS', 'validate', function VALIDATE_PARAMETERS(req) {
       var rules = req.service.api.operations[req.operation].input;
-      var isStrict = req.service.config.strictParamValidation;
-      new AWS.ParamValidator(isStrict).validate(rules, req.params);
+      var validation = req.service.config.paramValidation;
+      new AWS.ParamValidator(validation).validate(rules, req.params);
     });
 
     addAsync('COMPUTE_SHA256', 'afterBuild', function COMPUTE_SHA256(req, done) {

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -85,7 +85,8 @@ AWS.EventListeners = {
 
     add('VALIDATE_PARAMETERS', 'validate', function VALIDATE_PARAMETERS(req) {
       var rules = req.service.api.operations[req.operation].input;
-      new AWS.ParamValidator().validate(rules, req.params);
+      var isStrict = req.service.config.strictParamValidation;
+      new AWS.ParamValidator(isStrict).validate(rules, req.params);
     });
 
     addAsync('COMPUTE_SHA256', 'afterBuild', function COMPUTE_SHA256(req, done) {

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -20,6 +20,10 @@ function Shape(shape, options, memberName) {
   property(this, 'shape', shape.shape);
   property(this, 'api', options.api, false);
   property(this, 'type', shape.type);
+  property(this, 'enum', shape.enum);
+  property(this, 'min', shape.min);
+  property(this, 'max', shape.max);
+  property(this, 'pattern', shape.pattern);
   property(this, 'location', shape.location || this.location || 'body');
   property(this, 'name', this.name || shape.xmlName || shape.queryName ||
     shape.locationName || memberName);

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -4,6 +4,15 @@ var AWS = require('./core');
  * @api private
  */
 AWS.ParamValidator = AWS.util.inherit({
+  /**
+   * Create a new validator object.
+   *
+   * @param strict [bool] Whether or not to use strict validation.
+   */
+  constructor: function Service(strict) {
+    this.strict = strict === true;
+  },
+
   validate: function validate(shape, params, context) {
     this.errors = [];
     this.validateMember(shape, params || {}, context || 'params');
@@ -21,8 +30,12 @@ AWS.ParamValidator = AWS.util.inherit({
     }
   },
 
+  fail: function fail(code, message) {
+    this.errors.push(AWS.util.error(new Error(message), {code: code}));
+  },
+
   validateStructure: function validateStructure(shape, params, context) {
-    this.validateType(context, params, ['object'], 'structure');
+    this.validateType(params, context, ['object'], 'structure');
 
     var paramName;
     for (var i = 0; shape.required && i < shape.required.length; i++) {
@@ -67,21 +80,29 @@ AWS.ParamValidator = AWS.util.inherit({
   },
 
   validateList: function validateList(shape, params, context) {
-    this.validateType(context, params, [Array]);
-
-    // validate array members
-    for (var i = 0; i < params.length; i++) {
-      this.validateMember(shape.member, params[i], context + '[' + i + ']');
+    if (this.validateType(params, context, [Array])) {
+      this.validateRange(shape, params.length, context, 'list member count');
+      // validate array members
+      for (var i = 0; i < params.length; i++) {
+        this.validateMember(shape.member, params[i], context + '[' + i + ']');
+      }
     }
   },
 
   validateMap: function validateMap(shape, params, context) {
-    this.validateType(context, params, ['object'], 'map');
-
-    for (var param in params) {
-      if (!params.hasOwnProperty(param)) continue;
-      this.validateMember(shape.value, params[param],
-                          context + '[\'' + param + '\']');
+    if (this.validateType(params, context, ['object'], 'map')) {
+      // Build up a count of map members to validate range traits.
+      var mapCount = 0;
+      for (var param in params) {
+        if (!params.hasOwnProperty(param)) continue;
+        // Validate any map key trait constraints
+        this.validateMember(shape.key, param,
+                            context + '[key=\'' + param + '\']')
+        this.validateMember(shape.value, params[param],
+                            context + '[\'' + param + '\']');
+        mapCount++;
+      }
+      this.validateRange(shape, mapCount, context, 'map member count');
     }
   },
 
@@ -90,17 +111,17 @@ AWS.ParamValidator = AWS.util.inherit({
       case null:
       case undefined:
       case 'string':
-        return this.validateType(context, value, ['string']);
+        return this.validateString(shape, value, context);
       case 'base64':
       case 'binary':
-        return this.validatePayload(context, value);
+        return this.validatePayload(value, context);
       case 'integer':
       case 'float':
-        return this.validateNumber(context, value);
+        return this.validateNumber(shape, value, context);
       case 'boolean':
-        return this.validateType(context, value, ['boolean']);
+        return this.validateType(value, context, ['boolean']);
       case 'timestamp':
-        return this.validateType(context, value, [Date,
+        return this.validateType(value, context, [Date,
           /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/, 'number'],
           'Date object, ISO-8601 string, or a UNIX timestamp');
       default:
@@ -109,22 +130,60 @@ AWS.ParamValidator = AWS.util.inherit({
     }
   },
 
-  fail: function fail(code, message) {
-    this.errors.push(AWS.util.error(new Error(message), {code: code}));
+  validateString: function validateString(shape, value, context) {
+    if (this.validateType(value, context, ['string'])) {
+      this.validateEnum(shape, value, context);
+      this.validateRange(shape, value.length, context, 'string length');
+      this.validatePattern(shape, value, context);
+    }
   },
 
-  validateType: function validateType(context, value, acceptedTypes, type) {
-    if (value === null || value === undefined) return;
+  validatePattern: function validatePattern(shape, value, context) {
+    if (this.strict && shape['pattern'] !== undefined) {
+      if (!(new RegExp(shape['pattern'])).test(value)) {
+        this.fail('PatternMatchError', 'Provided value "' + value + '" '
+          + 'does not match regex pattern /' + shape['pattern'] + '/');
+      }
+    }
+  },
+
+  validateRange: function validateRange(shape, value, context, descriptor) {
+    if (this.strict) {
+      if (shape['min'] !== undefined && value < shape['min']) {
+        this.fail('MinRangeError', 'Expected ' + descriptor + ' >= '
+          + shape['min'] + ', but found ' + value);
+      }
+      if (shape['max'] !== undefined && value > shape['max']) {
+        this.fail('MaxRangeError', 'Expected ' + descriptor + ' <= '
+          + shape['max'] + ', but found ' + value);
+      }
+    }
+  },
+
+  validateEnum: function validateRange(shape, value, context) {
+    if (this.strict && shape['enum'] !== undefined) {
+      // Fail if the string value is not present in the enum list
+      if (shape['enum'].indexOf(value) === -1) {
+        this.fail('EnumError', 'Found string value of ' + value + ', but '
+          + 'expected ' + shape['enum'].join('|'));
+      }
+    }
+  },
+
+  validateType: function validateType(value, context, acceptedTypes, type) {
+    // We will not log an error for null or undefined, but we will return
+    // false so that callers know that the expected type was not strictly met.
+    if (value === null || value === undefined) return false;
 
     var foundInvalidType = false;
     for (var i = 0; i < acceptedTypes.length; i++) {
       if (typeof acceptedTypes[i] === 'string') {
-        if (typeof value === acceptedTypes[i]) return;
+        if (typeof value === acceptedTypes[i]) return true;
       } else if (acceptedTypes[i] instanceof RegExp) {
-        if ((value || '').toString().match(acceptedTypes[i])) return;
+        if ((value || '').toString().match(acceptedTypes[i])) return true;
       } else {
-        if (value instanceof acceptedTypes[i]) return;
-        if (AWS.util.isType(value, acceptedTypes[i])) return;
+        if (value instanceof acceptedTypes[i]) return true;
+        if (AWS.util.isType(value, acceptedTypes[i])) return true;
         if (!type && !foundInvalidType) acceptedTypes = acceptedTypes.slice();
         acceptedTypes[i] = AWS.util.typeName(acceptedTypes[i]);
       }
@@ -139,18 +198,21 @@ AWS.ParamValidator = AWS.util.inherit({
     var vowel = acceptedType.match(/^[aeiou]/i) ? 'n' : '';
     this.fail('InvalidParameterType', 'Expected ' + context + ' to be a' +
               vowel + ' ' + acceptedType);
+    return false;
   },
 
-  validateNumber: function validateNumber(context, value) {
+  validateNumber: function validateNumber(shape, value, context) {
     if (value === null || value === undefined) return;
     if (typeof value === 'string') {
       var castedValue = parseFloat(value);
       if (castedValue.toString() === value) value = castedValue;
     }
-    this.validateType(context, value, ['number']);
+    if (this.validateType(value, context, ['number'])) {
+      this.validateRange(shape, value, context, 'numeric value');
+    }
   },
 
-  validatePayload: function validatePayload(context, value) {
+  validatePayload: function validatePayload(value, context) {
     if (value === null || value === undefined) return;
     if (typeof value === 'string') return;
     if (value && typeof value.byteLength === 'number') return; // typed arrays

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -22,7 +22,7 @@ AWS.ParamValidator = AWS.util.inherit({
    *     * **enum** [Boolean] &mdash; Validates that a string value matches one
    *       of the allowable enum values.
    */
-  constructor: function Service(validation) {
+  constructor: function ParamValidator(validation) {
     if (validation === true || validation === undefined) {
       validation = {'min': true};
     }

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -7,10 +7,26 @@ AWS.ParamValidator = AWS.util.inherit({
   /**
    * Create a new validator object.
    *
-   * @param strict [bool] Whether or not to use strict validation.
+   * @param validation [Boolean|map] whether input parameters should be
+   *     validated against the operation description before sending the
+   *     request. Pass a map to enable any of the following specific
+   *     validation features:
+   *
+   *     * **min** [Boolean] &mdash; Validates that a value meets the min
+   *       constraint. This is enabled by default when paramValidation is set
+   *       to `true`.
+   *     * **max** [Boolean] &mdash; Validates that a value meets the max
+   *       constraint.
+   *     * **pattern** [Boolean] &mdash; Validates that a string value matches a
+   *       regular expression.
+   *     * **enum** [Boolean] &mdash; Validates that a string value matches one
+   *       of the allowable enum values.
    */
-  constructor: function Service(strict) {
-    this.strict = strict === true;
+  constructor: function Service(validation) {
+    if (validation === true || validation === undefined) {
+      validation = {'min': true};
+    }
+    this.validation = validation;
   },
 
   validate: function validate(shape, params, context) {
@@ -139,33 +155,36 @@ AWS.ParamValidator = AWS.util.inherit({
   },
 
   validatePattern: function validatePattern(shape, value, context) {
-    if (this.strict && shape['pattern'] !== undefined) {
+    if (this.validation['pattern'] && shape['pattern'] !== undefined) {
       if (!(new RegExp(shape['pattern'])).test(value)) {
         this.fail('PatternMatchError', 'Provided value "' + value + '" '
-          + 'does not match regex pattern /' + shape['pattern'] + '/');
+          + 'does not match regex pattern /' + shape['pattern'] + '/ for '
+          + context);
       }
     }
   },
 
   validateRange: function validateRange(shape, value, context, descriptor) {
-    if (this.strict) {
+    if (this.validation['min']) {
       if (shape['min'] !== undefined && value < shape['min']) {
         this.fail('MinRangeError', 'Expected ' + descriptor + ' >= '
-          + shape['min'] + ', but found ' + value);
+          + shape['min'] + ', but found ' + value + ' for ' + context);
       }
+    }
+    if (this.validation['max']) {
       if (shape['max'] !== undefined && value > shape['max']) {
         this.fail('MaxRangeError', 'Expected ' + descriptor + ' <= '
-          + shape['max'] + ', but found ' + value);
+          + shape['max'] + ', but found ' + value + ' for ' + context);
       }
     }
   },
 
   validateEnum: function validateRange(shape, value, context) {
-    if (this.strict && shape['enum'] !== undefined) {
+    if (this.validation['enum'] && shape['enum'] !== undefined) {
       // Fail if the string value is not present in the enum list
       if (shape['enum'].indexOf(value) === -1) {
         this.fail('EnumError', 'Found string value of ' + value + ', but '
-          + 'expected ' + shape['enum'].join('|'));
+          + 'expected ' + shape['enum'].join('|') + ' for ' + context);
       }
     }
   },

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -62,6 +62,10 @@ describe 'AWS.Config', ->
     it 'defaults to true', ->
       expect(configure().paramValidation).to.equal(true)
 
+  describe 'strictParamValidation', ->
+    it 'defaults to false', ->
+      expect(configure().strictParamValidation).to.equal(false)
+
   describe 'computeChecksums', ->
     it 'defaults to true', ->
       expect(configure().computeChecksums).to.equal(true)

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -62,10 +62,6 @@ describe 'AWS.Config', ->
     it 'defaults to true', ->
       expect(configure().paramValidation).to.equal(true)
 
-  describe 'strictParamValidation', ->
-    it 'defaults to false', ->
-      expect(configure().strictParamValidation).to.equal(false)
-
   describe 'computeChecksums', ->
     it 'defaults to true', ->
       expect(configure().computeChecksums).to.equal(true)

--- a/test/param_validator.spec.coffee
+++ b/test/param_validator.spec.coffee
@@ -498,79 +498,82 @@ describe 'AWS.ParamValidator', ->
               min: 2
               max: 4
 
-    it 'ignores range violations when strict is disabled', ->
-      expectValid {number: 1000}
+    it 'ignores max violations when max is disabled', ->
+      expectValid {number: 1000}, max: false
 
-    it 'accepts numbers at minimum', ->
-      expectValid {number: 2}, true
-
-    it 'accepts numbers above minimum', ->
-      expectValid {number: 3}, true
+    it 'ignores min violations when min is disabled', ->
+      expectValid {number: 1}, min: false
 
     it 'accepts numbers at maximum', ->
-      expectValid {number: 10}, true
-
-    it 'rejects numbers below minimum', ->
-      expectError 'Expected numeric value >= 2, but found 1',
-        {number: 1}, true
+      expectValid {number: 10}, max: true
 
     it 'rejects numbers above maximum', ->
-      expectError 'Expected numeric value <= 10, but found 11',
-        {number: 11}, true
+      expectError 'Expected numeric value <= 10, but found 11 for ' +
+        'params.number', {number: 11}, max: true
+
+    it 'accepts numbers at minimum', ->
+      expectValid {number: 2}, min: true
+
+    it 'accepts numbers above minimum', ->
+      expectValid {number: 3}, min: true
+
+    it 'rejects numbers below minimum', ->
+      expectError 'Expected numeric value >= 2, but found 1 for params.number',
+        {number: 1}, min: true
 
     it 'accepts strings at minimum', ->
-      expectValid {str: '123'}, true
+      expectValid {str: '123'}, min: true
 
     it 'accepts strings above minimum', ->
-      expectValid {str: '12345'}, true
-
-    it 'accepts strings at maximum', ->
-      expectValid {str: '123456'}, true
+      expectValid {str: '12345'}, min: true
 
     it 'rejects strings below minimum', ->
-      expectError 'Expected string length >= 3, but found 2',
-        {str: '12'}, true
+      expectError 'Expected string length >= 3, but found 2 for params.str',
+        {str: '12'}, min: true
+
+    it 'accepts strings at maximum', ->
+      expectValid {str: '123456'}, max: true
 
     it 'rejects strings above maximum', ->
-      expectError 'Expected string length <= 6, but found 9',
-        {str: '123456789'}, true
+      expectError 'Expected string length <= 6, but found 9 for params.str',
+        {str: '123456789'}, max: true
 
     it 'accepts lists at minimum', ->
-      expectValid {list: ['a', 'b']}, true
+      expectValid {list: ['a', 'b']}, min: true
 
     it 'accepts lists above minimum', ->
-      expectValid {list: ['a', 'b', 'c']}, true
+      expectValid {list: ['a', 'b', 'c']}, min: true
 
     it 'accepts lists at maximum', ->
-      expectValid {list: ['a', 'b', 'c', 'd']}, true
+      expectValid {list: ['a', 'b', 'c', 'd']}, max: true
 
     it 'rejects lists below minimum', ->
-      expectError 'Expected list member count >= 2, but found 1',
-        {list: ['a']}, true
-      expectError 'Expected list member count >= 2, but found 0',
-        {list: []}, true
+      expectError 'Expected list member count >= 2, but found 1 ' +
+        'for params.list', {list: ['a']}, min: true
+      expectError 'Expected list member count >= 2, but found 0 for ' +
+        'params.list', {list: []}, min: true
 
     it 'rejects lists above maximum', ->
-      expectError 'Expected list member count <= 4, but found 5',
-        {list: ['a', 'b', 'c', 'd', 'e']}, true
+      expectError 'Expected list member count <= 4, but found 5 ' +
+        'for params.list', {list: ['a', 'b', 'c', 'd', 'e']}, max: true
 
     it 'accepts maps at minimum', ->
-      expectValid {map: {ab: '1', cd: '2'}}, true
+      expectValid {map: {ab: '1', cd: '2'}}, min: true
 
     it 'accepts maps at maximum', ->
-      expectValid {map: {ab: '1', cd: '2', de: '3'}}, true
+      expectValid {map: {ab: '1', cd: '2', de: '3'}}, max: true
 
     it 'rejects maps below minimum', ->
-      expectError 'Expected map member count >= 2, but found 1',
-        {map: {ab: '1'}}, true
+      expectError 'Expected map member count >= 2, but found 1 ' +
+        'for params.map', {map: {ab: '1'}}, min: true
 
     it 'rejects maps above maximum member count', ->
-      expectError 'Expected map member count <= 3, but found 4',
-        {map: {ab: '1', cd: '2', de: '3', ef: '4'}}, true
+      expectError 'Expected map member count <= 3, but found 4 for params.map',
+        {map: {ab: '1', cd: '2', de: '3', ef: '4'}}, max: true
 
     it 'rejects maps where key is out of range', ->
-      expectError 'Expected string length <= 4, but found 5',
-        {map: {abcde: '1', fg: '2'}}, true
+      expectError 'Expected string length <= 4, but found 5 for params.map',
+        {map: {abcde: '1', fg: '2'}}, max: true
 
   describe 'strict enum validation', ->
     beforeEach ->
@@ -587,31 +590,31 @@ describe 'AWS.ParamValidator', ->
               type: 'string'
               enum: ['old', 'man', 'sea']
 
+    it 'ignores enum violations when strict is disabled', ->
+      expectValid {str: 'Dickens'}, enum: false
+
     it 'accepts strings matching first enum value', ->
-      expectValid str: 'Hemingway', true
+      expectValid {str: 'Hemingway'}, enum: true
 
     it 'accepts strings matching last enum value', ->
-      expectValid str: 'Poe', true
-
-    it 'ignores enum violations when strict is disabled', ->
-      expectValid str: 'Dickens'
+      expectValid {str: 'Poe'}, enum: true
 
     it 'rejects strings not in enum list', ->
       expectError 'Found string value of Shakespeare, but expected ' +
-        'Hemingway|Faulkner|Twain|Poe',
-        str: 'Shakespeare', true
+        'Hemingway|Faulkner|Twain|Poe for params.str',
+        {str: 'Shakespeare'}, enum: true
 
     it 'rejects strings not exactly in enum list', ->
       expectError 'Found string value of twain, but expected ' +
-        'Hemingway|Faulkner|Twain|Poe',
-        str: 'twain', true
+        'Hemingway|Faulkner|Twain|Poe for params.str',
+        {str: 'twain'}, enum: true
 
     it 'accepts map keys found in enum trait', ->
-      expectValid {map: {old: 'abc'}}, true
+      expectValid {map: {old: 'abc'}}, enum: true
 
     it 'rejects map keys not found in enum trait', ->
-      expectError 'Found string value of the, but expected old|man|sea',
-        {map: {the: 'abc'}}, true
+      expectError 'Found string value of the, but expected old|man|sea ' +
+        'for params.map[key=\'the\']', {map: {the: 'abc'}}, enum: true
 
   describe 'strict pattern validation', ->
     beforeEach ->
@@ -621,12 +624,13 @@ describe 'AWS.ParamValidator', ->
             type: 'string'
             pattern: '^[0-9a-f]{8,63}$'
 
+    it 'ignores pattern violations when strict is disabled', ->
+      expectValid {str: 'foobazbar'}, pattern: false
+
     it 'accepts strings matching pattern', ->
-      expectValid str: '1234aaee', true
+      expectValid {str: '1234aaee'}, pattern: true
 
     it 'rejects strings that do not match pattern', ->
       expectError 'Provided value "foobazbar" does not match ' +
-        'regex pattern /^[0-9a-f]{8,63}$/', str: 'foobazbar', true
-
-    it 'ignores pattern violations when strict is disabled', ->
-      expectValid str: 'foobazbar'
+        'regex pattern /^[0-9a-f]{8,63}$/ for params.str',
+        {str: 'foobazbar'}, pattern: true

--- a/test/param_validator.spec.coffee
+++ b/test/param_validator.spec.coffee
@@ -5,19 +5,19 @@ Buffer = AWS.util.Buffer
 describe 'AWS.ParamValidator', ->
   [members, input] = [{}, {}]
 
-  validate = (params) ->
+  validate = (params, strict) ->
     r = input
     if r && !r.xml && !r.payload
       r = AWS.Model.Shape.create(input, {api: {}})
-    new AWS.ParamValidator().validate(r, params)
+    new AWS.ParamValidator(strict).validate(r, params)
 
-  expectValid = (params) ->
-    expect(validate(params)).to.equal(true)
+  expectValid = (params, strict) ->
+    expect(validate(params, strict)).to.equal(true)
 
-  expectError = (message, params) ->
+  expectError = (message, params, strict) ->
     if params == undefined
       [message, params] = [undefined, message]
-    expect(-> validate(params)).to.throw(message)
+    expect(-> validate(params, strict)).to.throw(message)
 
   # empty input (nil or {}) means no arguments are accepted
   describe 'empty input', ->
@@ -468,3 +468,165 @@ describe 'AWS.ParamValidator', ->
         "* MissingRequiredParameter: Missing required key 'param2' in params\n" +
         "* InvalidParameterType: Expected params.param1 to be a boolean"
       expectError msg, param1: 'notboolean'
+
+  describe 'strict range validation', ->
+    beforeEach ->
+      input =
+        members:
+          number:
+            type: 'float'
+            min: 2
+            max: 10
+          str:
+            type: 'string'
+            min: 3
+            max: 6
+          list:
+            type: 'list'
+            min: 2
+            max: 4
+            member:
+              type: 'string'
+          map:
+            type: 'map'
+            min: 2
+            max: 3
+            value:
+              type: 'string'
+            key:
+              type: 'string'
+              min: 2
+              max: 4
+
+    it 'ignores range violations when strict is disabled', ->
+      expectValid {number: 1000}
+
+    it 'accepts numbers at minimum', ->
+      expectValid {number: 2}, true
+
+    it 'accepts numbers above minimum', ->
+      expectValid {number: 3}, true
+
+    it 'accepts numbers at maximum', ->
+      expectValid {number: 10}, true
+
+    it 'rejects numbers below minimum', ->
+      expectError 'Expected numeric value >= 2, but found 1',
+        {number: 1}, true
+
+    it 'rejects numbers above maximum', ->
+      expectError 'Expected numeric value <= 10, but found 11',
+        {number: 11}, true
+
+    it 'accepts strings at minimum', ->
+      expectValid {str: '123'}, true
+
+    it 'accepts strings above minimum', ->
+      expectValid {str: '12345'}, true
+
+    it 'accepts strings at maximum', ->
+      expectValid {str: '123456'}, true
+
+    it 'rejects strings below minimum', ->
+      expectError 'Expected string length >= 3, but found 2',
+        {str: '12'}, true
+
+    it 'rejects strings above maximum', ->
+      expectError 'Expected string length <= 6, but found 9',
+        {str: '123456789'}, true
+
+    it 'accepts lists at minimum', ->
+      expectValid {list: ['a', 'b']}, true
+
+    it 'accepts lists above minimum', ->
+      expectValid {list: ['a', 'b', 'c']}, true
+
+    it 'accepts lists at maximum', ->
+      expectValid {list: ['a', 'b', 'c', 'd']}, true
+
+    it 'rejects lists below minimum', ->
+      expectError 'Expected list member count >= 2, but found 1',
+        {list: ['a']}, true
+      expectError 'Expected list member count >= 2, but found 0',
+        {list: []}, true
+
+    it 'rejects lists above maximum', ->
+      expectError 'Expected list member count <= 4, but found 5',
+        {list: ['a', 'b', 'c', 'd', 'e']}, true
+
+    it 'accepts maps at minimum', ->
+      expectValid {map: {ab: '1', cd: '2'}}, true
+
+    it 'accepts maps at maximum', ->
+      expectValid {map: {ab: '1', cd: '2', de: '3'}}, true
+
+    it 'rejects maps below minimum', ->
+      expectError 'Expected map member count >= 2, but found 1',
+        {map: {ab: '1'}}, true
+
+    it 'rejects maps above maximum member count', ->
+      expectError 'Expected map member count <= 3, but found 4',
+        {map: {ab: '1', cd: '2', de: '3', ef: '4'}}, true
+
+    it 'rejects maps where key is out of range', ->
+      expectError 'Expected string length <= 4, but found 5',
+        {map: {abcde: '1', fg: '2'}}, true
+
+  describe 'strict enum validation', ->
+    beforeEach ->
+      input =
+        members:
+          str:
+            type: 'string'
+            enum: ['Hemingway', 'Faulkner', 'Twain', 'Poe']
+          map:
+            type: 'map',
+            value:
+              type: 'string'
+            key:
+              type: 'string'
+              enum: ['old', 'man', 'sea']
+
+    it 'accepts strings matching first enum value', ->
+      expectValid str: 'Hemingway', true
+
+    it 'accepts strings matching last enum value', ->
+      expectValid str: 'Poe', true
+
+    it 'ignores enum violations when strict is disabled', ->
+      expectValid str: 'Dickens'
+
+    it 'rejects strings not in enum list', ->
+      expectError 'Found string value of Shakespeare, but expected ' +
+        'Hemingway|Faulkner|Twain|Poe',
+        str: 'Shakespeare', true
+
+    it 'rejects strings not exactly in enum list', ->
+      expectError 'Found string value of twain, but expected ' +
+        'Hemingway|Faulkner|Twain|Poe',
+        str: 'twain', true
+
+    it 'accepts map keys found in enum trait', ->
+      expectValid {map: {old: 'abc'}}, true
+
+    it 'rejects map keys not found in enum trait', ->
+      expectError 'Found string value of the, but expected old|man|sea',
+        {map: {the: 'abc'}}, true
+
+  describe 'strict pattern validation', ->
+    beforeEach ->
+      input =
+        members:
+          str:
+            type: 'string'
+            pattern: '^[0-9a-f]{8,63}$'
+
+    it 'accepts strings matching pattern', ->
+      expectValid str: '1234aaee', true
+
+    it 'rejects strings that do not match pattern', ->
+      expectError 'Provided value "foobazbar" does not match ' +
+        'regex pattern /^[0-9a-f]{8,63}$/', str: 'foobazbar', true
+
+    it 'ignores pattern violations when strict is disabled', ->
+      expectValid str: 'foobazbar'


### PR DESCRIPTION
This commit updates the JavaScript SDK to allow it to perform strict
validation client-side using the enum, min, max, and pattern traits.
Validating based on these traits are (and should be) an opt-in for
customers as overly strict client-side validation can cause unnecessary
inconvenience when a service team relaxes any validation constraints.
However, being able to perform strict validation would enable tooling
that utilizes the JavaScript SDK to have more confidence on whether or
not inputs and outputs match a service's model at a point in time.

Note that this commit does not switch the JS SDK over to using the
regular models without minification.

/cc @chrisradek @jeskew 