### PR TITLE
Adds accelerate as a subresource to s3 v2 signer

### DIFF
--- a/lib/signers/s3.js
+++ b/lib/signers/s3.js
@@ -11,6 +11,7 @@ AWS.Signers.S3 = inherit(AWS.Signers.RequestSigner, {
    */
   subResources: {
     'acl': 1,
+    'accelerate': 1,
     'cors': 1,
     'lifecycle': 1,
     'delete': 1,


### PR DESCRIPTION
For new accelerate operations, accelerate is added as a subresource for v2 signing.

/cc: @chrisradek 