### PR TITLE
adding support to run within a web worker context

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -18,3 +18,4 @@ require('./http/xhr');
 
 if (typeof window !== 'undefined') window.AWS = AWS;
 if (typeof module !== 'undefined') module.exports = AWS;
+if (typeof self !== 'undefined') self.AWS = AWS;


### PR DESCRIPTION
if the library is loaded inside a webworker, the window object is undefined. instead, self can be used as the global root object. 