### PR TITLE
docs/fix: Explicit about bucket name uniqueness

### DIFF
--- a/doc-src/guide/node-examples.md
+++ b/doc-src/guide/node-examples.md
@@ -35,8 +35,11 @@ var AWS = require('aws-sdk');
 AWS.config.region = 'us-west-2';
 
 // Create a bucket using bound parameters and put something in it.
-// Make sure to change the bucket name from "myBucket" to something unique.
+
 var s3bucket = new AWS.S3({params: {Bucket: 'myBucket'}});
+
+// IMPORTANT: Make sure to change the bucket name from "myBucket" above to something unique.
+
 s3bucket.createBucket(function() {
   var params = {Key: 'myKey', Body: 'Hello!'};
   s3bucket.upload(params, function(err, data) {


### PR DESCRIPTION
It's easy to miss the line that s3 bucket names must be to be unique-- provided whitespace & IMPORTANT to call it out. 

The error is a bit cryptic & reads like a permissions error:
![image](https://cloud.githubusercontent.com/assets/1396559/17186692/1a63e606-53eb-11e6-8d20-84f208105142.png)


These docs need a unique S3 bucket name comment: https://aws.amazon.com/sdk-for-node-js/