### PR TITLE
Allows non-file streams to be used with S3 SigV4 when body signing is disabled (default).

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -734,8 +734,6 @@ AWS.util.update(AWS.S3.prototype, {
    * @param request
    */
   disableBodySigning: function disableBodySigning(request) {
-    // Only file streams are supported (content-md5 still calculated)
-    request.service.validateStreamBody(request.httpRequest.body || '');
     var headers = request.httpRequest.headers;
     // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
     if (!headers.hasOwnProperty('presigned-expires')) {
@@ -743,24 +741,13 @@ AWS.util.update(AWS.S3.prototype, {
     }
   },
 
+  /**
+   * @api private
+   */
   noPresignedContentLength: function noPresignedContentLength(request) {
     if (request.params.ContentLength !== undefined) {
       throw AWS.util.error(new Error(), {code: 'UnexpectedParameter',
         message: 'ContentLength is not supported in pre-signed URLs.'});
-    }
-  },
-
-  /**
-   * @api private
-   */
-  validateStreamBody: function validateStreamBody(body) {
-    if (AWS.util.isNode()) {
-      var Stream = AWS.util.nodeRequire('stream').Stream;
-      if (body instanceof Stream) {
-        if (typeof body.path !== 'string') {
-          throw new Error('Non-file stream objects are not supported with SigV4');
-        }
-      }
     }
   },
 

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -1204,12 +1204,20 @@ describe 'AWS.S3', ->
         req = s3.putObject(Bucket: 'example', Key: 'foo', Body: new Stream.Stream)
         expect(req.build(->).httpRequest.headers['Content-MD5']).to.equal(undefined)
 
-      it 'throws an error in SigV4, if a non-file stream is provided', (done) ->
-        s3 = new AWS.S3({signatureVersion: 'v4'})
+      it 'throws an error in SigV4, if a non-file stream is provided when body signing enabled', (done) ->
+        s3 = new AWS.S3({signatureVersion: 'v4', s3DisableBodySigning: false})
         req = s3.putObject(Bucket: 'example', Key: 'key', Body: new Stream.Stream)
         req.send (err) ->
           expect(err.message).to.contain('stream objects are not supported')
           done()
+
+      it 'does not throw an error in SigV4, if a non-file stream is provided when body signing disabled with ContentLength', (done) ->
+        s3 = new AWS.S3({signatureVersion: 'v4', s3DisableBodySigning: true})
+        helpers.mockResponse data: ETag: 'etag'
+        req = s3.putObject(Bucket: 'example', Key: 'key', Body: new Stream.Stream, ContentLength: 10)
+        req.send (err) ->
+          expect(err).not.to.exist
+          done()          
 
       it 'opens separate stream if a file object is provided (signed payload)', (done) ->
         hash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'


### PR DESCRIPTION
Users uploading non-file streams when using sigv2 by default may have been affected when version 2.4.0 of the SDK was updated to switch sigv4 as the default signer.

Related to #965

/cc @LiuJoyceC 