### PR TITLE
Parse ini files with comments starting with #

### DIFF
--- a/.changes/next-release/feature-util-5a565afe.json
+++ b/.changes/next-release/feature-util-5a565afe.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "util",
+  "description": "Parse ini files containing comments using #"
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -189,7 +189,7 @@ var util = {
     parse: function string(ini) {
       var currentSection, map = {};
       util.arrayEach(ini.split(/\r?\n/), function(line) {
-        line = line.split(/(^|\s);/)[0]; // remove comments
+        line = line.split(/(^|\s)[;#]/)[0]; // remove comments
         var section = line.match(/^\s*\[([^\[\]]+)\]\s*$/);
         if (section) {
           currentSection = section[1];

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -207,11 +207,14 @@ describe 'AWS.util.ini', ->
       invalidline
       key1=value1 ; another comment
         key2 = value2;value3
+        key3 = value4 # yet another comment
       [emptysection]
+      #key1=value1
       '''
       map = AWS.util.ini.parse(ini)
       expect(map.section1.key1).to.equal('value1')
       expect(map.section1.key2).to.equal('value2;value3')
+      expect(map.section1.key3).to.equal('value4')
       expect(map.emptysection).to.equal(undefined)
 
     it 'ignores leading and trailing white space', ->


### PR DESCRIPTION
Related to https://github.com/aws/aws-sdk-ruby/issues/837.

Boto config says to use # to begin comments and some may use it as an alternative to ; in the shared credentials file. This change will support using both for comments.


