### PR TITLE
Modifies SDK region request to use headBucket instead of listObjects in Node

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -536,7 +536,7 @@ AWS.util.update(AWS.S3.prototype, {
    *
    * @api private
    */
-   requestBucketRegion: function requestBucketRegion(resp, done) {
+  requestBucketRegion: function requestBucketRegion(resp, done) {
     var error = resp.error;
     var req = resp.request;
     var bucket = req.params.Bucket || null;
@@ -547,15 +547,15 @@ AWS.util.update(AWS.S3.prototype, {
         regionRedirectErrorCodes.indexOf(error.code) === -1) {
       return done();
     }
-
-    var regionReq = req.service.listObjects({Bucket: bucket, MaxKeys: 0});
+    var reqOperation = AWS.util.isNode() ? 'headBucket' : 'listObjects';
+    var regionReq = req.service[reqOperation]({Bucket: bucket, MaxKeys: 0});
     regionReq._requestRegionForBucket = bucket;
     regionReq.send(function() {
       var region = req.service.bucketRegionCache[bucket] || null;
       error.region = region;
       done();
     });
-   },
+  },
 
    /**
    * For browser only. If NetworkingError received, will attempt to obtain

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -548,7 +548,9 @@ AWS.util.update(AWS.S3.prototype, {
       return done();
     }
     var reqOperation = AWS.util.isNode() ? 'headBucket' : 'listObjects';
-    var regionReq = req.service[reqOperation]({Bucket: bucket, MaxKeys: 0});
+    var reqParams = {Bucket: bucket};
+    if (reqOperation === 'listObjects') reqParams.MaxKeys = 0;
+    var regionReq = req.service[reqOperation](reqParams);
     regionReq._requestRegionForBucket = bucket;
     regionReq.send(function() {
       var region = req.service.bucketRegionCache[bucket] || null;

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -7,6 +7,7 @@ describe 'AWS.S3', ->
 
   s3 = null
   request = (operation, params) -> s3.makeRequest(operation, params)
+  regionReqOperation = if AWS.util.isNode() then 'headBucket' else 'listObjects'
 
   beforeEach (done) ->
     s3 = new AWS.S3(region: undefined)
@@ -577,7 +578,7 @@ describe 'AWS.S3', ->
     it 'does not make async request for bucket region if error.region is set', ->
       regionReq = send: (fn) ->
         fn()
-      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      spy = helpers.spyOn(s3, regionReqOperation).andReturn(regionReq)
       req = request('operation', {Bucket: 'name'})
       body = """
         <Error>
@@ -594,7 +595,7 @@ describe 'AWS.S3', ->
     it 'makes async request for bucket region if error.region not set for a region redirect error code', ->
       regionReq = send: (fn) ->
         fn()
-      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      spy = helpers.spyOn(s3, regionReqOperation).andReturn(regionReq)
       params = Bucket: 'name'
       req = request('operation', params)
       body = """
@@ -611,7 +612,7 @@ describe 'AWS.S3', ->
     it 'does not make request for bucket region if error code is not a region redirect code', ->
       regionReq = send: (fn) ->
         fn()
-      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      spy = helpers.spyOn(s3, regionReqOperation).andReturn(regionReq)
       req = request('operation', {Bucket: 'name'})
       body = """
         <Error>
@@ -628,7 +629,7 @@ describe 'AWS.S3', ->
       regionReq = send: (fn) ->
         s3.bucketRegionCache.name = 'us-west-2'
         fn()
-      spy = helpers.spyOn(s3, 'listObjects').andReturn(regionReq)
+      spy = helpers.spyOn(s3, regionReqOperation).andReturn(regionReq)
       req = request('operation', {Bucket: 'name'})
       body = """
         <Error>

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -7,7 +7,6 @@ describe 'AWS.S3', ->
 
   s3 = null
   request = (operation, params) -> s3.makeRequest(operation, params)
-  regionReqOperation = if AWS.util.isNode() then 'headBucket' else 'listObjects'
 
   beforeEach (done) ->
     s3 = new AWS.S3(region: undefined)
@@ -486,6 +485,8 @@ describe 'AWS.S3', ->
   # S3 returns a handful of errors without xml bodies (to match the
   # http spec) these tests ensure we give meaningful codes/messages for these.
   describe 'errors with no XML body', ->
+    regionReqOperation = if AWS.util.isNode() then 'headBucket' else 'listObjects'
+    maxKeysParam = if regionReqOperation == 'listObjects' then 0 else undefined
 
     extractError = (statusCode, body, addHeaders, req) ->
       if !req
@@ -607,6 +608,8 @@ describe 'AWS.S3', ->
       error = extractError(301, body, {}, req)
       expect(error.region).to.not.exist
       expect(spy.calls.length).to.equal(1)
+      expect(spy.calls[0].arguments[0].Bucket).to.equal('name')
+      expect(spy.calls[0].arguments[0].MaxKeys).to.equal(maxKeysParam)
       expect(regionReq._requestRegionForBucket).to.exist
 
     it 'does not make request for bucket region if error code is not a region redirect code', ->
@@ -639,6 +642,8 @@ describe 'AWS.S3', ->
         """
       error = extractError(301, body, {}, req)
       expect(spy.calls.length).to.equal(1)
+      expect(spy.calls[0].arguments[0].Bucket).to.equal('name')
+      expect(spy.calls[0].arguments[0].MaxKeys).to.equal(maxKeysParam)
       expect(error.region).to.equal('us-west-2')
 
     it 'extracts the request ids', ->


### PR DESCRIPTION
Currently, when the SDK makes a request for bucket region for redirect purposes, it calls listObjects because in the browser, CORS restrictions may prevent region information from being obtained through headBucket because region information is only exposed in the response header. However, this restriction does not apply in Node, so this PR changes the region request to use headBucket instead of listObjects in the Node environment.

/cc: @chrisradek 