### PR TITLE
Adds a new S3 configuration options: s3DisableBodySigning

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -77,6 +77,10 @@ require('./credentials/credential_provider_chain');
  *   @return [Boolean] whether the provided endpoint addresses an individual
  *     bucket (false if it addresses the root API endpoint).
  *
+ * @!attribute s3DisableBodySigning
+ *   @return [Boolean] whether to disable S3 body signing when using signature version `v4`.
+ *     Defaults to `true`.
+ *
  * @!attribute useAccelerateEndpoint
  *   @note This configuration option is only compatible with S3 while accessing
  *     dns-compatible buckets.
@@ -203,6 +207,9 @@ AWS.Config = AWS.util.inherit({
    *   addresses an individual bucket (false if it addresses the root API
    *   endpoint). Note that setting this configuration option requires an
    *   `endpoint` to be provided explicitly to the service constructor.
+   * @option options s3DisableBodySigning [Boolean] whether S3 body signing
+   *   should be disabled when using signature version `v4`. Defaults to `true`.
+   *
    * @option options retryDelayOptions [map] A set of options to configure
    *   the retry delay on retryable errors. Currently supported options are:
    *
@@ -457,6 +464,7 @@ AWS.Config = AWS.util.inherit({
     sslEnabled: true,
     s3ForcePathStyle: false,
     s3BucketEndpoint: false,
+    s3DisableBodySigning: true,
     computeChecksums: true,
     convertResponseTypes: true,
     correctClockSkew: false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -79,7 +79,7 @@ require('./credentials/credential_provider_chain');
  *
  * @!attribute s3DisableBodySigning
  *   @return [Boolean] whether to disable S3 body signing when using signature version `v4`.
- *     Defaults to `true`.
+ *     Body signing can only be disabled when using https. Defaults to `true`.
  *
  * @!attribute useAccelerateEndpoint
  *   @note This configuration option is only compatible with S3 while accessing
@@ -208,7 +208,8 @@ AWS.Config = AWS.util.inherit({
    *   endpoint). Note that setting this configuration option requires an
    *   `endpoint` to be provided explicitly to the service constructor.
    * @option options s3DisableBodySigning [Boolean] whether S3 body signing
-   *   should be disabled when using signature version `v4`. Defaults to `true`.
+   *   should be disabled when using signature version `v4`. Body signing
+   *   can only be disabled when using https. Defaults to `true`.
    *
    * @option options retryDelayOptions [map] A set of options to configure
    *   the retry delay on retryable errors. Currently supported options are:

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -468,7 +468,7 @@ AWS.util.update(AWS.S3.prototype, {
     request.service.validateStreamBody(request.httpRequest.body || '');
     var headers = request.httpRequest.headers;
     // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
-    if (headers.hasOwnProperty('X-Amz-Content-Sha256') || !headers.hasOwnProperty('presigned-expires')) {
+    if (!headers.hasOwnProperty('presigned-expires')) {
       headers['X-Amz-Content-Sha256'] = 'UNSIGNED-PAYLOAD';
     }
   },

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -464,6 +464,8 @@ AWS.util.update(AWS.S3.prototype, {
    * @param request
    */
   disableBodySigning: function disableBodySigning(request) {
+    // Only file streams are supported (content-md5 still calculated)
+    request.service.validateStreamBody(request.httpRequest.body || '');
     var headers = request.httpRequest.headers;
     // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
     if (headers.hasOwnProperty('X-Amz-Content-Sha256') || !headers.hasOwnProperty('presigned-expires')) {
@@ -475,6 +477,20 @@ AWS.util.update(AWS.S3.prototype, {
     if (request.params.ContentLength !== undefined) {
       throw AWS.util.error(new Error(), {code: 'UnexpectedParameter',
         message: 'ContentLength is not supported in pre-signed URLs.'});
+    }
+  },
+
+  /**
+   * @api private
+   */
+  validateStreamBody: function validateStreamBody(body) {
+    if (AWS.util.isNode()) {
+      var Stream = AWS.util.nodeRequire('stream').Stream;
+      if (body instanceof Stream) {
+        if (typeof body.path !== 'string') {
+          throw new Error('Non-file stream objects are not supported with SigV4');
+        }
+      }
     }
   },
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -31,6 +31,18 @@ AWS.util.update(AWS.S3.prototype, {
   /**
    * @api private
    */
+  shouldDisableBodySigning: function shouldDisableBodySigning(request) {
+    var signerClass = this.getSignerClass();
+    if (this.config.s3DisableBodySigning === true && signerClass === AWS.Signers.V4
+        && request.httpRequest.endpoint.protocol === 'https:') {
+      return true;
+    }
+    return false;
+  },
+
+  /**
+   * @api private
+   */
   setupRequestListeners: function setupRequestListeners(request) {
     request.addListener('validate', this.validateScheme);
     request.addListener('validate', this.validateBucketEndpoint);
@@ -45,6 +57,10 @@ AWS.util.update(AWS.S3.prototype, {
     request.addListener('extractData', this.extractData);
     request.addListener('extractData', AWS.util.hoistPayloadMember);
     request.addListener('beforePresign', this.prepareSignedUrl);
+    if (this.shouldDisableBodySigning(request))  {
+      request.removeListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
+      request.addListener('afterBuild', this.disableBodySigning);
+    }
   },
 
   /**
@@ -200,6 +216,13 @@ AWS.util.update(AWS.S3.prototype, {
     }
 
     var rules = req.service.api.operations[req.operation].input.members;
+
+    // Sha256 signing disabled, and not a presigned url
+    if (req.service.shouldDisableBodySigning(req) && !req.httpRequest.headers.hasOwnProperty('presigned-expires')) {
+      if (rules.ContentMD5 && !req.params.ContentMD5) {
+        return true;
+      }
+    }
 
     // V4 signer uses SHA256 signatures so only compute MD5 if it is required
     if (req.service.getSignerClass(req) === AWS.Signers.V4) {
@@ -433,6 +456,18 @@ AWS.util.update(AWS.S3.prototype, {
       request.removeListener('build', request.service.computeContentMd5);
     } else {
       request.addListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
+    }
+  },
+
+  /**
+   * @api private
+   * @param request
+   */
+  disableBodySigning: function disableBodySigning(request) {
+    var headers = request.httpRequest.headers;
+    // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
+    if (headers.hasOwnProperty('X-Amz-Content-Sha256') || !headers.hasOwnProperty('presigned-expires')) {
+      headers['X-Amz-Content-Sha256'] = 'UNSIGNED-PAYLOAD';
     }
   },
 

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -190,7 +190,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   },
 
   hexEncodedBodyHash: function hexEncodedBodyHash() {
-    if (this.isPresigned() && this.serviceName === 's3') {
+    if (this.isPresigned() && this.serviceName === 's3' && !this.request.body) {
       return 'UNSIGNED-PAYLOAD';
     } else if (this.request.headers['X-Amz-Content-Sha256']) {
       return this.request.headers['X-Amz-Content-Sha256'];

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -98,6 +98,10 @@ describe 'AWS.Config', ->
     it 'defaults to false', ->
       expect(configure().useAccelerateEndpoint).to.equal(false)
 
+  describe 's3DisableBodySigning', ->
+    it 'defaults to true', ->
+      expect(configure().s3DisableBodySigning).to.equal(true)
+
   describe 'set', ->
     it 'should set a default value for a key', ->
       config = new AWS.Config()

--- a/test/service.spec.coffee
+++ b/test/service.spec.coffee
@@ -8,9 +8,10 @@ describe 'AWS.Service', ->
   retryableError = (error, result) ->
     expect(service.retryableError(error)).to.eql(result)
 
-  beforeEach ->
+  beforeEach (done) ->
     config = new AWS.Config()
     service = new AWS.Service(config)
+    done()
 
   describe 'apiVersions', ->
     it 'should set apiVersions property', ->
@@ -257,13 +258,14 @@ describe 'AWS.Service', ->
     operations = null
     serviceConstructor = null
     
-    beforeEach ->
+    beforeEach (done) ->
       serviceConstructor = () ->
         AWS.Service.call(this, new AWS.Config())
       serviceConstructor.prototype = Object.create(AWS.Service.prototype)  
       serviceConstructor.prototype.api = {}
       operations = {'foo': {}, 'bar': {}}
-      serviceConstructor.prototype.api.operations = operations  
+      serviceConstructor.prototype.api.operations = operations
+      done()
     
     it 'should add operation methods', ->
       AWS.Service.defineMethods(serviceConstructor);

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -799,13 +799,13 @@ describe 'AWS.S3', ->
         expect(req.build(->).httpRequest.headers['Content-MD5']).to.equal(undefined)
 
       it 'throws an error in SigV4, if a non-file stream is provided', (done) ->
-        s3 = new AWS.S3({signatureVersion: 'v4', s3DisableBodySigning: false})
+        s3 = new AWS.S3({signatureVersion: 'v4'})
         req = s3.putObject(Bucket: 'example', Key: 'key', Body: new Stream.Stream)
         req.send (err) ->
           expect(err.message).to.contain('stream objects are not supported')
           done()
 
-      it 'opens separate stream if a file object is provided', (done) ->
+      it 'opens separate stream if a file object is provided (signed payload)', (done) ->
         hash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
         helpers.mockResponse data: ETag: 'etag'
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -8,8 +8,9 @@ describe 'AWS.S3', ->
   s3 = null
   request = (operation, params) -> s3.makeRequest(operation, params)
 
-  beforeEach ->
+  beforeEach (done) ->
     s3 = new AWS.S3(region: undefined)
+    done()
 
   describe 'dnsCompatibleBucketName', ->
 
@@ -157,6 +158,43 @@ describe 'AWS.S3', ->
         it 'does not add expect header in the browser', ->
           req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024 * 1024 + 1))
           expect(req.headers['Expect']).not.to.exist
+
+    describe 'with s3DisableBodySigning set to true', ->
+
+      it 'will disable body signing when using signature version 4 and the endpoint uses https', ->
+        s3 = new AWS.S3(s3DisableBodySigning: true, signatureVersion: 'v4')
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['X-Amz-Content-Sha256']).to.equal('UNSIGNED-PAYLOAD')
+
+      it 'will compute contentMD5', ->
+        s3 = new AWS.S3(s3DisableBodySigning: true, signatureVersion: 'v4')
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['Content-MD5']).to.equal('XzY+DlipXwbL6bvGYsXftg==')
+
+      it 'will not disable body signing when the endpoint is not https', ->
+        s3 = new AWS.S3(s3DisableBodySigning: true, signatureVersion: 'v4', sslEnabled: false)
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['X-Amz-Content-Sha256']).to.exist
+        expect(req.headers['X-Amz-Content-Sha256']).to.not.equal('UNSIGNED-PAYLOAD')
+
+      it 'will have no effect when sigv2 signing is used', ->
+        s3 = new AWS.S3(s3DisableBodySigning: true, signatureVersion: 's3', sslEnabled: true)
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['X-Amz-Content-Sha256']).to.not.exist
+
+    describe 'with s3DisableBodySigning set to false', ->
+
+      it 'will sign the body when sigv4 is used', ->
+        s3 = new AWS.S3(s3DisableBodySigning: false, signatureVersion: 'v4')
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['X-Amz-Content-Sha256']).to.exist
+        expect(req.headers['X-Amz-Cotnent-Sha256']).to.not.equal('UNSIGNED-PAYLOAD')
+
+      it 'will have no effect when sigv2 signing is used', ->
+        s3 = new AWS.S3(s3DisableBodySigning: false, signatureVersion: 's3', sslEnabled: true)
+        req = build('putObject', Bucket: 'bucket', Key: 'key', Body: new Buffer(1024*1024*5))
+        expect(req.headers['X-Amz-Content-Sha256']).to.not.exist
+
 
     describe 'adding Content-Type', ->
       beforeEach -> helpers.spyOn(AWS.util, 'isBrowser').andReturn(true)
@@ -761,7 +799,7 @@ describe 'AWS.S3', ->
         expect(req.build(->).httpRequest.headers['Content-MD5']).to.equal(undefined)
 
       it 'throws an error in SigV4, if a non-file stream is provided', (done) ->
-        s3 = new AWS.S3(signatureVersion: 'v4')
+        s3 = new AWS.S3({signatureVersion: 'v4', s3DisableBodySigning: false})
         req = s3.putObject(Bucket: 'example', Key: 'key', Body: new Stream.Stream)
         req.send (err) ->
           expect(err.message).to.contain('stream objects are not supported')
@@ -781,7 +819,7 @@ describe 'AWS.S3', ->
           tr.end()
           tr
 
-        s3 = new AWS.S3(signatureVersion: 'v4')
+        s3 = new AWS.S3({signatureVersion: 'v4', s3DisableBodySigning: false})
         stream = fs.createReadStream('path/to/file')
         req = s3.putObject(Bucket: 'example', Key: 'key', Body: stream)
         req.send (err) ->
@@ -793,11 +831,14 @@ describe 'AWS.S3', ->
 
   describe 'getSignedUrl', ->
     date = null
-    beforeEach ->
+    beforeEach (done) ->
       date = AWS.util.date.getDate
       AWS.util.date.getDate = -> new Date(0)
-    afterEach ->
+      done()
+
+    afterEach (done) ->
       AWS.util.date.getDate = date
+      done()
 
     it 'gets a signed URL for getObject', ->
       url = s3.getSignedUrl('getObject', Bucket: 'bucket', Key: 'key')
@@ -864,6 +905,16 @@ describe 'AWS.S3', ->
       s3 = new AWS.S3(signatureVersion: 'v4', region: undefined)
       url = s3.getSignedUrl('getObject', Bucket: 'bucket', Key: 'object')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=akid%2F19700101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=900&X-Amz-Security-Token=session&X-Amz-Signature=05ae40d2d22c93549a1de0686232ff56baf556876ec497d0d8349431f98b8dfe&X-Amz-SignedHeaders=host')
+
+    it 'gets a signed URL for putObject using SigV4', ->
+      s3 = new AWS.S3(signatureVersion: 'v4', region: undefined)
+      url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'object')
+      expect(url).to.equal('https://bucket.s3.amazonaws.com/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=akid%2F19700101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=900&X-Amz-Security-Token=session&X-Amz-Signature=1b6f75301a2e480bcfbb53d47d8940c28c8657ea70f23c24846a5595a53b1dfe&X-Amz-SignedHeaders=host')
+
+    it 'gets a signed URL for putObject using SigV4 with body', ->
+      s3 = new AWS.S3(signatureVersion: 'v4', region: undefined)
+      url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'object', Body: 'foo')
+      expect(url).to.equal('https://bucket.s3.amazonaws.com/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae&X-Amz-Credential=akid%2F19700101%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=900&X-Amz-Security-Token=session&X-Amz-Signature=600a64aff20c4ea6c28d11fd0639fb33a0107d072f4c2dd1ea38a16d057513f3&X-Amz-SignedHeaders=host%3Bx-amz-content-sha256')
 
     it 'errors when expiry time is greater than a week out on SigV4', (done) ->
       err = null; data = null


### PR DESCRIPTION
s3DisableBodySigning turns off signing of the body for S3 operations when Sigv4 and https are being used. The Content-MD5 will still be sent. Defaults to true.
This should greatly help performance when uploading to Sigv4 regions from within the browser.

Related to #942

Fixes S3 SigV4 presigned URLs when supplying a body.

/cc @LiuJoyceC 