### PR TITLE
Changes default signer when using the S3 client to signature version 4.

### DIFF
--- a/features/s3/buckets.feature
+++ b/features/s3/buckets.feature
@@ -46,7 +46,7 @@ Feature: Working with Buckets
     Then I delete the bucket
 
   Scenario: Access bucket following 307 redirects
-    Given I am using the S3 "us-east-1" region
+    Given I am using the S3 "us-east-1" region with signatureVersion "s3"
     When I create a bucket with the location constraint "EU"
     Then the bucket should exist
     Then the bucket should have a location constraint of "EU"
@@ -69,7 +69,7 @@ Feature: Working with Buckets
     Then I delete the bucket
 
   Scenario: Follow 307 redirect on new buckets
-    Given I am using the S3 "us-east-1" region
+    Given I am using the S3 "us-east-1" region with signatureVersion "s3"
     When I create a bucket with the location constraint "us-west-2"
     And I put a large buffer to the key "largeobject" in the bucket
     Then the object "largeobject" should exist in the bucket

--- a/features/s3/step_definitions/buckets.js
+++ b/features/s3/step_definitions/buckets.js
@@ -5,6 +5,11 @@ module.exports = function() {
     callback();
   });
 
+  this.Given(/^I am using the S3 "([^"]*)" region with signatureVersion "([^"]*)"$/, function(region, signatureVersion, callback) {
+    this.s3 = new this.AWS.S3({region: region, signatureVersion: signatureVersion});
+    callback();
+  });
+
   this.When(/^I create a bucket with the location constraint "([^"]*)"$/, function(location, callback) {
     this.bucket = this.uniqueName('aws-sdk-js-integration');
     var params = {

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -92,7 +92,7 @@ AWS.EventListeners = {
     addAsync('COMPUTE_SHA256', 'afterBuild', function COMPUTE_SHA256(req, done) {
       req.haltHandlersOnError();
       if (!req.service.api.signatureVersion) return done(); // none
-      if (req.service.getSignerClass(req.isPresigned()) === AWS.Signers.V4) {
+      if (req.service.getSignerClass(req) === AWS.Signers.V4) {
         var body = req.httpRequest.body || '';
         AWS.util.computeSha256(body, function(err, sha) {
           if (err) {
@@ -146,7 +146,7 @@ AWS.EventListeners = {
 
         try {
           var date = AWS.util.date.getDate();
-          var SignerClass = req.service.getSignerClass(req.isPresigned());
+          var SignerClass = req.service.getSignerClass(req);
           var signer = new SignerClass(req.httpRequest,
             req.service.api.signingName || req.service.api.endpointPrefix,
             req.service.config.signatureCache);

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -92,7 +92,7 @@ AWS.EventListeners = {
     addAsync('COMPUTE_SHA256', 'afterBuild', function COMPUTE_SHA256(req, done) {
       req.haltHandlersOnError();
       if (!req.service.api.signatureVersion) return done(); // none
-      if (req.service.getSignerClass(req) === AWS.Signers.V4) {
+      if (req.service.getSignerClass(req.isPresigned()) === AWS.Signers.V4) {
         var body = req.httpRequest.body || '';
         AWS.util.computeSha256(body, function(err, sha) {
           if (err) {
@@ -146,7 +146,7 @@ AWS.EventListeners = {
 
         try {
           var date = AWS.util.date.getDate();
-          var SignerClass = req.service.getSignerClass(req);
+          var SignerClass = req.service.getSignerClass(req.isPresigned());
           var signer = new SignerClass(req.httpRequest,
             req.service.api.signingName || req.service.api.endpointPrefix,
             req.service.config.signatureCache);

--- a/lib/request.js
+++ b/lib/request.js
@@ -651,6 +651,13 @@ AWS.Request = inherit({
   /**
    * @api private
    */
+  isPresigned: function isPresigned() {
+    return this.httpRequest.headers.hasOwnProperty('presigned-expires');
+  },
+
+  /**
+   * @api private
+   */
   toUnauthenticated: function toUnauthenticated() {
     this.removeListener('validate', AWS.EventListeners.Core.VALIDATE_CREDENTIALS);
     this.removeListener('sign', AWS.EventListeners.Core.SIGN);

--- a/lib/service.js
+++ b/lib/service.js
@@ -24,7 +24,16 @@ AWS.Service = inherit({
         'Service must be constructed with `new\' operator');
     }
     var ServiceClass = this.loadServiceClass(config || {});
-    if (ServiceClass) return new ServiceClass(config);
+    if (ServiceClass) {
+      var originalConfig = AWS.util.copy(config);
+      var svc = new ServiceClass(config);
+      Object.defineProperty(svc, '_originalConfig', {
+        get: function() { return originalConfig; },
+        enumerable: false,
+        configurable: true
+      });
+      return svc;
+    }
     this.initialize(config);
   },
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -26,10 +26,11 @@ AWS.util.update(AWS.S3.prototype, {
   /**
    * @api private
    */
-  getSignerClass: function getSignerClass(isPresigner) {
+  getSignerClass: function getSignerClass(request) {
     var defaultApiVersion = this.api.signatureVersion;
     var userDefinedVersion = this._originalConfig ? this._originalConfig.signatureVersion : null;
     var regionDefinedVersion = this.config.signatureVersion;
+    var isPresigned = request ? request.isPresigned() : false;
     /*
       1) User defined version specified:
         a) always return user defined version
@@ -41,7 +42,7 @@ AWS.util.update(AWS.S3.prototype, {
       userDefinedVersion = userDefinedVersion === 'v2' ? 's3' : userDefinedVersion;
       return AWS.Signers.RequestSigner.getVersion(userDefinedVersion);
     }
-    if (isPresigner !== true) {
+    if (isPresigned !== true) {
       defaultApiVersion = 'v4';
     } else if (regionDefinedVersion) {
       defaultApiVersion = regionDefinedVersion;
@@ -280,7 +281,7 @@ AWS.util.update(AWS.S3.prototype, {
     }
 
     // V4 signer uses SHA256 signatures so only compute MD5 if it is required
-    if (req.service.getSignerClass(req.isPresigned()) === AWS.Signers.V4) {
+    if (req.service.getSignerClass(req) === AWS.Signers.V4) {
       if (rules.ContentMD5 && !rules.ContentMD5.required) return false;
     }
 

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -26,6 +26,33 @@ AWS.util.update(AWS.S3.prototype, {
   /**
    * @api private
    */
+  getSignerClass: function getSignerClass(isPresigner) {
+    var defaultApiVersion = this.api.signatureVersion;
+    var userDefinedVersion = this._originalConfig ? this._originalConfig.signatureVersion : null;
+    var regionDefinedVersion = this.config.signatureVersion;
+    /*
+      1) User defined version specified:
+        a) always return user defined version
+      2) No user defined version specified:
+        a) If not using presigned urls, default to V4
+        b) If using presigned urls, default to lowest version the region supports
+    */
+    if (userDefinedVersion) {
+      userDefinedVersion = userDefinedVersion === 'v2' ? 's3' : userDefinedVersion;
+      return AWS.Signers.RequestSigner.getVersion(userDefinedVersion);
+    }
+    if (isPresigner !== true) {
+      defaultApiVersion = 'v4';
+    } else if (regionDefinedVersion) {
+      defaultApiVersion = regionDefinedVersion;
+    }
+
+    return AWS.Signers.RequestSigner.getVersion(defaultApiVersion);
+  },
+
+  /**
+   * @api private
+   */
   validateService: function validateService() {
     // default to us-east-1 when no region is provided
     if (!this.config.region) this.config.region = 'us-east-1';
@@ -253,7 +280,7 @@ AWS.util.update(AWS.S3.prototype, {
     }
 
     // V4 signer uses SHA256 signatures so only compute MD5 if it is required
-    if (req.service.getSignerClass(req) === AWS.Signers.V4) {
+    if (req.service.getSignerClass(req.isPresigned()) === AWS.Signers.V4) {
       if (rules.ContentMD5 && !rules.ContentMD5.required) return false;
     }
 

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -11,7 +11,6 @@ var expiresHeader = 'presigned-expires';
  */
 function signedUrlBuilder(request) {
   var expires = request.httpRequest.headers[expiresHeader];
-  var isPresigner = true;
   var signerClass = request.service.getSignerClass(request);
 
   delete request.httpRequest.headers['User-Agent'];

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -12,7 +12,7 @@ var expiresHeader = 'presigned-expires';
 function signedUrlBuilder(request) {
   var expires = request.httpRequest.headers[expiresHeader];
   var isPresigner = true;
-  var signerClass = request.service.getSignerClass(isPresigner);
+  var signerClass = request.service.getSignerClass(request);
 
   delete request.httpRequest.headers['User-Agent'];
   delete request.httpRequest.headers['X-Amz-User-Agent'];

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -11,11 +11,13 @@ var expiresHeader = 'presigned-expires';
  */
 function signedUrlBuilder(request) {
   var expires = request.httpRequest.headers[expiresHeader];
+  var isPresigner = true;
+  var signerClass = request.service.getSignerClass(isPresigner);
 
   delete request.httpRequest.headers['User-Agent'];
   delete request.httpRequest.headers['X-Amz-User-Agent'];
 
-  if (request.service.getSignerClass() === AWS.Signers.V4) {
+  if (signerClass === AWS.Signers.V4) {
     if (expires > 604800) { // one week expiry is invalid
       var message = 'Presigning does not support expiry time greater ' +
                     'than a week with SigV4 signing.';
@@ -24,7 +26,7 @@ function signedUrlBuilder(request) {
       });
     }
     request.httpRequest.headers[expiresHeader] = expires;
-  } else if (request.service.getSignerClass() === AWS.Signers.S3) {
+  } else if (signerClass === AWS.Signers.S3) {
     request.httpRequest.headers[expiresHeader] = parseInt(
       AWS.util.date.unixTimestamp() + expires, 10).toString();
   } else {

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -93,52 +93,67 @@ describe 'AWS.S3', ->
         return 'v2'
     
     describe 'when using presigned requests', ->
+      req = null
+
+      beforeEach (done) ->
+        req = request('mock')
+        helpers.spyOn(req, 'isPresigned').andReturn(true)
+        done()
 
       describe 'will return an s3 (v2) signer when', ->
 
-        it 'user does not specify a signatureVersion for a region that supports v2', ->
+        it 'user does not specify a signatureVersion for a region that supports v2', (done) ->
           s3 = new AWS.S3(region: 'us-east-1')
-          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+          expect(getVersion(s3.getSignerClass(req))).to.equal('s3')
+          done()
 
-        it 'user specifies a signatureVersion of s3', ->
+        it 'user specifies a signatureVersion of s3', (done) ->
           s3 = new AWS.S3(signatureVersion: 's3')
-          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+          expect(getVersion(s3.getSignerClass(req))).to.equal('s3')
+          done()
 
-        it 'user specifies a signatureVersion of v2', ->
+        it 'user specifies a signatureVersion of v2', (done) ->
           s3 = new AWS.S3(signatureVersion: 'v2')
-          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+          expect(getVersion(s3.getSignerClass(req))).to.equal('s3')
+          done()
 
       describe 'will return a v4 signer when', ->
 
-        it 'user does not specify a signatureVersion for a region that supports only v4', ->
+        it 'user does not specify a signatureVersion for a region that supports only v4', (done) ->
           s3 = new AWS.S3(region: 'eu-central-1')
-          expect(getVersion(s3.getSignerClass(true))).to.equal('v4')
+          expect(getVersion(s3.getSignerClass(req))).to.equal('v4')
+          done()
 
-        it 'user specifies a signatureVersion of v4', ->
+        it 'user specifies a signatureVersion of v4', (done) ->
           s3 = new AWS.S3(signatureVersion: 'v4')
-          expect(getVersion(s3.getSignerClass(true))).to.equal('v4')
+          expect(getVersion(s3.getSignerClass(req))).to.equal('v4')
+          done()
 
     describe 'when not using presigned requests', ->
 
       describe 'will return an s3 (v2) signer when', ->
 
-        it 'user specifies a signatureVersion of s3', ->
+        it 'user specifies a signatureVersion of s3', (done) ->
           s3 = new AWS.S3(signatureVersion: 's3')
           expect(getVersion(s3.getSignerClass())).to.equal('s3')
+          done()
 
-        it 'user specifies a signatureVersion of v2', ->
+        it 'user specifies a signatureVersion of v2', (done) ->
           s3 = new AWS.S3(signatureVersion: 'v2')
           expect(getVersion(s3.getSignerClass())).to.equal('s3')
+          done()
 
       describe 'will return a v4 signer when', ->
 
-        it 'user does not specify a signatureVersion', ->
+        it 'user does not specify a signatureVersion', (done) ->
           s3 = new AWS.S3()
           expect(getVersion(s3.getSignerClass())).to.equal('v4')
+          done()
 
-        it 'user specifies a signatureVersion of v4', ->
+        it 'user specifies a signatureVersion of v4', (done) ->
           s3 = new AWS.S3(signatureVersion: 'v4')
           expect(getVersion(s3.getSignerClass())).to.equal('v4')
+          done()
 
   describe 'building a request', ->
     build = (operation, params) ->

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -83,6 +83,63 @@ describe 'AWS.S3', ->
       s3.clearBucketRegionCache()
       expect(s3.bucketRegionCache).to.eql({})
 
+  describe 'getSignerClass', ->
+    getVersion = (signer) ->
+      if (signer == AWS.Signers.S3)
+        return 's3'
+      else if (signer == AWS.Signers.V4)
+        return 'v4'
+      else if (signer == AWS.Signers.V2)
+        return 'v2'
+    
+    describe 'when using presigned requests', ->
+
+      describe 'will return an s3 (v2) signer when', ->
+
+        it 'user does not specify a signatureVersion for a region that supports v2', ->
+          s3 = new AWS.S3(region: 'us-east-1')
+          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+
+        it 'user specifies a signatureVersion of s3', ->
+          s3 = new AWS.S3(signatureVersion: 's3')
+          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+
+        it 'user specifies a signatureVersion of v2', ->
+          s3 = new AWS.S3(signatureVersion: 'v2')
+          expect(getVersion(s3.getSignerClass(true))).to.equal('s3')
+
+      describe 'will return a v4 signer when', ->
+
+        it 'user does not specify a signatureVersion for a region that supports only v4', ->
+          s3 = new AWS.S3(region: 'eu-central-1')
+          expect(getVersion(s3.getSignerClass(true))).to.equal('v4')
+
+        it 'user specifies a signatureVersion of v4', ->
+          s3 = new AWS.S3(signatureVersion: 'v4')
+          expect(getVersion(s3.getSignerClass(true))).to.equal('v4')
+
+    describe 'when not using presigned requests', ->
+
+      describe 'will return an s3 (v2) signer when', ->
+
+        it 'user specifies a signatureVersion of s3', ->
+          s3 = new AWS.S3(signatureVersion: 's3')
+          expect(getVersion(s3.getSignerClass())).to.equal('s3')
+
+        it 'user specifies a signatureVersion of v2', ->
+          s3 = new AWS.S3(signatureVersion: 'v2')
+          expect(getVersion(s3.getSignerClass())).to.equal('s3')
+
+      describe 'will return a v4 signer when', ->
+
+        it 'user does not specify a signatureVersion', ->
+          s3 = new AWS.S3()
+          expect(getVersion(s3.getSignerClass())).to.equal('v4')
+
+        it 'user specifies a signatureVersion of v4', ->
+          s3 = new AWS.S3(signatureVersion: 'v4')
+          expect(getVersion(s3.getSignerClass())).to.equal('v4')
+
   describe 'building a request', ->
     build = (operation, params) ->
       request(operation, params).build().httpRequest


### PR DESCRIPTION
Replaces #989 

/cc @LiuJoyceC 

This is exactly the same as #989, except that it fixes the merge conflicts and removes the unused variable from `presign.signedUrlBuilder` based on your last comment.

With this change I'll do a minor update to the SDK.