### PR TITLE
Add support for AWS_DEFAULT_PROFILE environment variable

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -47,7 +47,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     options = options || {};
 
     this.filename = options.filename;
-    this.profile = options.profile || process.env.AWS_PROFILE || 'default';
+    this.profile = options.profile || process.env.AWS_PROFILE || process.env.AWS_DEFAULT_PROFILE || 'default';
     this.get(function() {});
   },
 


### PR DESCRIPTION
The other SDKs use AWS_DEFAULT_PROFILE and not AWS_PROFILE.