### PR TITLE
Profile assume role

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -34,7 +34,7 @@ AWS.util.update(AWS.Config.prototype.keys, {
     new AWS.CredentialProviderChain([
       function () { return new AWS.EnvironmentCredentials('AWS'); },
       function () { return new AWS.EnvironmentCredentials('AMAZON'); },
-      function () { return new AWS.SharedIniFileCredentials(); }
+      function () { return new AWS.SharedIniFileCredentials({ disableAssumeRole: true }); }
     ]).resolve(function(err, creds) {
       if (!err) credentials = creds;
     });

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -40,6 +40,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   the name of the profile to load.
    * @option options filename [String] ('~/.aws/credentials') the filename
    *   to use when loading credentials.
+   * @option options disableAssumeRole [Boolean] (false) True to disable
+   *   support for profiles that assume an IAM role. If true, and an assume
+   *   role profile is selected, an error is raised.
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
@@ -48,7 +51,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || 'default';
-    this.get(function() {});
+    this.disableAssumeRole = !!options.disableAssumeRole;
   },
 
   /**
@@ -67,11 +70,21 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     try {
       if (!this.filename) this.loadDefaultFilename();
       var creds = AWS.util.ini.parse(AWS.util.readFileSync(this.filename));
-      if (typeof creds[this.profile] === 'object') {
-        this.accessKeyId = creds[this.profile]['aws_access_key_id'];
-        this.secretAccessKey = creds[this.profile]['aws_secret_access_key'];
-        this.sessionToken = creds[this.profile]['aws_session_token'];
+      var profile = creds[this.profile];
+
+      if (typeof profile !== 'object') {
+        throw new Error('Profile ' + this.profile + ' not found in ' +
+                        this.filename);
       }
+
+      if (profile['role_arn']) {
+        this.loadRoleProfile(creds, profile, callback);
+        return;
+      }
+
+      this.accessKeyId = profile['aws_access_key_id'];
+      this.secretAccessKey = profile['aws_secret_access_key'];
+      this.sessionToken = profile['aws_session_token'];
 
       if (!this.accessKeyId || !this.secretAccessKey) {
         throw new Error('Credentials not set in ' + this.filename +
@@ -82,6 +95,74 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     } catch (err) {
       callback(err);
     }
+  },
+
+  /**
+   * @api private
+   */
+  loadRoleProfile: function loadRoleProfile(creds, roleProfile, callback) {
+    if (this.disableAssumeRole) {
+      throw new Error('Role assumption profiles are disabled. ' +
+                      'Failed to load profile ' + this.profile + ' from ' +
+                      this.filename);
+    }
+
+    var self = this;
+    var roleArn = roleProfile['role_arn'];
+    var roleSessionName = roleProfile['role_session_name'];
+    var externalId = roleProfile['external_id'];
+    var sourceProfileName = roleProfile['source_profile'];
+
+    if (!sourceProfileName) {
+      throw new Error('source_profile is not set in ' + this.filename +
+                      ' using profile ' + this.profile);
+    }
+
+    var sourceProfile = creds[sourceProfileName];
+
+    if (typeof sourceProfile !== 'object') {
+      throw new Error('source_profile ' + sourceProfileName + ' set in ' +
+                      this.filename + ' using profile ' + this.profile +
+                      ' does not exist')
+    }
+
+    var sourceCredentials = {
+      accessKeyId: sourceProfile['aws_access_key_id'],
+      secretAccessKey: sourceProfile['aws_secret_access_key'],
+      sessionToken: sourceProfile['aws_session_token']
+    };
+
+    if (!sourceCredentials.accessKeyId || !sourceCredentials.secretAccessKey) {
+      throw new Error('Credentials not set in source_profile ' +
+                      sourceProfileName + ' set in ' + this.filename +
+                      ' using profile ' + this.profile);
+    }
+
+    var sts = new AWS.STS({
+      credentials: new AWS.Credentials(sourceCredentials)
+    });
+
+    var roleParams = {
+      RoleArn: roleArn,
+      RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
+    };
+
+    if (externalId) {
+      roleParams.ExternalId = externalId;
+    }
+
+    sts.assumeRole(roleParams, function (err, data) {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      self.accessKeyId = data.Credentials.AccessKeyId;
+      self.secretAccessKey = data.Credentials.SecretAccessKey;
+      self.sessionToken = data.Credentials.SessionToken;
+      self.expireTime = data.Credentials.Expiration;
+      callback();
+    });
   },
 
   /**

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -52,7 +52,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   },
 
   /**
-   * Loads the credentials from the instance metadata service
+   * Loads the credentials from the shared credentials file
    *
    * @callback callback function(err)
    *   Called after the shared INI file on disk is read and parsed. When this

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -171,20 +171,24 @@ if AWS.util.isNode()
         process.env.HOMEDRIVE = 'd:/'
         process.env.HOMEPATH = 'homepath'
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         expect(creds.filename).to.equal('d:/homepath/.aws/credentials')
 
       it 'uses default HOMEDRIVE of C:/', ->
         process.env.HOMEPATH = 'homepath'
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         expect(creds.filename).to.equal('C:/homepath/.aws/credentials')
 
       it 'uses USERPROFILE if HOME is not set', ->
         process.env.USERPROFILE = '/userprofile'
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         expect(creds.filename).to.equal('/userprofile/.aws/credentials')
 
       it 'can override filename as a constructor argument', ->
         creds = new AWS.SharedIniFileCredentials(filename: '/etc/creds')
+        creds.get();
         expect(creds.filename).to.equal('/etc/creds')
 
     describe 'loading', ->
@@ -200,6 +204,7 @@ if AWS.util.isNode()
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         validateCredentials(creds)
         expect(AWS.util.readFileSync.calls[0].arguments[0]).to.equal('/home/user/.aws/credentials')
 
@@ -214,6 +219,7 @@ if AWS.util.isNode()
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         validateCredentials(creds)
 
       it 'accepts a profile name parameter', ->
@@ -226,6 +232,7 @@ if AWS.util.isNode()
         spy = helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         creds = new AWS.SharedIniFileCredentials(profile: 'foo')
+        creds.get();
         validateCredentials(creds)
 
       it 'sets profile based on ENV', ->
@@ -239,6 +246,7 @@ if AWS.util.isNode()
         spy = helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         validateCredentials(creds)
 
     describe 'refresh', ->
@@ -254,6 +262,7 @@ if AWS.util.isNode()
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         creds = new AWS.SharedIniFileCredentials()
+        creds.get();
         validateCredentials(creds, 'RELOADED', 'RELOADED', 'RELOADED')
 
       it 'fails if credentials are not in the file', ->
@@ -261,10 +270,10 @@ if AWS.util.isNode()
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
 
         new AWS.SharedIniFileCredentials().refresh (err) ->
-          expect(err.message).to.equal('Credentials not set in /home/user/.aws/credentials using profile default')
+          expect(err.message).to.equal('Profile default not found in /home/user/.aws/credentials')
 
         expect(-> new AWS.SharedIniFileCredentials().refresh()).
-          to.throw('Credentials not set in /home/user/.aws/credentials using profile default')
+          to.throw('Profile default not found in /home/user/.aws/credentials')
 
   describe 'AWS.EC2MetadataCredentials', ->
     creds = null


### PR DESCRIPTION
The implementation matches what is in botocore and my [PR for the Java SDK](https://github.com/aws/aws-sdk-java/pull/641).

I had to remove the `get` call from the constructor and the provider from the Config credentials load to prevent multiple role assumptions from happening.