### PR TITLE
fix typo: refreshhing -> refreshing

### DIFF
--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -81,7 +81,7 @@ AWS.Credentials = AWS.util.inherit({
   },
 
   /**
-   * @return [Integer] the window size in seconds to attempt refreshhing of
+   * @return [Integer] the window size in seconds to attempt refreshing of
    *   credentials before the expireTime occurs.
    */
   expiryWindow: 15,


### PR DESCRIPTION
Fix typo in comments `refreshhing` to `refreshing`.