### PR TITLE
Remove mention of the old .done()/.fail() methods

### DIFF
--- a/doc-src/guide/browser-making-requests.md
+++ b/doc-src/guide/browser-making-requests.md
@@ -185,7 +185,7 @@ with the serialized response data from the service.
 For example:
 
 ```javascript
-s3.listBuckets().done(function(response) {
+s3.listBuckets().on('success', function(response) {
   console.log(response.data);
 }).send();
 ```
@@ -214,7 +214,7 @@ as the first parameter to the event:
 
 ```javascript
 s3.config.credentials.accessKeyId = 'invalid';
-s3.listBuckets().fail(function(error, response) {
+s3.listBuckets().on('error', function(error, response) {
   console.log(error);
   // or:
   console.log(response.error);

--- a/doc-src/guide/node-making-requests.md
+++ b/doc-src/guide/node-making-requests.md
@@ -185,7 +185,7 @@ with the serialized response data from the service.
 For example:
 
 ```javascript
-s3.listBuckets().done(function(response) {
+s3.listBuckets().on('success', function(response) {
   console.log(response.data);
 }).send();
 ```
@@ -214,7 +214,7 @@ as the first parameter to the event:
 
 ```javascript
 s3.config.credentials.accessKeyId = 'invalid';
-s3.listBuckets().fail(function(error, response) {
+s3.listBuckets().on('error', function(error, response) {
   console.log(error);
   // or:
   console.log(response.error);


### PR DESCRIPTION
These were removed in #22 but still exist in the [public documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-making-requests.html)