### PR TITLE
Use AWS.config.httpOptions as default httpOptions

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -13,7 +13,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
     var cbAlreadyCalled = false;
     var endpoint = httpRequest.endpoint;
     var pathPrefix = '';
-    if (!httpOptions) httpOptions = {};
+    httpOptions = httpOptions ? AWS.util.merge(AWS.config.httpOptions, httpOptions) : AWS.util.copy(AWS.config.httpOptions);
     if (httpOptions.proxy) {
       pathPrefix = endpoint.protocol + '//' + endpoint.hostname;
       if (endpoint.port !== 80 && endpoint.port !== 443) {

--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -8,6 +8,7 @@ require('../http');
 AWS.XHRClient = AWS.util.inherit({
   handleRequest: function handleRequest(httpRequest, httpOptions, callback, errCallback) {
     var self = this;
+    httpOptions = httpOptions ? AWS.util.merge(AWS.config.httpOptions, httpOptions) : AWS.util.copy(AWS.config.httpOptions);
     var endpoint = httpRequest.endpoint;
     var emitter = new EventEmitter();
     var href = endpoint.protocol + '//' + endpoint.hostname;


### PR DESCRIPTION
Currently, AWS.config.httpOptions seems not to be used in handleRequest. Which makes the answer to  #671 incorrect.