### PR TITLE
Adds Promise support for S3.ManagedUpload

### DIFF
--- a/.changes/next-release/feature-CredentialProviderChain-37b741a7.json
+++ b/.changes/next-release/feature-CredentialProviderChain-37b741a7.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CredentialProviderChain",
+  "description": "Adds promise support for the `resolve` method on the AWS.CredentialProviderChain class. Corresponding promise method is called `resolvePromise`."
+}

--- a/.changes/next-release/feature-Credentials-67b2b1b9.json
+++ b/.changes/next-release/feature-Credentials-67b2b1b9.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Credentials",
+  "description": "Adds promise support for the `get` and `refresh` methods of the AWS.Credentials class. Corresponding promise methods are called `getPromise` and `refreshPromise`."
+}

--- a/.changes/next-release/feature-ManagedUpload-00442c00.json
+++ b/.changes/next-release/feature-ManagedUpload-00442c00.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "ManagedUpload",
+  "description": "Adds promise support for S3.ManagedUpload. Calling `s3.upload(params).promise()` will return a promise."
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -503,14 +503,13 @@ AWS.Config = AWS.util.inherit({
     PromisesDependency = dep;
     var constructors = [AWS.Request, AWS.Credentials, AWS.CredentialProviderChain];
     if (AWS.S3 && AWS.S3.ManagedUpload) constructors.push(AWS.S3.ManagedUpload);
-    AWS.util.addPromises(AWS.Request, dep);
+    AWS.util.addPromises(constructors, dep);
   },
 
   /**
-   * Gets the promise dependency the SDK will use wherever Promises are returned.
+   * Gets the promise dependency set by `AWS.config.setPromisesDependency`.
    */
   getPromisesDependency: function getPromisesDependency() {
-    if (!PromisesDependency && typeof Promise === 'function') return Promise;
     return PromisesDependency;
   }
 });

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
 var AWS = require('./core');
 require('./credentials');
 require('./credentials/credential_provider_chain');
+var PromisesDependency;
 
 /**
  * The main configuration class used by all service objects to set
@@ -499,7 +500,18 @@ AWS.Config = AWS.util.inherit({
    * @param [Constructor] dep A reference to a Promise constructor
    */
   setPromisesDependency: function setPromisesDependency(dep) {
-    AWS.util.addPromisesToRequests(AWS.Request, dep);
+    PromisesDependency = dep;
+    var constructors = [AWS.Request, AWS.Credentials, AWS.CredentialProviderChain];
+    if (AWS.S3 && AWS.S3.ManagedUpload) constructors.push(AWS.S3.ManagedUpload);
+    AWS.util.addPromises(AWS.Request, dep);
+  },
+
+  /**
+   * Gets the promise dependency the SDK will use wherever Promises are returned.
+   */
+  getPromisesDependency: function getPromisesDependency() {
+    if (!PromisesDependency && typeof Promise === 'function') return Promise;
+    return PromisesDependency;
   }
 });
 

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -148,3 +148,6 @@ AWS.Credentials = AWS.util.inherit({
     callback();
   }
 });
+
+AWS.util.addPromises(AWS.Credentials);
+AWS.util.addPromises(AWS.CredentialProviderChain);

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -146,23 +146,23 @@ AWS.Credentials = AWS.util.inherit({
   refresh: function refresh(callback) {
     this.expired = false;
     callback();
-  },
-
-  /**
-   * @api private
-   */
-  addPromisesToClass: function addPromises(PromiseDependency) {
-    this.getPromise = AWS.util.promisifyMethod('get', PromiseDependency);
-    this.refreshPromise = AWS.util.promisifyMethod('refresh', PromiseDependency);
-  },
-
-  /**
-   * @api private
-   */
-  deletePromisesFromClass: function deletePromisesFromClass() {
-    delete this.getPromise;
-    delete this.refreshPromise;
   }
 });
+
+/**
+ * @api private
+ */
+AWS.Credentials.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+  this.prototype.getPromise = AWS.util.promisifyMethod('get', PromiseDependency);
+  this.prototype.refreshPromise = AWS.util.promisifyMethod('refresh', PromiseDependency);
+};
+
+/**
+ * @api private
+ */
+AWS.Credentials.deletePromisesFromClass = function deletePromisesFromClass() {
+  delete this.prototype.getPromise;
+  delete this.prototype.refreshPromise;
+};
 
 AWS.util.addPromises(AWS.Credentials);

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -109,10 +109,10 @@ AWS.Credentials = AWS.util.inherit({
    * loaded into the object.
    *
    * @callback callback function(err)
-   *   Called when the instance metadata service responds (or fails). When
-   *   this callback is called with no error, it means that the credentials
-   *   information has been loaded into the object (as the `accessKeyId`,
-   *   `secretAccessKey`, and `sessionToken` properties).
+   *   When this callback is called with no error, it means either credentials
+   *   do not need to be refreshed or refreshed credentials information has
+   *   been loaded into the object (as the `accessKeyId`, `secretAccessKey`,
+   *   and `sessionToken` properties).
    *   @param err [Error] if an error occurred, this value will be filled
    */
   get: function get(callback) {
@@ -128,14 +128,60 @@ AWS.Credentials = AWS.util.inherit({
   },
 
   /**
+   * @!method  getPromise()
+   *   Returns a 'thenable' promise.
+   *   Gets the existing credentials, refreshing them if they are not yet loaded
+   *   or have expired. Users should call this method before using {refresh},
+   *   as this will not attempt to reload credentials when they are already
+   *   loaded into the object.
+   *
+   *   Two callbacks can be provided to the `then` method on the returned promise.
+   *   The first callback will be called if the promise is fulfilled, and the second
+   *   callback will be called if the promise is rejected.
+   *   @callback fulfilledCallback function()
+   *     Called if the promise is fulfilled. When this callback is called, it
+   *     means either credentials do not need to be refreshed or refreshed
+   *     credentials information has been loaded into the object (as the
+   *     `accessKeyId`, `secretAccessKey`, and `sessionToken` properties).
+   *   @callback rejectedCallback function(err)
+   *     Called if the promise is rejected.
+   *     @param err [Error] if an error occurred, this value will be filled
+   *   @return [Promise] A promise that represents the state of the `get` call.
+   *   @example Calling the `getPromise` method.
+   *     var promise = credProvider.getPromise();
+   *     promise.then(function() { ... }, function(err) { ... });
+   */
+
+  /**
+   * @!method  refreshPromise()
+   *   Returns a 'thenable' promise.
+   *   Refreshes the credentials. Users should call {get} before attempting
+   *   to forcibly refresh credentials.
+   *
+   *   Two callbacks can be provided to the `then` method on the returned promise.
+   *   The first callback will be called if the promise is fulfilled, and the second
+   *   callback will be called if the promise is rejected.
+   *   @callback fulfilledCallback function()
+   *     Called if the promise is fulfilled. When this callback is called, it
+   *     means refreshed credentials information has been loaded into the object
+   *     (as the `accessKeyId`, `secretAccessKey`, and `sessionToken` properties).
+   *   @callback rejectedCallback function(err)
+   *     Called if the promise is rejected.
+   *     @param err [Error] if an error occurred, this value will be filled
+   *   @return [Promise] A promise that represents the state of the `refresh` call.
+   *   @example Calling the `refreshPromise` method.
+   *     var promise = credProvider.refreshPromise();
+   *     promise.then(function() { ... }, function(err) { ... });
+   */
+
+  /**
    * Refreshes the credentials. Users should call {get} before attempting
    * to forcibly refresh credentials.
    *
    * @callback callback function(err)
-   *   Called when the instance metadata service responds (or fails). When
-   *   this callback is called with no error, it means that the credentials
-   *   information has been loaded into the object (as the `accessKeyId`,
-   *   `secretAccessKey`, and `sessionToken` properties).
+   *   When this callback is called with no error, it means refreshed
+   *   credentials information has been loaded into the object (as the
+   *   `accessKeyId`, `secretAccessKey`, and `sessionToken` properties).
    *   @param err [Error] if an error occurred, this value will be filled
    * @note Subclasses should override this class to reset the
    *   {accessKeyId}, {secretAccessKey} and optional {sessionToken}

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -146,8 +146,23 @@ AWS.Credentials = AWS.util.inherit({
   refresh: function refresh(callback) {
     this.expired = false;
     callback();
+  },
+
+  /**
+   * @api private
+   */
+  addPromisesToClass: function addPromises(PromiseDependency) {
+    this.getPromise = AWS.util.promisifyMethod('get', PromiseDependency);
+    this.refreshPromise = AWS.util.promisifyMethod('refresh', PromiseDependency);
+  },
+
+  /**
+   * @api private
+   */
+  deletePromisesFromClass: function deletePromisesFromClass() {
+    delete this.getPromise;
+    delete this.refreshPromise;
   }
 });
 
 AWS.util.addPromises(AWS.Credentials);
-AWS.util.addPromises(AWS.CredentialProviderChain);

--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -103,6 +103,20 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
 
     resolveNext();
     return this;
+  },
+
+  /**
+   * @api private
+   */
+  addPromisesToClass: function addPromises(PromiseDependency) {
+    this.resolvePromise = AWS.util.promisifyMethod('resolve', PromiseDependency);
+  },
+
+  /**
+   * @api private
+   */
+  deletePromisesFromClass: function deletePromisesFromClass() {
+    delete this.resolvePromise;
   }
 
 });
@@ -133,3 +147,4 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
  * ```
  */
 AWS.CredentialProviderChain.defaultProviders = [];
+AWS.util.addPromises(AWS.CredentialProviderChain);

--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -57,6 +57,29 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
   },
 
   /**
+   * @!method  resolvePromise()
+   *   Returns a 'thenable' promise.
+   *   Resolves the provider chain by searching for the first set of
+   *   credentials in {providers}.
+   *
+   *   Two callbacks can be provided to the `then` method on the returned promise.
+   *   The first callback will be called if the promise is fulfilled, and the second
+   *   callback will be called if the promise is rejected.
+   *   @callback fulfilledCallback function(credentials)
+   *     Called if the promise is fulfilled and the provider resolves the chain
+   *     to a credentials object
+   *     @param credentials [AWS.Credentials] the credentials object resolved
+   *       by the provider chain.
+   *   @callback rejectedCallback function(error)
+   *     Called if the promise is rejected.
+   *     @param err [Error] the error object returned if no credentials are found.
+   *   @return [Promise] A promise that represents the state of the `resolve` method call.
+   *   @example Calling the `resolvePromise` method.
+   *     var promise = chain.resolvePromise();
+   *     promise.then(function(credentials) { ... }, function(err) { ... });
+   */
+
+  /**
    * Resolves the provider chain by searching for the first set of
    * credentials in {providers}.
    *

--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -103,22 +103,7 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
 
     resolveNext();
     return this;
-  },
-
-  /**
-   * @api private
-   */
-  addPromisesToClass: function addPromises(PromiseDependency) {
-    this.resolvePromise = AWS.util.promisifyMethod('resolve', PromiseDependency);
-  },
-
-  /**
-   * @api private
-   */
-  deletePromisesFromClass: function deletePromisesFromClass() {
-    delete this.resolvePromise;
   }
-
 });
 
 /**
@@ -147,4 +132,19 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
  * ```
  */
 AWS.CredentialProviderChain.defaultProviders = [];
+
+/**
+ * @api private
+ */
+AWS.CredentialProviderChain.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+  this.prototype.resolvePromise = AWS.util.promisifyMethod('resolve', PromiseDependency);
+};
+
+/**
+ * @api private
+ */
+AWS.CredentialProviderChain.deletePromisesFromClass = function deletePromisesFromClass() {
+  delete this.prototype.resolvePromise;
+};
+
 AWS.util.addPromises(AWS.CredentialProviderChain);

--- a/lib/request.js
+++ b/lib/request.js
@@ -748,34 +748,34 @@ AWS.Request = inherit({
    */
   haltHandlersOnError: function haltHandlersOnError() {
     this._haltHandlersOnError = true;
-  },
-
-  /**
-   * @api private
-   */
-  addPromisesToClass: function addPromises(PromiseDependency) {
-    this.promise = function promise() {
-      var self = this;
-      return new PromiseDependency(function(resolve, reject) {
-        self.on('complete', function(resp) {
-          if (resp.error) {
-            reject(resp.error);
-          } else {
-            resolve(resp.data);
-          }
-        });
-        self.runTo();
-      });
-    };
-  },
-
-  /**
-   * @api private
-   */
-  deletePromisesFromClass: function deletePromisesFromClass() {
-    delete this.promise;
   }
 });
+
+/**
+ * @api private
+ */
+AWS.Request.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+  this.prototype.promise = function promise() {
+    var self = this;
+    return new PromiseDependency(function(resolve, reject) {
+      self.on('complete', function(resp) {
+        if (resp.error) {
+          reject(resp.error);
+        } else {
+          resolve(resp.data);
+        }
+      });
+      self.runTo();
+    });
+  };
+};
+
+/**
+ * @api private
+ */
+AWS.Request.deletePromisesFromClass = function deletePromisesFromClass() {
+  delete this.prototype.promise;
+};
 
 AWS.util.addPromises(AWS.Request);
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -751,6 +751,6 @@ AWS.Request = inherit({
   }
 });
 
-AWS.util.addPromisesToRequests(AWS.Request);
+AWS.util.addPromises(AWS.Request);
 
 AWS.util.mixin(AWS.Request, AWS.SequentialExecutor);

--- a/lib/request.js
+++ b/lib/request.js
@@ -748,6 +748,32 @@ AWS.Request = inherit({
    */
   haltHandlersOnError: function haltHandlersOnError() {
     this._haltHandlersOnError = true;
+  },
+
+  /**
+   * @api private
+   */
+  addPromisesToClass: function addPromises(PromiseDependency) {
+    this.promise = function promise() {
+      var self = this;
+      return new PromiseDependency(function(resolve, reject) {
+        self.on('complete', function(resp) {
+          if (resp.error) {
+            reject(resp.error);
+          } else {
+            resolve(resp.data);
+          }
+        });
+        self.runTo();
+      });
+    };
+  },
+
+  /**
+   * @api private
+   */
+  deletePromisesFromClass: function deletePromisesFromClass() {
+    delete this.promise;
   }
 });
 

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -595,24 +595,24 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       };
     }
     upload.emit('httpUploadProgress', [info]);
-  },
-
-  /**
-   * @api private
-   */
-  addPromisesToClass: function addPromises(PromiseDependency) {
-    this.promise = AWS.util.promisifyMethod('send', PromiseDependency);
-  },
-
-  /**
-   * @api private
-   */
-  deletePromisesFromClass: function deletePromisesFromClass() {
-    delete this.promise;
   }
 });
 
 AWS.util.mixin(AWS.S3.ManagedUpload, AWS.SequentialExecutor);
+
+/**
+ * @api private
+ */
+AWS.S3.ManagedUpload.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+  this.prototype.promise = AWS.util.promisifyMethod('send', PromiseDependency);
+};
+
+/**
+ * @api private
+ */
+AWS.S3.ManagedUpload.deletePromisesFromClass = function deletePromisesFromClass() {
+  delete this.prototype.promise;
+};
 
 AWS.util.addPromises(AWS.S3.ManagedUpload);
 

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -595,28 +595,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       };
     }
     upload.emit('httpUploadProgress', [info]);
-  },
-
-  /**
-   * Returns a Promise for the managed uploader.
-   */
-  promise: function() {
-    var self = this;
-    var PromiseDependency = AWS.Request._PromiseDependency;
-    if (typeof PromiseDependency !== 'function') {
-      throw new Error('Promise dependency not set');
-    }
-    return new PromiseDependency(function(resolve, reject) {
-      self.send(function(err, data) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data);
-        }
-      });
-    });
   }
 });
 
 AWS.util.mixin(AWS.S3.ManagedUpload, AWS.SequentialExecutor);
+AWS.util.addPromises(AWS.S3.ManagedUpload);
 module.exports = AWS.S3.ManagedUpload;

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -182,6 +182,30 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   },
 
   /**
+   * @!method  promise()
+   *   Returns a 'thenable' promise.
+   *
+   *   Two callbacks can be provided to the `then` method on the returned promise.
+   *   The first callback will be called if the promise is fulfilled, and the second
+   *   callback will be called if the promise is rejected.
+   *   @callback fulfilledCallback function(data)
+   *     Called if the promise is fulfilled.
+   *     @param data [map] The response data from the successful upload:
+   *       `Location` (String) the URL of the uploaded object
+   *       `ETag` (String) the ETag of the uploaded object
+   *       `Bucket` (String) the bucket to which the object was uploaded
+   *       `Key` (String) the key to which the object was uploaded
+   *   @callback rejectedCallback function(err)
+   *     Called if the promise is rejected.
+   *     @param err [Error] an error or null if no error occurred.
+   *   @return [Promise] A promise that represents the state of the upload request.
+   *   @example Sending an upload request using promises.
+   *     var upload = s3.upload({Bucket: 'bucket', Key: 'key', Body: stream});
+   *     var promise = upload.promise();
+   *     promise.then(function(data) { ... }, function(err) { ... });
+   */
+
+  /**
    * Aborts a managed upload, including all concurrent upload requests.
    * @note By default, calling this function will cleanup a multipart upload
    *   if one was created. To leave the multipart upload around after aborting
@@ -215,7 +239,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   validateBody: function validateBody() {
     var self = this;
     self.body = self.service.config.params.Body;
-    if (!self.body) throw new Error('params.Body is required');
+    if (self.body === undefined) throw new Error('params.Body is required');
     if (typeof self.body === 'string') {
       self.body = new AWS.util.Buffer(self.body);
     }

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -595,9 +595,25 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       };
     }
     upload.emit('httpUploadProgress', [info]);
+  },
+
+  /**
+   * @api private
+   */
+  addPromisesToClass: function addPromises(PromiseDependency) {
+    this.promise = AWS.util.promisifyMethod('send', PromiseDependency);
+  },
+
+  /**
+   * @api private
+   */
+  deletePromisesFromClass: function deletePromisesFromClass() {
+    delete this.promise;
   }
 });
 
 AWS.util.mixin(AWS.S3.ManagedUpload, AWS.SequentialExecutor);
+
 AWS.util.addPromises(AWS.S3.ManagedUpload);
+
 module.exports = AWS.S3.ManagedUpload;

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -239,7 +239,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   validateBody: function validateBody() {
     var self = this;
     self.body = self.service.config.params.Body;
-    if (self.body === undefined) throw new Error('params.Body is required');
+    if (!self.body) throw new Error('params.Body is required');
     if (typeof self.body === 'string') {
       self.body = new AWS.util.Buffer(self.body);
     }

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -595,6 +595,26 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       };
     }
     upload.emit('httpUploadProgress', [info]);
+  },
+
+  /**
+   * Returns a Promise for the managed uploader.
+   */
+  promise: function() {
+    var self = this;
+    var PromiseDependency = AWS.Request._PromiseDependency;
+    if (typeof PromiseDependency !== 'function') {
+      throw new Error('Promise dependency not set');
+    }
+    return new PromiseDependency(function(resolve, reject) {
+      self.send(function(err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
   }
 });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -748,29 +748,75 @@ var util = {
   /**
    * @api private
    */
-  addPromisesToRequests: function addPromisesToRequests(constructor, PromiseDependency) {
-    PromiseDependency = PromiseDependency || null;
-    if (!PromiseDependency && typeof Promise !== 'undefined') {
-      PromiseDependency = Promise;
-    }
-    if (typeof PromiseDependency !== 'function') {
-      delete constructor.prototype.promise;
-      return;
-    }
-    constructor.prototype.promise = function promise() {
-      var self = this;
-      return new PromiseDependency(function(resolve, reject) {
-        self.on('complete', function(resp) {
-          if (resp.error) {
-            reject(resp.error);
-          } else {
-            resolve(resp.data);
-          }
+  addPromises: function addPromises(constructors, PromiseDependency) {
+    if (!AWS) AWS = require('./core');
+    if (!AWS.config) require('./config');
+    if (PromiseDependency === undefined) PromiseDependency = AWS.config.getPromisesDependency();
+    if (typeof PromiseDependency !== 'function') var deletePromise = true;
+    if (!Array.isArray(constructors)) constructors = [constructors];
+
+    var promisifyMethod = function(methodName) {
+      return function promise() {
+        var self = this;
+        return new PromiseDependency(function(resolve, reject) {
+          self[methodName](function(err, data) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(data);
+            }
+          });
         });
-        self.runTo();
-      });
+      };
     };
-    constructor._PromiseDependency = PromiseDependency;
+
+    for (var ind = 0; ind < constructors.length; ind++) {
+      var constructor = constructors[ind];
+      switch (constructor.name) {
+        case 'Request':
+          if (deletePromise) {
+            delete constructor.prototype.promise;
+            break;
+          }
+          constructor.prototype.promise = function promise() {
+            var self = this;
+            return new PromiseDependency(function(resolve, reject) {
+              self.on('complete', function(resp) {
+                if (resp.error) {
+                  reject(resp.error);
+                } else {
+                  resolve(resp.data);
+                }
+              });
+              self.runTo();
+            });
+          };
+          break;
+        case 'ManagedUpload':
+          if (deletePromise) {
+            delete constructor.prototype.promise;
+            break;
+          }
+          constructor.prototype.promise = promisifyMethod('send');
+          break;
+        case 'Credentials':
+          if (deletePromise) {
+            delete constructor.prototype.getPromise;
+            delete constructor.prototype.refreshPromise;
+            break;
+          }
+          constructor.prototype.getPromise = promisifyMethod('get');
+          constructor.prototype.refreshPromise = promisifyMethod('refresh');
+          break;
+        case 'CredentialProviderChain':
+          if (deletePromise) {
+            delete constructor.prototype.resolvePromise;
+            break;
+          }
+          constructor.prototype.resolvePromise = promisifyMethod('resolve');
+          break;
+      }
+    }
   },
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -769,7 +769,8 @@ var util = {
         });
         self.runTo();
       });
-    }
+    };
+    constructor._PromiseDependency = PromiseDependency;
   },
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -749,74 +749,43 @@ var util = {
    * @api private
    */
   addPromises: function addPromises(constructors, PromiseDependency) {
-    if (!AWS) AWS = require('./core');
-    if (!AWS.config) require('./config');
-    if (PromiseDependency === undefined) PromiseDependency = AWS.config.getPromisesDependency();
-    if (typeof PromiseDependency !== 'function') var deletePromise = true;
+    if (PromiseDependency === undefined && AWS && AWS.config) {
+      PromiseDependency = AWS.config.getPromisesDependency();
+    }
+    if (PromiseDependency === undefined && typeof Promise !== 'undefined') {
+      PromiseDependency = Promise;
+    }
+    if (typeof PromiseDependency !== 'function') var deletePromises = true;
     if (!Array.isArray(constructors)) constructors = [constructors];
 
-    var promisifyMethod = function(methodName) {
-      return function promise() {
-        var self = this;
-        return new PromiseDependency(function(resolve, reject) {
-          self[methodName](function(err, data) {
-            if (err) {
-              reject(err);
-            } else {
-              resolve(data);
-            }
-          });
-        });
-      };
-    };
-
     for (var ind = 0; ind < constructors.length; ind++) {
-      var constructor = constructors[ind];
-      switch (constructor.name) {
-        case 'Request':
-          if (deletePromise) {
-            delete constructor.prototype.promise;
-            break;
-          }
-          constructor.prototype.promise = function promise() {
-            var self = this;
-            return new PromiseDependency(function(resolve, reject) {
-              self.on('complete', function(resp) {
-                if (resp.error) {
-                  reject(resp.error);
-                } else {
-                  resolve(resp.data);
-                }
-              });
-              self.runTo();
-            });
-          };
-          break;
-        case 'ManagedUpload':
-          if (deletePromise) {
-            delete constructor.prototype.promise;
-            break;
-          }
-          constructor.prototype.promise = promisifyMethod('send');
-          break;
-        case 'Credentials':
-          if (deletePromise) {
-            delete constructor.prototype.getPromise;
-            delete constructor.prototype.refreshPromise;
-            break;
-          }
-          constructor.prototype.getPromise = promisifyMethod('get');
-          constructor.prototype.refreshPromise = promisifyMethod('refresh');
-          break;
-        case 'CredentialProviderChain':
-          if (deletePromise) {
-            delete constructor.prototype.resolvePromise;
-            break;
-          }
-          constructor.prototype.resolvePromise = promisifyMethod('resolve');
-          break;
+      var classPrototype = constructors[ind].prototype;
+      if (deletePromises) {
+        if (classPrototype.deletePromisesFromClass) {
+          classPrototype.deletePromisesFromClass();
+        }
+      } else if (classPrototype.addPromisesToClass) {
+        classPrototype.addPromisesToClass(PromiseDependency);
       }
     }
+  },
+
+  /**
+   * @api private
+   */
+  promisifyMethod: function promisifyMethod(methodName, PromiseDependency) {
+    return function promise() {
+      var self = this;
+      return new PromiseDependency(function(resolve, reject) {
+        self[methodName](function(err, data) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+    };
   },
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -759,13 +759,13 @@ var util = {
     if (!Array.isArray(constructors)) constructors = [constructors];
 
     for (var ind = 0; ind < constructors.length; ind++) {
-      var classPrototype = constructors[ind].prototype;
+      var constructor = constructors[ind];
       if (deletePromises) {
-        if (classPrototype.deletePromisesFromClass) {
-          classPrototype.deletePromisesFromClass();
+        if (constructor.deletePromisesFromClass) {
+          constructor.deletePromisesFromClass();
         }
-      } else if (classPrototype.addPromisesToClass) {
-        classPrototype.addPromisesToClass(PromiseDependency);
+      } else if (constructor.addPromisesToClass) {
+        constructor.addPromisesToClass(PromiseDependency);
       }
     }
   },

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -251,6 +251,19 @@ describe 'AWS.config', ->
 
   describe 'setPromisesDependency', ->
     it 'updates promise support on requests', ->
-      utilSpy = helpers.spyOn(AWS.util, 'addPromisesToRequests')
+      utilSpy = helpers.spyOn(AWS.util, 'addPromises')
       AWS.config.setPromisesDependency(->)
       expect(utilSpy.calls.length).to.equal(1)
+
+  describe 'getPromisesDependency', ->
+    it 'returns native Promises (if supported) if PromisesDependency not set', ->
+      AWS.config.setPromisesDependency()
+      dep = AWS.config.getPromisesDependency()
+      # returns undefined if no native Promise
+      expect(dep).to.equal(global.Promise)
+
+    it 'returns PromisesDependency if set', ->
+      P = ->
+      AWS.config.setPromisesDependency(P)
+      dep = AWS.config.getPromisesDependency()
+      expect(dep).to.equal(P)

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -254,15 +254,13 @@ describe 'AWS.config', ->
       utilSpy = helpers.spyOn(AWS.util, 'addPromises')
       AWS.config.setPromisesDependency(->)
       expect(utilSpy.calls.length).to.equal(1)
+      expect(Array.isArray(utilSpy.calls[0].arguments[0])).to.be.true
+      expect(utilSpy.calls[0].arguments[0].length).to.equal(4)
 
   describe 'getPromisesDependency', ->
-    it 'returns native Promises (if supported) if PromisesDependency not set', ->
-      AWS.config.setPromisesDependency()
-      dep = AWS.config.getPromisesDependency()
-      # returns undefined if no native Promise
-      expect(dep).to.equal(global.Promise)
-
     it 'returns PromisesDependency if set', ->
+      AWS.config.setPromisesDependency()
+      expect(AWS.config.getPromisesDependency()).to.be.undefined
       P = ->
       AWS.config.setPromisesDependency(P)
       dep = AWS.config.getPromisesDependency()

--- a/test/credential_provider_chain.spec.coffee
+++ b/test/credential_provider_chain.spec.coffee
@@ -107,6 +107,9 @@ if AWS.util.isNode()
             provider.forceRefreshError = true
           provider
 
+        before ->
+          AWS.config.setPromisesDependency()
+
         beforeEach ->
           err = null
           creds = null

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -253,6 +253,7 @@ describe 'AWS.Request', ->
 
   describe 'promise', ->
     it 'exists if Promises are available', ->
+      AWS.config.setPromisesDependency()
       req = service.makeRequest('mockMethod')
       if typeof Promise == 'undefined'
         expect(typeof req.promise).to.equal('undefined')

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -377,7 +377,7 @@ describe 'AWS.S3.ManagedUpload', ->
           err = e
 
         before ->
-          AWS.Request._PromiseDependency = Promise
+          AWS.util.addPromises(AWS.S3.ManagedUpload, Promise)
 
         it 'resolves when single part upload is successful', ->
           reqs = helpers.mockResponses [
@@ -387,6 +387,8 @@ describe 'AWS.S3.ManagedUpload', ->
           params = Body: smallbody, ContentEncoding: 'encoding'
           upload = new AWS.S3.ManagedUpload(service: s3, params: params)
 
+          # if a promise is returned from a test, then done callback not needed
+          # and next test will wait for promise to resolve before running
           return upload.promise().then(thenFunction).catch(catchFunction).then ->
             expect(err).not.to.exist
             expect(data.ETag).to.equal('ETAG')

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -653,21 +653,28 @@ describe 'AWS.util.extractRequestId', ->
     AWS.util.extractRequestId(req.response)
     expect(req.response.error.requestId).to.equal('RequestId1')
 
-describe 'AWS.util.addPromisesToRequests', ->
+describe 'AWS.util.addPromises', ->
+  beforeEach ->
+    AWS.config.setPromisesDependency()
+
   afterEach ->
     delete AWS.Request.prototype.promise
+    delete AWS.S3.ManagedUpload.prototype.promise
+    delete AWS.Credentials.prototype.getPromise
+    delete AWS.Credentials.prototype.refreshPromise
+    delete AWS.CredentialProviderChain.prototype.resolvePromise
 
   if typeof Promise != 'undefined'
     describe 'with native promises', ->
       it 'can use native promises', ->
-        AWS.util.addPromisesToRequests(AWS.Request)
+        AWS.util.addPromises(AWS.Request)
         expect(typeof AWS.Request.prototype.promise).to.equal('function')
 
       it 'will use specified dependency over native promises', ->
         service = new helpers.MockService()
         count = 0
         P = -> count++
-        AWS.util.addPromisesToRequests(AWS.Request, P)
+        AWS.util.addPromises(AWS.Request, P)
         req = service.makeRequest('mockMethod')
         expect(typeof AWS.Request.prototype.promise).to.equal('function')
         reqSpy = helpers.spyOn(req, 'promise').andCallThrough()
@@ -677,20 +684,30 @@ describe 'AWS.util.addPromisesToRequests', ->
   else
     describe 'without native promises', ->
       it 'will not add promise method if no dependency is provided', ->
-        AWS.util.addPromisesToRequests(AWS.Request)
+        AWS.util.addPromises(AWS.Request)
         expect(typeof AWS.Request.prototype.promise).to.equal('undefined')
 
       it 'will add promise method if dependency is provided', ->
         P = ->
-        AWS.util.addPromisesToRequests(AWS.Request, P)
+        AWS.util.addPromises(AWS.Request, P)
         expect(typeof AWS.Request.prototype.promise).to.equal('function')
 
       it 'will remove promise method if dependency is not a function', ->
         P = ->
-        AWS.util.addPromisesToRequests(AWS.Request, P)
+        AWS.util.addPromises(AWS.Request, P)
         expect(typeof AWS.Request.prototype.promise).to.equal('function')
-        AWS.util.addPromisesToRequests(AWS.Request, null)
+        AWS.util.addPromises(AWS.Request, null)
         expect(typeof AWS.Request.prototype.promise).to.equal('undefined')
+
+  it 'adds promises to supported constructors', ->
+    constructors = [AWS.Request, AWS.S3.ManagedUpload, AWS.Credentials, AWS.CredentialProviderChain]
+    P = ->
+    AWS.util.addPromises(constructors, P)
+    expect(typeof AWS.Request.prototype.promise).to.equal('function')
+    expect(typeof AWS.S3.ManagedUpload.prototype.promise).to.equal('function')
+    expect(typeof AWS.Credentials.prototype.getPromise).to.equal('function')
+    expect(typeof AWS.Credentials.prototype.refreshPromise).to.equal('function')
+    expect(typeof AWS.CredentialProviderChain.prototype.resolvePromise).to.equal('function')
 
 describe 'AWS.util.isDualstackAvailable', ->
   metadata = require('../apis/metadata.json')

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -709,6 +709,17 @@ describe 'AWS.util.addPromises', ->
     expect(typeof AWS.Credentials.prototype.refreshPromise).to.equal('function')
     expect(typeof AWS.CredentialProviderChain.prototype.resolvePromise).to.equal('function')
 
+  it 'deletes promises from all supported constructors when promise dependency is not a function', ->
+    constructors = [AWS.Request, AWS.S3.ManagedUpload, AWS.Credentials, AWS.CredentialProviderChain]
+    P = ->
+    AWS.util.addPromises(constructors, P)
+    AWS.util.addPromises(constructors, 'not a function')
+    expect(AWS.Request.prototype.promise).to.be.undefined
+    expect(AWS.S3.ManagedUpload.prototype.promise).to.be.undefined
+    expect(AWS.Credentials.prototype.getPromise).to.be.undefined
+    expect(AWS.Credentials.prototype.refreshPromise).to.be.undefined
+    expect(AWS.CredentialProviderChain.prototype.resolvePromise).to.be.undefined
+
 describe 'AWS.util.isDualstackAvailable', ->
   metadata = require('../apis/metadata.json')
 


### PR DESCRIPTION
Adds Promise support for S3.ManagedUpload. `s3.upload(params).promise()` returns a Promise.

Updated original PR to now also support promises for AWS.Credentials and AWS.CredentialProviderChain, in addition to AWS.S3.ManagedUpload.

Resolves #1076 
Resolves #982 
Resolves #1121 

/cc: @chrisradek 