### PR TITLE
Fixes error response for truncated XML response in Node, for issue #886.

### DIFF
--- a/lib/xml/browser_parser.js
+++ b/lib/xml/browser_parser.js
@@ -14,24 +14,43 @@ DomXmlParser.prototype.parse = function(xml, shape) {
         result = parser.parseFromString(xml, 'text/xml');
       } catch (syntaxError) {
         throw util.error(new Error('Parse error in document'),
-          {originalError: syntaxError});
+          {
+            originalError: syntaxError,
+            code: 'XMLParserError',
+            retryable: true
+          });
       }
 
       if (result.documentElement === null) {
-        throw new Error('Cannot parse empty document.');
+        throw util.error(new Error('Cannot parse empty document.'),
+          {
+            code: 'XMLParserError',
+            retryable: true
+          });
       }
 
       var isError = result.getElementsByTagName('parsererror')[0];
       if (isError && (isError.parentNode === result ||
-          isError.parentNode.nodeName === 'body')) {
-        throw new Error(isError.getElementsByTagName('div')[0].textContent);
+          isError.parentNode.nodeName === 'body' ||
+          isError.parentNode.parentNode === result ||
+          isError.parentNode.parentNode.nodeName === 'body')) {
+        var errorElement = isError.getElementsByTagName('div')[0] || isError;
+        throw util.error(new Error(errorElement.textContent || 'Parser error in document'),
+          {
+            code: 'XMLParserError',
+            retryable: true
+          });
       }
     } else if (window.ActiveXObject) {
       result = new window.ActiveXObject('Microsoft.XMLDOM');
       result.async = false;
 
       if (!result.loadXML(xml)) {
-        throw new Error('Parse error in document');
+        throw util.error(new Error('Parse error in document'),
+          {
+            code: 'XMLParserError',
+            retryable: true
+          });
       }
     } else {
       throw new Error('Cannot load XML parser');
@@ -48,7 +67,7 @@ DomXmlParser.prototype.parse = function(xml, shape) {
     }
     return data;
   } else if (error) {
-    throw util.error(error || new Error(), {code: 'XMLParserError'});
+    throw util.error(error || new Error(), {code: 'XMLParserError', retryable: true});
   } else { // empty xml document
     return {};
   }

--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -39,7 +39,7 @@ NodeXmlParser.prototype.parse = function(xml, shape) {
     }
     return data;
   } else if (error) {
-    throw util.error(error, {code: 'XMLParserError'});
+    throw util.error(error, {code: 'XMLParserError', retryable: true});
   } else { // empty xml document
     return parseXml({}, shape);
   }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
       "insert-module-globals": "^7.0.0"
     },
     "dependencies": {
-      "sax": "0.5.3",
-      "xml2js": "0.2.8",
-      "xmlbuilder": "0.4.2"
+      "sax": "1.1.5",
+      "xml2js": "0.4.16",
+      "xmlbuilder": "4.2.1"
     },
     "main": "lib/aws.js",
     "browser": "lib/browser.js",

--- a/test/xml/parser.spec.coffee
+++ b/test/xml/parser.spec.coffee
@@ -612,3 +612,13 @@ describe 'AWS.XML.Parser', ->
         error = e
       expect(error.code).to.equal('XMLParserError')
 
+    if AWS.util.isNode()
+      it 'throws an error when xml is incomplete or does not close all tags', ->
+        xml = '<Content><Member>MemberText</Member><Subcontent><Submember>SubMemberText'
+        rules = {}
+        error = {}
+        try
+          new AWS.XML.Parser().parse(xml, rules)
+        catch e
+          error = e
+        expect(error.code).to.equal('XMLParserError')

--- a/test/xml/parser.spec.coffee
+++ b/test/xml/parser.spec.coffee
@@ -612,13 +612,22 @@ describe 'AWS.XML.Parser', ->
         error = e
       expect(error.code).to.equal('XMLParserError')
 
-    if AWS.util.isNode()
-      it 'throws an error when xml is incomplete or does not close all tags', ->
-        xml = '<Content><Member>MemberText</Member><Subcontent><Submember>SubMemberText'
-        rules = {}
-        error = {}
-        try
-          new AWS.XML.Parser().parse(xml, rules)
-        catch e
-          error = e
-        expect(error.code).to.equal('XMLParserError')
+    it 'throws an error when xml is incomplete or does not close all tags', ->
+      xml = '<Content><Member>MemberText</Member><Subcontent><Submember>SubMemberText'
+      rules = {}
+      error = {}
+      try
+        new AWS.XML.Parser().parse(xml, rules)
+      catch e
+        error = e
+      expect(error.code).to.equal('XMLParserError')
+
+    it 'xml parser errors are retryable', ->
+      xml = '<Content><Member>MemberText</Member><Subcontent><Submember>SubMemberText'
+      rules = {}
+      error = {}
+      try
+        new AWS.XML.Parser().parse(xml, rules)
+      catch e
+        error = e
+      expect(error.retryable).to.be.true


### PR DESCRIPTION
S3.listObjects was not passing an error to the callback when the XML response was truncated. This fix corrects this issue in Node, and makes the error retryable. Resolves #886 

/cc @chrisradek 