### PR TITLE
Add/cust retry delay

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -80,13 +80,20 @@ require('./credentials/credential_provider_chain');
  * @!attribute retryDelayOptions
  *   @example Set the base retry delay for all services to 100 ms
  *     AWS.config.update({retryDelayOptions: {base: 100}});
- *     //Delays with maxRetries = 3: 100, 200, 400
+ *     // Delays with maxRetries = 3: 100, 200, 400
+ *   @example Set a custom backoff function to provide delay values on retries
+ *     AWS.config.update({retryDelayOptions: {customBackoff: function(retryCount) {
+ *       // returns delay in ms
+ *     }}});
  *   @note This works with all services except DynamoDB.
  *   @return [map] A set of options to configure the retry delay on retryable errors.
  *     Currently supported options are:
  *
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
  *       exponential backoff for operation retries. Defaults to 30 ms.
+ *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
+ *       and returns the amount of time to delay in milliseconds. The `base` option will be
+ *       ignored if this option is supplied.
  *
  * @!attribute httpOptions
  *   @return [map] A set of options to pass to the low-level HTTP request.

--- a/lib/config.js
+++ b/lib/config.js
@@ -202,6 +202,9 @@ AWS.Config = AWS.util.inherit({
    *
    *   * **base** [Integer] &mdash; The base number of milliseconds to use in the
    *     exponential backoff for operation retries. Defaults to 30 ms.
+   *   * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
+   *     and returns the amount of time to delay in milliseconds. The `base` option will be
+   *     ignored if this option is supplied.
    * @option options httpOptions [map] A set of options to pass to the low-level
    *   HTTP request. Currently supported options are:
    *

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,17 @@ require('./credentials/credential_provider_chain');
  *   @return [Boolean] whether the provided endpoint addresses an individual
  *     bucket (false if it addresses the root API endpoint).
  *
+ * @!attribute retryDelayOptions
+ *   @example Set the base retry delay for all services to 100 ms
+ *     AWS.config.update({retryDelayOptions: {base: 100}});
+ *     //Delays with maxRetries = 3: 100, 200, 400
+ *   @note This works with all services except DynamoDB.
+ *   @return [map] A set of options to configure the retry delay on retryable errors.
+ *     Currently supported options are:
+ *
+ *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
+ *       exponential backoff for operation retries. Defaults to 30 ms.
+ *
  * @!attribute httpOptions
  *   @return [map] A set of options to pass to the low-level HTTP request.
  *     Currently supported options are:
@@ -179,6 +190,11 @@ AWS.Config = AWS.util.inherit({
    *   addresses an individual bucket (false if it addresses the root API
    *   endpoint). Note that setting this configuration option requires an
    *   `endpoint` to be provided explicitly to the service constructor.
+   * @option options retryDelayOptions [map] A set of options to configure
+   *   the retry delay on retryable errors. Currently supported options are:
+   *
+   *   * **base** [Integer] &mdash; The base number of milliseconds to use in the
+   *     exponential backoff for operation retries. Defaults to 30 ms.
    * @option options httpOptions [map] A set of options to pass to the low-level
    *   HTTP request. Currently supported options are:
    *
@@ -432,7 +448,10 @@ AWS.Config = AWS.util.inherit({
     dynamoDbCrc32: true,
     systemClockOffset: 0,
     signatureVersion: null,
-    signatureCache: true
+    signatureCache: true,
+    retryDelayOptions: {
+      base: 30
+    }
   },
 
   /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,9 +78,9 @@ require('./credentials/credential_provider_chain');
  *     bucket (false if it addresses the root API endpoint).
  *
  * @!attribute retryDelayOptions
- *   @example Set the base retry delay for all services to 100 ms
- *     AWS.config.update({retryDelayOptions: {base: 100}});
- *     // Delays with maxRetries = 3: 100, 200, 400
+ *   @example Set the base retry delay for all services to 300 ms
+ *     AWS.config.update({retryDelayOptions: {base: 300}});
+ *     // Delays with maxRetries = 3: 300, 600, 1200
  *   @example Set a custom backoff function to provide delay values on retries
  *     AWS.config.update({retryDelayOptions: {customBackoff: function(retryCount) {
  *       // returns delay in ms
@@ -90,7 +90,7 @@ require('./credentials/credential_provider_chain');
  *     Currently supported options are:
  *
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
- *       exponential backoff for operation retries. Defaults to 30 ms.
+ *       exponential backoff for operation retries. Defaults to 100 ms.
  *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
  *       and returns the amount of time to delay in milliseconds. The `base` option will be
  *       ignored if this option is supplied.
@@ -201,7 +201,7 @@ AWS.Config = AWS.util.inherit({
    *   the retry delay on retryable errors. Currently supported options are:
    *
    *   * **base** [Integer] &mdash; The base number of milliseconds to use in the
-   *     exponential backoff for operation retries. Defaults to 30 ms.
+   *     exponential backoff for operation retries. Defaults to 100 ms.
    *   * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
    *     and returns the amount of time to delay in milliseconds. The `base` option will be
    *     ignored if this option is supplied.
@@ -460,7 +460,7 @@ AWS.Config = AWS.util.inherit({
     signatureVersion: null,
     signatureCache: true,
     retryDelayOptions: {
-      base: 30
+      base: 100
     }
   },
 

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -351,8 +351,7 @@ AWS.EventListeners = {
         if (resp.error.redirect && resp.redirectCount < resp.maxRedirects) {
           resp.error.retryDelay = 0;
         } else if (resp.retryCount < resp.maxRetries) {
-          var delays = this.service.retryDelays();
-          resp.error.retryDelay = delays[resp.retryCount] || 0;
+          resp.error.retryDelay = this.service.retryDelays(resp.retryCount);
         }
       }
     });

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -351,7 +351,7 @@ AWS.EventListeners = {
         if (resp.error.redirect && resp.redirectCount < resp.maxRedirects) {
           resp.error.retryDelay = 0;
         } else if (resp.retryCount < resp.maxRetries) {
-          resp.error.retryDelay = this.service.retryDelays(resp.retryCount);
+          resp.error.retryDelay = this.service.retryDelays(resp.retryCount) || 0;
         }
       }
     });

--- a/lib/service.js
+++ b/lib/service.js
@@ -299,13 +299,11 @@ AWS.Service = inherit({
   /**
    * @api private
    */
-  retryDelays: function retryDelays() {
-    var retryCount = this.numRetries();
-    var delays = [];
-    for (var i = 0; i < retryCount; ++i) {
-      delays[i] = Math.pow(2, i) * 30;
-    }
-    return delays;
+  retryDelays: function retryDelays(retryCount) {
+    var retryDelayOptions = this.config.retryDelayOptions || {};
+    var base = retryDelayOptions.base || 30;
+    var delay = Math.pow(2, retryCount) * base;
+    return delay;
   },
 
   /**

--- a/lib/service.js
+++ b/lib/service.js
@@ -301,6 +301,10 @@ AWS.Service = inherit({
    */
   retryDelays: function retryDelays(retryCount) {
     var retryDelayOptions = this.config.retryDelayOptions || {};
+    var customBackoff = retryDelayOptions.customBackoff || null;
+    if (typeof customBackoff === 'function') {
+      return customBackoff(retryCount);
+    }
     var base = retryDelayOptions.base || 30;
     var delay = Math.pow(2, retryCount) * base;
     return delay;

--- a/lib/service.js
+++ b/lib/service.js
@@ -306,7 +306,7 @@ AWS.Service = inherit({
       return customBackoff(retryCount);
     }
     var base = retryDelayOptions.base || 30;
-    var delay = Math.pow(2, retryCount) * base;
+    var delay = Math.random() * (Math.pow(2, retryCount) * base);
     return delay;
   },
 

--- a/lib/services/dynamodb.js
+++ b/lib/services/dynamodb.js
@@ -45,16 +45,8 @@ AWS.util.update(AWS.DynamoDB.prototype, {
   /**
    * @api private
    */
-  retryDelays: function retryDelays() {
-    var retryCount = this.numRetries();
-    var delays = [];
-    for (var i = 0; i < retryCount; ++i) {
-      if (i === 0) {
-        delays.push(0);
-      } else {
-        delays.push(50 * Math.pow(2, i - 1));
-      }
-    }
-    return delays;
+  retryDelays: function retryDelays(retryCount) {
+    var delay = retryCount > 0 ? (50 * Math.pow(2, retryCount - 1)) : 0;
+    return delay;
   }
 });

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -59,10 +59,10 @@ describe 'AWS.Config', ->
       expect(configure(maxRetries: 2).maxRetries).to.equal(2)
 
   describe 'retryDelayOptions', ->
-    it 'defaults to "base: 30"', ->
-      expect(configure().retryDelayOptions).to.eql({base: 30})
+    it 'defaults to "base: 100"', ->
+      expect(configure().retryDelayOptions).to.eql({base: 100})
     it 'can set "base" to an integer', ->
-      expect(configure(retryDelayOptions: {base: 100}).retryDelayOptions).to.eql({base: 100})
+      expect(configure(retryDelayOptions: {base: 30}).retryDelayOptions).to.eql({base: 30})
 
   describe 'paramValidation', ->
     it 'defaults to true', ->

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -58,6 +58,12 @@ describe 'AWS.Config', ->
     it 'can be set to an integer', ->
       expect(configure(maxRetries: 2).maxRetries).to.equal(2)
 
+  describe 'retryDelayOptions', ->
+    it 'defaults to "base: 30"', ->
+      expect(configure().retryDelayOptions).to.eql({base: 30})
+    it 'can set "base" to an integer', ->
+      expect(configure(retryDelayOptions: {base: 100}).retryDelayOptions).to.eql({base: 100})
+
   describe 'paramValidation', ->
     it 'defaults to true', ->
       expect(configure().paramValidation).to.equal(true)

--- a/test/event_listeners.spec.coffee
+++ b/test/event_listeners.spec.coffee
@@ -353,6 +353,27 @@ describe 'AWS.EventListeners', ->
       makeRequest(->)
       expect(delays).to.eql([30, 60, 120])
 
+    it 'retries with falloff using custom base', ->
+      service.config.update(retryDelayOptions: {base: 100})
+      helpers.mockHttpResponse
+        code: 'NetworkingError', message: 'Cannot connect'
+      makeRequest(->)
+      expect(delays).to.eql([100, 200, 400])
+
+    it 'retries with falloff using custom backoff', ->
+      service.config.update(retryDelayOptions: {customBackoff: (retryCount) -> 2 * retryCount })
+      helpers.mockHttpResponse
+        code: 'NetworkingError', message: 'Cannot connect'
+      makeRequest(->)
+      expect(delays).to.eql([0, 2, 4])
+
+    it 'retries with falloff using custom backoff instead of base', ->
+      service.config.update(retryDelayOptions: {base: 100, customBackoff: (retryCount) -> 2 * retryCount })
+      helpers.mockHttpResponse
+        code: 'NetworkingError', message: 'Cannot connect'
+      makeRequest(->)
+      expect(delays).to.eql([0, 2, 4])
+
     it 'uses retry from error.retryDelay property', ->
       helpers.mockHttpResponse
         code: 'NetworkingError', message: 'Cannot connect'

--- a/test/event_listeners.spec.coffee
+++ b/test/event_listeners.spec.coffee
@@ -5,9 +5,10 @@ MockService = helpers.MockService
 describe 'AWS.EventListeners', ->
 
   oldSetTimeout = setTimeout
+  oldMathRandom = Math.random
   config = null; service = null; totalWaited = null; delays = []
   successHandler = null; errorHandler = null; completeHandler = null
-  retryHandler = null
+  retryHandler = null; randomValues = []
 
   beforeEach ->
     # Mock the timer manually
@@ -22,6 +23,15 @@ describe 'AWS.EventListeners', ->
     service = new MockService(maxRetries: 3)
     service.config.credentials = AWS.util.copy(service.config.credentials)
 
+    #Mock the random method
+    `Math.random = helpers.createSpy('random');`
+    Math.random.andCallFake () ->
+      val = oldMathRandom()
+      randomValues.push(val)
+      val
+
+    randomValues = []
+
     # Helpful handlers
     successHandler = helpers.createSpy('success')
     errorHandler = helpers.createSpy('error')
@@ -29,7 +39,7 @@ describe 'AWS.EventListeners', ->
     retryHandler = helpers.createSpy('retry')
 
   # Safely tear down setTimeout hack
-  afterEach -> `setTimeout = oldSetTimeout`
+  afterEach -> `setTimeout = oldSetTimeout; Math.random = oldMathRandom`
 
   makeRequest = (callback) ->
     request = service.makeRequest('mockMethod', foo: 'bar')
@@ -351,14 +361,18 @@ describe 'AWS.EventListeners', ->
       helpers.mockHttpResponse
         code: 'NetworkingError', message: 'Cannot connect'
       makeRequest(->)
-      expect(delays).to.eql([30, 60, 120])
+      baseDelays = [100, 200, 400]
+      expectedDelays = ((baseDelays[i] * randomValues[i]) for i in [0..service.numRetries()-1])
+      expect(delays).to.eql(expectedDelays)
 
     it 'retries with falloff using custom base', ->
-      service.config.update(retryDelayOptions: {base: 100})
+      service.config.update(retryDelayOptions: {base: 30})
       helpers.mockHttpResponse
         code: 'NetworkingError', message: 'Cannot connect'
       makeRequest(->)
-      expect(delays).to.eql([100, 200, 400])
+      baseDelays = [30, 60, 120]
+      expectedDelays = ((baseDelays[i] * randomValues[i]) for i in [0..service.numRetries()-1])
+      expect(delays).to.eql(expectedDelays)
 
     it 'retries with falloff using custom backoff', ->
       service.config.update(retryDelayOptions: {customBackoff: (retryCount) -> 2 * retryCount })
@@ -398,7 +412,9 @@ describe 'AWS.EventListeners', ->
 
       response = makeRequest(->)
 
-      expect(totalWaited).to.equal(90)
+      baseDelays = [100, 200]
+      expectedDelays = ((baseDelays[i] * randomValues[i]) for i in [0..delays.length-1])
+      expect(totalWaited).to.equal(expectedDelays.reduce (a, b) -> a + b)
       expect(response.retryCount).to.be.lessThan(service.config.maxRetries)
       expect(response.data).to.equal('foo')
       expect(errorHandler.calls.length).to.equal(0)

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,5 @@
 --compilers coffee:coffee-script
 --reporter dot
 --ui bdd
---timeout 2000
+--timeout 4000
 --no-exit

--- a/test/services/dynamodb.spec.coffee
+++ b/test/services/dynamodb.spec.coffee
@@ -27,8 +27,9 @@ describe 'AWS.DynamoDB', ->
   describe 'retryDelays', ->
 
     it 'has a custom backoff function', ->
-      delays = [ 0, 50, 100, 200, 400, 800, 1600, 3200, 6400, 12800 ]
-      expect(ddb().retryDelays()).to.eql(delays)
+      expectedDelays = [ 0, 50, 100, 200, 400, 800, 1600, 3200, 6400, 12800 ]
+      actualDelays = (ddb().retryDelays(i) for i in [0..ddb().numRetries()-1])
+      expect(actualDelays).to.eql(expectedDelays)
 
   describe 'CRC32 check', ->
     dynamo = null


### PR DESCRIPTION
Added 2 new options for customizing retry delays

Retry delays will default to using exponential backoff with a base of 30 ms (current behavior).
1) User can specify a `base` value for the exponential backoff to use, in ms.
2) User can specify their own backoff function that accepts the current retry count, and returns a retry delay in ms.

These options do not currently work with DynamoDB because we implemented custom retry logic for this service already. In the future we could allow this customization for DynamoDB as well.

/cc @LiuJoyceC @jeskew 