### PR TITLE
test & support node 4.2 (latest LTS) and 5.x (Stable)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 #  - "0.8"
   - "0.10"
   - "0.12"
+  - "4.2"
+  - "node"
 
 before_install:
   - "if [[ `node -v` == v0.8.* ]]; then npm install -g npm || exit 0; fi"

--- a/dist-tools/browser-builder.js
+++ b/dist-tools/browser-builder.js
@@ -52,7 +52,7 @@ function build(options, callback) {
     options = {};
   }
 
-  var img = require('browserify/node_modules/insert-module-globals');
+  var img = require('insert-module-globals');
   img.vars.process = function() { return '{browser:true}'; };
 
   if (options.services) process.env.AWS_SERVICES = options.services;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
       "mocha": "*",
       "chai": "*",
       "istanbul": "*",
-      "coveralls": "2.x"
+      "coveralls": "2.x",
+      "insert-module-globals": "^7.0.0"
     },
     "dependencies": {
       "sax": "0.5.3",


### PR DESCRIPTION
The change at `dist-tools/browser-builder.js` was required because of npm@3 flat structure.