### PR TITLE
Uses POST instead of GET for CloudSearch Domain search operation

### DIFF
--- a/lib/services/cloudsearchdomain.js
+++ b/lib/services/cloudsearchdomain.js
@@ -76,6 +76,9 @@ AWS.util.update(AWS.CloudSearchDomain.prototype, {
     );
     request.onAsync('validate', this.validateCredentials);
     request.addListener('validate', this.updateRegion);
+    if (request.operation === 'search') {
+      request.addListener('build', this.convertGetToPost);
+    }
   },
 
   /**
@@ -89,6 +92,20 @@ AWS.util.update(AWS.CloudSearchDomain.prototype, {
       }
       done();
     });
+  },
+
+  /**
+   * @api private
+   */
+  convertGetToPost: function(request) {
+    var httpRequest = request.httpRequest
+    // convert queries to POST to avoid length restrictions
+    var path = httpRequest.path.split('?')
+    httpRequest.method = 'POST'
+    httpRequest.path = path[0]
+    httpRequest.body = path[1]
+    httpRequest.headers['Content-Length'] = httpRequest.body.length
+    httpRequest.headers['Content-Type'] = 'application/x-www-form-urlencoded'
   },
 
   /**

--- a/test/services/cloudsearchdomain.spec.coffee
+++ b/test/services/cloudsearchdomain.spec.coffee
@@ -49,8 +49,16 @@ describe 'AWS.CloudSearchDomain', ->
       params = { query: 'foo' }
       req = build('search', params)
       expect(req.headers).not.to.have.property('Authorization')
-    
+
     it 'signs request if credentials are provided', ->
       params = { query: 'foo' }
       req = build('search', params)
       expect(req.headers).to.have.property('Authorization')
+
+    it 'converts the GET request to POST for search operation', ->
+      params = { query: 'food' }
+      req = build('search', params)
+      expect(req.method).to.equal('POST')
+      expect(req.path.indexOf('?')).to.equal(-1)
+      expect(typeof req.body).to.equal('string')
+      expect(req.headers['Content-Length']).to.equal(req.body.length)

--- a/test/services/cloudsearchdomain.spec.coffee
+++ b/test/services/cloudsearchdomain.spec.coffee
@@ -56,9 +56,16 @@ describe 'AWS.CloudSearchDomain', ->
       expect(req.headers).to.have.property('Authorization')
 
     it 'converts the GET request to POST for search operation', ->
-      params = { query: 'food' }
+      params = { query: 'foo' }
       req = build('search', params)
       expect(req.method).to.equal('POST')
       expect(req.path.indexOf('?')).to.equal(-1)
       expect(typeof req.body).to.equal('string')
       expect(req.headers['Content-Length']).to.equal(req.body.length)
+
+    it 'keeps the suggest operation as a GET request', ->
+      params = { query: 'foo', suggester: 'bar' }
+      req = build('suggest', params)
+      expect(req.method).to.equal('GET')
+      expect(req.path.split('?')[1]).to.equal('format=sdk&pretty=true&q=foo&suggester=bar')
+      expect(!!req.body).to.be.false

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -117,7 +117,10 @@ describe 'AWS.Signers.V4', ->
 
   describe 'canonicalString', ->
     it 'sorts the search string', ->
-      req = new AWS.CloudSearchDomain({endpoint: 'host.domain.com'}).search({query: 'foo', cursor: 'initial', queryOptions: '{}'}).build()
+      req = new AWS.CloudSearchDomain({endpoint: 'host.domain.com'})
+        .search({query: 'foo', cursor: 'initial', queryOptions: '{}'})
+        .removeListener('build', AWS.CloudSearchDomain.prototype.convertGetToPost)
+        .build()
       signer = new AWS.Signers.V4(req.httpRequest, 'cloudsearchdomain')
       expect(signer.canonicalString().split('\n')[2]).to.equal('cursor=initial&format=sdk&pretty=true&q=foo&q.options=%7B%7D')
 


### PR DESCRIPTION
Converts search requests to CloudSearch Domain to use POST instead of GET to lift restriction on query length. Resolves #614 