### PR TITLE
Added 'Key' and 'Bucket' to data returned from s3.upload when single …

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -143,6 +143,8 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    *   @param data [map] The response data from the successful upload:
    *     * `Location` (String) the URL of the uploaded object
    *     * `ETag` (String) the ETag of the uploaded object
+   *     * `Bucket` (String) the bucket to which the object was uploaded
+   *     * `Key` (String) the key to which the object was uploaded
    * @example Sending a managed upload object
    *   var params = {Bucket: 'bucket', Key: 'key', Body: stream};
    *   var upload = new AWS.S3.ManagedUpload({params: params});
@@ -566,7 +568,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     if (err) return upload.callback(err);
     data.Location =
       [endpoint.protocol, '//', endpoint.host, httpReq.path].join('');
-    data.key = this.request.params.Key;
+    data.key = this.request.params.Key; // will stay undocumented
+    data.Key = this.request.params.Key;
+    data.Bucket = this.request.params.Bucket;
     upload.callback(err, data);
   },
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -447,6 +447,8 @@ AWS.util.update(AWS.S3.prototype, {
    *   @param data [map] The response data from the successful upload:
    *     * `Location` (String) the URL of the uploaded object
    *     * `ETag` (String) the ETag of the uploaded object
+   *     * `Bucket` (String) the bucket to which the object was uploaded
+   *     * `Key` (String) the key to which the object was uploaded
    *   @see AWS.S3.ManagedUpload
    */
   upload: function upload(params, options, callback) {

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -325,6 +325,18 @@ describe 'AWS.S3.ManagedUpload', ->
           expect(data).not.to.exist
           done()
 
+    it 'returns data with ETag, Location, Bucket, and Key with single part upload', (done) ->
+      reqs = helpers.mockResponses [
+        data: ETag: 'ETAG'
+      ]
+      send Body: smallbody, ContentEncoding: 'encoding', ->
+        expect(err).not.to.exist
+        expect(data.ETag).to.equal('ETAG')
+        expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/key')
+        expect(data.Key).to.equal('key')
+        expect(data.Bucket).to.equal('bucket')
+        done()
+
     if AWS.util.isNode()
       describe 'streaming', ->
         it 'sends a small stream in a single putObject', (done) ->


### PR DESCRIPTION
…part upload is used. This is to be consistent with the data that is returned from s3.upload when multipart upload is used. Resolves #918
/cc @chrisradek 