### PR TITLE
Fixes a bug where httpUploadProgress isn't emitted for files less than 16KB

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -91,10 +91,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
       // The provided body is a buffer/string and is already fully available in memory -
       // For performance it's best to send it as a whole by calling stream.end(body),
       // Callers expect a 'sendProgress' event which is best emitted once
-      // the http request stream drain the data written data.
+      // the http request stream has been fully written and all data flushed.
       // The use of totalBytes is important over body.length for strings where
       // length is char length and not byte length.
-      stream.once('drain', function() {
+      stream.once('finish', function() {
         stream.emit('sendProgress', {
           loaded: totalBytes,
           total: totalBytes


### PR DESCRIPTION
By default, nodejs streams buffer 16KB of data before a drain event will
be triggered. For small enough files, this means that the drain event
never occurs, the sendProgress event is never triggered, and thus
downstream httpUploadProgress never occurs. This change opts to use the
finish event which indicates that stream.end() has been called and all
data has been flushed.