### PR TITLE
Documents that S3 requests with stream bodies cannot be retried.

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -774,7 +774,9 @@ AWS.util.update(AWS.S3.prototype, {
    * @overload upload(params = {}, [options], [callback])
    *   Uploads an arbitrarily sized buffer, blob, or stream, using intelligent
    *   concurrent handling of parts if the payload is large enough. You can
-   *   configure the concurrent queue size by setting `options`.
+   *   configure the concurrent queue size by setting `options`. Note that in
+   *   Node.js, streams are not rewindable, so the SDK cannot retry a request
+   *   for stream bodies.
    *
    *   @param (see AWS.S3.putObject)
    *   @option (see AWS.S3.ManagedUpload.constructor)

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -774,9 +774,9 @@ AWS.util.update(AWS.S3.prototype, {
    * @overload upload(params = {}, [options], [callback])
    *   Uploads an arbitrarily sized buffer, blob, or stream, using intelligent
    *   concurrent handling of parts if the payload is large enough. You can
-   *   configure the concurrent queue size by setting `options`. Note that in
-   *   Node.js, streams are not rewindable, so the SDK cannot retry a request
-   *   for stream bodies.
+   *   configure the concurrent queue size by setting `options`. Note that this
+   *   is the only operation for which the SDK can retry requests with stream
+   *   bodies.
    *
    *   @param (see AWS.S3.putObject)
    *   @option (see AWS.S3.ManagedUpload.constructor)


### PR DESCRIPTION
Resolves #1043 
/cc: @chrisradek 