### PR TITLE
S3 region redirect

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -340,21 +340,46 @@ AWS.util.update(AWS.S3.prototype, {
 
     var code = resp.httpResponse.statusCode;
     var body = resp.httpResponse.body || '';
+    var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
+    var bucket = resp.request.params.Bucket || null;
+    var bucketRegionCache = this.service.bucketRegionCache;
+    if (region && bucket && region !== bucketRegionCache[bucket]) {
+      bucketRegionCache[bucket] = region;
+    }
     if (codes[code] && body.length === 0) {
+      if (bucket && !region) {
+        region = bucketRegionCache[bucket] || null;
+      }
       resp.error = AWS.util.error(new Error(), {
-        code: codes[resp.httpResponse.statusCode],
-        message: null
+        code: codes[code],
+        message: null,
+        region: region
       });
     } else {
       var data = new AWS.XML.Parser().parse(body.toString());
+      if (data.Region && !region) {
+        region = data.Region;
+        if (bucket && region !== bucketRegionCache[bucket]) {
+          bucketRegionCache[bucket] = region;
+        }
+      } else if (bucket && !region && !data.Region) {
+        region = bucketRegionCache[bucket] || null;
+      }
       resp.error = AWS.util.error(new Error(), {
         code: data.Code || code,
         message: data.Message || null,
-        region: data.Region || null
+        region: region
       });
     }
     resp.request.service.extractRequestIds(resp);
   },
+
+  /**
+   * Cache for bucket region.
+   *
+   * @api private
+   */
+   bucketRegionCache: {},
 
   /**
    * Extracts S3 specific request ids from the http response.

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -495,7 +495,7 @@ AWS.util.update(AWS.S3.prototype, {
       return done();
     }
 
-    var regionReq = req.service.listObjects({Bucket: bucket});
+    var regionReq = req.service.listObjects({Bucket: bucket, MaxKeys: 0});
     regionReq._requestRegionForBucket = bucket;
     regionReq.send(function() {
       var region = req.service.bucketRegionCache[bucket] || null;
@@ -535,7 +535,7 @@ AWS.util.update(AWS.S3.prototype, {
       }
       done();
     } else if (request.httpRequest.virtualHostedBucket) {
-      var getRegionReq = service.listObjects({Bucket: bucket});
+      var getRegionReq = service.listObjects({Bucket: bucket, MaxKeys: 0});
       service.updateReqBucketRegion(getRegionReq, 'us-east-1');
       getRegionReq._requestRegionForBucket = bucket;
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -351,6 +351,9 @@ AWS.util.update(AWS.S3.prototype, {
     if (typeof region === 'string' && region.length) {
       httpRequest.region = region;
     }
+    if (!httpRequest.endpoint.host.match(/s3(?!-accelerate).*\.amazonaws\.com$/)) {
+      return;
+    }
     var service = request.service;
     var s3Config = service.config;
     var s3BucketEndpoint = s3Config.s3BucketEndpoint;

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -364,8 +364,7 @@ AWS.util.update(AWS.S3.prototype, {
     delete newConfig.endpoint;
     newConfig.region = httpRequest.region;
 
-    var endpoint = (new AWS.S3(newConfig)).endpoint;
-    httpRequest.endpoint = new AWS.Endpoint(endpoint);
+    httpRequest.endpoint = (new AWS.S3(newConfig)).endpoint;
     service.populateURI(request);
     s3Config.s3BucketEndpoint = s3BucketEndpoint;
     httpRequest.headers.Host = httpRequest.endpoint.host;

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -12,6 +12,16 @@ var operationsWith200StatusCodeError = {
   'uploadPartCopy': true
 };
 
+/**
+ * @api private
+ */
+ var regionRedirectErrorCodes = [
+  'AuthorizationHeaderMalformed', // non-head operations on virtual-hosted bucket endpoints
+  'BadRequest', // head operations on virtual-hosted bucket endpoints
+  'PermanentRedirect', // non-head operations on path-style bucket endpoints
+  301 // head operations on path-style bucket endpoints
+ ];
+
 AWS.util.update(AWS.S3.prototype, {
   /**
    * @api private
@@ -295,9 +305,20 @@ AWS.util.update(AWS.S3.prototype, {
       return true;
     } else if (error && error.code === 'RequestTimeout') {
       return true;
-    } else if (error && error.code === 'AuthorizationHeaderMalformed' &&
+    } else if (error &&
+        regionRedirectErrorCodes.indexOf(error.code) != -1 &&
         error.region && error.region != request.httpRequest.region) {
-      request.httpRequest.region = error.region;
+      var httpRequest = request.httpRequest;
+      httpRequest.region = error.region;
+      if (error.statusCode === 301) {
+        var s3config = AWS.util.copy(this.config);
+        delete s3config.endpoint;
+        s3config.region = error.region;
+        var endpoint = (new AWS.S3(s3config)).endpoint;
+        httpRequest.endpoint = new AWS.Endpoint(endpoint);
+        this.populateURI(request);
+        httpRequest.headers.Host = httpRequest.endpoint.host;
+      }
       return true;
     } else {
       var _super = AWS.Service.prototype.retryableError;
@@ -321,6 +342,13 @@ AWS.util.update(AWS.S3.prototype, {
       } else {
         resp.data.LocationConstraint = '';
       }
+    }
+    var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
+    if (region) {
+      var bucket = req.params.Bucket;
+        if (bucket && region !== this.service.bucketRegionCache[bucket]) {
+          this.service.bucketRegionCache[bucket] = region;
+        }
     }
     resp.request.service.extractRequestIds(resp);
   },

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -44,6 +44,7 @@ AWS.util.update(AWS.S3.prototype, {
   setupRequestListeners: function setupRequestListeners(request) {
     request.addListener('validate', this.validateScheme);
     request.addListener('validate', this.validateBucketEndpoint);
+    request.addListener('validate', this.correctBucketRegionFromCache);
     request.addListener('build', this.addContentType);
     request.addListener('build', this.populateURI);
     request.addListener('build', this.computeContentMd5);
@@ -347,7 +348,8 @@ AWS.util.update(AWS.S3.prototype, {
     if (typeof region === 'string' && region.length) {
       httpRequest.region = region;
     }
-    var s3Config = request.service.config;
+    var service = request.service;
+    var s3Config = service.config;
     var s3BucketEndpoint = s3Config.s3BucketEndpoint;
     if (s3BucketEndpoint) {
       delete s3Config.s3BucketEndpoint;
@@ -358,9 +360,13 @@ AWS.util.update(AWS.S3.prototype, {
 
     var endpoint = (new AWS.S3(newConfig)).endpoint;
     httpRequest.endpoint = new AWS.Endpoint(endpoint);
-    request.service.populateURI(request);
+    service.populateURI(request);
     s3Config.s3BucketEndpoint = s3BucketEndpoint;
     httpRequest.headers.Host = httpRequest.endpoint.host;
+    if (request._asm.currentState === 'validate') {
+      request.removeListener('build', service.populateURI);
+      request.addListener('build', service.removeVirtualHostedBucketFromPath);
+    }
   },
 
   /**
@@ -380,12 +386,26 @@ AWS.util.update(AWS.S3.prototype, {
         resp.data.LocationConstraint = '';
       }
     }
-    var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
-    if (region) {
-      var bucket = req.params.Bucket;
-        if (bucket && region !== req.service.bucketRegionCache[bucket]) {
-          req.service.bucketRegionCache[bucket] = region;
+    var bucket = req.params.Bucket || null;
+    if (req.operation === 'deleteBucket' && typeof bucket === 'string' && !resp.error) {
+      req.service.clearBucketRegionCache(bucket);
+    } else {
+      var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
+      if (!region && req.operation === 'createBucket' && !resp.error) {
+        var createBucketConfiguration = req.params.CreateBucketConfiguration;
+        if (!createBucketConfiguration) {
+          region = 'us-east-1';
+        } else if (createBucketConfiguration.LocationConstraint === 'EU') {
+          region = 'eu-west-1';
+        } else {
+          region = createBucketConfiguration.LocationConstraint;
         }
+      }
+      if (region) {
+          if (bucket && region !== req.service.bucketRegionCache[bucket]) {
+            req.service.bucketRegionCache[bucket] = region;
+          }
+      }
     }
     req.service.extractRequestIds(resp);
   },
@@ -452,11 +472,11 @@ AWS.util.update(AWS.S3.prototype, {
    */
    requestBucketRegion: function requestBucketRegion(resp, done) {
     var error = resp.error;
-    if (!error || error.region) {
+    var req = resp.request;
+    if (!error || error.region || req.operation === 'listObjects') {
       return done();
     }
     if (regionRedirectErrorCodes.indexOf(error.code) !== -1) {
-      var req = resp.request;
       var bucket = req.params.Bucket || null;
       if (bucket) {
         req.service.listObjects({Bucket: bucket}, function() {
@@ -501,8 +521,6 @@ AWS.util.update(AWS.S3.prototype, {
     } else if (request.httpRequest.virtualHostedBucket) {
       var getRegionReq = service.listObjects({Bucket: bucket});
       service.updateReqBucketRegion(getRegionReq, 'us-east-1');
-      getRegionReq.removeListener('build', service.populateURI);
-      getRegionReq.addListener('build', service.removeVirtualHostedBucketFromPath);
 
       getRegionReq.send(function() {
         var region = service.bucketRegionCache[bucket] || null;
@@ -543,6 +561,23 @@ AWS.util.update(AWS.S3.prototype, {
     }
     return bucketRegionCache;
    },
+
+   /**
+    * Corrects request region if bucket's cached region is different
+    *
+    * @api private
+    */
+  correctBucketRegionFromCache: function correctBucketRegionFromCache(req) {
+    var bucket = req.params.Bucket || null;
+    if (bucket) {
+      var service = req.service;
+      var requestRegion = req.httpRequest.region;
+      var cachedRegion = service.bucketRegionCache[bucket];
+      if (cachedRegion && cachedRegion !== requestRegion) {
+        service.updateReqBucketRegion(req, cachedRegion);
+      }
+    }
+  },
 
   /**
    * Extracts S3 specific request ids from the http response.

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -16,10 +16,10 @@ var operationsWith200StatusCodeError = {
  * @api private
  */
  var regionRedirectErrorCodes = [
-  'AuthorizationHeaderMalformed', // non-head operations on virtual-hosted bucket endpoints
-  'BadRequest', // head operations on virtual-hosted bucket endpoints
-  'PermanentRedirect', // non-head operations on path-style bucket endpoints
-  301 // head operations on path-style bucket endpoints
+  'AuthorizationHeaderMalformed', // non-head operations on virtual-hosted global bucket endpoints
+  'BadRequest', // head operations on virtual-hosted global bucket endpoints
+  'PermanentRedirect', // non-head operations on path-style or regional endpoints
+  301 // head operations on path-style or regional endpoints
  ];
 
 AWS.util.update(AWS.S3.prototype, {
@@ -56,6 +56,9 @@ AWS.util.update(AWS.S3.prototype, {
     request.addListener('extractData', this.extractData);
     request.addListener('extractData', AWS.util.hoistPayloadMember);
     request.addListener('beforePresign', this.prepareSignedUrl);
+    if (AWS.util.isBrowser()) {
+      request.onAsync('retry', this.reqRegionForNetworkingError);
+    }
   },
 
   /**
@@ -126,10 +129,23 @@ AWS.util.update(AWS.S3.prototype, {
         }
 
         httpRequest.virtualHostedBucket = b; // needed for signing the request
-        httpRequest.path = httpRequest.path.replace(new RegExp('/' + b), '');
-        if (httpRequest.path[0] !== '/') {
-          httpRequest.path = '/' + httpRequest.path;
-        }
+        service.removeVirtualHostedBucketFromPath(req);
+      }
+    }
+  },
+
+  /**
+   * Takes the bucket name out of the path if bucket is virtual-hosted
+   *
+   * @api private
+   */
+  removeVirtualHostedBucketFromPath: function removeVirtualHostedBucketFromPath(req) {
+    var httpRequest = req.httpRequest;
+    var bucket = httpRequest.virtualHostedBucket;
+    if (bucket && httpRequest.path) {
+      httpRequest.path = httpRequest.path.replace(new RegExp('/' + bucket), '');
+      if (httpRequest.path[0] !== '/') {
+        httpRequest.path = '/' + httpRequest.path;
       }
     }
   },
@@ -309,22 +325,42 @@ AWS.util.update(AWS.S3.prototype, {
     } else if (error &&
         regionRedirectErrorCodes.indexOf(error.code) != -1 &&
         error.region && error.region != request.httpRequest.region) {
-      var httpRequest = request.httpRequest;
-      httpRequest.region = error.region;
+      request.httpRequest.region = error.region;
       if (error.statusCode === 301) {
-        var s3config = AWS.util.copy(this.config);
-        delete s3config.endpoint;
-        s3config.region = error.region;
-        var endpoint = (new AWS.S3(s3config)).endpoint;
-        httpRequest.endpoint = new AWS.Endpoint(endpoint);
-        this.populateURI(request);
-        httpRequest.headers.Host = httpRequest.endpoint.host;
+        request.service.updateReqBucketRegion(request);
       }
       return true;
     } else {
       var _super = AWS.Service.prototype.retryableError;
       return _super.call(this, error, request);
     }
+  },
+
+  /**
+   * Updates httpRequest with region. If region is not provided, then
+   * the httpRequest will be updated based on httpRequest.region
+   *
+   * @api private
+   */
+  updateReqBucketRegion: function updateReqBucketRegion(request, region) {
+    var httpRequest = request.httpRequest;
+    if (typeof region === 'string' && region.length) {
+      httpRequest.region = region;
+    }
+    var s3Config = request.service.config;
+    var s3BucketEndpoint = s3Config.s3BucketEndpoint;
+    if (s3BucketEndpoint) {
+      delete s3Config.s3BucketEndpoint;
+    }
+    var newConfig = AWS.util.copy(s3Config);
+    delete newConfig.endpoint;
+    newConfig.region = httpRequest.region;
+
+    var endpoint = (new AWS.S3(newConfig)).endpoint;
+    httpRequest.endpoint = new AWS.Endpoint(endpoint);
+    request.service.populateURI(request);
+    s3Config.s3BucketEndpoint = s3BucketEndpoint;
+    httpRequest.headers.Host = httpRequest.endpoint.host;
   },
 
   /**
@@ -347,11 +383,11 @@ AWS.util.update(AWS.S3.prototype, {
     var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
     if (region) {
       var bucket = req.params.Bucket;
-        if (bucket && region !== this.service.bucketRegionCache[bucket]) {
-          this.service.bucketRegionCache[bucket] = region;
+        if (bucket && region !== req.service.bucketRegionCache[bucket]) {
+          req.service.bucketRegionCache[bucket] = region;
         }
     }
-    resp.request.service.extractRequestIds(resp);
+    req.service.extractRequestIds(resp);
   },
 
   /**
@@ -367,14 +403,17 @@ AWS.util.update(AWS.S3.prototype, {
       404: 'NotFound'
     };
 
+    var req = resp.request;
     var code = resp.httpResponse.statusCode;
     var body = resp.httpResponse.body || '';
+
     var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
-    var bucket = resp.request.params.Bucket || null;
-    var bucketRegionCache = this.service.bucketRegionCache;
+    var bucket = req.params.Bucket || null;
+    var bucketRegionCache = req.service.bucketRegionCache;
     if (region && bucket && region !== bucketRegionCache[bucket]) {
       bucketRegionCache[bucket] = region;
     }
+
     if (codes[code] && body.length === 0) {
       if (bucket && !region) {
         region = bucketRegionCache[bucket] || null;
@@ -386,6 +425,7 @@ AWS.util.update(AWS.S3.prototype, {
       });
     } else {
       var data = new AWS.XML.Parser().parse(body.toString());
+
       if (data.Region && !region) {
         region = data.Region;
         if (bucket && region !== bucketRegionCache[bucket]) {
@@ -394,13 +434,14 @@ AWS.util.update(AWS.S3.prototype, {
       } else if (bucket && !region && !data.Region) {
         region = bucketRegionCache[bucket] || null;
       }
+
       resp.error = AWS.util.error(new Error(), {
         code: data.Code || code,
         message: data.Message || null,
         region: region
       });
     }
-    resp.request.service.extractRequestIds(resp);
+    req.service.extractRequestIds(resp);
   },
 
   /**
@@ -415,10 +456,11 @@ AWS.util.update(AWS.S3.prototype, {
       return done();
     }
     if (regionRedirectErrorCodes.indexOf(error.code) !== -1) {
-      var bucket = resp.request.params.Bucket || null;
+      var req = resp.request;
+      var bucket = req.params.Bucket || null;
       if (bucket) {
-        resp.request.service.listObjects({Bucket: bucket}, function() {
-          var region = resp.request.service.bucketRegionCache[bucket] || null;
+        req.service.listObjects({Bucket: bucket}, function() {
+          var region = req.service.bucketRegionCache[bucket] || null;
           error.region = region;
           done();
         });
@@ -426,6 +468,53 @@ AWS.util.update(AWS.S3.prototype, {
         done();
       }
     } else {
+      done();
+    }
+   },
+
+   /**
+   * For browser only. If NetworkingError received, will attempt to obtain
+   * the bucket region.
+   *
+   * @api private
+   */
+   reqRegionForNetworkingError: function reqRegionForNetworkingError(resp, done) {
+    if (!AWS.util.isBrowser()) {
+      return done();
+    }
+    var error = resp.error;
+    var request = resp.request;
+    var bucket = request.params.Bucket;
+    if (!error || error.code !== 'NetworkingError' || !bucket ||
+        request.httpRequest.region === 'us-east-1') {
+      return done();
+    }
+    var service = request.service;
+    var bucketRegionCache = service.bucketRegionCache;
+
+    if (!service.dnsCompatibleBucketName(bucket)) {
+      service.updateReqBucketRegion(request, 'us-east-1');
+      if (bucketRegionCache[bucket] !== 'us-east-1') {
+        bucketRegionCache[bucket] = 'us-east-1';
+      }
+      done();
+    } else if (request.httpRequest.virtualHostedBucket) {
+      var getRegionReq = service.listObjects({Bucket: bucket});
+      service.updateReqBucketRegion(getRegionReq, 'us-east-1');
+      getRegionReq.removeListener('build', service.populateURI);
+      getRegionReq.addListener('build', service.removeVirtualHostedBucketFromPath);
+
+      getRegionReq.send(function() {
+        var region = service.bucketRegionCache[bucket] || null;
+        if (region && region !== request.httpRequest.region) {
+          service.updateReqBucketRegion(request, region);
+        }
+        done();
+      });
+    } else {
+      // DNS-compatible path-style
+      // (s3ForcePathStyle or bucket name with dot over https)
+      // Cannot obtain region information for this case
       done();
     }
    },
@@ -443,15 +532,16 @@ AWS.util.update(AWS.S3.prototype, {
    * @api private
    */
    clearBucketRegionCache: function(buckets) {
+    var bucketRegionCache = this.bucketRegionCache;
     if (!buckets) {
-      buckets = Object.keys(this.bucketRegionCache);
+      buckets = Object.keys(bucketRegionCache);
     } else if (typeof buckets === 'string') {
       buckets = [buckets];
     }
     for (var i = 0; i < buckets.length; i++) {
-      delete this.bucketRegionCache[buckets[i]];
+      delete bucketRegionCache[buckets[i]];
     }
-    return this.bucketRegionCache;
+    return bucketRegionCache;
    },
 
   /**

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -52,6 +52,7 @@ AWS.util.update(AWS.S3.prototype, {
     request.removeListener('validate',
       AWS.EventListeners.Core.VALIDATE_REGION);
     request.addListener('extractError', this.extractError);
+    request.onAsync('extractError', this.requestBucketRegion);
     request.addListener('extractData', this.extractData);
     request.addListener('extractData', AWS.util.hoistPayloadMember);
     request.addListener('beforePresign', this.prepareSignedUrl);
@@ -403,11 +404,55 @@ AWS.util.update(AWS.S3.prototype, {
   },
 
   /**
+   * If region was not obtained synchronously, then send async request
+   * to get bucket region for errors resulting from wrong region.
+   *
+   * @api private
+   */
+   requestBucketRegion: function requestBucketRegion(resp, done) {
+    var error = resp.error;
+    if (!error || error.region) {
+      return done();
+    }
+    if (regionRedirectErrorCodes.indexOf(error.code) !== -1) {
+      var bucket = resp.request.params.Bucket || null;
+      if (bucket) {
+        resp.request.service.listObjects({Bucket: bucket}, function() {
+          var region = resp.request.service.bucketRegionCache[bucket] || null;
+          error.region = region;
+          done();
+        });
+      } else {
+        done();
+      }
+    } else {
+      done();
+    }
+   },
+
+  /**
    * Cache for bucket region.
    *
    * @api private
    */
    bucketRegionCache: {},
+
+  /**
+   * Clears bucket region cache.
+   *
+   * @api private
+   */
+   clearBucketRegionCache: function(buckets) {
+    if (!buckets) {
+      buckets = Object.keys(this.bucketRegionCache);
+    } else if (typeof buckets === 'string') {
+      buckets = [buckets];
+    }
+    for (var i = 0; i < buckets.length; i++) {
+      delete this.bucketRegionCache[buckets[i]];
+    }
+    return this.bucketRegionCache;
+   },
 
   /**
    * Extracts S3 specific request ids from the http response.

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -438,9 +438,13 @@ AWS.util.update(AWS.S3.prototype, {
       bucketRegionCache[bucket] = region;
     }
 
+    var cachedRegion;
     if (codes[code] && body.length === 0) {
       if (bucket && !region) {
-        region = bucketRegionCache[bucket] || null;
+        cachedRegion = bucketRegionCache[bucket] || null;
+        if (cachedRegion !== req.httpRequest.region) {
+          region = cachedRegion;
+        }
       }
       resp.error = AWS.util.error(new Error(), {
         code: codes[code],
@@ -456,7 +460,10 @@ AWS.util.update(AWS.S3.prototype, {
           bucketRegionCache[bucket] = region;
         }
       } else if (bucket && !region && !data.Region) {
-        region = bucketRegionCache[bucket] || null;
+        cachedRegion = bucketRegionCache[bucket] || null;
+        if (cachedRegion !== req.httpRequest.region) {
+          region = cachedRegion;
+        }
       }
 
       resp.error = AWS.util.error(new Error(), {
@@ -477,25 +484,22 @@ AWS.util.update(AWS.S3.prototype, {
    requestBucketRegion: function requestBucketRegion(resp, done) {
     var error = resp.error;
     var req = resp.request;
-    if (!error || error.region || req.operation === 'listObjects') {
+    var bucket = req.params.Bucket || null;
+
+    if (!error || !bucket || error.region || req.operation === 'listObjects' ||
+        (AWS.util.isNode() && req.operation === 'headBucket') ||
+        (error.statusCode === 400 && req.operation !== 'headObject') ||
+        regionRedirectErrorCodes.indexOf(error.code) === -1) {
       return done();
     }
-    if (regionRedirectErrorCodes.indexOf(error.code) !== -1) {
-      var bucket = req.params.Bucket || null;
-      if (bucket) {
-        var regionReq = req.service.listObjects({Bucket: bucket});
-        regionReq._requestRegionForBucket = bucket;
-        regionReq.send(function() {
-          var region = req.service.bucketRegionCache[bucket] || null;
-          error.region = region;
-          done();
-        });
-      } else {
-        done();
-      }
-    } else {
+
+    var regionReq = req.service.listObjects({Bucket: bucket});
+    regionReq._requestRegionForBucket = bucket;
+    regionReq.send(function() {
+      var region = req.service.bucketRegionCache[bucket] || null;
+      error.region = region;
       done();
-    }
+    });
    },
 
    /**
@@ -517,8 +521,12 @@ AWS.util.update(AWS.S3.prototype, {
     }
     var service = request.service;
     var bucketRegionCache = service.bucketRegionCache;
+    var cachedRegion = bucketRegionCache[bucket] || null;
 
-    if (!service.dnsCompatibleBucketName(bucket)) {
+    if (cachedRegion && cachedRegion !== request.httpRequest.region) {
+      service.updateReqBucketRegion(request, cachedRegion);
+      done();
+    } else if (!service.dnsCompatibleBucketName(bucket)) {
       service.updateReqBucketRegion(request, 'us-east-1');
       if (bucketRegionCache[bucket] !== 'us-east-1') {
         bucketRegionCache[bucket] = 'us-east-1';

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -321,6 +321,9 @@ AWS.util.update(AWS.S3.prototype, {
     if (operationsWith200StatusCodeError[request.operation] &&
         error.statusCode === 200) {
       return true;
+    } else if (request._requestRegionForBucket &&
+        request.service.bucketRegionCache[request._requestRegionForBucket]) {
+      return false;
     } else if (error && error.code === 'RequestTimeout') {
       return true;
     } else if (error &&
@@ -363,6 +366,7 @@ AWS.util.update(AWS.S3.prototype, {
     service.populateURI(request);
     s3Config.s3BucketEndpoint = s3BucketEndpoint;
     httpRequest.headers.Host = httpRequest.endpoint.host;
+    
     if (request._asm.currentState === 'validate') {
       request.removeListener('build', service.populateURI);
       request.addListener('build', service.removeVirtualHostedBucketFromPath);
@@ -479,7 +483,9 @@ AWS.util.update(AWS.S3.prototype, {
     if (regionRedirectErrorCodes.indexOf(error.code) !== -1) {
       var bucket = req.params.Bucket || null;
       if (bucket) {
-        req.service.listObjects({Bucket: bucket}, function() {
+        var regionReq = req.service.listObjects({Bucket: bucket});
+        regionReq._requestRegionForBucket = bucket;
+        regionReq.send(function() {
           var region = req.service.bucketRegionCache[bucket] || null;
           error.region = region;
           done();
@@ -521,6 +527,7 @@ AWS.util.update(AWS.S3.prototype, {
     } else if (request.httpRequest.virtualHostedBucket) {
       var getRegionReq = service.listObjects({Bucket: bucket});
       service.updateReqBucketRegion(getRegionReq, 'us-east-1');
+      getRegionReq._requestRegionForBucket = bucket;
 
       getRegionReq.send(function() {
         var region = service.bucketRegionCache[bucket] || null;

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -366,7 +366,7 @@ AWS.util.update(AWS.S3.prototype, {
     service.populateURI(request);
     s3Config.s3BucketEndpoint = s3BucketEndpoint;
     httpRequest.headers.Host = httpRequest.endpoint.host;
-    
+
     if (request._asm.currentState === 'validate') {
       request.removeListener('build', service.populateURI);
       request.addListener('build', service.removeVirtualHostedBucketFromPath);
@@ -394,7 +394,8 @@ AWS.util.update(AWS.S3.prototype, {
     if (req.operation === 'deleteBucket' && typeof bucket === 'string' && !resp.error) {
       req.service.clearBucketRegionCache(bucket);
     } else {
-      var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
+      var headers = resp.httpResponse.headers || {};
+      var region = headers['x-amz-bucket-region'] || null;
       if (!region && req.operation === 'createBucket' && !resp.error) {
         var createBucketConfiguration = req.params.CreateBucketConfiguration;
         if (!createBucketConfiguration) {
@@ -431,7 +432,8 @@ AWS.util.update(AWS.S3.prototype, {
     var code = resp.httpResponse.statusCode;
     var body = resp.httpResponse.body || '';
 
-    var region = resp.httpResponse.headers['x-amz-bucket-region'] || null;
+    var headers = resp.httpResponse.headers || {};
+    var region = headers['x-amz-bucket-region'] || null;
     var bucket = req.params.Bucket || null;
     var bucketRegionCache = req.service.bucketRegionCache;
     if (region && bucket && region !== bucketRegionCache[bucket]) {

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -10,6 +10,7 @@ describe 'AWS.S3', ->
 
   beforeEach ->
     s3 = new AWS.S3(region: undefined)
+    s3.clearBucketRegionCache()
 
   describe 'dnsCompatibleBucketName', ->
 
@@ -65,6 +66,22 @@ describe 'AWS.S3', ->
       s3 = new AWS.S3(region: 'us-west-1')
       expect(s3.endpoint.hostname).to.equal('s3-us-west-1.amazonaws.com')
 
+  describe 'clearing bucket region cache', ->
+    beforeEach ->
+      s3.bucketRegionCache = a: 'rg-fake-1', b: 'rg-fake-2', c: 'rg-fake-3'
+
+    it 'clears one bucket name', ->
+      s3.clearBucketRegionCache 'b'
+      expect(s3.bucketRegionCache).to.eql(a: 'rg-fake-1', c: 'rg-fake-3')
+
+    it 'clears a list of bucket names', ->
+      s3.clearBucketRegionCache ['a', 'c']
+      expect(s3.bucketRegionCache).to.eql(b: 'rg-fake-2')
+
+    it 'clears entire cache', ->
+      s3.clearBucketRegionCache()
+      expect(s3.bucketRegionCache).to.eql({})
+
   describe 'building a request', ->
     build = (operation, params) ->
       request(operation, params).build().httpRequest
@@ -94,6 +111,28 @@ describe 'AWS.S3', ->
       s3 = new AWS.S3(endpoint: 'foo.bar', s3BucketEndpoint: true, paramValidation: true)
       req = s3.listBuckets().build()
       expect(req.response.error.code).to.equal('ConfigError')
+
+    it 'corrects virtual-hosted bucket region on request if bucket region stored in cache', ->
+      s3 = new AWS.S3(region: 'us-east-1')
+      s3.bucketRegionCache.name = 'us-west-2'
+      param = Bucket: 'name'
+      req = s3.headBucket(param).build()
+      httpRequest = req.httpRequest
+      expect(httpRequest.region).to.equal('us-west-2')
+      expect(httpRequest.endpoint.hostname).to.equal('name.s3-us-west-2.amazonaws.com')
+      expect(httpRequest.headers.Host).to.equal('name.s3-us-west-2.amazonaws.com')
+      expect(httpRequest.path).to.equal('/')
+
+    it 'corrects path-style bucket region on request if bucket region stored in cache', ->
+      s3 = new AWS.S3(region: 'us-east-1', s3ForcePathStyle: true)
+      s3.bucketRegionCache.name = 'us-west-2'
+      param = Bucket: 'name'
+      req = s3.headBucket(param).build()
+      httpRequest = req.httpRequest
+      expect(httpRequest.region).to.equal('us-west-2')
+      expect(httpRequest.endpoint.hostname).to.equal('s3-us-west-2.amazonaws.com')
+      expect(httpRequest.headers.Host).to.equal('s3-us-west-2.amazonaws.com')
+      expect(httpRequest.path).to.equal('/name')
 
     describe 'with useAccelerateEndpoint set to true', ->
       beforeEach ->
@@ -325,16 +364,27 @@ describe 'AWS.S3', ->
     it 'does not send if no callback is supplied', ->
       s3.upload(Bucket: 'bucket', Key: 'key', Body: 'body')
 
+  describe 'extractData', ->
+    it 'caches bucket region if found in header', ->
+      req = request('operation', {Bucket: 'name'})
+      resp = new AWS.Response(req)
+      resp.httpResponse.headers = 'x-amz-bucket-region': 'rg-fake-1'
+      req.emit('extractData', [resp])
+      expect(s3.bucketRegionCache.name).to.equal('rg-fake-1')
+
   # S3 returns a handful of errors without xml bodies (to match the
   # http spec) these tests ensure we give meaningful codes/messages for these.
   describe 'errors with no XML body', ->
 
-    extractError = (statusCode, body) ->
-      req = request('operation')
+    extractError = (statusCode, body, addHeaders, req) ->
+      if !req
+        req = request('operation')
       resp = new AWS.Response(req)
       resp.httpResponse.body = new Buffer(body || '')
       resp.httpResponse.statusCode = statusCode
       resp.httpResponse.headers = {'x-amz-request-id': 'RequestId', 'x-amz-id-2': 'ExtendedRequestId'}
+      for header, value of addHeaders
+        resp.httpResponse.headers[header] = value
       req.emit('extractError', [resp])
       resp.error
 
@@ -358,7 +408,9 @@ describe 'AWS.S3', ->
       expect(error.code).to.equal('NotFound')
       expect(error.message).to.equal(null)
 
-    it 'extracts the region', ->
+    it 'extracts the region from body and takes precedence over cache', ->
+      s3.bucketRegionCache.name = 'us-west-2'
+      req = request('operation', {Bucket: 'name'})
       body = """
         <Error>
           <Code>InvalidArgument</Code>
@@ -366,8 +418,117 @@ describe 'AWS.S3', ->
           <Region>eu-west-1</Region>
         </Error>
         """
-      error = extractError(400, body)
+      error = extractError(400, body, {}, req)
       expect(error.region).to.equal('eu-west-1')
+      expect(s3.bucketRegionCache.name).to.equal('eu-west-1')
+
+    it 'extracts the region from header and takes precedence over body and cache', ->
+      s3.bucketRegionCache.name = 'us-west-2'
+      req = request('operation', {Bucket: 'name'})
+      body = """
+        <Error>
+          <Code>InvalidArgument</Code>
+          <Message>Provided param is bad</Message>
+          <Region>eu-west-1</Region>
+        </Error>
+        """
+      headers = 'x-amz-bucket-region': 'us-east-1'
+      error = extractError(400, body, headers, req)
+      expect(error.region).to.equal('us-east-1')
+      expect(s3.bucketRegionCache.name).to.equal('us-east-1')
+
+    it 'uses cache if region not extracted from body or header', ->
+      s3.bucketRegionCache.name = 'us-west-2'
+      req = request('operation', {Bucket: 'name'})
+      body = """
+        <Error>
+          <Code>InvalidArgument</Code>
+          <Message>Provided param is bad</Message>
+        </Error>
+        """
+      error = extractError(400, body, {}, req)
+      expect(error.region).to.equal('us-west-2')
+      expect(s3.bucketRegionCache.name).to.equal('us-west-2')
+
+    it 'does not use cache if not different from current region', ->
+      s3.bucketRegionCache.name = 'us-west-2'
+      req = request('operation', {Bucket: 'name'})
+      req.httpRequest.region = 'us-west-2'
+      body = """
+        <Error>
+          <Code>InvalidArgument</Code>
+          <Message>Provided param is bad</Message>
+        </Error>
+        """
+      error = extractError(400, body)
+      expect(error.region).to.not.exist
+      expect(s3.bucketRegionCache.name).to.equal('us-west-2')
+
+    it 'does not make async request for bucket region if error.region is set', ->
+      regionReq = send: (fn) ->
+        fn()
+      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      req = request('operation', {Bucket: 'name'})
+      body = """
+        <Error>
+          <Code>PermanentRedirect</Code>
+          <Message>Message</Message>
+        </Error>
+        """
+      headers = 'x-amz-bucket-region': 'us-east-1'
+      error = extractError(301, body, headers, req)
+      expect(error.region).to.exist
+      expect(spy.calls.length).to.equal(0)
+      expect(regionReq._requestRegionForBucket).to.not.exist
+
+    it 'makes async request for bucket region if error.region not set for a region redirect error code', ->
+      regionReq = send: (fn) ->
+        fn()
+      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      params = Bucket: 'name'
+      req = request('operation', params)
+      body = """
+        <Error>
+          <Code>PermanentRedirect</Code>
+          <Message>Message</Message>
+        </Error>
+        """
+      error = extractError(301, body, {}, req)
+      expect(error.region).to.not.exist
+      expect(spy.calls.length).to.equal(1)
+      expect(regionReq._requestRegionForBucket).to.exist
+
+    it 'does not make request for bucket region if error code is not a region redirect code', ->
+      regionReq = send: (fn) ->
+        fn()
+      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      req = request('operation', {Bucket: 'name'})
+      body = """
+        <Error>
+          <Code>InvalidCode</Code>
+          <Message>Message</Message>
+        </Error>
+        """
+      error = extractError(301, body, {}, req)
+      expect(error.region).to.not.exist
+      expect(spy.calls.length).to.equal(0)
+      expect(regionReq._requestRegionForBucket).to.not.exist
+
+    it 'updates error.region if async request adds region to cache', ->
+      regionReq = send: (fn) ->
+        s3.bucketRegionCache.name = 'us-west-2'
+        fn()
+      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      req = request('operation', {Bucket: 'name'})
+      body = """
+        <Error>
+          <Code>PermanentRedirect</Code>
+          <Message>Message</Message>
+        </Error>
+        """
+      error = extractError(301, body, {}, req)
+      expect(spy.calls.length).to.equal(1)
+      expect(error.region).to.equal('us-west-2')
 
     it 'extracts the request ids', ->
       error = extractError(400)
@@ -393,11 +554,134 @@ describe 'AWS.S3', ->
   describe 'retryableError', ->
 
     it 'should retry on authorization header with updated region', ->
-      err = {code: 'AuthorizationHeaderMalformed', statusCode:400, region: "eu-west-1"}
-      req = request()
+      err = {code: 'AuthorizationHeaderMalformed', statusCode:400, region: 'eu-west-1'}
+      req = request('operation', {Bucket: 'name'})
+      req.build()
       retryable = s3.retryableError(err, req)
       expect(retryable).to.equal(true)
-      expect(req.httpRequest.region).to.equal("eu-west-1")
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3.amazonaws.com')
+
+    it 'should retry on bad request with updated region', ->
+      err = {code: 'BadRequest', statusCode:400, region: 'eu-west-1'}
+      req = request('operation', {Bucket: 'name'})
+      req.build()
+      retryable = s3.retryableError(err, req)
+      expect(retryable).to.equal(true)
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3.amazonaws.com')
+
+    it 'should retry on permanent redirect with updated region and endpoint', ->
+      err = {code: 'PermanentRedirect', statusCode:301, region: 'eu-west-1'}
+      req = request('operation', {Bucket: 'name'})
+      req.build()
+      retryable = s3.retryableError(err, req)
+      expect(retryable).to.equal(true)
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+
+    it 'should retry on error code 301 with updated region and endpoint', ->
+      err = {code: 301, statusCode:301, region: 'eu-west-1'}
+      req = request('operation', {Bucket: 'name'})
+      req.build()
+      retryable = s3.retryableError(err, req)
+      expect(retryable).to.equal(true)
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+
+    it 'should retry with updated endpoint even when bucket endpoint is specified', ->
+      err = {code: 'PermanentRedirect', statusCode:301, region: 'eu-west-1'}
+      s3 = new AWS.S3(endpoint: 'https://fake-custom-url.com', s3BucketEndpoint: true)
+      req = request('operation', {Bucket: 'name'})
+      req.build()
+      expect(req.httpRequest.endpoint.hostname).to.equal('fake-custom-url.com')
+      retryable = s3.retryableError(err, req)
+      expect(retryable).to.equal(true)
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+
+    it 'should not retry on requests for bucket region once region is obtained', ->
+      err = {code: 'PermanentRedirect', statusCode:301, region: 'eu-west-1'}
+      req = request('operation', {Bucket: 'name'})
+      req._requestRegionForBucket = 'name'
+      retryable = []
+      retryable.push s3.retryableError(err, req)
+      s3.bucketRegionCache.name = 'eu-west-1'
+      retryable.push s3.retryableError(err, req)
+      expect(retryable).to.eql([true, false])
+
+  describe 'browser NetworkingError due to wrong region', ->
+    done = ->
+    spy = null
+    regionReq = null
+
+    callNetworkingErrorListener = (req) ->
+      if !req
+        req = request('operation', {Bucket: 'name'})
+      if req._asm.currentState == 'validate'
+        req.build()
+      resp = new AWS.Response(req)
+      resp.error = code: 'NetworkingError'
+      s3.reqRegionForNetworkingError(resp, done)
+      req
+
+    beforeEach ->
+      s3 = new AWS.S3(region: 'us-west-2')
+      regionReq = request('operation', {Bucket: 'name'})
+      regionReq.send = (fn) ->
+        fn()
+      helpers.spyOn(AWS.util, 'isBrowser').andReturn(true)
+      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+
+    it 'updates region to us-east-1 if bucket name not DNS compatible', ->
+      req = request('operation', {Bucket: 'name!'})
+      callNetworkingErrorListener(req)
+      expect(req.httpRequest.region).to.equal('us-east-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('s3.amazonaws.com')
+      expect(s3.bucketRegionCache['name!']).to.equal('us-east-1')
+      expect(spy.calls.length).to.equal(0)
+
+    it 'updates region if cached and not current region', ->
+      req = request('operation', {Bucket: 'name'})
+      req.build()
+      s3.bucketRegionCache.name = 'eu-west-1'
+      callNetworkingErrorListener(req)
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+      expect(spy.calls.length).to.equal(0)
+
+    it 'makes async request in us-east-1 if not in cache', ->
+      regionReq.send = (fn) ->
+        s3.bucketRegionCache.name = 'eu-west-1'
+        fn()
+      req = callNetworkingErrorListener()
+      expect(spy.calls.length).to.equal(1)
+      expect(regionReq.httpRequest.region).to.equal('us-east-1')
+      expect(regionReq.httpRequest.endpoint.hostname).to.equal('name.s3.amazonaws.com')
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+
+    it 'makes async request in us-east-1 if cached region matches current region', ->
+      s3.bucketRegionCache.name = 'us-west-2'
+      regionReq.send = (fn) ->
+        s3.bucketRegionCache.name = 'eu-west-1'
+        fn()
+      req = callNetworkingErrorListener()
+      expect(spy.calls.length).to.equal(1)  
+      expect(regionReq.httpRequest.region).to.equal('us-east-1')
+      expect(regionReq.httpRequest.endpoint.hostname).to.equal('name.s3.amazonaws.com')
+      expect(req.httpRequest.region).to.equal('eu-west-1')
+      expect(req.httpRequest.endpoint.hostname).to.equal('name.s3-eu-west-1.amazonaws.com')
+
+    it 'does not update region if path-style bucket is dns-compliant and not in cache', ->
+      s3.config.s3ForcePathStyle = true
+      regionReq.send = (fn) ->
+        s3.bucketRegionCache.name = 'eu-west-1'
+        fn()
+      req = callNetworkingErrorListener()
+      expect(spy.calls.length).to.equal(0)
+      expect(req.httpRequest.region).to.equal('us-west-2')
+      expect(req.httpRequest.endpoint.hostname).to.equal('s3-us-west-2.amazonaws.com')
 
   # tests from this point on are "special cases" for specific aws operations
 
@@ -706,6 +990,37 @@ describe 'AWS.S3', ->
       s3.createBucket(undefined, () -> called = 1)
       expect(loc).to.equal('eu-west-1')
       expect(called).to.equal(1)
+
+    it 'caches bucket region based on LocationConstraint upon successful response', ->
+      s3 = new AWS.S3()
+      params = Bucket: 'name', CreateBucketConfiguration: LocationConstraint: 'rg-fake-1'
+      helpers.mockHttpResponse 200, {}, ''
+      s3.createBucket params, ->
+        expect(s3.bucketRegionCache.name).to.equal('rg-fake-1')
+
+    it 'caches bucket region without LocationConstraint upon successful response', ->
+      s3 = new AWS.S3(region: 'us-east-1')
+      params = Bucket: 'name'
+      helpers.mockHttpResponse 200, {}, ''
+      s3.createBucket params, ->
+        expect(params.CreateBucketConfiguration).to.not.exist
+        expect(s3.bucketRegionCache.name).to.equal('us-east-1')
+
+    it 'caches bucket region with LocationConstraint "EU" upon successful response', ->
+      s3 = new AWS.S3()
+      params = Bucket: 'name', CreateBucketConfiguration: LocationConstraint: 'EU'
+      helpers.mockHttpResponse 200, {}, ''
+      s3.createBucket params, ->
+        expect(s3.bucketRegionCache.name).to.equal('eu-west-1')
+
+  describe 'deleteBucket', ->
+    it 'removes bucket from region cache on successful response', ->
+      s3 = new AWS.S3()
+      params = Bucket: 'name'
+      s3.bucketRegionCache.name = 'rg-fake-1'
+      helpers.mockHttpResponse 204, {}, '' 
+      s3.deleteBucket params, ->
+        expect(s3.bucketRegionCache.name).to.not.exist
 
   AWS.util.each AWS.S3.prototype.computableChecksumOperations, (operation) ->
     describe operation, ->


### PR DESCRIPTION
Redirects to correct S3 bucket region if configured region does not match the bucket region. Should work in all cases except for requests in the browser for path-style buckets. Also caches bucket region so that future requests are corrected to the right region on the first try. Resolves #835 
/cc @chrisradek 

