### PR TITLE
request.createReadStream emits error for mismatched content-length

### DIFF
--- a/.changes/next-release/bugfix-Request-ebe20e8d.json
+++ b/.changes/next-release/bugfix-Request-ebe20e8d.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Request",
+  "description": "Adds a content-length check for the stream returned from c`createReadStream()`, and the stream will emit an error when the bytes received are fewer than specified by the response content-length header."
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -585,15 +585,17 @@ AWS.Request = inherit({
         if (expectedLen !== undefined && !isNaN(expectedLen) && expectedLen >= 0) {
           shouldCheckContentLength = true;
           var receivedLen = 0;
+        }
 
-          var checkContentLength = function checkContentLength() {
-            if (receivedLen !== expectedLen) {
-              stream.emit('error', AWS.util.error(
-                new Error('Stream content length mismatch. Received ' +
-                  receivedLen + ' of ' + expectedLen + ' bytes.'),
-                { code: 'StreamContentLengthMismatch' }
-              ));
-            }
+        var checkContentLengthAndEmit = function checkContentLengthAndEmit() {
+          if (shouldCheckContentLength && receivedLen !== expectedLen) {
+            stream.emit('error', AWS.util.error(
+              new Error('Stream content length mismatch. Received ' +
+                receivedLen + ' of ' + expectedLen + ' bytes.'),
+              { code: 'StreamContentLengthMismatch' }
+            ));
+          } else {
+            stream.emit('end')
           }
         }
 
@@ -609,8 +611,8 @@ AWS.Request = inherit({
               return streams.PassThrough.prototype._write.apply(this, arguments);
             };
 
-            lengthAccumulator.on('end', checkContentLength);
-            httpStream.pipe(lengthAccumulator).pipe(stream);
+            lengthAccumulator.on('end', checkContentLengthAndEmit);
+            httpStream.pipe(lengthAccumulator).pipe(stream, { end: false });
           } else {
             httpStream.pipe(stream);
           }
@@ -622,18 +624,16 @@ AWS.Request = inherit({
                 receivedLen += arg.length;
               }
             });
-            httpStream.on('end', checkContentLength);
           }
 
           httpStream.on('data', function(arg) {
             stream.emit('data', arg);
           });
-          httpStream.on('end', function() {
-            stream.emit('end');
-          });
+          httpStream.on('end', checkContentLengthAndEmit);
         }
 
         httpStream.on('error', function(err) {
+          shouldCheckContentLength = false;
           stream.emit('error', err);
         });
       }

--- a/lib/request.js
+++ b/lib/request.js
@@ -576,10 +576,55 @@ AWS.Request = inherit({
           resp.error.retryable = false;
         });
 
+        var shouldCheckContentLength = false;
+        var expectedLen;
+        if (req.httpRequest.method !== 'HEAD') {
+          var contentLength = headers['content-length'] || headers['Content-Length'];
+          expectedLen = parseInt(contentLength, 10);
+        }
+        if (expectedLen !== undefined && !isNaN(expectedLen) && expectedLen >= 0) {
+          shouldCheckContentLength = true;
+          var receivedLen = 0;
+
+          var checkContentLength = function checkContentLength() {
+            if (receivedLen !== expectedLen) {
+              stream.emit('error', AWS.util.error(
+                new Error('Stream content length mismatch. Received ' +
+                  receivedLen + ' of ' + expectedLen + ' bytes.'),
+                { code: 'StreamContentLengthMismatch' }
+              ));
+            }
+          }
+        }
+
         var httpStream = resp.httpResponse.createUnbufferedStream();
+
         if (AWS.HttpClient.streamsApiVersion === 2) {
-          httpStream.pipe(stream);
+          if (shouldCheckContentLength) {
+            var lengthAccumulator = new streams.PassThrough();
+            lengthAccumulator._write = function(chunk) {
+              if (chunk && chunk.length) {
+                receivedLen += chunk.length;
+              }
+              return streams.PassThrough.prototype._write.apply(this, arguments);
+            };
+
+            lengthAccumulator.on('end', checkContentLength);
+            httpStream.pipe(lengthAccumulator).pipe(stream);
+          } else {
+            httpStream.pipe(stream);
+          }
         } else {
+
+          if (shouldCheckContentLength) {
+            httpStream.on('data', function(arg) {
+              if (arg && arg.length) {
+                receivedLen += arg.length;
+              }
+            });
+            httpStream.on('end', checkContentLength);
+          }
+
           httpStream.on('data', function(arg) {
             stream.emit('data', arg);
           });

--- a/lib/request.js
+++ b/lib/request.js
@@ -593,6 +593,8 @@ AWS.Request = inherit({
                 receivedLen + ' of ' + expectedLen + ' bytes.'),
               { code: 'StreamContentLengthMismatch' }
             ));
+          } else if (AWS.HttpClient.streamsApiVersion === 2) {
+            stream.end();
           } else {
             stream.emit('end')
           }

--- a/lib/request.js
+++ b/lib/request.js
@@ -579,8 +579,7 @@ AWS.Request = inherit({
         var shouldCheckContentLength = false;
         var expectedLen;
         if (req.httpRequest.method !== 'HEAD') {
-          var contentLength = headers['content-length'] || headers['Content-Length'];
-          expectedLen = parseInt(contentLength, 10);
+          expectedLen = parseInt(headers['content-length'], 10);
         }
         if (expectedLen !== undefined && !isNaN(expectedLen) && expectedLen >= 0) {
           shouldCheckContentLength = true;

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -68,9 +68,10 @@ _spyOn = (obj, methodName) ->
   spies.push(spy)
   spy
 
-# Disable setTimeout for tests
+# Disable setTimeout for tests, but keep original in case test needs to use it
 # Warning: this might cause unpredictable results
 # TODO: refactor this out.
+global.setTimeoutOrig = global.setTimeout
 global.setTimeout = (fn) -> fn()
 
 global.expect = require('chai').expect

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -267,8 +267,7 @@ describe 'AWS.Request', ->
       server = require('http').createServer (req, resp) ->
         app(req, resp)
 
-      if server.setTimeout
-        server.setTimeout(1)
+      server.setTimeout(1)
 
       beforeEach (done) ->
         data = ''; error = null
@@ -323,9 +322,6 @@ describe 'AWS.Request', ->
           done()
 
       it 'emits error when stream length is less than content-length header', (done) ->
-        if server.setTimeout == undefined
-          return done()
-
         AWS.HttpClient.streamsApiVersion = 1
 
         app = (req, resp) ->

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -253,11 +253,8 @@ describe 'AWS.Request', ->
   if AWS.util.isNode()
     describe 'createReadStream', ->
       nstream = require('stream')
-
-      app = (req, resp) ->
-        resp.writeHead(200, {})
-        resp.write('FOOBARBAZQUX')
-        resp.end()
+      streamsApiVersion = AWS.HttpClient.streamsApiVersion
+      app = undefined; data = undefined; error = undefined
 
       getport = (cb, startport) ->
         port = startport or 45678
@@ -271,34 +268,110 @@ describe 'AWS.Request', ->
         app(req, resp)
 
       beforeEach (done) ->
+        data = ''; error = null
+
+        app = (req, resp) ->
+          resp.writeHead(200, {})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
         getport (port) ->
           server.listen(port)
           service = new MockService(endpoint: 'http://localhost:' + port)
           done()
 
       afterEach ->
+        AWS.HttpClient.streamsApiVersion = streamsApiVersion
         server.close()
 
       it 'streams data', (done) ->
-        data = ''
-        helpers.spyOn(AWS.HttpClient, 'streamsApiVersion').andReturn 1
+        AWS.HttpClient.streamsApiVersion = 1
 
         request = service.makeRequest('mockMethod')
         s = request.createReadStream()
-        s.on 'end', -> done = true
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
         s.on 'data', (c) -> data += c.toString()
-        request.on 'complete', ->
+        s.on 'end', ->
+          expect(error).to.be.null
           expect(data).to.equal('FOOBARBAZQUX')
+          done()
+
+      it 'succeeds when stream length matches content-length header', (done) ->
+        AWS.HttpClient.streamsApiVersion = 1
+
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '12'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
+        s.on 'data', (c) -> data += c.toString()
+        s.on 'end', ->
+          expect(error).to.be.null
+          expect(data).to.equal('FOOBARBAZQUX')
+          done()
+
+      it 'emits error when stream length is less than content-length header', (done) ->
+        AWS.HttpClient.streamsApiVersion = 1
+
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '13'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'data', (c) -> data += c.toString()
+        s.on 'end', (a) ->
+          # will fail if 'error' was not emitted
+          expect(error).to.not.be.null
+        s.on 'error', (e) ->
+          error = e
+          expect(error).to.not.be.null
+          expect(error.code).to.equal('StreamContentLengthMismatch')
+          expect(data).to.equal('FOOBARBAZQUX')
+          done()
+
+      it 'only accepts data up to the specified content-length', (done) ->
+        AWS.HttpClient.streamsApiVersion = 1
+
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '11'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
+        s.on 'data', (c) -> data += c.toString()
+        s.on 'end', ->
+          expect(error).to.be.null
+          expect(data).to.equal('FOOBARBAZQU')
           done()
 
       it 'streams2 data (readable event)', (done) ->
         if AWS.HttpClient.streamsApiVersion < 2
           return done()
 
-        data = ''
         request = service.makeRequest('mockMethod')
         s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
         s.on 'end', ->
+          expect(error).to.be.null
           expect(data).to.equal('FOOBARBAZQUX')
           done()
         s.on 'readable', ->
@@ -309,15 +382,79 @@ describe 'AWS.Request', ->
           catch e
             console.log(e.stack)
 
-      it 'streams2 data does not hang out while waiting response', (done) ->
+      it 'succeeds when streams2 length matches content-length header', (done) ->
         if AWS.HttpClient.streamsApiVersion < 2
           return done()
 
-        data = ''
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '12'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
         request = service.makeRequest('mockMethod')
         s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
         s.on 'end', ->
+          expect(error).to.be.null
           expect(data).to.equal('FOOBARBAZQUX')
+          done()
+        s.on 'readable', ->
+          try
+            chunk = s.read()
+            if chunk
+              data += chunk
+          catch e
+            console.log(e.stack)
+
+      it 'emits error when streams2 length is less than content-length header', (done) ->
+        if AWS.HttpClient.streamsApiVersion < 2
+          return done()
+
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '13'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          expect(error).to.not.be.null
+          expect(error.code).to.equal('StreamContentLengthMismatch')
+          expect(data).to.equal('FOOBARBAZQUX')
+          done()
+        s.on 'end', ->
+          # will fail if 'error' was not emitted
+          expect(error).to.not.be.null
+        s.on 'readable', ->
+          try
+            chunk = s.read()
+            if chunk
+              data += chunk
+          catch e
+            console.log(e.stack)
+
+      it 'only accepts data up to the specified content-length', (done) ->
+        if AWS.HttpClient.streamsApiVersion < 2
+          return done()
+
+        app = (req, resp) ->
+          resp.writeHead(200, {'content-length': '11'})
+          resp.write('FOOBARBAZQUX')
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          # should fail because 'error' should not be emitted
+          expect(error).to.be.null
+        s.on 'end', ->
+          expect(error).to.be.null
+          expect(data).to.equal('FOOBARBAZQU')
           done()
         s.on 'readable', ->
           try
@@ -328,21 +465,52 @@ describe 'AWS.Request', ->
             console.log(e.stack)
 
       it 'does not stream data on failures', (done) ->
-        data = ''; error = null
+        AWS.HttpClient.streamsApiVersion = 1
         app = (req, resp) ->
           resp.writeHead(404, {})
           resp.end()
 
         request = service.makeRequest('mockMethod')
         s = request.createReadStream()
-        s.on 'error', (error) ->
-          expect(data).to.equal('')
+        s.on 'error', (e) ->
+          error = e
+          expect(error).to.not.be.null
           expect(error.statusCode).to.equal(404)
+          expect(data).to.equal('')
           done()
+        s.on 'end', ->
+          # will fail if 'error' not emitted
+          expect(error).to.not.be.null
         s.on 'data', (c) -> data += c.toString()
 
+      it 'does not stream data on failures for streams2', (done) ->
+        if AWS.HttpClient.streamsApiVersion < 2
+          return done()
+
+        app = (req, resp) ->
+          resp.writeHead(404, {})
+          resp.end()
+
+        request = service.makeRequest('mockMethod')
+        s = request.createReadStream()
+        s.on 'error', (e) ->
+          error = e
+          expect(error).to.not.be.null
+          expect(error.statusCode).to.equal(404)
+          expect(data).to.equal('')
+          done()
+        s.on 'end', ->
+          # will fail if 'error' not emitted
+          expect(error).to.not.be.null
+        s.on 'readable', ->
+          try
+            chunk = s.read()
+            if chunk
+              data += chunk
+          catch e
+            console.log(e.stack)
+
       it 'retries temporal errors and streams resulting successful response', (done) ->
-        data = ''; error = null
         errs = 0
         app = (req, resp) ->
           status = if errs < 2 then 500 else 200
@@ -350,6 +518,8 @@ describe 'AWS.Request', ->
           resp.writeHead(status, {})
           if status == 200
             resp.write('FOOBARBAZQUX')
+          else
+            resp.write('SOME_ERROR')
           resp.end()
 
         request = service.makeRequest('mockMethod')
@@ -357,12 +527,12 @@ describe 'AWS.Request', ->
         s.on 'error', (e) -> error = e
         s.on 'data', (c) -> data += c.toString()
         request.on 'complete', ->
+          expect(error).to.be.null
           expect(data).to.equal('FOOBARBAZQUX')
-          expect(error).to.equal(null)
           done()
 
       it 'streams partial data and raises an error', (done) ->
-        data = ''; error = null; reqError = null
+        reqError = null
         helpers.spyOn(AWS.HttpClient, 'getInstance')
         AWS.HttpClient.getInstance.andReturn handleRequest: (req, opts, cb, errCb) ->
           req = new EventEmitter()
@@ -395,7 +565,7 @@ describe 'AWS.Request', ->
         s.on 'data', (c) -> data += c.toString()
 
       it 'fails if retry occurs in the middle of a successful stream', (done) ->
-        data = ''; error = null; reqError = null; resp = null
+        reqError = null; resp = null
         retryCount = 0
         helpers.spyOn(AWS.HttpClient, 'getInstance')
         AWS.HttpClient.getInstance.andReturn handleRequest: (req, opts, cb, errCb) ->

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -267,6 +267,9 @@ describe 'AWS.Request', ->
       server = require('http').createServer (req, resp) ->
         app(req, resp)
 
+      if server.setTimeout
+        server.setTimeout(1)
+
       beforeEach (done) ->
         data = ''; error = null
 
@@ -320,6 +323,9 @@ describe 'AWS.Request', ->
           done()
 
       it 'emits error when stream length is less than content-length header', (done) ->
+        if server.setTimeout == undefined
+          return done()
+
         AWS.HttpClient.streamsApiVersion = 1
 
         app = (req, resp) ->


### PR DESCRIPTION
Readable stream from request.createReadStream emits error when bytes received is fewer than content-length header

/cc: @chrisradek 