### PR TITLE
Sets a default value for maxSockets of 50 when the https.globalAgent.maxSockets is set to Infinity.

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -114,10 +114,13 @@ AWS.NodeHttpClient = AWS.util.inherit({
       AWS.NodeHttpClient.sslAgent = new https.Agent({rejectUnauthorized: true});
       AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
 
-      // delegate maxSockets to globalAgent
+      // delegate maxSockets to globalAgent, set a default limit of 50 if current value is Infinity.
+      // Users can bypass this default by supplying their own Agent as part of SDK configuration.
       Object.defineProperty(AWS.NodeHttpClient.sslAgent, 'maxSockets', {
         enumerable: true,
-        get: function() { return https.globalAgent.maxSockets; }
+        get: function() {
+          return https.globalAgent.maxSockets !== Infinity ? https.globalAgent.maxSockets : 50;
+        }
       });
     }
     return AWS.NodeHttpClient.sslAgent;

--- a/test/node_http_client.spec.coffee
+++ b/test/node_http_client.spec.coffee
@@ -9,9 +9,16 @@ if AWS.util.isNode()
       it 'delegates maxSockets from agent to globalAgent', ->
         https = require('https')
         agent = http.sslAgent()
+        https.globalAgent.maxSockets = 5
         expect(https.globalAgent.maxSockets).to.equal(agent.maxSockets)
         https.globalAgent.maxSockets += 1
         expect(https.globalAgent.maxSockets).to.equal(agent.maxSockets)
+
+      it 'overrides globalAgent value if global is set to Infinity', ->
+        https = require('https')
+        agent = http.sslAgent()
+        https.globalAgent.maxSockets = Infinity
+        expect(agent.maxSockets).to.equal(50)
 
     describe 'handleRequest', ->
       it 'emits error event', (done) ->


### PR DESCRIPTION
This is a performance tuning change. With node.js 0.10 and lower, the default maxSockets on the global agent was 5, but later versions of node.js sets this to Infinity.

/cc @LiuJoyceC 