### PR TITLE
Correction and clarification for CognitoIdentityCredentials documentation

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -69,28 +69,29 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    * Creates a new credentials object.
    * @example Creating a new credentials object
    *   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
-   *     
+   *
    *     // either IdentityPoolId or IdentityId is required
    *     IdentityPoolId: 'us-east-1:1699ebc0-7900-4099-b910-2df94f52a030',
    *     IdentityId: 'us-east-1:128d0a74-c82f-4553-916d-90053e4a8b0f'
-   *     
+   *
    *     // optional, only necessary when the identity pool is not configured
    *     // to use IAM roles in the Amazon Cognito Console
    *     RoleArn: 'arn:aws:iam::1234567890:role/MYAPP-CognitoIdentity',
-   *     
+   *
    *     // optional tokens, used for authenticated login
    *     Logins: {
    *       'graph.facebook.com': 'FBTOKEN',
    *       'www.amazon.com': 'AMAZONTOKEN',
    *       'accounts.google.com': 'GOOGLETOKEN'
    *     },
-   *     
+   *
    *     // optional name, defaults to web-identity
    *     RoleSessionName: 'web',
-   *     
+   *
    *     // optional, only necessary when application runs in a browser
    *     // and multiple users are signed in at once, used for caching
    *     LoginId: 'example@gmail.com'
+   *
    *   });
    * @see AWS.CognitoIdentity.getId
    * @see AWS.CognitoIdentity.getCredentialsForIdentity

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -71,21 +71,29 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    *   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
    *
    *     // either IdentityPoolId or IdentityId is required
+   *     // See the IdentityPoolId param for AWS.CognitoIdentity.getID (linked below)
+   *     // See the IdentityId param for AWS.CognitoIdentity.getCredentialsForIdentity
+   *     // or AWS.CognitoIdentity.getOpenIdToken (linked below)
    *     IdentityPoolId: 'us-east-1:1699ebc0-7900-4099-b910-2df94f52a030',
    *     IdentityId: 'us-east-1:128d0a74-c82f-4553-916d-90053e4a8b0f'
    *
    *     // optional, only necessary when the identity pool is not configured
    *     // to use IAM roles in the Amazon Cognito Console
+   *     // See the RoleArn param for AWS.STS.assumeRoleWithWebIdentity (linked below)
    *     RoleArn: 'arn:aws:iam::1234567890:role/MYAPP-CognitoIdentity',
    *
    *     // optional tokens, used for authenticated login
+   *     // See the Logins param for AWS.CognitoIdentity.getID (linked below) 
    *     Logins: {
    *       'graph.facebook.com': 'FBTOKEN',
    *       'www.amazon.com': 'AMAZONTOKEN',
-   *       'accounts.google.com': 'GOOGLETOKEN'
+   *       'accounts.google.com': 'GOOGLETOKEN',
+   *       'api.twitter.com': 'TWITTERTOKEN',
+   *       'www.digits.com': 'DIGITSTOKEN'
    *     },
    *
    *     // optional name, defaults to web-identity
+   *     // See the RoleSessionName param for AWS.STS.assumeRoleWithWebIdentity (linked below)
    *     RoleSessionName: 'web',
    *
    *     // optional, only necessary when application runs in a browser

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -83,7 +83,7 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    *     RoleArn: 'arn:aws:iam::1234567890:role/MYAPP-CognitoIdentity',
    *
    *     // optional tokens, used for authenticated login
-   *     // See the Logins param for AWS.CognitoIdentity.getID (linked below) 
+   *     // See the Logins param for AWS.CognitoIdentity.getID (linked below)
    *     Logins: {
    *       'graph.facebook.com': 'FBTOKEN',
    *       'www.amazon.com': 'AMAZONTOKEN',

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -5,15 +5,16 @@ var AWS = require('../core');
  * the Amazon Cognito Identity service.
  *
  * By default this provider gets credentials using the
- * {AWS.CognitoIdentity.getCredentialsForIdentity} service operation,
- * after first getting an `IdentityId` from {AWS.CognitoIdentity.getId}. This
- * operation requires an `IdentityPoolId` (Amazon Cognito Identity Pool ID).
- * If a `RoleArn` is provided, then this provider gets credentials using the
- * {AWS.STS.assumeRoleWithWebIdentity} service operation, after first getting
- * an Open ID token from {AWS.CognitoIdentity.getOpenIdToken}. These operations
- * require an `IdentityPoolId` (Amazon Cognito Identity Pool ID), and `RoleArn`
- * containing the ARN of the IAM trust policy for the Amazon Cognito role that
- * the user will log into.
+ * {AWS.CognitoIdentity.getCredentialsForIdentity} service operation, which
+ * requires either an `IdentityId` or an `IdentityPoolId` (Amazon Cognito
+ * Identity Pool ID), which is used to call {AWS.CognitoIdentity.getId} to
+ * obtain an `IdentityId`. If the identity or identity pool is not configured in
+ * the Amazon Cognito Console to use IAM roles with the appropriate permissions,
+ * then additionally a `RoleArn` is required containing the ARN of the IAM trust
+ * policy for the Amazon Cognito role that the user will log into. If a `RoleArn`
+ * is provided, then this provider gets credentials using the
+ * {AWS.STS.assumeRoleWithWebIdentity} service operation, after first getting an
+ * Open ID token from {AWS.CognitoIdentity.getOpenIdToken}.
  *
  * In addition, if this credential provider is used to provide authenticated
  * login, the `Logins` map may be set to the tokens provided by the respective
@@ -66,27 +67,35 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
 
   /**
    * Creates a new credentials object.
-   * @param (see AWS.CognitoIdentity.getId)
-   * @param (see AWS.STS.assumeRoleWithWebIdentity)
-   * @param (see AWS.CognitoIdentity.getOpenIdToken)
    * @example Creating a new credentials object
    *   AWS.config.credentials = new AWS.CognitoIdentityCredentials({
+   *     
+   *     // either IdentityPoolId or IdentityId is required
    *     IdentityPoolId: 'us-east-1:1699ebc0-7900-4099-b910-2df94f52a030',
+   *     IdentityId: 'us-east-1:128d0a74-c82f-4553-916d-90053e4a8b0f'
+   *     
    *     // optional, only necessary when the identity pool is not configured
    *     // to use IAM roles in the Amazon Cognito Console
    *     RoleArn: 'arn:aws:iam::1234567890:role/MYAPP-CognitoIdentity',
-   *     Logins: { // optional tokens, used for authenticated login
+   *     
+   *     // optional tokens, used for authenticated login
+   *     Logins: {
    *       'graph.facebook.com': 'FBTOKEN',
    *       'www.amazon.com': 'AMAZONTOKEN',
    *       'accounts.google.com': 'GOOGLETOKEN'
    *     },
-   *     RoleSessionName: 'web' // optional name, defaults to web-identity,
+   *     
+   *     // optional name, defaults to web-identity
+   *     RoleSessionName: 'web',
+   *     
    *     // optional, only necessary when application runs in a browser
-   *     // and multiple users are signed in at once
+   *     // and multiple users are signed in at once, used for caching
    *     LoginId: 'example@gmail.com'
    *   });
-   * @see AWS.STS.assumeRoleWithWebIdentity
+   * @see AWS.CognitoIdentity.getId
    * @see AWS.CognitoIdentity.getCredentialsForIdentity
+   * @see AWS.STS.assumeRoleWithWebIdentity
+   * @see AWS.CognitoIdentity.getOpenIdToken
    */
   constructor: function CognitoIdentityCredentials(params) {
     AWS.Credentials.call(this);


### PR DESCRIPTION
This adds clarification to the `CognitoIdentityCredentials` documentation, and adds a correction to state that either `IdentityId` or `IdentityPoolId` (which uses `AWS.CognitoIdentity.getId()` to obtain `IdentityId`) is required, regardless if `AWS.CognitoIdentity.getCredentialsForIdentity()` or `AWS.STS.assumeRoleWithWebIdentity()` is used to obtain credentials.
Resolves #912 
/cc @chrisradek 