### PR TITLE
Normalizes Metadata keys when calling s3.getSignedUrl when using sigv4

### DIFF
--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -51,6 +51,8 @@ function signedUrlSigner(request) {
   AWS.util.each(request.httpRequest.headers, function (key, value) {
     if (key === expiresHeader) key = 'Expires';
     if (key.indexOf('x-amz-meta-') === 0) {
+      // Delete existing, potentially not normalized key
+      delete queryParams[key];
       key = key.toLowerCase();
     }
     queryParams[key] = value;

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -70,9 +70,14 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     // need to pull in any other X-Amz-* headers
     AWS.util.each.call(this, this.request.headers, function(key, value) {
       if (key === expiresHeader) return;
-      if (this.isSignableHeader(key) &&
-          key.toLowerCase().indexOf('x-amz-') === 0) {
-        qs[key] = value;
+      if (this.isSignableHeader(key)) {
+        var lowerKey = key.toLowerCase();
+        // Metadata should be normalized
+        if (lowerKey.indexOf('x-amz-meta-') === 0) {
+          qs[lowerKey] = value;
+        } else if (lowerKey.indexOf('x-amz-') === 0) {
+          qs[key] = value;
+        }
       }
     });
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -1307,6 +1307,12 @@ describe 'AWS.S3', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key', Metadata: {someKey: 'someValue'})
       expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=5Lcbv0WLGWseQhtmNQ8WwIpX6Kw%3D&x-amz-meta-somekey=someValue&x-amz-security-token=session')
 
+    it 'gets a signed URL for putObject with Metadata using Sigv4', ->
+      s3 = new AWS.S3
+        signatureVersion: 'v4'
+      url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: 'key', Metadata: {someKey: 'someValue'})
+      expect(url).to.equal('https://bucket.s3.mock-region.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=akid%2F19700101%2Fmock-region%2Fs3%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=900&X-Amz-Security-Token=session&X-Amz-Signature=0a1ef336042a7a03b8a2e130ac36097cb1fbab54f8ed5105977a863a5139e679&X-Amz-SignedHeaders=host%3Bx-amz-meta-somekey&x-amz-meta-somekey=someValue')
+
     it 'gets a signed URL for putObject with special characters', ->
       url = s3.getSignedUrl('putObject', Bucket: 'bucket', Key: '!@#$%^&*();\':"{}[],./?`~')
       expect(url).to.equal('https://bucket.s3.amazonaws.com/%21%40%23%24%25%5E%26%2A%28%29%3B%27%3A%22%7B%7D%5B%5D%2C./%3F%60~?AWSAccessKeyId=akid&Expires=900&Signature=9nEltJACZKsriZqU2cmRel6g8LQ%3D&x-amz-security-token=session')


### PR DESCRIPTION
Fixes #1013 
/cc @LiuJoyceC 