### PR TITLE
Updates S3 ManagedUploader abort docs to clarify how it works in the browser.

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -182,7 +182,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    * @note By default, calling this function will cleanup a multipart upload
    *   if one was created. To leave the multipart upload around after aborting
    *   a request, configure `leavePartsOnError` to `true` in the {constructor}.
-   * @!macro nobrowser
+   * @note Calling {abort} in the browser environment will not abort any requests
+   *   that are already in flight. If a multipart upload was created, any parts
+   *   not yet uploaded will not be sent, and the multipart upload will be cleaned up.
    * @example Aborting an upload
    *   var params = {
    *     Bucket: 'bucket', Key: 'key',


### PR DESCRIPTION
Related to issue #760

/cc @LiuJoyceC 