### PR TITLE
Updates AWS.APIGateway.getSdk to return body as a buffer

### DIFF
--- a/lib/services/apigateway.js
+++ b/lib/services/apigateway.js
@@ -16,6 +16,19 @@ AWS.util.update(AWS.APIGateway.prototype, {
    */
   setupRequestListeners: function setupRequestListeners(request) {
     request.addListener('build', this.setAcceptHeader);
+    if (request.operation === 'getSdk') {
+      request.addListener('extractData', this.useRawPayload);
+    }
+  },
+
+  useRawPayload: function useRawPayload(resp) {
+    var req = resp.request;
+    var operation = req.operation;
+    var rules = req.service.api.operations[operation].output || {};
+    if (rules.payload) {
+      var body = resp.httpResponse.body;
+      resp.data[rules.payload] = body;
+    }
   }
 });
 

--- a/test/services/apigateway.spec.coffee
+++ b/test/services/apigateway.spec.coffee
@@ -1,5 +1,6 @@
 helpers = require('../helpers')
 AWS = helpers.AWS
+Buffer = AWS.util.Buffer
 
 describe 'AWS.APIGateway', ->
   apigateway = null
@@ -20,3 +21,11 @@ describe 'AWS.APIGateway', ->
         expect(req.headers['Accept']).to.equal('application/json')
         req = build('updateApiKey', apiKey: 'apiKey')
         expect(req.headers['Accept']).to.equal('application/json')
+        
+    describe 'getSdk', ->
+      it 'returns the raw payload as the body', (done) ->
+        body = new Buffer('∂ƒ©∆')
+        helpers.mockHttpResponse 200, {}, body
+        apigateway.getSdk (err, data) ->
+          expect(data.body).to.eql(body)
+          done()        


### PR DESCRIPTION
 instead of a utf-8 string

fixes #815 
/cc @LiuJoyceC 