### PR TITLE
EC2MetadataCredentials and ECSCredentials retry

### DIFF
--- a/.changes/next-release/feature-MetadataService-053a415b.json
+++ b/.changes/next-release/feature-MetadataService-053a415b.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "MetadataService",
+  "description": "Adds retry logic to the EC2 Metadata Service, so that EC2MetadataCredentials will retry TimeoutError. This retry logic is also added to ECSCredentials. Resolves #692"
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -100,7 +100,7 @@ require('./credentials/credential_provider_chain');
  *     Currently supported options are:
  *
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
- *       exponential backoff for operation retries. Defaults to 100 ms.
+ *       exponential backoff for operation retries. Defaults to 30 ms.
  *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
  *       and returns the amount of time to delay in milliseconds. The `base` option will be
  *       ignored if this option is supplied.

--- a/lib/config.js
+++ b/lib/config.js
@@ -100,7 +100,7 @@ require('./credentials/credential_provider_chain');
  *     Currently supported options are:
  *
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
- *       exponential backoff for operation retries. Defaults to 30 ms.
+ *       exponential backoff for operation retries. Defaults to 100 ms.
  *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
  *       and returns the amount of time to delay in milliseconds. The `base` option will be
  *       ignored if this option is supplied.

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -18,7 +18,7 @@ require('../metadata_service');
  * AWS.config.credentials = new AWS.EC2MetadataCredentials({
  *   httpOptions: { timeout: 5000 }, // 5 second timeout
  *   maxRetries: 10, // retry 10 times
- *   retryDelayOptions: { base: 30 } // see AWS.Config for information
+ *   retryDelayOptions: { base: 200 } // see AWS.Config for information
  * });
  * ```
  *

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -9,15 +9,20 @@ require('../metadata_service');
  * can connect, and credentials are available, these will be used with zero
  * configuration.
  *
- * This credentials class will timeout after 1 second of inactivity by default.
+ * This credentials class will by default timeout after 1 second of inactivity
+ * and retry 3 times.
  * If your requests to the EC2 metadata service are timing out, you can increase
- * the value by configuring them directly:
+ * these values by configuring them directly:
  *
  * ```javascript
  * AWS.config.credentials = new AWS.EC2MetadataCredentials({
- *   httpOptions: { timeout: 5000 } // 5 second timeout
+ *   httpOptions: { timeout: 5000 }, // 5 second timeout
+ *   maxRetries: 10, // retry 10 times
+ *   retryDelayOptions: { base: 30 } // see AWS.Config for information
  * });
  * ```
+ *
+ * @see AWS.Config.retryDelayOptions
  *
  * @!macro nobrowser
  */
@@ -26,6 +31,8 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
     AWS.Credentials.call(this);
 
     options = options ? AWS.util.copy(options) : {};
+    options = AWS.util.merge(
+      {maxRetries: this.defaultMaxRetries}, options);
     if (!options.httpOptions) options.httpOptions = {};
     options.httpOptions = AWS.util.merge(
       {timeout: this.defaultTimeout}, options.httpOptions);
@@ -38,6 +45,11 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   defaultTimeout: 1000,
+
+  /**
+   * @api private
+   */
+  defaultMaxRetries: 3,
 
   /**
    * Loads the credentials from the instance metadata service

--- a/lib/credentials/ecs_credentials.js
+++ b/lib/credentials/ecs_credentials.js
@@ -8,15 +8,20 @@ var AWS = require('../core');
  * in the container. If valid credentials are returned in the response, these
  * will be used with zero configuration.
  *
- * This credentials class will timeout after 1 second of inactivity by default.
+ * This credentials class will by default timeout after 1 second of inactivity
+ * and retry 3 times.
  * If your requests to the relative URI are timing out, you can increase
  * the value by configuring them directly:
  *
  * ```javascript
  * AWS.config.credentials = new AWS.ECSCredentials({
- *   httpOptions: { timeout: 5000 } // 5 second timeout
+ *   httpOptions: { timeout: 5000 }, // 5 second timeout
+ *   maxRetries: 10, // retry 10 times
+ *   retryDelayOptions: { base: 30 } // see AWS.Config for information
  * });
  * ```
+ *
+ * @see AWS.Config.retryDelayOptions
  *
  * @!macro nobrowser
  */
@@ -39,6 +44,11 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   host: '169.254.170.2',
+
+  /**
+   * @api private
+   */
+  maxRetries: 3,
 
   /**
    * Sets the name of the ECS environment variable to check for relative URI
@@ -69,21 +79,16 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   request: function request(path, callback) {
     path = path || '/';
-
-    var data = '';
-    var http = AWS.HttpClient.getInstance();
     var httpRequest = new AWS.HttpRequest('http://' + this.host + path);
     httpRequest.method = 'GET';
     httpRequest.headers.Accept = 'application/json';
-    var httpOptions = this.httpOptions;
-
-    process.nextTick(function() {
-      http.handleRequest(httpRequest, httpOptions, function(httpResponse) {
-        httpResponse.on('data', function(chunk) { data += chunk.toString(); });
-        httpResponse.on('end', function() { callback(null, data); });
-      }, callback);
-    });
+    AWS.util.handleRequestWithTimeoutRetries(httpRequest, this, callback);
   },
+
+  /**
+   * @api private
+   */
+  refreshQueue: [],
 
   /**
    * Loads the credentials from the relative URI specified by container
@@ -98,10 +103,25 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     var self = this;
+    var refreshQueue = self.refreshQueue;
     if (!callback) callback = function(err) { if (err) throw err; };
+    refreshQueue.push({
+      provider: self,
+      errCallback: callback
+    });
+    if (refreshQueue.length > 1) { return; }
+
+    function callbacks(err, creds) {
+      var call, cb;
+      while ((call = refreshQueue.shift()) !== undefined) {
+        cb = call.errCallback;
+        if (!err) AWS.util.update(call.provider, creds);
+        cb(err);
+      }
+    }
 
     if (process === undefined) {
-      callback(AWS.util.error(
+      callbacks(AWS.util.error(
         new Error('No process info available'),
         { code: 'ECSCredentialsProviderFailure' }
       ));
@@ -109,7 +129,7 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
     }
     var relativeUri = this.getECSRelativeUri();
     if (relativeUri === undefined) {
-      callback(AWS.util.error(
+      callbacks(AWS.util.error(
         new Error('Variable ' + this.environmentVar + ' not set.'),
         { code: 'ECSCredentialsProviderFailure' }
       ));
@@ -119,13 +139,15 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
     this.request(relativeUri, function(err, data) {
       if (!err) {
         try {
-          var creds = JSON.parse(data);
-          if (self.credsFormatIsValid(creds)) {
-            self.expired = false;
-            self.accessKeyId = creds.AccessKeyId;
-            self.secretAccessKey = creds.SecretAccessKey;
-            self.sessionToken = creds.Token;
-            self.expireTime = new Date(creds.Expiration);
+          data = JSON.parse(data);
+          if (self.credsFormatIsValid(data)) {
+            var creds = {
+              expired: false,
+              accessKeyId: data.AccessKeyId,
+              secretAccessKey: data.SecretAccessKey,
+              sessionToken: data.Token,
+              expireTime: new Date(data.Expiration)
+            };
           } else {
             throw AWS.util.error(
               new Error('Response data is not in valid format'),
@@ -136,7 +158,7 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
           err = dataError;
         }
       }
-      callback(err);
+      callbacks(err, creds);
     });
   }
 });

--- a/lib/credentials/ecs_credentials.js
+++ b/lib/credentials/ecs_credentials.js
@@ -17,7 +17,7 @@ var AWS = require('../core');
  * AWS.config.credentials = new AWS.ECSCredentials({
  *   httpOptions: { timeout: 5000 }, // 5 second timeout
  *   maxRetries: 10, // retry 10 times
- *   retryDelayOptions: { base: 30 } // see AWS.Config for information
+ *   retryDelayOptions: { base: 200 } // see AWS.Config for information
  * });
  * ```
  *

--- a/lib/credentials/ecs_credentials.js
+++ b/lib/credentials/ecs_credentials.js
@@ -82,7 +82,7 @@ AWS.ECSCredentials = AWS.util.inherit(AWS.Credentials, {
     var httpRequest = new AWS.HttpRequest('http://' + this.host + path);
     httpRequest.method = 'GET';
     httpRequest.headers.Accept = 'application/json';
-    AWS.util.handleRequestWithTimeoutRetries(httpRequest, this, callback);
+    AWS.util.handleRequestWithRetries(httpRequest, this, callback);
   },
 
   /**

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -44,6 +44,10 @@ AWS.MetadataService = inherit({
    *
    *   * **timeout** (Number) &mdash; a timeout value in milliseconds to wait
    *     before aborting the connection. Set to 0 for no timeout.
+   * @option options maxRetries [Integer] the maximum number of retries to
+   *   perform for timeout errors
+   * @option options retryDelayOptions [map] A set of options to configure the
+   *   retry delay on retryable errors. See AWS.Config for details.
    */
   constructor: function MetadataService(options) {
     AWS.util.update(this, options);
@@ -61,19 +65,9 @@ AWS.MetadataService = inherit({
    */
   request: function request(path, callback) {
     path = path || '/';
-
-    var data = '';
-    var http = AWS.HttpClient.getInstance();
     var httpRequest = new AWS.HttpRequest('http://' + this.host + path);
     httpRequest.method = 'GET';
-    var httpOptions = this.httpOptions;
-
-    process.nextTick(function() {
-      http.handleRequest(httpRequest, httpOptions, function(httpResponse) {
-        httpResponse.on('data', function(chunk) { data += chunk.toString(); });
-        httpResponse.on('end', function() { callback(null, data); });
-      }, callback);
-    });
+    AWS.util.handleRequestWithTimeoutRetries(httpRequest, this, callback);
   },
 
   /**

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -67,7 +67,7 @@ AWS.MetadataService = inherit({
     path = path || '/';
     var httpRequest = new AWS.HttpRequest('http://' + this.host + path);
     httpRequest.method = 'GET';
-    AWS.util.handleRequestWithTimeoutRetries(httpRequest, this, callback);
+    AWS.util.handleRequestWithRetries(httpRequest, this, callback);
   },
 
   /**

--- a/lib/service.js
+++ b/lib/service.js
@@ -311,14 +311,7 @@ AWS.Service = inherit({
    * @api private
    */
   retryDelays: function retryDelays(retryCount) {
-    var retryDelayOptions = this.config.retryDelayOptions || {};
-    var customBackoff = retryDelayOptions.customBackoff || null;
-    if (typeof customBackoff === 'function') {
-      return customBackoff(retryCount);
-    }
-    var base = retryDelayOptions.base || 30;
-    var delay = Math.random() * (Math.pow(2, retryCount) * base);
-    return delay;
+    return AWS.util.calculateRetryDelay(retryCount, this.config.retryDelayOptions);
   },
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -841,7 +841,7 @@ var util = {
           } else {
             var retryAfter = parseInt(httpResponse.headers['retry-after']) * 1000 || 0;
             var err = util.error(new Error(),
-              { retryable: !!(statusCode >= 500 || (statusCode >= 400 && retryAfter)) }
+              { retryable: statusCode >= 500 || statusCode === 429 }
             );
             if (retryAfter && err.retryable) err.retryAfter = retryAfter;
             errCallback(err);

--- a/lib/util.js
+++ b/lib/util.js
@@ -804,7 +804,7 @@ var util = {
     if (typeof customBackoff === 'function') {
       return customBackoff(retryCount);
     }
-    var base = retryDelayOptions.base || 30;
+    var base = retryDelayOptions.base || 100;
     var delay = Math.random() * (Math.pow(2, retryCount) * base);
     return delay;
   },

--- a/lib/util.js
+++ b/lib/util.js
@@ -812,7 +812,7 @@ var util = {
   /**
    * @api private
    */
-  handleRequestWithTimeoutRetries: function handleRequestWithTimeoutRetries(httpRequest, options, cb) {
+  handleRequestWithRetries: function handleRequestWithRetries(httpRequest, options, cb) {
     if (!options) options = {};
     var http = AWS.HttpClient.getInstance();
     var httpOptions = options.httpOptions || {};
@@ -820,10 +820,11 @@ var util = {
 
     var errCallback = function(err) {
       var maxRetries = options.maxRetries || 0;
-      if (err && err.code === 'TimeoutError' && retryCount < maxRetries) {
+      if (err && err.code === 'TimeoutError') err.retryable = true;
+      if (err && err.retryable && retryCount < maxRetries) {
         retryCount++;
         var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions);
-        setTimeout(sendRequest, delay);
+        setTimeout(sendRequest, delay + (err.retryAfter || 0));
       } else {
         cb(err);
       }
@@ -833,7 +834,19 @@ var util = {
       var data = '';
       http.handleRequest(httpRequest, httpOptions, function(httpResponse) {
         httpResponse.on('data', function(chunk) { data += chunk.toString(); });
-        httpResponse.on('end', function() { cb(null, data); });
+        httpResponse.on('end', function() {
+          var statusCode = httpResponse.statusCode;
+          if (statusCode < 300) {
+            cb(null, data);
+          } else {
+            var retryAfter = parseInt(httpResponse.headers['retry-after']) * 1000 || 0;
+            var err = util.error(new Error(),
+              { retryable: !!(statusCode >= 500 || (statusCode >= 400 && retryAfter)) }
+            );
+            if (retryAfter && err.retryable) err.retryAfter = retryAfter;
+            errCallback(err);
+          }
+        });
       }, errCallback);
     };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -839,7 +839,7 @@ var util = {
           if (statusCode < 300) {
             cb(null, data);
           } else {
-            var retryAfter = parseInt(httpResponse.headers['retry-after']) * 1000 || 0;
+            var retryAfter = parseInt(httpResponse.headers['retry-after'], 10) * 1000 || 0;
             var err = util.error(new Error(),
               { retryable: statusCode >= 500 || statusCode === 429 }
             );

--- a/lib/util.js
+++ b/lib/util.js
@@ -793,6 +793,51 @@ var util = {
     if (typeof service !== 'string') service = service.serviceIdentifier;
     if (typeof service !== 'string' || !metadata.hasOwnProperty(service)) return false;
     return !!metadata[service].dualstackAvailable;
+  },
+
+  /**
+   * @api private
+   */
+  calculateRetryDelay: function calculateRetryDelay(retryCount, retryDelayOptions) {
+    if (!retryDelayOptions) retryDelayOptions = {};
+    var customBackoff = retryDelayOptions.customBackoff || null;
+    if (typeof customBackoff === 'function') {
+      return customBackoff(retryCount);
+    }
+    var base = retryDelayOptions.base || 30;
+    var delay = Math.random() * (Math.pow(2, retryCount) * base);
+    return delay;
+  },
+
+  /**
+   * @api private
+   */
+  handleRequestWithTimeoutRetries: function handleRequestWithTimeoutRetries(httpRequest, options, cb) {
+    if (!options) options = {};
+    var http = AWS.HttpClient.getInstance();
+    var httpOptions = options.httpOptions || {};
+    var retryCount = 0;
+
+    var errCallback = function(err) {
+      var maxRetries = options.maxRetries || 0;
+      if (err && err.code === 'TimeoutError' && retryCount < maxRetries) {
+        retryCount++;
+        var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions);
+        setTimeout(sendRequest, delay);
+      } else {
+        cb(err);
+      }
+    };
+
+    var sendRequest = function() {
+      var data = '';
+      http.handleRequest(httpRequest, httpOptions, function(httpResponse) {
+        httpResponse.on('data', function(chunk) { data += chunk.toString(); });
+        httpResponse.on('end', function() { cb(null, data); });
+      }, errCallback);
+    };
+
+    process.nextTick(sendRequest);
   }
 
 };

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -530,8 +530,6 @@ if AWS.util.isNode()
       it 'makes only one request when multiple calls are made before first one finishes', (done) ->
         concurrency = countdown = 10
         process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/path'
-        creds = AWS.ECSCredentials.prototype
-        spy = mockEndpoint(new Date(0))
         spy = helpers.spyOn(AWS.ECSCredentials.prototype, 'request').andCallFake (path, cb) ->
           respond = ->
             cb null, JSON.stringify(responseData)

--- a/test/metadata_service.spec.coffee
+++ b/test/metadata_service.spec.coffee
@@ -7,22 +7,28 @@ if AWS.util.isNode()
   describe 'AWS.MetadataService', ->
     describe 'loadCredentials', ->
       [server, port, service] = [null, 1024 + parseInt(Math.random() * 100), null]
+      [forceTimeout, httpRequest] = [false, null]
+      httpClient = AWS.HttpClient.getInstance()
 
       beforeEach ->
+        [forceTimeout, httpRequest] = [false, null]
         service = new AWS.MetadataService(host: '127.0.0.1:' + port)
         server = http.createServer (req, res) ->
-          re = new RegExp('^/latest/meta-data/iam/security-credentials/(.*)$')
-          match = url.parse(req.url).pathname.match(re)
-          if match
-            res.writeHead(200, 'Content-Type': 'text/plain')
-            if match[1] == ''
-              res.write('TestingRole\n')
-              res.write('TestingRole2\n')
-            else
-              data = '{"Code":"Success","AccessKeyId":"KEY","SecretAccessKey":"SECRET","Token":"TOKEN"}'
-              res.write(data)
+          if forceTimeout
+            httpRequest.stream.emit('error', {code: 'TimeoutError'})
           else
-            res.writeHead(404, {})
+            re = new RegExp('^/latest/meta-data/iam/security-credentials/(.*)$')
+            match = url.parse(req.url).pathname.match(re)
+            if match
+              res.writeHead(200, 'Content-Type': 'text/plain')
+              if match[1] == ''
+                res.write('TestingRole\n')
+                res.write('TestingRole2\n')
+              else
+                data = '{"Code":"Success","AccessKeyId":"KEY","SecretAccessKey":"SECRET","Token":"TOKEN"}'
+                res.write(data)
+            else
+              res.writeHead(404, {})
           res.end()
 
         server.listen(port)
@@ -52,7 +58,6 @@ if AWS.util.isNode()
             if countdown == 0
               done()
 
-
       it 'should fail if server is not up', (done) ->
         server.close(); server = null
         service = new AWS.MetadataService(host: '255.255.255.255')
@@ -61,3 +66,64 @@ if AWS.util.isNode()
           expect(err).to.be.instanceOf(Error)
           expect(data).not.to.exist
           done()
+
+      it 'should retry when request times out', (done) ->
+        options = {
+          host: '127.0.0.1:' + port,
+          maxRetries: 5
+        }
+
+        firstTry = true
+        spy = helpers.spyOn(httpClient, 'handleRequest').andCallFake ->
+          if firstTry
+            forceTimeout = true
+            firstTry = false
+          else
+            forceTimeout = false
+          args = spy.calls[spy.calls.length - 1].arguments
+          httpRequest = args[0]
+          return spy.origMethod.apply(httpClient, args)
+
+        service = new AWS.MetadataService(options)
+        service.loadCredentials (err, data) ->
+          expect(err).to.be.null
+          expect(data.AccessKeyId).to.equal('KEY')
+          # 2 successful calls to retrieve credentials + 1 timeout
+          expect(spy.calls.length).to.equal(3)
+          done()
+
+      it 'should retry up to the specified maxRetries when requests time out', (done) ->
+        options = {
+          host: '127.0.0.1:' + port,
+          maxRetries: 5
+        }
+
+        spy = helpers.spyOn(httpClient, 'handleRequest').andCallFake ->
+          forceTimeout = true
+          args = spy.calls[spy.calls.length - 1].arguments
+          httpRequest = args[0]
+          return spy.origMethod.apply(httpClient, args)
+
+        service = new AWS.MetadataService(options)
+        service.loadCredentials (err, data) ->
+          expect(data).to.be.undefined
+          expect(err).to.not.be.null
+          expect(err.code).to.equal('TimeoutError')
+          # 1st failed try + 5 retries
+          expect(spy.calls.length).to.equal(6)
+          done()
+
+      it 'makes only one pair of requests when multiple calls are made before first one finishes', (done) ->
+        options = {host: '127.0.0.1:' + port}
+        spy = helpers.spyOn(httpClient, 'handleRequest').andCallThrough()
+        concurrency = countdown = 10
+        services = []
+        for x in [1..concurrency]
+          services[x - 1] = new AWS.MetadataService(options)
+          services[x - 1].loadCredentials (err, data) ->
+            expect(err).to.equal(null)
+            expect(data.AccessKeyId).to.equal('KEY')
+            countdown--
+            if countdown == 0
+              expect(spy.calls.length).to.equal(2)
+              done()

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -805,7 +805,6 @@ if AWS.util.isNode()
         resp.write('FOOBAR')
         resp.end()
       sendRequest (err, data) ->
-        console.log('cb was called')
         expect(data).to.be.undefined
         expect(err).to.not.be.null
         expect(err.code).to.equal('SomeError')

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -833,9 +833,9 @@ if AWS.util.isNode()
         expect(spy.calls.length).to.equal(options.maxRetries + 1)
         done()
 
-    it 'retries errors with status code 4xx with retry-after header', (done) ->
+    it 'retries errors with status code 429', (done) ->
       app = (req, resp) ->
-        resp.writeHead(400, {'retry-after': 1})
+        resp.writeHead(429, {})
         resp.write('FOOBAR')
         resp.end()
       sendRequest (err, data) ->


### PR DESCRIPTION
Adds retry to sourcing credentials for IAM Roles in the EC2 Metadata Service or in ECS. By default will retry up to 3 times, with exponential backoff. Also for ECSCredentials, this PR will allow one asynchronous request to serve multiple refresh calls, so that at most only one request will be in flight at any point. Resolves #692 

/cc: @chrisradek 