### PR TITLE
Fixes multiple bugs in scripts/console

### DIFF
--- a/scripts/console
+++ b/scripts/console
@@ -14,26 +14,59 @@ function customEval(cmd, context, filename, callback) {
       callback(err, null);
       return;
     }
+
+    function consoleDataExtraction(resp) {
+      context.data = resp.data;
+      context.error = resp.error;
+      callback(resp.error, resp.data);
+    }
     
-    if (value && value.constructor === AWS.Request) {
-      if (!value.__hasBeenSent__) {
-        value.__hasBeenSent__ = true;
-        try {
-          value.on('complete', function consoleDataExtraction(resp) {
-            context.data = resp.data;
-            context.error = resp.error;
-            callback(resp.error, resp.data);
-          });
-          context.request = value;
-          context.data = null;
-          context.error = null;
-          context.response = value.send();
-        } catch (err2) {
-          callback(err2, null);
-          return;
+    if (value && value.constructor === AWS.Request && !value.__hasBeenEval__) {
+      
+      try {
+        value.__hasBeenEval__ = true;
+        if (value.response) value.response.__hasBeenEval__ = true;
+        context.request = value;
+        context.response = value.response || null;
+        context.data = null;
+        context.error = null;
+        if (value._asm.currentState === 'complete' && value.response) {
+          context.data = value.response.data || null;
+          context.error = value.response.error || null;
+          callback(value.response.error, value.response.data);
+        } else {
+          value.on('complete', consoleDataExtraction);
+          if (!value.__hasBeenSent__) {
+            if (context.autoSend) {
+              value.send();
+            } else {
+              callback(null, value);
+            }
+          }
         }
-      } else {
-        callback(null, value);
+      } catch (err2) {
+        callback(err2, null);
+        return;
+      }
+
+    } else if (value && value.constructor === AWS.Response && !value.__hasBeenEval__) {
+      try {
+        value.__hasBeenEval__ = true;
+        context.response = value;
+        context.request = value.request || null;
+        context.data = value.data || null;
+        context.error = value.error || null;
+        if (value.request) {
+          value.request.__hasBeenEval__ = true;
+          if (value.request._asm.currentState === 'complete') {
+            callback(value.error, value.data);
+          } else {
+            value.request.on('complete', consoleDataExtraction);
+          }
+        }
+      } catch (err2) {
+        callback(err2, null);
+        return;
       }
     } else {
       callback(null, value);
@@ -58,6 +91,17 @@ try {
   console.log("Missing repl.history package, history will not be supported.");
   console.log("  Type `npm install repl.history` to enable history.");
 }
+
+// modify Request.prototype.send listener to track if the listener has been called
+var sendListener = AWS.Request.prototype.send;
+AWS.Request.prototype.send = function(callback) {
+  this.__hasBeenSent__ = true;
+  return sendListener.call(this, callback);
+};
+
+// flag to indicate that requests should be sent when callback is not provided
+// by default this is on, but can be turned off by setting `autoSend = false`
+repl.context.autoSend = true;
 
 // load services as defined instances
 for (var key in AWS) {


### PR DESCRIPTION
Fixes a bug in which .send() is called twice on a request whenever a callback is supplied to a service call, causing unintended retry behavior. Also fixes a bug in which manually calling .send() on a Request instance would not properly write to the data, error, request, and response variables in the REPL context and also would not show the error stack trace if an unsuccessful response was received. Also adds an optional flag 'autoSend', which can be set to false to turn off the default behavior of sending requests when callbacks are not supplied, allowing inspection of the Request instance before it gets sent.

/cc @chrisradek 