### PR TITLE
Allow calling createBucket with only bound params. Resolves #799.

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -38,9 +38,8 @@ AWS.util.update(AWS.S3.prototype, {
     request.addListener('beforePresign', this.prepareSignedUrl);
   },
 
-  /*
+  /**
    * @api private
-   *
    */
   validateScheme: function(req) {
     var params = req.params,
@@ -54,9 +53,8 @@ AWS.util.update(AWS.S3.prototype, {
     }
   },
 
-  /*
+  /**
    * @api private
-   *
    */
   validateBucketEndpoint: function(req) {
     if (!req.params.Bucket && req.service.config.s3BucketEndpoint) {
@@ -411,7 +409,10 @@ AWS.util.update(AWS.S3.prototype, {
     // This chunk of code will set the location constraint param based
     // on the region (when possible), but it will not override a passed-in
     // location constraint.
-    if (!params) params = {};
+    if (typeof params === 'function' || !params) {
+      callback = callback || params;
+      params = {};
+    }
     var hostname = this.endpoint.hostname;
     if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
       params.CreateBucketConfiguration = { LocationConstraint: this.config.region };

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -547,11 +547,42 @@ describe 'AWS.S3', ->
       loc = null
       s3 = new AWS.S3(region:'eu-west-1')
       s3.makeRequest = (op, params) ->
+        expect(params).to['be'].a('object')
         loc = params.CreateBucketConfiguration.LocationConstraint
       s3.createBucket(Bucket:'name')
       expect(loc).to.equal('eu-west-1')
 
-    it 'correctly builds the xml', ->
+    it 'auto-populates the LocationConstraint based on the region when using bound params', ->
+      loc = null
+      s3 = new AWS.S3(region:'eu-west-1', Bucket:'name')
+      s3.makeRequest = (op, params) ->
+        expect(params).to['be'].a('object')
+        loc = params.CreateBucketConfiguration.LocationConstraint
+      s3.createBucket(AWS.util.fn.noop)
+      expect(loc).to.equal('eu-west-1')
+
+    it 'auto-populates the LocationConstraint based on the region when using invalid params', ->
+      loc = null
+      s3 = new AWS.S3(region:'eu-west-1', Bucket:'name')
+      s3.makeRequest = (op, params) ->
+        expect(params).to['be'].a('object')
+        loc = params.CreateBucketConfiguration.LocationConstraint
+      s3.createBucket(null)
+      expect(loc).to.equal('eu-west-1')
+      s3.createBucket(undefined)
+      expect(loc).to.equal('eu-west-1')
+
+    it 'auto-populates the LocationConstraint based on the region when using invalid params and a valid callback', ->
+      loc = null
+      s3 = new AWS.S3(region:'eu-west-1', Bucket:'name')
+      s3.makeRequest = (op, params, cb) ->
+        expect(params).to['be'].a('object')
+        loc = params.CreateBucketConfiguration.LocationConstraint
+        cb() if typeof cb == 'function'
+      called = 0
+      s3.createBucket(undefined, () -> called = 1)
+      expect(loc).to.equal('eu-west-1')
+      expect(called).to.equal(1)
 
   AWS.util.each AWS.S3.prototype.computableChecksumOperations, (operation) ->
     describe operation, ->


### PR DESCRIPTION
`AWS.S3.createBucket` was not handling cases where users passed in only a callback.

/cc @chrisradek @LiuJoyceC 