### PR TITLE
Updated documentation for CredentialProviderChain.defaultProvider

### DIFF
--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -109,5 +109,22 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
 
 /**
  * The default set of providers used by a vanilla CredentialProviderChain.
+ *
+ * In the browser:
+ *
+ * ```javascript
+ * AWS.CredentialProviderChain.defaultProviders = []
+ * ```
+ *
+ * In Node.js:
+ *
+ * ```javascript
+ * AWS.CredentialProviderChain.defaultProviders = [
+ *   function () { return new AWS.EnvironmentCredentials('AWS'); },
+ *   function () { return new AWS.EnvironmentCredentials('AMAZON'); },
+ *   function () { return new AWS.SharedIniFileCredentials(); },
+ *   function () { return new AWS.EC2MetadataCredentials(); }
+ * ]
+ * ```
  */
 AWS.CredentialProviderChain.defaultProviders = [];


### PR DESCRIPTION
Updated documentation to reflect default provider list for Node.js.
Resolves #955.