### PR TITLE
Fixes DynamoDB response data for CRC32CheckFailed error

### DIFF
--- a/lib/services/dynamodb.js
+++ b/lib/services/dynamodb.js
@@ -18,6 +18,7 @@ AWS.util.update(AWS.DynamoDB.prototype, {
    */
   checkCrc32: function checkCrc32(resp) {
     if (!resp.httpResponse.streaming && !resp.request.service.crc32IsValid(resp)) {
+      resp.data = null;
       resp.error = AWS.util.error(new Error(), {
         code: 'CRC32CheckFailed',
         message: 'CRC32 integrity check failed',

--- a/test/services/dynamodb.spec.coffee
+++ b/test/services/dynamodb.spec.coffee
@@ -68,6 +68,7 @@ describe 'AWS.DynamoDB', ->
       request = dynamo.listTables()
       request.send (err, data) ->
         expect(err.code).to.eql('CRC32CheckFailed')
+        expect(data).to.eql(null)
 
     it 'retries request when response checksum does not match', ->
       helpers.mockHttpResponse 200, {'x-amz-crc32': '0'}, """{"TableNames":["mock-table"]}"""


### PR DESCRIPTION
Fixes bug in which response data is not null when DynamoDB returns a CRC32CheckFailed error. Response data will now return null when error occurs. Fixes #981 
/cc @chrisradek 