### PR TITLE
Fixes AWS.S3.putBucketReplication signature errors

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -152,7 +152,8 @@ AWS.util.update(AWS.S3.prototype, {
     putBucketLifecycle: true,
     putBucketLifecycleConfiguration: true,
     putBucketTagging: true,
-    deleteObjects: true
+    deleteObjects: true,
+    putBucketReplication: true
   },
 
   /**

--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -20,6 +20,7 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
     'partNumber': 1,
     'policy': 1,
     'requestPayment': 1,
+    'replication': 1,
     'restore': 1,
     'tagging': 1,
     'torrent': 1,

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -612,6 +612,7 @@ describe 'AWS.S3', ->
       willCompute 'putBucketLifecycle', computeChecksums: true
       willCompute 'putBucketLifecycleConfiguration', computeChecksums: true
       willCompute 'putBucketTagging', computeChecksums: true
+      willCompute 'putBucketReplication', computeChecksums: true
 
     it 'computes checksums if computeChecksums is off and operation requires it', ->
       willCompute 'deleteObjects', computeChecksums: false
@@ -619,6 +620,7 @@ describe 'AWS.S3', ->
       willCompute 'putBucketLifecycle', computeChecksums: false
       willCompute 'putBucketLifecycleConfiguration', computeChecksums: false
       willCompute 'putBucketTagging', computeChecksums: false
+      willCompute 'putBucketReplication', computeChecksums: false
 
     it 'does not compute checksums if computeChecksums is off', ->
       willCompute 'putObject', computeChecksums: false, hash: null

--- a/test/signers/s3.spec.coffee
+++ b/test/signers/s3.spec.coffee
@@ -276,6 +276,17 @@ describe 'AWS.Signers.S3', ->
       /?versionId=a%2Bb
       """)
 
+    it 'includes the replication subresource without a value', ->
+      path = '/?replication'
+      expect(stringToSign()).to.equal("""
+      POST
+
+
+
+      x-amz-date:DATE-STRING
+      /?replication
+      """)
+
     it 'includes the non-encoded query string get header overrides', ->
       path = '/?response-content-type=a%2Bb' # a+b
       expect(stringToSign()).to.equal("""


### PR DESCRIPTION
Fixes issue #910 

This pr fixes putBucketReplication when using sigv2 or sigv4.

/cc @LiuJoyceC @jeskew 