### PR TITLE
Lazy loads services when requiring the full SDK. Fixes #1124

### DIFF
--- a/.changes/next-release/bugfix-SDK-a6e681af.json
+++ b/.changes/next-release/bugfix-SDK-a6e681af.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SDK",
+  "description": "Fixes an issue that caused all services to be loaded into memory when requiring the SDK. This issue was introduced in version `2.6.0` of the SDK, and address #1124."
+}

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@ configuration.sample
 coverage
 doc
 doc-src
+doc-custom
 eslint-rules
 Gemfile
 Gemfile.lock

--- a/.yardopts
+++ b/.yardopts
@@ -15,6 +15,7 @@
 --mixin-module-expr (AWS\.util\.)?mixin
 lib/core.js
 lib/**/*.js
+doc-custom/**/*.js
 -
 README.md
 UPGRADING.md

--- a/clients/acm.js
+++ b/clients/acm.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ACM')) {
-  apiLoader.services['acm'] = {};
-  AWS.ACM = Service.defineService('acm', ['2015-12-08']);
+apiLoader.services['acm'] = {};
+ACM = Service.defineService('acm', ['2015-12-08']);
 
-  apiLoader.services['acm']['2015-12-08'] = require('../apis/acm-2015-12-08.min.json');
-  apiLoader.services['acm']['2015-12-08'].paginators = require('../apis/acm-2015-12-08.paginators.json').pagination;
+apiLoader.services['acm']['2015-12-08'] = require('../apis/acm-2015-12-08.min.json');
+apiLoader.services['acm']['2015-12-08'].paginators = require('../apis/acm-2015-12-08.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ACM')) {
+  AWS.ACM = ACM;
 }
 
-module.exports = AWS.ACM;
+module.exports = ACM;

--- a/clients/all.js
+++ b/clients/all.js
@@ -1,76 +1,522 @@
-module.exports = {
-  ACM: require('./acm'),
-  APIGateway: require('./apigateway'),
-  ApplicationAutoScaling: require('./applicationautoscaling'),
-  AutoScaling: require('./autoscaling'),
-  CloudFormation: require('./cloudformation'),
-  CloudFront: require('./cloudfront'),
-  CloudHSM: require('./cloudhsm'),
-  CloudSearch: require('./cloudsearch'),
-  CloudSearchDomain: require('./cloudsearchdomain'),
-  CloudTrail: require('./cloudtrail'),
-  CloudWatch: require('./cloudwatch'),
-  CloudWatchEvents: require('./cloudwatchevents'),
-  CloudWatchLogs: require('./cloudwatchlogs'),
-  CodeCommit: require('./codecommit'),
-  CodeDeploy: require('./codedeploy'),
-  CodePipeline: require('./codepipeline'),
-  CognitoIdentity: require('./cognitoidentity'),
-  CognitoIdentityServiceProvider: require('./cognitoidentityserviceprovider'),
-  CognitoSync: require('./cognitosync'),
-  ConfigService: require('./configservice'),
-  DataPipeline: require('./datapipeline'),
-  DeviceFarm: require('./devicefarm'),
-  DirectConnect: require('./directconnect'),
-  DirectoryService: require('./directoryservice'),
-  Discovery: require('./discovery'),
-  DMS: require('./dms'),
-  DynamoDB: require('./dynamodb'),
-  DynamoDBStreams: require('./dynamodbstreams'),
-  EC2: require('./ec2'),
-  ECR: require('./ecr'),
-  ECS: require('./ecs'),
-  EFS: require('./efs'),
-  ElastiCache: require('./elasticache'),
-  ElasticBeanstalk: require('./elasticbeanstalk'),
-  ELB: require('./elb'),
-  ELBv2: require('./elbv2'),
-  EMR: require('./emr'),
-  ES: require('./es'),
-  ElasticTranscoder: require('./elastictranscoder'),
-  Firehose: require('./firehose'),
-  GameLift: require('./gamelift'),
-  Glacier: require('./glacier'),
-  IAM: require('./iam'),
-  ImportExport: require('./importexport'),
-  Inspector: require('./inspector'),
-  Iot: require('./iot'),
-  IotData: require('./iotdata'),
-  Kinesis: require('./kinesis'),
-  KinesisAnalytics: require('./kinesisanalytics'),
-  KMS: require('./kms'),
-  Lambda: require('./lambda'),
-  MachineLearning: require('./machinelearning'),
-  MarketplaceCommerceAnalytics: require('./marketplacecommerceanalytics'),
-  MarketplaceMetering: require('./marketplacemetering'),
-  MobileAnalytics: require('./mobileanalytics'),
-  OpsWorks: require('./opsworks'),
-  RDS: require('./rds'),
-  Redshift: require('./redshift'),
-  Route53: require('./route53'),
-  Route53Domains: require('./route53domains'),
-  S3: require('./s3'),
-  ServiceCatalog: require('./servicecatalog'),
-  SES: require('./ses'),
-  SimpleDB: require('./simpledb'),
-  Snowball: require('./snowball'),
-  SNS: require('./sns'),
-  SQS: require('./sqs'),
-  SSM: require('./ssm'),
-  StorageGateway: require('./storagegateway'),
-  STS: require('./sts'),
-  Support: require('./support'),
-  SWF: require('./swf'),
-  WAF: require('./waf'),
-  WorkSpaces: require('./workspaces')
-};
+require('../lib/node_loader');
+var AWS = require('../lib/core');
+
+Object.defineProperty(AWS, 'ACM', {
+  get: function get() {
+    return require('./acm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'APIGateway', {
+  get: function get() {
+    return require('./apigateway');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ApplicationAutoScaling', {
+  get: function get() {
+    return require('./applicationautoscaling');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'AutoScaling', {
+  get: function get() {
+    return require('./autoscaling');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudFormation', {
+  get: function get() {
+    return require('./cloudformation');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudFront', {
+  get: function get() {
+    return require('./cloudfront');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudHSM', {
+  get: function get() {
+    return require('./cloudhsm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudSearch', {
+  get: function get() {
+    return require('./cloudsearch');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudSearchDomain', {
+  get: function get() {
+    return require('./cloudsearchdomain');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudTrail', {
+  get: function get() {
+    return require('./cloudtrail');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatch', {
+  get: function get() {
+    return require('./cloudwatch');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatchEvents', {
+  get: function get() {
+    return require('./cloudwatchevents');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatchLogs', {
+  get: function get() {
+    return require('./cloudwatchlogs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodeCommit', {
+  get: function get() {
+    return require('./codecommit');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodeDeploy', {
+  get: function get() {
+    return require('./codedeploy');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodePipeline', {
+  get: function get() {
+    return require('./codepipeline');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoIdentity', {
+  get: function get() {
+    return require('./cognitoidentity');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoIdentityServiceProvider', {
+  get: function get() {
+    return require('./cognitoidentityserviceprovider');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoSync', {
+  get: function get() {
+    return require('./cognitosync');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ConfigService', {
+  get: function get() {
+    return require('./configservice');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DataPipeline', {
+  get: function get() {
+    return require('./datapipeline');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DeviceFarm', {
+  get: function get() {
+    return require('./devicefarm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DirectConnect', {
+  get: function get() {
+    return require('./directconnect');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DirectoryService', {
+  get: function get() {
+    return require('./directoryservice');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Discovery', {
+  get: function get() {
+    return require('./discovery');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DMS', {
+  get: function get() {
+    return require('./dms');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DynamoDB', {
+  get: function get() {
+    return require('./dynamodb');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DynamoDBStreams', {
+  get: function get() {
+    return require('./dynamodbstreams');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'EC2', {
+  get: function get() {
+    return require('./ec2');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ECR', {
+  get: function get() {
+    return require('./ecr');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ECS', {
+  get: function get() {
+    return require('./ecs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'EFS', {
+  get: function get() {
+    return require('./efs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElastiCache', {
+  get: function get() {
+    return require('./elasticache');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElasticBeanstalk', {
+  get: function get() {
+    return require('./elasticbeanstalk');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ELB', {
+  get: function get() {
+    return require('./elb');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ELBv2', {
+  get: function get() {
+    return require('./elbv2');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'EMR', {
+  get: function get() {
+    return require('./emr');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ES', {
+  get: function get() {
+    return require('./es');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElasticTranscoder', {
+  get: function get() {
+    return require('./elastictranscoder');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Firehose', {
+  get: function get() {
+    return require('./firehose');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'GameLift', {
+  get: function get() {
+    return require('./gamelift');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Glacier', {
+  get: function get() {
+    return require('./glacier');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'IAM', {
+  get: function get() {
+    return require('./iam');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ImportExport', {
+  get: function get() {
+    return require('./importexport');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Inspector', {
+  get: function get() {
+    return require('./inspector');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Iot', {
+  get: function get() {
+    return require('./iot');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'IotData', {
+  get: function get() {
+    return require('./iotdata');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Kinesis', {
+  get: function get() {
+    return require('./kinesis');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'KinesisAnalytics', {
+  get: function get() {
+    return require('./kinesisanalytics');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'KMS', {
+  get: function get() {
+    return require('./kms');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Lambda', {
+  get: function get() {
+    return require('./lambda');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MachineLearning', {
+  get: function get() {
+    return require('./machinelearning');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MarketplaceCommerceAnalytics', {
+  get: function get() {
+    return require('./marketplacecommerceanalytics');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MarketplaceMetering', {
+  get: function get() {
+    return require('./marketplacemetering');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MobileAnalytics', {
+  get: function get() {
+    return require('./mobileanalytics');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'OpsWorks', {
+  get: function get() {
+    return require('./opsworks');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'RDS', {
+  get: function get() {
+    return require('./rds');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Redshift', {
+  get: function get() {
+    return require('./redshift');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Route53', {
+  get: function get() {
+    return require('./route53');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Route53Domains', {
+  get: function get() {
+    return require('./route53domains');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'S3', {
+  get: function get() {
+    return require('./s3');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ServiceCatalog', {
+  get: function get() {
+    return require('./servicecatalog');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SES', {
+  get: function get() {
+    return require('./ses');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SimpleDB', {
+  get: function get() {
+    return require('./simpledb');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Snowball', {
+  get: function get() {
+    return require('./snowball');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SNS', {
+  get: function get() {
+    return require('./sns');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SQS', {
+  get: function get() {
+    return require('./sqs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SSM', {
+  get: function get() {
+    return require('./ssm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'StorageGateway', {
+  get: function get() {
+    return require('./storagegateway');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'STS', {
+  get: function get() {
+    return require('./sts');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Support', {
+  get: function get() {
+    return require('./support');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SWF', {
+  get: function get() {
+    return require('./swf');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'WAF', {
+  get: function get() {
+    return require('./waf');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'WorkSpaces', {
+  get: function get() {
+    return require('./workspaces');
+  },
+  enumerable: true,
+  configurable: true
+});
+module.exports = AWS;

--- a/clients/apigateway.js
+++ b/clients/apigateway.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'APIGateway')) {
-  apiLoader.services['apigateway'] = {};
-  AWS.APIGateway = Service.defineService('apigateway', ['2015-07-09']);
-  require('../lib/services/apigateway');
+apiLoader.services['apigateway'] = {};
+APIGateway = Service.defineService('apigateway', ['2015-07-09']);
+require('../lib/services/apigateway')(APIGateway);
 
-  apiLoader.services['apigateway']['2015-07-09'] = require('../apis/apigateway-2015-07-09.min.json');
-  apiLoader.services['apigateway']['2015-07-09'].paginators = require('../apis/apigateway-2015-07-09.paginators.json').pagination;
+apiLoader.services['apigateway']['2015-07-09'] = require('../apis/apigateway-2015-07-09.min.json');
+apiLoader.services['apigateway']['2015-07-09'].paginators = require('../apis/apigateway-2015-07-09.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'APIGateway')) {
+  AWS.APIGateway = APIGateway;
 }
 
-module.exports = AWS.APIGateway;
+module.exports = APIGateway;

--- a/clients/applicationautoscaling.js
+++ b/clients/applicationautoscaling.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ApplicationAutoScaling')) {
-  apiLoader.services['applicationautoscaling'] = {};
-  AWS.ApplicationAutoScaling = Service.defineService('applicationautoscaling', ['2016-02-06']);
+apiLoader.services['applicationautoscaling'] = {};
+ApplicationAutoScaling = Service.defineService('applicationautoscaling', ['2016-02-06']);
 
-  apiLoader.services['applicationautoscaling']['2016-02-06'] = require('../apis/application-autoscaling-2016-02-06.min.json');
-  apiLoader.services['applicationautoscaling']['2016-02-06'].paginators = require('../apis/application-autoscaling-2016-02-06.paginators.json').pagination;
+apiLoader.services['applicationautoscaling']['2016-02-06'] = require('../apis/application-autoscaling-2016-02-06.min.json');
+apiLoader.services['applicationautoscaling']['2016-02-06'].paginators = require('../apis/application-autoscaling-2016-02-06.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ApplicationAutoScaling')) {
+  AWS.ApplicationAutoScaling = ApplicationAutoScaling;
 }
 
-module.exports = AWS.ApplicationAutoScaling;
+module.exports = ApplicationAutoScaling;

--- a/clients/autoscaling.js
+++ b/clients/autoscaling.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'AutoScaling')) {
-  apiLoader.services['autoscaling'] = {};
-  AWS.AutoScaling = Service.defineService('autoscaling', ['2011-01-01']);
+apiLoader.services['autoscaling'] = {};
+AutoScaling = Service.defineService('autoscaling', ['2011-01-01']);
 
-  apiLoader.services['autoscaling']['2011-01-01'] = require('../apis/autoscaling-2011-01-01.min.json');
-  apiLoader.services['autoscaling']['2011-01-01'].paginators = require('../apis/autoscaling-2011-01-01.paginators.json').pagination;
+apiLoader.services['autoscaling']['2011-01-01'] = require('../apis/autoscaling-2011-01-01.min.json');
+apiLoader.services['autoscaling']['2011-01-01'].paginators = require('../apis/autoscaling-2011-01-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'AutoScaling')) {
+  AWS.AutoScaling = AutoScaling;
 }
 
-module.exports = AWS.AutoScaling;
+module.exports = AutoScaling;

--- a/clients/browser_default.js
+++ b/clients/browser_default.js
@@ -1,58 +1,396 @@
-module.exports = {
-  ACM: require('./acm'),
-  APIGateway: require('./apigateway'),
-  ApplicationAutoScaling: require('./applicationautoscaling'),
-  AutoScaling: require('./autoscaling'),
-  CloudFormation: require('./cloudformation'),
-  CloudFront: require('./cloudfront'),
-  CloudHSM: require('./cloudhsm'),
-  CloudTrail: require('./cloudtrail'),
-  CloudWatch: require('./cloudwatch'),
-  CloudWatchEvents: require('./cloudwatchevents'),
-  CloudWatchLogs: require('./cloudwatchlogs'),
-  CodeCommit: require('./codecommit'),
-  CodeDeploy: require('./codedeploy'),
-  CodePipeline: require('./codepipeline'),
-  CognitoIdentity: require('./cognitoidentity'),
-  CognitoIdentityServiceProvider: require('./cognitoidentityserviceprovider'),
-  CognitoSync: require('./cognitosync'),
-  ConfigService: require('./configservice'),
-  DeviceFarm: require('./devicefarm'),
-  DirectConnect: require('./directconnect'),
-  DynamoDB: require('./dynamodb'),
-  DynamoDBStreams: require('./dynamodbstreams'),
-  EC2: require('./ec2'),
-  ECR: require('./ecr'),
-  ECS: require('./ecs'),
-  ElastiCache: require('./elasticache'),
-  ElasticBeanstalk: require('./elasticbeanstalk'),
-  ELB: require('./elb'),
-  ELBv2: require('./elbv2'),
-  EMR: require('./emr'),
-  ElasticTranscoder: require('./elastictranscoder'),
-  Firehose: require('./firehose'),
-  GameLift: require('./gamelift'),
-  Inspector: require('./inspector'),
-  Iot: require('./iot'),
-  IotData: require('./iotdata'),
-  Kinesis: require('./kinesis'),
-  KMS: require('./kms'),
-  Lambda: require('./lambda'),
-  MachineLearning: require('./machinelearning'),
-  MarketplaceCommerceAnalytics: require('./marketplacecommerceanalytics'),
-  MobileAnalytics: require('./mobileanalytics'),
-  OpsWorks: require('./opsworks'),
-  RDS: require('./rds'),
-  Redshift: require('./redshift'),
-  Route53: require('./route53'),
-  Route53Domains: require('./route53domains'),
-  S3: require('./s3'),
-  ServiceCatalog: require('./servicecatalog'),
-  SES: require('./ses'),
-  SNS: require('./sns'),
-  SQS: require('./sqs'),
-  SSM: require('./ssm'),
-  StorageGateway: require('./storagegateway'),
-  STS: require('./sts'),
-  WAF: require('./waf')
-};
+require('../lib/node_loader');
+var AWS = require('../lib/core');
+
+Object.defineProperty(AWS, 'ACM', {
+  get: function get() {
+    return require('./acm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'APIGateway', {
+  get: function get() {
+    return require('./apigateway');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ApplicationAutoScaling', {
+  get: function get() {
+    return require('./applicationautoscaling');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'AutoScaling', {
+  get: function get() {
+    return require('./autoscaling');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudFormation', {
+  get: function get() {
+    return require('./cloudformation');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudFront', {
+  get: function get() {
+    return require('./cloudfront');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudHSM', {
+  get: function get() {
+    return require('./cloudhsm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudTrail', {
+  get: function get() {
+    return require('./cloudtrail');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatch', {
+  get: function get() {
+    return require('./cloudwatch');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatchEvents', {
+  get: function get() {
+    return require('./cloudwatchevents');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CloudWatchLogs', {
+  get: function get() {
+    return require('./cloudwatchlogs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodeCommit', {
+  get: function get() {
+    return require('./codecommit');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodeDeploy', {
+  get: function get() {
+    return require('./codedeploy');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CodePipeline', {
+  get: function get() {
+    return require('./codepipeline');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoIdentity', {
+  get: function get() {
+    return require('./cognitoidentity');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoIdentityServiceProvider', {
+  get: function get() {
+    return require('./cognitoidentityserviceprovider');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'CognitoSync', {
+  get: function get() {
+    return require('./cognitosync');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ConfigService', {
+  get: function get() {
+    return require('./configservice');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DeviceFarm', {
+  get: function get() {
+    return require('./devicefarm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DirectConnect', {
+  get: function get() {
+    return require('./directconnect');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DynamoDB', {
+  get: function get() {
+    return require('./dynamodb');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'DynamoDBStreams', {
+  get: function get() {
+    return require('./dynamodbstreams');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'EC2', {
+  get: function get() {
+    return require('./ec2');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ECR', {
+  get: function get() {
+    return require('./ecr');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ECS', {
+  get: function get() {
+    return require('./ecs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElastiCache', {
+  get: function get() {
+    return require('./elasticache');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElasticBeanstalk', {
+  get: function get() {
+    return require('./elasticbeanstalk');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ELB', {
+  get: function get() {
+    return require('./elb');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ELBv2', {
+  get: function get() {
+    return require('./elbv2');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'EMR', {
+  get: function get() {
+    return require('./emr');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ElasticTranscoder', {
+  get: function get() {
+    return require('./elastictranscoder');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Firehose', {
+  get: function get() {
+    return require('./firehose');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'GameLift', {
+  get: function get() {
+    return require('./gamelift');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Inspector', {
+  get: function get() {
+    return require('./inspector');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Iot', {
+  get: function get() {
+    return require('./iot');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'IotData', {
+  get: function get() {
+    return require('./iotdata');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Kinesis', {
+  get: function get() {
+    return require('./kinesis');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'KMS', {
+  get: function get() {
+    return require('./kms');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Lambda', {
+  get: function get() {
+    return require('./lambda');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MachineLearning', {
+  get: function get() {
+    return require('./machinelearning');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MarketplaceCommerceAnalytics', {
+  get: function get() {
+    return require('./marketplacecommerceanalytics');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'MobileAnalytics', {
+  get: function get() {
+    return require('./mobileanalytics');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'OpsWorks', {
+  get: function get() {
+    return require('./opsworks');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'RDS', {
+  get: function get() {
+    return require('./rds');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Redshift', {
+  get: function get() {
+    return require('./redshift');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Route53', {
+  get: function get() {
+    return require('./route53');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'Route53Domains', {
+  get: function get() {
+    return require('./route53domains');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'S3', {
+  get: function get() {
+    return require('./s3');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'ServiceCatalog', {
+  get: function get() {
+    return require('./servicecatalog');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SES', {
+  get: function get() {
+    return require('./ses');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SNS', {
+  get: function get() {
+    return require('./sns');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SQS', {
+  get: function get() {
+    return require('./sqs');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'SSM', {
+  get: function get() {
+    return require('./ssm');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'StorageGateway', {
+  get: function get() {
+    return require('./storagegateway');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'STS', {
+  get: function get() {
+    return require('./sts');
+  },
+  enumerable: true,
+  configurable: true
+});
+Object.defineProperty(AWS, 'WAF', {
+  get: function get() {
+    return require('./waf');
+  },
+  enumerable: true,
+  configurable: true
+});
+module.exports = AWS;

--- a/clients/cloudformation.js
+++ b/clients/cloudformation.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudFormation')) {
-  apiLoader.services['cloudformation'] = {};
-  AWS.CloudFormation = Service.defineService('cloudformation', ['2010-05-15']);
+apiLoader.services['cloudformation'] = {};
+CloudFormation = Service.defineService('cloudformation', ['2010-05-15']);
 
-  apiLoader.services['cloudformation']['2010-05-15'] = require('../apis/cloudformation-2010-05-15.min.json');
-  apiLoader.services['cloudformation']['2010-05-15'].paginators = require('../apis/cloudformation-2010-05-15.paginators.json').pagination;
-  apiLoader.services['cloudformation']['2010-05-15'].waiters = require('../apis/cloudformation-2010-05-15.waiters2.json').waiters;
+apiLoader.services['cloudformation']['2010-05-15'] = require('../apis/cloudformation-2010-05-15.min.json');
+apiLoader.services['cloudformation']['2010-05-15'].paginators = require('../apis/cloudformation-2010-05-15.paginators.json').pagination;
+apiLoader.services['cloudformation']['2010-05-15'].waiters = require('../apis/cloudformation-2010-05-15.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudFormation')) {
+  AWS.CloudFormation = CloudFormation;
 }
 
-module.exports = AWS.CloudFormation;
+module.exports = CloudFormation;

--- a/clients/cloudfront.js
+++ b/clients/cloudfront.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudFront')) {
-  apiLoader.services['cloudfront'] = {};
-  AWS.CloudFront = Service.defineService('cloudfront', ['2016-09-07']);
-  require('../lib/services/cloudfront');
+apiLoader.services['cloudfront'] = {};
+CloudFront = Service.defineService('cloudfront', ['2016-09-07']);
+require('../lib/services/cloudfront')(CloudFront);
 
-  apiLoader.services['cloudfront']['2016-09-07'] = require('../apis/cloudfront-2016-09-07.min.json');
-  apiLoader.services['cloudfront']['2016-09-07'].paginators = require('../apis/cloudfront-2016-09-07.paginators.json').pagination;
-  apiLoader.services['cloudfront']['2016-09-07'].waiters = require('../apis/cloudfront-2016-09-07.waiters2.json').waiters;
+apiLoader.services['cloudfront']['2016-09-07'] = require('../apis/cloudfront-2016-09-07.min.json');
+apiLoader.services['cloudfront']['2016-09-07'].paginators = require('../apis/cloudfront-2016-09-07.paginators.json').pagination;
+apiLoader.services['cloudfront']['2016-09-07'].waiters = require('../apis/cloudfront-2016-09-07.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudFront')) {
+  AWS.CloudFront = CloudFront;
 }
 
-module.exports = AWS.CloudFront;
+module.exports = CloudFront;

--- a/clients/cloudhsm.js
+++ b/clients/cloudhsm.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudHSM')) {
-  apiLoader.services['cloudhsm'] = {};
-  AWS.CloudHSM = Service.defineService('cloudhsm', ['2014-05-30']);
+apiLoader.services['cloudhsm'] = {};
+CloudHSM = Service.defineService('cloudhsm', ['2014-05-30']);
 
-  apiLoader.services['cloudhsm']['2014-05-30'] = require('../apis/cloudhsm-2014-05-30.min.json');
+apiLoader.services['cloudhsm']['2014-05-30'] = require('../apis/cloudhsm-2014-05-30.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudHSM')) {
+  AWS.CloudHSM = CloudHSM;
 }
 
-module.exports = AWS.CloudHSM;
+module.exports = CloudHSM;

--- a/clients/cloudsearch.js
+++ b/clients/cloudsearch.js
@@ -3,15 +3,16 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
+apiLoader.services['cloudsearch'] = {};
+CloudSearch = Service.defineService('cloudsearch', ['2011-02-01', '2013-01-01']);
+
+apiLoader.services['cloudsearch']['2011-02-01'] = require('../apis/cloudsearch-2011-02-01.min.json');
+apiLoader.services['cloudsearch']['2011-02-01'].paginators = require('../apis/cloudsearch-2011-02-01.paginators.json').pagination;
+
+apiLoader.services['cloudsearch']['2013-01-01'] = require('../apis/cloudsearch-2013-01-01.min.json');
+apiLoader.services['cloudsearch']['2013-01-01'].paginators = require('../apis/cloudsearch-2013-01-01.paginators.json').pagination;
 if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudSearch')) {
-  apiLoader.services['cloudsearch'] = {};
-  AWS.CloudSearch = Service.defineService('cloudsearch', ['2011-02-01', '2013-01-01']);
-
-  apiLoader.services['cloudsearch']['2011-02-01'] = require('../apis/cloudsearch-2011-02-01.min.json');
-  apiLoader.services['cloudsearch']['2011-02-01'].paginators = require('../apis/cloudsearch-2011-02-01.paginators.json').pagination;
-
-  apiLoader.services['cloudsearch']['2013-01-01'] = require('../apis/cloudsearch-2013-01-01.min.json');
-  apiLoader.services['cloudsearch']['2013-01-01'].paginators = require('../apis/cloudsearch-2013-01-01.paginators.json').pagination;
+  AWS.CloudSearch = CloudSearch;
 }
 
-module.exports = AWS.CloudSearch;
+module.exports = CloudSearch;

--- a/clients/cloudsearchdomain.js
+++ b/clients/cloudsearchdomain.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudSearchDomain')) {
-  apiLoader.services['cloudsearchdomain'] = {};
-  AWS.CloudSearchDomain = Service.defineService('cloudsearchdomain', ['2013-01-01']);
-  require('../lib/services/cloudsearchdomain');
+apiLoader.services['cloudsearchdomain'] = {};
+CloudSearchDomain = Service.defineService('cloudsearchdomain', ['2013-01-01']);
+require('../lib/services/cloudsearchdomain')(CloudSearchDomain);
 
-  apiLoader.services['cloudsearchdomain']['2013-01-01'] = require('../apis/cloudsearchdomain-2013-01-01.min.json');
+apiLoader.services['cloudsearchdomain']['2013-01-01'] = require('../apis/cloudsearchdomain-2013-01-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudSearchDomain')) {
+  AWS.CloudSearchDomain = CloudSearchDomain;
 }
 
-module.exports = AWS.CloudSearchDomain;
+module.exports = CloudSearchDomain;

--- a/clients/cloudtrail.js
+++ b/clients/cloudtrail.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudTrail')) {
-  apiLoader.services['cloudtrail'] = {};
-  AWS.CloudTrail = Service.defineService('cloudtrail', ['2013-11-01']);
+apiLoader.services['cloudtrail'] = {};
+CloudTrail = Service.defineService('cloudtrail', ['2013-11-01']);
 
-  apiLoader.services['cloudtrail']['2013-11-01'] = require('../apis/cloudtrail-2013-11-01.min.json');
-  apiLoader.services['cloudtrail']['2013-11-01'].paginators = require('../apis/cloudtrail-2013-11-01.paginators.json').pagination;
+apiLoader.services['cloudtrail']['2013-11-01'] = require('../apis/cloudtrail-2013-11-01.min.json');
+apiLoader.services['cloudtrail']['2013-11-01'].paginators = require('../apis/cloudtrail-2013-11-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudTrail')) {
+  AWS.CloudTrail = CloudTrail;
 }
 
-module.exports = AWS.CloudTrail;
+module.exports = CloudTrail;

--- a/clients/cloudwatch.js
+++ b/clients/cloudwatch.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatch')) {
-  apiLoader.services['cloudwatch'] = {};
-  AWS.CloudWatch = Service.defineService('cloudwatch', ['2010-08-01']);
+apiLoader.services['cloudwatch'] = {};
+CloudWatch = Service.defineService('cloudwatch', ['2010-08-01']);
 
-  apiLoader.services['cloudwatch']['2010-08-01'] = require('../apis/monitoring-2010-08-01.min.json');
-  apiLoader.services['cloudwatch']['2010-08-01'].paginators = require('../apis/monitoring-2010-08-01.paginators.json').pagination;
-  apiLoader.services['cloudwatch']['2010-08-01'].waiters = require('../apis/monitoring-2010-08-01.waiters2.json').waiters;
+apiLoader.services['cloudwatch']['2010-08-01'] = require('../apis/monitoring-2010-08-01.min.json');
+apiLoader.services['cloudwatch']['2010-08-01'].paginators = require('../apis/monitoring-2010-08-01.paginators.json').pagination;
+apiLoader.services['cloudwatch']['2010-08-01'].waiters = require('../apis/monitoring-2010-08-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatch')) {
+  AWS.CloudWatch = CloudWatch;
 }
 
-module.exports = AWS.CloudWatch;
+module.exports = CloudWatch;

--- a/clients/cloudwatchevents.js
+++ b/clients/cloudwatchevents.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatchEvents')) {
-  apiLoader.services['cloudwatchevents'] = {};
-  AWS.CloudWatchEvents = Service.defineService('cloudwatchevents', ['2015-10-07']);
+apiLoader.services['cloudwatchevents'] = {};
+CloudWatchEvents = Service.defineService('cloudwatchevents', ['2015-10-07']);
 
-  apiLoader.services['cloudwatchevents']['2015-10-07'] = require('../apis/events-2015-10-07.min.json');
+apiLoader.services['cloudwatchevents']['2015-10-07'] = require('../apis/events-2015-10-07.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatchEvents')) {
+  AWS.CloudWatchEvents = CloudWatchEvents;
 }
 
-module.exports = AWS.CloudWatchEvents;
+module.exports = CloudWatchEvents;

--- a/clients/cloudwatchlogs.js
+++ b/clients/cloudwatchlogs.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatchLogs')) {
-  apiLoader.services['cloudwatchlogs'] = {};
-  AWS.CloudWatchLogs = Service.defineService('cloudwatchlogs', ['2014-03-28']);
+apiLoader.services['cloudwatchlogs'] = {};
+CloudWatchLogs = Service.defineService('cloudwatchlogs', ['2014-03-28']);
 
-  apiLoader.services['cloudwatchlogs']['2014-03-28'] = require('../apis/logs-2014-03-28.min.json');
-  apiLoader.services['cloudwatchlogs']['2014-03-28'].paginators = require('../apis/logs-2014-03-28.paginators.json').pagination;
+apiLoader.services['cloudwatchlogs']['2014-03-28'] = require('../apis/logs-2014-03-28.min.json');
+apiLoader.services['cloudwatchlogs']['2014-03-28'].paginators = require('../apis/logs-2014-03-28.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CloudWatchLogs')) {
+  AWS.CloudWatchLogs = CloudWatchLogs;
 }
 
-module.exports = AWS.CloudWatchLogs;
+module.exports = CloudWatchLogs;

--- a/clients/codecommit.js
+++ b/clients/codecommit.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CodeCommit')) {
-  apiLoader.services['codecommit'] = {};
-  AWS.CodeCommit = Service.defineService('codecommit', ['2015-04-13']);
+apiLoader.services['codecommit'] = {};
+CodeCommit = Service.defineService('codecommit', ['2015-04-13']);
 
-  apiLoader.services['codecommit']['2015-04-13'] = require('../apis/codecommit-2015-04-13.min.json');
-  apiLoader.services['codecommit']['2015-04-13'].paginators = require('../apis/codecommit-2015-04-13.paginators.json').pagination;
+apiLoader.services['codecommit']['2015-04-13'] = require('../apis/codecommit-2015-04-13.min.json');
+apiLoader.services['codecommit']['2015-04-13'].paginators = require('../apis/codecommit-2015-04-13.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CodeCommit')) {
+  AWS.CodeCommit = CodeCommit;
 }
 
-module.exports = AWS.CodeCommit;
+module.exports = CodeCommit;

--- a/clients/codedeploy.js
+++ b/clients/codedeploy.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CodeDeploy')) {
-  apiLoader.services['codedeploy'] = {};
-  AWS.CodeDeploy = Service.defineService('codedeploy', ['2014-10-06']);
+apiLoader.services['codedeploy'] = {};
+CodeDeploy = Service.defineService('codedeploy', ['2014-10-06']);
 
-  apiLoader.services['codedeploy']['2014-10-06'] = require('../apis/codedeploy-2014-10-06.min.json');
-  apiLoader.services['codedeploy']['2014-10-06'].paginators = require('../apis/codedeploy-2014-10-06.paginators.json').pagination;
-  apiLoader.services['codedeploy']['2014-10-06'].waiters = require('../apis/codedeploy-2014-10-06.waiters2.json').waiters;
+apiLoader.services['codedeploy']['2014-10-06'] = require('../apis/codedeploy-2014-10-06.min.json');
+apiLoader.services['codedeploy']['2014-10-06'].paginators = require('../apis/codedeploy-2014-10-06.paginators.json').pagination;
+apiLoader.services['codedeploy']['2014-10-06'].waiters = require('../apis/codedeploy-2014-10-06.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CodeDeploy')) {
+  AWS.CodeDeploy = CodeDeploy;
 }
 
-module.exports = AWS.CodeDeploy;
+module.exports = CodeDeploy;

--- a/clients/codepipeline.js
+++ b/clients/codepipeline.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CodePipeline')) {
-  apiLoader.services['codepipeline'] = {};
-  AWS.CodePipeline = Service.defineService('codepipeline', ['2015-07-09']);
+apiLoader.services['codepipeline'] = {};
+CodePipeline = Service.defineService('codepipeline', ['2015-07-09']);
 
-  apiLoader.services['codepipeline']['2015-07-09'] = require('../apis/codepipeline-2015-07-09.min.json');
+apiLoader.services['codepipeline']['2015-07-09'] = require('../apis/codepipeline-2015-07-09.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CodePipeline')) {
+  AWS.CodePipeline = CodePipeline;
 }
 
-module.exports = AWS.CodePipeline;
+module.exports = CodePipeline;

--- a/clients/cognitoidentity.js
+++ b/clients/cognitoidentity.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoIdentity')) {
-  apiLoader.services['cognitoidentity'] = {};
-  AWS.CognitoIdentity = Service.defineService('cognitoidentity', ['2014-06-30']);
-  require('../lib/services/cognitoidentity');
+apiLoader.services['cognitoidentity'] = {};
+CognitoIdentity = Service.defineService('cognitoidentity', ['2014-06-30']);
+require('../lib/services/cognitoidentity')(CognitoIdentity);
 
-  apiLoader.services['cognitoidentity']['2014-06-30'] = require('../apis/cognito-identity-2014-06-30.min.json');
+apiLoader.services['cognitoidentity']['2014-06-30'] = require('../apis/cognito-identity-2014-06-30.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoIdentity')) {
+  AWS.CognitoIdentity = CognitoIdentity;
 }
 
-module.exports = AWS.CognitoIdentity;
+module.exports = CognitoIdentity;

--- a/clients/cognitoidentityserviceprovider.js
+++ b/clients/cognitoidentityserviceprovider.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoIdentityServiceProvider')) {
-  apiLoader.services['cognitoidentityserviceprovider'] = {};
-  AWS.CognitoIdentityServiceProvider = Service.defineService('cognitoidentityserviceprovider', ['2016-04-18']);
+apiLoader.services['cognitoidentityserviceprovider'] = {};
+CognitoIdentityServiceProvider = Service.defineService('cognitoidentityserviceprovider', ['2016-04-18']);
 
-  apiLoader.services['cognitoidentityserviceprovider']['2016-04-18'] = require('../apis/cognito-idp-2016-04-18.min.json');
+apiLoader.services['cognitoidentityserviceprovider']['2016-04-18'] = require('../apis/cognito-idp-2016-04-18.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoIdentityServiceProvider')) {
+  AWS.CognitoIdentityServiceProvider = CognitoIdentityServiceProvider;
 }
 
-module.exports = AWS.CognitoIdentityServiceProvider;
+module.exports = CognitoIdentityServiceProvider;

--- a/clients/cognitosync.js
+++ b/clients/cognitosync.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoSync')) {
-  apiLoader.services['cognitosync'] = {};
-  AWS.CognitoSync = Service.defineService('cognitosync', ['2014-06-30']);
+apiLoader.services['cognitosync'] = {};
+CognitoSync = Service.defineService('cognitosync', ['2014-06-30']);
 
-  apiLoader.services['cognitosync']['2014-06-30'] = require('../apis/cognito-sync-2014-06-30.min.json');
+apiLoader.services['cognitosync']['2014-06-30'] = require('../apis/cognito-sync-2014-06-30.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'CognitoSync')) {
+  AWS.CognitoSync = CognitoSync;
 }
 
-module.exports = AWS.CognitoSync;
+module.exports = CognitoSync;

--- a/clients/configservice.js
+++ b/clients/configservice.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ConfigService')) {
-  apiLoader.services['configservice'] = {};
-  AWS.ConfigService = Service.defineService('configservice', ['2014-11-12']);
+apiLoader.services['configservice'] = {};
+ConfigService = Service.defineService('configservice', ['2014-11-12']);
 
-  apiLoader.services['configservice']['2014-11-12'] = require('../apis/config-2014-11-12.min.json');
-  apiLoader.services['configservice']['2014-11-12'].paginators = require('../apis/config-2014-11-12.paginators.json').pagination;
+apiLoader.services['configservice']['2014-11-12'] = require('../apis/config-2014-11-12.min.json');
+apiLoader.services['configservice']['2014-11-12'].paginators = require('../apis/config-2014-11-12.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ConfigService')) {
+  AWS.ConfigService = ConfigService;
 }
 
-module.exports = AWS.ConfigService;
+module.exports = ConfigService;

--- a/clients/datapipeline.js
+++ b/clients/datapipeline.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DataPipeline')) {
-  apiLoader.services['datapipeline'] = {};
-  AWS.DataPipeline = Service.defineService('datapipeline', ['2012-10-29']);
+apiLoader.services['datapipeline'] = {};
+DataPipeline = Service.defineService('datapipeline', ['2012-10-29']);
 
-  apiLoader.services['datapipeline']['2012-10-29'] = require('../apis/datapipeline-2012-10-29.min.json');
-  apiLoader.services['datapipeline']['2012-10-29'].paginators = require('../apis/datapipeline-2012-10-29.paginators.json').pagination;
+apiLoader.services['datapipeline']['2012-10-29'] = require('../apis/datapipeline-2012-10-29.min.json');
+apiLoader.services['datapipeline']['2012-10-29'].paginators = require('../apis/datapipeline-2012-10-29.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DataPipeline')) {
+  AWS.DataPipeline = DataPipeline;
 }
 
-module.exports = AWS.DataPipeline;
+module.exports = DataPipeline;

--- a/clients/devicefarm.js
+++ b/clients/devicefarm.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DeviceFarm')) {
-  apiLoader.services['devicefarm'] = {};
-  AWS.DeviceFarm = Service.defineService('devicefarm', ['2015-06-23']);
+apiLoader.services['devicefarm'] = {};
+DeviceFarm = Service.defineService('devicefarm', ['2015-06-23']);
 
-  apiLoader.services['devicefarm']['2015-06-23'] = require('../apis/devicefarm-2015-06-23.min.json');
-  apiLoader.services['devicefarm']['2015-06-23'].paginators = require('../apis/devicefarm-2015-06-23.paginators.json').pagination;
+apiLoader.services['devicefarm']['2015-06-23'] = require('../apis/devicefarm-2015-06-23.min.json');
+apiLoader.services['devicefarm']['2015-06-23'].paginators = require('../apis/devicefarm-2015-06-23.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DeviceFarm')) {
+  AWS.DeviceFarm = DeviceFarm;
 }
 
-module.exports = AWS.DeviceFarm;
+module.exports = DeviceFarm;

--- a/clients/directconnect.js
+++ b/clients/directconnect.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DirectConnect')) {
-  apiLoader.services['directconnect'] = {};
-  AWS.DirectConnect = Service.defineService('directconnect', ['2012-10-25']);
+apiLoader.services['directconnect'] = {};
+DirectConnect = Service.defineService('directconnect', ['2012-10-25']);
 
-  apiLoader.services['directconnect']['2012-10-25'] = require('../apis/directconnect-2012-10-25.min.json');
-  apiLoader.services['directconnect']['2012-10-25'].paginators = require('../apis/directconnect-2012-10-25.paginators.json').pagination;
+apiLoader.services['directconnect']['2012-10-25'] = require('../apis/directconnect-2012-10-25.min.json');
+apiLoader.services['directconnect']['2012-10-25'].paginators = require('../apis/directconnect-2012-10-25.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DirectConnect')) {
+  AWS.DirectConnect = DirectConnect;
 }
 
-module.exports = AWS.DirectConnect;
+module.exports = DirectConnect;

--- a/clients/directoryservice.js
+++ b/clients/directoryservice.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DirectoryService')) {
-  apiLoader.services['directoryservice'] = {};
-  AWS.DirectoryService = Service.defineService('directoryservice', ['2015-04-16']);
+apiLoader.services['directoryservice'] = {};
+DirectoryService = Service.defineService('directoryservice', ['2015-04-16']);
 
-  apiLoader.services['directoryservice']['2015-04-16'] = require('../apis/ds-2015-04-16.min.json');
+apiLoader.services['directoryservice']['2015-04-16'] = require('../apis/ds-2015-04-16.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DirectoryService')) {
+  AWS.DirectoryService = DirectoryService;
 }
 
-module.exports = AWS.DirectoryService;
+module.exports = DirectoryService;

--- a/clients/discovery.js
+++ b/clients/discovery.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Discovery')) {
-  apiLoader.services['discovery'] = {};
-  AWS.Discovery = Service.defineService('discovery', ['2015-11-01']);
+apiLoader.services['discovery'] = {};
+Discovery = Service.defineService('discovery', ['2015-11-01']);
 
-  apiLoader.services['discovery']['2015-11-01'] = require('../apis/discovery-2015-11-01.min.json');
+apiLoader.services['discovery']['2015-11-01'] = require('../apis/discovery-2015-11-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Discovery')) {
+  AWS.Discovery = Discovery;
 }
 
-module.exports = AWS.Discovery;
+module.exports = Discovery;

--- a/clients/dms.js
+++ b/clients/dms.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DMS')) {
-  apiLoader.services['dms'] = {};
-  AWS.DMS = Service.defineService('dms', ['2016-01-01']);
+apiLoader.services['dms'] = {};
+DMS = Service.defineService('dms', ['2016-01-01']);
 
-  apiLoader.services['dms']['2016-01-01'] = require('../apis/dms-2016-01-01.min.json');
+apiLoader.services['dms']['2016-01-01'] = require('../apis/dms-2016-01-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DMS')) {
+  AWS.DMS = DMS;
 }
 
-module.exports = AWS.DMS;
+module.exports = DMS;

--- a/clients/dynamodb.js
+++ b/clients/dynamodb.js
@@ -3,18 +3,19 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
+apiLoader.services['dynamodb'] = {};
+DynamoDB = Service.defineService('dynamodb', ['2011-12-05', '2012-08-10']);
+require('../lib/services/dynamodb')(DynamoDB);
+
+apiLoader.services['dynamodb']['2011-12-05'] = require('../apis/dynamodb-2011-12-05.min.json');
+apiLoader.services['dynamodb']['2011-12-05'].paginators = require('../apis/dynamodb-2011-12-05.paginators.json').pagination;
+apiLoader.services['dynamodb']['2011-12-05'].waiters = require('../apis/dynamodb-2011-12-05.waiters2.json').waiters;
+
+apiLoader.services['dynamodb']['2012-08-10'] = require('../apis/dynamodb-2012-08-10.min.json');
+apiLoader.services['dynamodb']['2012-08-10'].paginators = require('../apis/dynamodb-2012-08-10.paginators.json').pagination;
+apiLoader.services['dynamodb']['2012-08-10'].waiters = require('../apis/dynamodb-2012-08-10.waiters2.json').waiters;
 if (!Object.prototype.hasOwnProperty.call(AWS, 'DynamoDB')) {
-  apiLoader.services['dynamodb'] = {};
-  AWS.DynamoDB = Service.defineService('dynamodb', ['2011-12-05', '2012-08-10']);
-  require('../lib/services/dynamodb');
-
-  apiLoader.services['dynamodb']['2011-12-05'] = require('../apis/dynamodb-2011-12-05.min.json');
-  apiLoader.services['dynamodb']['2011-12-05'].paginators = require('../apis/dynamodb-2011-12-05.paginators.json').pagination;
-  apiLoader.services['dynamodb']['2011-12-05'].waiters = require('../apis/dynamodb-2011-12-05.waiters2.json').waiters;
-
-  apiLoader.services['dynamodb']['2012-08-10'] = require('../apis/dynamodb-2012-08-10.min.json');
-  apiLoader.services['dynamodb']['2012-08-10'].paginators = require('../apis/dynamodb-2012-08-10.paginators.json').pagination;
-  apiLoader.services['dynamodb']['2012-08-10'].waiters = require('../apis/dynamodb-2012-08-10.waiters2.json').waiters;
+  AWS.DynamoDB = DynamoDB;
 }
 
-module.exports = AWS.DynamoDB;
+module.exports = DynamoDB;

--- a/clients/dynamodbstreams.js
+++ b/clients/dynamodbstreams.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'DynamoDBStreams')) {
-  apiLoader.services['dynamodbstreams'] = {};
-  AWS.DynamoDBStreams = Service.defineService('dynamodbstreams', ['2012-08-10']);
+apiLoader.services['dynamodbstreams'] = {};
+DynamoDBStreams = Service.defineService('dynamodbstreams', ['2012-08-10']);
 
-  apiLoader.services['dynamodbstreams']['2012-08-10'] = require('../apis/streams.dynamodb-2012-08-10.min.json');
+apiLoader.services['dynamodbstreams']['2012-08-10'] = require('../apis/streams.dynamodb-2012-08-10.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'DynamoDBStreams')) {
+  AWS.DynamoDBStreams = DynamoDBStreams;
 }
 
-module.exports = AWS.DynamoDBStreams;
+module.exports = DynamoDBStreams;

--- a/clients/ec2.js
+++ b/clients/ec2.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'EC2')) {
-  apiLoader.services['ec2'] = {};
-  AWS.EC2 = Service.defineService('ec2', ['2016-04-01']);
-  require('../lib/services/ec2');
+apiLoader.services['ec2'] = {};
+EC2 = Service.defineService('ec2', ['2016-04-01']);
+require('../lib/services/ec2')(EC2);
 
-  apiLoader.services['ec2']['2016-04-01'] = require('../apis/ec2-2016-04-01.min.json');
-  apiLoader.services['ec2']['2016-04-01'].paginators = require('../apis/ec2-2016-04-01.paginators.json').pagination;
-  apiLoader.services['ec2']['2016-04-01'].waiters = require('../apis/ec2-2016-04-01.waiters2.json').waiters;
+apiLoader.services['ec2']['2016-04-01'] = require('../apis/ec2-2016-04-01.min.json');
+apiLoader.services['ec2']['2016-04-01'].paginators = require('../apis/ec2-2016-04-01.paginators.json').pagination;
+apiLoader.services['ec2']['2016-04-01'].waiters = require('../apis/ec2-2016-04-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'EC2')) {
+  AWS.EC2 = EC2;
 }
 
-module.exports = AWS.EC2;
+module.exports = EC2;

--- a/clients/ecr.js
+++ b/clients/ecr.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ECR')) {
-  apiLoader.services['ecr'] = {};
-  AWS.ECR = Service.defineService('ecr', ['2015-09-21']);
+apiLoader.services['ecr'] = {};
+ECR = Service.defineService('ecr', ['2015-09-21']);
 
-  apiLoader.services['ecr']['2015-09-21'] = require('../apis/ecr-2015-09-21.min.json');
+apiLoader.services['ecr']['2015-09-21'] = require('../apis/ecr-2015-09-21.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ECR')) {
+  AWS.ECR = ECR;
 }
 
-module.exports = AWS.ECR;
+module.exports = ECR;

--- a/clients/ecs.js
+++ b/clients/ecs.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ECS')) {
-  apiLoader.services['ecs'] = {};
-  AWS.ECS = Service.defineService('ecs', ['2014-11-13']);
+apiLoader.services['ecs'] = {};
+ECS = Service.defineService('ecs', ['2014-11-13']);
 
-  apiLoader.services['ecs']['2014-11-13'] = require('../apis/ecs-2014-11-13.min.json');
-  apiLoader.services['ecs']['2014-11-13'].paginators = require('../apis/ecs-2014-11-13.paginators.json').pagination;
-  apiLoader.services['ecs']['2014-11-13'].waiters = require('../apis/ecs-2014-11-13.waiters2.json').waiters;
+apiLoader.services['ecs']['2014-11-13'] = require('../apis/ecs-2014-11-13.min.json');
+apiLoader.services['ecs']['2014-11-13'].paginators = require('../apis/ecs-2014-11-13.paginators.json').pagination;
+apiLoader.services['ecs']['2014-11-13'].waiters = require('../apis/ecs-2014-11-13.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ECS')) {
+  AWS.ECS = ECS;
 }
 
-module.exports = AWS.ECS;
+module.exports = ECS;

--- a/clients/efs.js
+++ b/clients/efs.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'EFS')) {
-  apiLoader.services['efs'] = {};
-  AWS.EFS = Service.defineService('efs', ['2015-02-01']);
+apiLoader.services['efs'] = {};
+EFS = Service.defineService('efs', ['2015-02-01']);
 
-  apiLoader.services['efs']['2015-02-01'] = require('../apis/elasticfilesystem-2015-02-01.min.json');
+apiLoader.services['efs']['2015-02-01'] = require('../apis/elasticfilesystem-2015-02-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'EFS')) {
+  AWS.EFS = EFS;
 }
 
-module.exports = AWS.EFS;
+module.exports = EFS;

--- a/clients/elasticache.js
+++ b/clients/elasticache.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ElastiCache')) {
-  apiLoader.services['elasticache'] = {};
-  AWS.ElastiCache = Service.defineService('elasticache', ['2015-02-02']);
+apiLoader.services['elasticache'] = {};
+ElastiCache = Service.defineService('elasticache', ['2015-02-02']);
 
-  apiLoader.services['elasticache']['2015-02-02'] = require('../apis/elasticache-2015-02-02.min.json');
-  apiLoader.services['elasticache']['2015-02-02'].paginators = require('../apis/elasticache-2015-02-02.paginators.json').pagination;
-  apiLoader.services['elasticache']['2015-02-02'].waiters = require('../apis/elasticache-2015-02-02.waiters2.json').waiters;
+apiLoader.services['elasticache']['2015-02-02'] = require('../apis/elasticache-2015-02-02.min.json');
+apiLoader.services['elasticache']['2015-02-02'].paginators = require('../apis/elasticache-2015-02-02.paginators.json').pagination;
+apiLoader.services['elasticache']['2015-02-02'].waiters = require('../apis/elasticache-2015-02-02.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ElastiCache')) {
+  AWS.ElastiCache = ElastiCache;
 }
 
-module.exports = AWS.ElastiCache;
+module.exports = ElastiCache;

--- a/clients/elasticbeanstalk.js
+++ b/clients/elasticbeanstalk.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ElasticBeanstalk')) {
-  apiLoader.services['elasticbeanstalk'] = {};
-  AWS.ElasticBeanstalk = Service.defineService('elasticbeanstalk', ['2010-12-01']);
+apiLoader.services['elasticbeanstalk'] = {};
+ElasticBeanstalk = Service.defineService('elasticbeanstalk', ['2010-12-01']);
 
-  apiLoader.services['elasticbeanstalk']['2010-12-01'] = require('../apis/elasticbeanstalk-2010-12-01.min.json');
-  apiLoader.services['elasticbeanstalk']['2010-12-01'].paginators = require('../apis/elasticbeanstalk-2010-12-01.paginators.json').pagination;
+apiLoader.services['elasticbeanstalk']['2010-12-01'] = require('../apis/elasticbeanstalk-2010-12-01.min.json');
+apiLoader.services['elasticbeanstalk']['2010-12-01'].paginators = require('../apis/elasticbeanstalk-2010-12-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ElasticBeanstalk')) {
+  AWS.ElasticBeanstalk = ElasticBeanstalk;
 }
 
-module.exports = AWS.ElasticBeanstalk;
+module.exports = ElasticBeanstalk;

--- a/clients/elastictranscoder.js
+++ b/clients/elastictranscoder.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ElasticTranscoder')) {
-  apiLoader.services['elastictranscoder'] = {};
-  AWS.ElasticTranscoder = Service.defineService('elastictranscoder', ['2012-09-25']);
+apiLoader.services['elastictranscoder'] = {};
+ElasticTranscoder = Service.defineService('elastictranscoder', ['2012-09-25']);
 
-  apiLoader.services['elastictranscoder']['2012-09-25'] = require('../apis/elastictranscoder-2012-09-25.min.json');
-  apiLoader.services['elastictranscoder']['2012-09-25'].paginators = require('../apis/elastictranscoder-2012-09-25.paginators.json').pagination;
-  apiLoader.services['elastictranscoder']['2012-09-25'].waiters = require('../apis/elastictranscoder-2012-09-25.waiters2.json').waiters;
+apiLoader.services['elastictranscoder']['2012-09-25'] = require('../apis/elastictranscoder-2012-09-25.min.json');
+apiLoader.services['elastictranscoder']['2012-09-25'].paginators = require('../apis/elastictranscoder-2012-09-25.paginators.json').pagination;
+apiLoader.services['elastictranscoder']['2012-09-25'].waiters = require('../apis/elastictranscoder-2012-09-25.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ElasticTranscoder')) {
+  AWS.ElasticTranscoder = ElasticTranscoder;
 }
 
-module.exports = AWS.ElasticTranscoder;
+module.exports = ElasticTranscoder;

--- a/clients/elb.js
+++ b/clients/elb.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ELB')) {
-  apiLoader.services['elb'] = {};
-  AWS.ELB = Service.defineService('elb', ['2012-06-01']);
+apiLoader.services['elb'] = {};
+ELB = Service.defineService('elb', ['2012-06-01']);
 
-  apiLoader.services['elb']['2012-06-01'] = require('../apis/elasticloadbalancing-2012-06-01.min.json');
-  apiLoader.services['elb']['2012-06-01'].paginators = require('../apis/elasticloadbalancing-2012-06-01.paginators.json').pagination;
-  apiLoader.services['elb']['2012-06-01'].waiters = require('../apis/elasticloadbalancing-2012-06-01.waiters2.json').waiters;
+apiLoader.services['elb']['2012-06-01'] = require('../apis/elasticloadbalancing-2012-06-01.min.json');
+apiLoader.services['elb']['2012-06-01'].paginators = require('../apis/elasticloadbalancing-2012-06-01.paginators.json').pagination;
+apiLoader.services['elb']['2012-06-01'].waiters = require('../apis/elasticloadbalancing-2012-06-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ELB')) {
+  AWS.ELB = ELB;
 }
 
-module.exports = AWS.ELB;
+module.exports = ELB;

--- a/clients/elbv2.js
+++ b/clients/elbv2.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ELBv2')) {
-  apiLoader.services['elbv2'] = {};
-  AWS.ELBv2 = Service.defineService('elbv2', ['2015-12-01']);
+apiLoader.services['elbv2'] = {};
+ELBv2 = Service.defineService('elbv2', ['2015-12-01']);
 
-  apiLoader.services['elbv2']['2015-12-01'] = require('../apis/elasticloadbalancingv2-2015-12-01.min.json');
-  apiLoader.services['elbv2']['2015-12-01'].paginators = require('../apis/elasticloadbalancingv2-2015-12-01.paginators.json').pagination;
+apiLoader.services['elbv2']['2015-12-01'] = require('../apis/elasticloadbalancingv2-2015-12-01.min.json');
+apiLoader.services['elbv2']['2015-12-01'].paginators = require('../apis/elasticloadbalancingv2-2015-12-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ELBv2')) {
+  AWS.ELBv2 = ELBv2;
 }
 
-module.exports = AWS.ELBv2;
+module.exports = ELBv2;

--- a/clients/emr.js
+++ b/clients/emr.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'EMR')) {
-  apiLoader.services['emr'] = {};
-  AWS.EMR = Service.defineService('emr', ['2009-03-31']);
+apiLoader.services['emr'] = {};
+EMR = Service.defineService('emr', ['2009-03-31']);
 
-  apiLoader.services['emr']['2009-03-31'] = require('../apis/elasticmapreduce-2009-03-31.min.json');
-  apiLoader.services['emr']['2009-03-31'].paginators = require('../apis/elasticmapreduce-2009-03-31.paginators.json').pagination;
-  apiLoader.services['emr']['2009-03-31'].waiters = require('../apis/elasticmapreduce-2009-03-31.waiters2.json').waiters;
+apiLoader.services['emr']['2009-03-31'] = require('../apis/elasticmapreduce-2009-03-31.min.json');
+apiLoader.services['emr']['2009-03-31'].paginators = require('../apis/elasticmapreduce-2009-03-31.paginators.json').pagination;
+apiLoader.services['emr']['2009-03-31'].waiters = require('../apis/elasticmapreduce-2009-03-31.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'EMR')) {
+  AWS.EMR = EMR;
 }
 
-module.exports = AWS.EMR;
+module.exports = EMR;

--- a/clients/es.js
+++ b/clients/es.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ES')) {
-  apiLoader.services['es'] = {};
-  AWS.ES = Service.defineService('es', ['2015-01-01']);
+apiLoader.services['es'] = {};
+ES = Service.defineService('es', ['2015-01-01']);
 
-  apiLoader.services['es']['2015-01-01'] = require('../apis/es-2015-01-01.min.json');
+apiLoader.services['es']['2015-01-01'] = require('../apis/es-2015-01-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ES')) {
+  AWS.ES = ES;
 }
 
-module.exports = AWS.ES;
+module.exports = ES;

--- a/clients/firehose.js
+++ b/clients/firehose.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Firehose')) {
-  apiLoader.services['firehose'] = {};
-  AWS.Firehose = Service.defineService('firehose', ['2015-08-04']);
+apiLoader.services['firehose'] = {};
+Firehose = Service.defineService('firehose', ['2015-08-04']);
 
-  apiLoader.services['firehose']['2015-08-04'] = require('../apis/firehose-2015-08-04.min.json');
+apiLoader.services['firehose']['2015-08-04'] = require('../apis/firehose-2015-08-04.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Firehose')) {
+  AWS.Firehose = Firehose;
 }
 
-module.exports = AWS.Firehose;
+module.exports = Firehose;

--- a/clients/gamelift.js
+++ b/clients/gamelift.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'GameLift')) {
-  apiLoader.services['gamelift'] = {};
-  AWS.GameLift = Service.defineService('gamelift', ['2015-10-01']);
+apiLoader.services['gamelift'] = {};
+GameLift = Service.defineService('gamelift', ['2015-10-01']);
 
-  apiLoader.services['gamelift']['2015-10-01'] = require('../apis/gamelift-2015-10-01.min.json');
+apiLoader.services['gamelift']['2015-10-01'] = require('../apis/gamelift-2015-10-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'GameLift')) {
+  AWS.GameLift = GameLift;
 }
 
-module.exports = AWS.GameLift;
+module.exports = GameLift;

--- a/clients/glacier.js
+++ b/clients/glacier.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Glacier')) {
-  apiLoader.services['glacier'] = {};
-  AWS.Glacier = Service.defineService('glacier', ['2012-06-01']);
-  require('../lib/services/glacier');
+apiLoader.services['glacier'] = {};
+Glacier = Service.defineService('glacier', ['2012-06-01']);
+require('../lib/services/glacier')(Glacier);
 
-  apiLoader.services['glacier']['2012-06-01'] = require('../apis/glacier-2012-06-01.min.json');
-  apiLoader.services['glacier']['2012-06-01'].paginators = require('../apis/glacier-2012-06-01.paginators.json').pagination;
-  apiLoader.services['glacier']['2012-06-01'].waiters = require('../apis/glacier-2012-06-01.waiters2.json').waiters;
+apiLoader.services['glacier']['2012-06-01'] = require('../apis/glacier-2012-06-01.min.json');
+apiLoader.services['glacier']['2012-06-01'].paginators = require('../apis/glacier-2012-06-01.paginators.json').pagination;
+apiLoader.services['glacier']['2012-06-01'].waiters = require('../apis/glacier-2012-06-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Glacier')) {
+  AWS.Glacier = Glacier;
 }
 
-module.exports = AWS.Glacier;
+module.exports = Glacier;

--- a/clients/iam.js
+++ b/clients/iam.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'IAM')) {
-  apiLoader.services['iam'] = {};
-  AWS.IAM = Service.defineService('iam', ['2010-05-08']);
+apiLoader.services['iam'] = {};
+IAM = Service.defineService('iam', ['2010-05-08']);
 
-  apiLoader.services['iam']['2010-05-08'] = require('../apis/iam-2010-05-08.min.json');
-  apiLoader.services['iam']['2010-05-08'].paginators = require('../apis/iam-2010-05-08.paginators.json').pagination;
-  apiLoader.services['iam']['2010-05-08'].waiters = require('../apis/iam-2010-05-08.waiters2.json').waiters;
+apiLoader.services['iam']['2010-05-08'] = require('../apis/iam-2010-05-08.min.json');
+apiLoader.services['iam']['2010-05-08'].paginators = require('../apis/iam-2010-05-08.paginators.json').pagination;
+apiLoader.services['iam']['2010-05-08'].waiters = require('../apis/iam-2010-05-08.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'IAM')) {
+  AWS.IAM = IAM;
 }
 
-module.exports = AWS.IAM;
+module.exports = IAM;

--- a/clients/importexport.js
+++ b/clients/importexport.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ImportExport')) {
-  apiLoader.services['importexport'] = {};
-  AWS.ImportExport = Service.defineService('importexport', ['2010-06-01']);
+apiLoader.services['importexport'] = {};
+ImportExport = Service.defineService('importexport', ['2010-06-01']);
 
-  apiLoader.services['importexport']['2010-06-01'] = require('../apis/importexport-2010-06-01.min.json');
-  apiLoader.services['importexport']['2010-06-01'].paginators = require('../apis/importexport-2010-06-01.paginators.json').pagination;
+apiLoader.services['importexport']['2010-06-01'] = require('../apis/importexport-2010-06-01.min.json');
+apiLoader.services['importexport']['2010-06-01'].paginators = require('../apis/importexport-2010-06-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ImportExport')) {
+  AWS.ImportExport = ImportExport;
 }
 
-module.exports = AWS.ImportExport;
+module.exports = ImportExport;

--- a/clients/inspector.js
+++ b/clients/inspector.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Inspector')) {
-  apiLoader.services['inspector'] = {};
-  AWS.Inspector = Service.defineService('inspector', ['2016-02-16']);
+apiLoader.services['inspector'] = {};
+Inspector = Service.defineService('inspector', ['2016-02-16']);
 
-  apiLoader.services['inspector']['2016-02-16'] = require('../apis/inspector-2016-02-16.min.json');
+apiLoader.services['inspector']['2016-02-16'] = require('../apis/inspector-2016-02-16.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Inspector')) {
+  AWS.Inspector = Inspector;
 }
 
-module.exports = AWS.Inspector;
+module.exports = Inspector;

--- a/clients/iot.js
+++ b/clients/iot.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Iot')) {
-  apiLoader.services['iot'] = {};
-  AWS.Iot = Service.defineService('iot', ['2015-05-28']);
+apiLoader.services['iot'] = {};
+Iot = Service.defineService('iot', ['2015-05-28']);
 
-  apiLoader.services['iot']['2015-05-28'] = require('../apis/iot-2015-05-28.min.json');
+apiLoader.services['iot']['2015-05-28'] = require('../apis/iot-2015-05-28.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Iot')) {
+  AWS.Iot = Iot;
 }
 
-module.exports = AWS.Iot;
+module.exports = Iot;

--- a/clients/iotdata.js
+++ b/clients/iotdata.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'IotData')) {
-  apiLoader.services['iotdata'] = {};
-  AWS.IotData = Service.defineService('iotdata', ['2015-05-28']);
-  require('../lib/services/iotdata');
+apiLoader.services['iotdata'] = {};
+IotData = Service.defineService('iotdata', ['2015-05-28']);
+require('../lib/services/iotdata')(IotData);
 
-  apiLoader.services['iotdata']['2015-05-28'] = require('../apis/iot-data-2015-05-28.min.json');
+apiLoader.services['iotdata']['2015-05-28'] = require('../apis/iot-data-2015-05-28.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'IotData')) {
+  AWS.IotData = IotData;
 }
 
-module.exports = AWS.IotData;
+module.exports = IotData;

--- a/clients/kinesis.js
+++ b/clients/kinesis.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Kinesis')) {
-  apiLoader.services['kinesis'] = {};
-  AWS.Kinesis = Service.defineService('kinesis', ['2013-12-02']);
+apiLoader.services['kinesis'] = {};
+Kinesis = Service.defineService('kinesis', ['2013-12-02']);
 
-  apiLoader.services['kinesis']['2013-12-02'] = require('../apis/kinesis-2013-12-02.min.json');
-  apiLoader.services['kinesis']['2013-12-02'].paginators = require('../apis/kinesis-2013-12-02.paginators.json').pagination;
-  apiLoader.services['kinesis']['2013-12-02'].waiters = require('../apis/kinesis-2013-12-02.waiters2.json').waiters;
+apiLoader.services['kinesis']['2013-12-02'] = require('../apis/kinesis-2013-12-02.min.json');
+apiLoader.services['kinesis']['2013-12-02'].paginators = require('../apis/kinesis-2013-12-02.paginators.json').pagination;
+apiLoader.services['kinesis']['2013-12-02'].waiters = require('../apis/kinesis-2013-12-02.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Kinesis')) {
+  AWS.Kinesis = Kinesis;
 }
 
-module.exports = AWS.Kinesis;
+module.exports = Kinesis;

--- a/clients/kinesisanalytics.js
+++ b/clients/kinesisanalytics.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'KinesisAnalytics')) {
-  apiLoader.services['kinesisanalytics'] = {};
-  AWS.KinesisAnalytics = Service.defineService('kinesisanalytics', ['2015-08-14']);
+apiLoader.services['kinesisanalytics'] = {};
+KinesisAnalytics = Service.defineService('kinesisanalytics', ['2015-08-14']);
 
-  apiLoader.services['kinesisanalytics']['2015-08-14'] = require('../apis/kinesisanalytics-2015-08-14.min.json');
+apiLoader.services['kinesisanalytics']['2015-08-14'] = require('../apis/kinesisanalytics-2015-08-14.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'KinesisAnalytics')) {
+  AWS.KinesisAnalytics = KinesisAnalytics;
 }
 
-module.exports = AWS.KinesisAnalytics;
+module.exports = KinesisAnalytics;

--- a/clients/kms.js
+++ b/clients/kms.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'KMS')) {
-  apiLoader.services['kms'] = {};
-  AWS.KMS = Service.defineService('kms', ['2014-11-01']);
+apiLoader.services['kms'] = {};
+KMS = Service.defineService('kms', ['2014-11-01']);
 
-  apiLoader.services['kms']['2014-11-01'] = require('../apis/kms-2014-11-01.min.json');
-  apiLoader.services['kms']['2014-11-01'].paginators = require('../apis/kms-2014-11-01.paginators.json').pagination;
+apiLoader.services['kms']['2014-11-01'] = require('../apis/kms-2014-11-01.min.json');
+apiLoader.services['kms']['2014-11-01'].paginators = require('../apis/kms-2014-11-01.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'KMS')) {
+  AWS.KMS = KMS;
 }
 
-module.exports = AWS.KMS;
+module.exports = KMS;

--- a/clients/lambda.js
+++ b/clients/lambda.js
@@ -3,15 +3,16 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
+apiLoader.services['lambda'] = {};
+Lambda = Service.defineService('lambda', ['2014-11-11', '2015-03-31']);
+
+apiLoader.services['lambda']['2014-11-11'] = require('../apis/lambda-2014-11-11.min.json');
+apiLoader.services['lambda']['2014-11-11'].paginators = require('../apis/lambda-2014-11-11.paginators.json').pagination;
+
+apiLoader.services['lambda']['2015-03-31'] = require('../apis/lambda-2015-03-31.min.json');
+apiLoader.services['lambda']['2015-03-31'].paginators = require('../apis/lambda-2015-03-31.paginators.json').pagination;
 if (!Object.prototype.hasOwnProperty.call(AWS, 'Lambda')) {
-  apiLoader.services['lambda'] = {};
-  AWS.Lambda = Service.defineService('lambda', ['2014-11-11', '2015-03-31']);
-
-  apiLoader.services['lambda']['2014-11-11'] = require('../apis/lambda-2014-11-11.min.json');
-  apiLoader.services['lambda']['2014-11-11'].paginators = require('../apis/lambda-2014-11-11.paginators.json').pagination;
-
-  apiLoader.services['lambda']['2015-03-31'] = require('../apis/lambda-2015-03-31.min.json');
-  apiLoader.services['lambda']['2015-03-31'].paginators = require('../apis/lambda-2015-03-31.paginators.json').pagination;
+  AWS.Lambda = Lambda;
 }
 
-module.exports = AWS.Lambda;
+module.exports = Lambda;

--- a/clients/machinelearning.js
+++ b/clients/machinelearning.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'MachineLearning')) {
-  apiLoader.services['machinelearning'] = {};
-  AWS.MachineLearning = Service.defineService('machinelearning', ['2014-12-12']);
-  require('../lib/services/machinelearning');
+apiLoader.services['machinelearning'] = {};
+MachineLearning = Service.defineService('machinelearning', ['2014-12-12']);
+require('../lib/services/machinelearning')(MachineLearning);
 
-  apiLoader.services['machinelearning']['2014-12-12'] = require('../apis/machinelearning-2014-12-12.min.json');
-  apiLoader.services['machinelearning']['2014-12-12'].paginators = require('../apis/machinelearning-2014-12-12.paginators.json').pagination;
-  apiLoader.services['machinelearning']['2014-12-12'].waiters = require('../apis/machinelearning-2014-12-12.waiters2.json').waiters;
+apiLoader.services['machinelearning']['2014-12-12'] = require('../apis/machinelearning-2014-12-12.min.json');
+apiLoader.services['machinelearning']['2014-12-12'].paginators = require('../apis/machinelearning-2014-12-12.paginators.json').pagination;
+apiLoader.services['machinelearning']['2014-12-12'].waiters = require('../apis/machinelearning-2014-12-12.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'MachineLearning')) {
+  AWS.MachineLearning = MachineLearning;
 }
 
-module.exports = AWS.MachineLearning;
+module.exports = MachineLearning;

--- a/clients/marketplacecommerceanalytics.js
+++ b/clients/marketplacecommerceanalytics.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'MarketplaceCommerceAnalytics')) {
-  apiLoader.services['marketplacecommerceanalytics'] = {};
-  AWS.MarketplaceCommerceAnalytics = Service.defineService('marketplacecommerceanalytics', ['2015-07-01']);
+apiLoader.services['marketplacecommerceanalytics'] = {};
+MarketplaceCommerceAnalytics = Service.defineService('marketplacecommerceanalytics', ['2015-07-01']);
 
-  apiLoader.services['marketplacecommerceanalytics']['2015-07-01'] = require('../apis/marketplacecommerceanalytics-2015-07-01.min.json');
+apiLoader.services['marketplacecommerceanalytics']['2015-07-01'] = require('../apis/marketplacecommerceanalytics-2015-07-01.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'MarketplaceCommerceAnalytics')) {
+  AWS.MarketplaceCommerceAnalytics = MarketplaceCommerceAnalytics;
 }
 
-module.exports = AWS.MarketplaceCommerceAnalytics;
+module.exports = MarketplaceCommerceAnalytics;

--- a/clients/marketplacemetering.js
+++ b/clients/marketplacemetering.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'MarketplaceMetering')) {
-  apiLoader.services['marketplacemetering'] = {};
-  AWS.MarketplaceMetering = Service.defineService('marketplacemetering', ['2016-01-14']);
+apiLoader.services['marketplacemetering'] = {};
+MarketplaceMetering = Service.defineService('marketplacemetering', ['2016-01-14']);
 
-  apiLoader.services['marketplacemetering']['2016-01-14'] = require('../apis/meteringmarketplace-2016-01-14.min.json');
+apiLoader.services['marketplacemetering']['2016-01-14'] = require('../apis/meteringmarketplace-2016-01-14.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'MarketplaceMetering')) {
+  AWS.MarketplaceMetering = MarketplaceMetering;
 }
 
-module.exports = AWS.MarketplaceMetering;
+module.exports = MarketplaceMetering;

--- a/clients/mobileanalytics.js
+++ b/clients/mobileanalytics.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'MobileAnalytics')) {
-  apiLoader.services['mobileanalytics'] = {};
-  AWS.MobileAnalytics = Service.defineService('mobileanalytics', ['2014-06-05']);
+apiLoader.services['mobileanalytics'] = {};
+MobileAnalytics = Service.defineService('mobileanalytics', ['2014-06-05']);
 
-  apiLoader.services['mobileanalytics']['2014-06-05'] = require('../apis/mobileanalytics-2014-06-05.min.json');
+apiLoader.services['mobileanalytics']['2014-06-05'] = require('../apis/mobileanalytics-2014-06-05.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'MobileAnalytics')) {
+  AWS.MobileAnalytics = MobileAnalytics;
 }
 
-module.exports = AWS.MobileAnalytics;
+module.exports = MobileAnalytics;

--- a/clients/opsworks.js
+++ b/clients/opsworks.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'OpsWorks')) {
-  apiLoader.services['opsworks'] = {};
-  AWS.OpsWorks = Service.defineService('opsworks', ['2013-02-18']);
+apiLoader.services['opsworks'] = {};
+OpsWorks = Service.defineService('opsworks', ['2013-02-18']);
 
-  apiLoader.services['opsworks']['2013-02-18'] = require('../apis/opsworks-2013-02-18.min.json');
-  apiLoader.services['opsworks']['2013-02-18'].paginators = require('../apis/opsworks-2013-02-18.paginators.json').pagination;
-  apiLoader.services['opsworks']['2013-02-18'].waiters = require('../apis/opsworks-2013-02-18.waiters2.json').waiters;
+apiLoader.services['opsworks']['2013-02-18'] = require('../apis/opsworks-2013-02-18.min.json');
+apiLoader.services['opsworks']['2013-02-18'].paginators = require('../apis/opsworks-2013-02-18.paginators.json').pagination;
+apiLoader.services['opsworks']['2013-02-18'].waiters = require('../apis/opsworks-2013-02-18.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'OpsWorks')) {
+  AWS.OpsWorks = OpsWorks;
 }
 
-module.exports = AWS.OpsWorks;
+module.exports = OpsWorks;

--- a/clients/rds.js
+++ b/clients/rds.js
@@ -3,23 +3,24 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
+apiLoader.services['rds'] = {};
+RDS = Service.defineService('rds', ['2013-01-10', '2013-02-12', '2013-09-09', '2014-10-31']);
+
+apiLoader.services['rds']['2013-01-10'] = require('../apis/rds-2013-01-10.min.json');
+apiLoader.services['rds']['2013-01-10'].paginators = require('../apis/rds-2013-01-10.paginators.json').pagination;
+
+apiLoader.services['rds']['2013-02-12'] = require('../apis/rds-2013-02-12.min.json');
+apiLoader.services['rds']['2013-02-12'].paginators = require('../apis/rds-2013-02-12.paginators.json').pagination;
+
+apiLoader.services['rds']['2013-09-09'] = require('../apis/rds-2013-09-09.min.json');
+apiLoader.services['rds']['2013-09-09'].paginators = require('../apis/rds-2013-09-09.paginators.json').pagination;
+apiLoader.services['rds']['2013-09-09'].waiters = require('../apis/rds-2013-09-09.waiters2.json').waiters;
+
+apiLoader.services['rds']['2014-10-31'] = require('../apis/rds-2014-10-31.min.json');
+apiLoader.services['rds']['2014-10-31'].paginators = require('../apis/rds-2014-10-31.paginators.json').pagination;
+apiLoader.services['rds']['2014-10-31'].waiters = require('../apis/rds-2014-10-31.waiters2.json').waiters;
 if (!Object.prototype.hasOwnProperty.call(AWS, 'RDS')) {
-  apiLoader.services['rds'] = {};
-  AWS.RDS = Service.defineService('rds', ['2013-01-10', '2013-02-12', '2013-09-09', '2014-10-31']);
-
-  apiLoader.services['rds']['2013-01-10'] = require('../apis/rds-2013-01-10.min.json');
-  apiLoader.services['rds']['2013-01-10'].paginators = require('../apis/rds-2013-01-10.paginators.json').pagination;
-
-  apiLoader.services['rds']['2013-02-12'] = require('../apis/rds-2013-02-12.min.json');
-  apiLoader.services['rds']['2013-02-12'].paginators = require('../apis/rds-2013-02-12.paginators.json').pagination;
-
-  apiLoader.services['rds']['2013-09-09'] = require('../apis/rds-2013-09-09.min.json');
-  apiLoader.services['rds']['2013-09-09'].paginators = require('../apis/rds-2013-09-09.paginators.json').pagination;
-  apiLoader.services['rds']['2013-09-09'].waiters = require('../apis/rds-2013-09-09.waiters2.json').waiters;
-
-  apiLoader.services['rds']['2014-10-31'] = require('../apis/rds-2014-10-31.min.json');
-  apiLoader.services['rds']['2014-10-31'].paginators = require('../apis/rds-2014-10-31.paginators.json').pagination;
-  apiLoader.services['rds']['2014-10-31'].waiters = require('../apis/rds-2014-10-31.waiters2.json').waiters;
+  AWS.RDS = RDS;
 }
 
-module.exports = AWS.RDS;
+module.exports = RDS;

--- a/clients/redshift.js
+++ b/clients/redshift.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Redshift')) {
-  apiLoader.services['redshift'] = {};
-  AWS.Redshift = Service.defineService('redshift', ['2012-12-01']);
+apiLoader.services['redshift'] = {};
+Redshift = Service.defineService('redshift', ['2012-12-01']);
 
-  apiLoader.services['redshift']['2012-12-01'] = require('../apis/redshift-2012-12-01.min.json');
-  apiLoader.services['redshift']['2012-12-01'].paginators = require('../apis/redshift-2012-12-01.paginators.json').pagination;
-  apiLoader.services['redshift']['2012-12-01'].waiters = require('../apis/redshift-2012-12-01.waiters2.json').waiters;
+apiLoader.services['redshift']['2012-12-01'] = require('../apis/redshift-2012-12-01.min.json');
+apiLoader.services['redshift']['2012-12-01'].paginators = require('../apis/redshift-2012-12-01.paginators.json').pagination;
+apiLoader.services['redshift']['2012-12-01'].waiters = require('../apis/redshift-2012-12-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Redshift')) {
+  AWS.Redshift = Redshift;
 }
 
-module.exports = AWS.Redshift;
+module.exports = Redshift;

--- a/clients/route53.js
+++ b/clients/route53.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Route53')) {
-  apiLoader.services['route53'] = {};
-  AWS.Route53 = Service.defineService('route53', ['2013-04-01']);
-  require('../lib/services/route53');
+apiLoader.services['route53'] = {};
+Route53 = Service.defineService('route53', ['2013-04-01']);
+require('../lib/services/route53')(Route53);
 
-  apiLoader.services['route53']['2013-04-01'] = require('../apis/route53-2013-04-01.min.json');
-  apiLoader.services['route53']['2013-04-01'].paginators = require('../apis/route53-2013-04-01.paginators.json').pagination;
-  apiLoader.services['route53']['2013-04-01'].waiters = require('../apis/route53-2013-04-01.waiters2.json').waiters;
+apiLoader.services['route53']['2013-04-01'] = require('../apis/route53-2013-04-01.min.json');
+apiLoader.services['route53']['2013-04-01'].paginators = require('../apis/route53-2013-04-01.paginators.json').pagination;
+apiLoader.services['route53']['2013-04-01'].waiters = require('../apis/route53-2013-04-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Route53')) {
+  AWS.Route53 = Route53;
 }
 
-module.exports = AWS.Route53;
+module.exports = Route53;

--- a/clients/route53domains.js
+++ b/clients/route53domains.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Route53Domains')) {
-  apiLoader.services['route53domains'] = {};
-  AWS.Route53Domains = Service.defineService('route53domains', ['2014-05-15']);
+apiLoader.services['route53domains'] = {};
+Route53Domains = Service.defineService('route53domains', ['2014-05-15']);
 
-  apiLoader.services['route53domains']['2014-05-15'] = require('../apis/route53domains-2014-05-15.min.json');
-  apiLoader.services['route53domains']['2014-05-15'].paginators = require('../apis/route53domains-2014-05-15.paginators.json').pagination;
+apiLoader.services['route53domains']['2014-05-15'] = require('../apis/route53domains-2014-05-15.min.json');
+apiLoader.services['route53domains']['2014-05-15'].paginators = require('../apis/route53domains-2014-05-15.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Route53Domains')) {
+  AWS.Route53Domains = Route53Domains;
 }
 
-module.exports = AWS.Route53Domains;
+module.exports = Route53Domains;

--- a/clients/s3.js
+++ b/clients/s3.js
@@ -3,14 +3,15 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'S3')) {
-  apiLoader.services['s3'] = {};
-  AWS.S3 = Service.defineService('s3', ['2006-03-01']);
-  require('../lib/services/s3');
+apiLoader.services['s3'] = {};
+S3 = Service.defineService('s3', ['2006-03-01']);
+require('../lib/services/s3')(S3);
 
-  apiLoader.services['s3']['2006-03-01'] = require('../apis/s3-2006-03-01.min.json');
-  apiLoader.services['s3']['2006-03-01'].paginators = require('../apis/s3-2006-03-01.paginators.json').pagination;
-  apiLoader.services['s3']['2006-03-01'].waiters = require('../apis/s3-2006-03-01.waiters2.json').waiters;
+apiLoader.services['s3']['2006-03-01'] = require('../apis/s3-2006-03-01.min.json');
+apiLoader.services['s3']['2006-03-01'].paginators = require('../apis/s3-2006-03-01.paginators.json').pagination;
+apiLoader.services['s3']['2006-03-01'].waiters = require('../apis/s3-2006-03-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'S3')) {
+  AWS.S3 = S3;
 }
 
-module.exports = AWS.S3;
+module.exports = S3;

--- a/clients/servicecatalog.js
+++ b/clients/servicecatalog.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'ServiceCatalog')) {
-  apiLoader.services['servicecatalog'] = {};
-  AWS.ServiceCatalog = Service.defineService('servicecatalog', ['2015-12-10']);
+apiLoader.services['servicecatalog'] = {};
+ServiceCatalog = Service.defineService('servicecatalog', ['2015-12-10']);
 
-  apiLoader.services['servicecatalog']['2015-12-10'] = require('../apis/servicecatalog-2015-12-10.min.json');
+apiLoader.services['servicecatalog']['2015-12-10'] = require('../apis/servicecatalog-2015-12-10.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'ServiceCatalog')) {
+  AWS.ServiceCatalog = ServiceCatalog;
 }
 
-module.exports = AWS.ServiceCatalog;
+module.exports = ServiceCatalog;

--- a/clients/ses.js
+++ b/clients/ses.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SES')) {
-  apiLoader.services['ses'] = {};
-  AWS.SES = Service.defineService('ses', ['2010-12-01']);
+apiLoader.services['ses'] = {};
+SES = Service.defineService('ses', ['2010-12-01']);
 
-  apiLoader.services['ses']['2010-12-01'] = require('../apis/email-2010-12-01.min.json');
-  apiLoader.services['ses']['2010-12-01'].paginators = require('../apis/email-2010-12-01.paginators.json').pagination;
-  apiLoader.services['ses']['2010-12-01'].waiters = require('../apis/email-2010-12-01.waiters2.json').waiters;
+apiLoader.services['ses']['2010-12-01'] = require('../apis/email-2010-12-01.min.json');
+apiLoader.services['ses']['2010-12-01'].paginators = require('../apis/email-2010-12-01.paginators.json').pagination;
+apiLoader.services['ses']['2010-12-01'].waiters = require('../apis/email-2010-12-01.waiters2.json').waiters;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SES')) {
+  AWS.SES = SES;
 }
 
-module.exports = AWS.SES;
+module.exports = SES;

--- a/clients/simpledb.js
+++ b/clients/simpledb.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SimpleDB')) {
-  apiLoader.services['simpledb'] = {};
-  AWS.SimpleDB = Service.defineService('simpledb', ['2009-04-15']);
+apiLoader.services['simpledb'] = {};
+SimpleDB = Service.defineService('simpledb', ['2009-04-15']);
 
-  apiLoader.services['simpledb']['2009-04-15'] = require('../apis/sdb-2009-04-15.min.json');
-  apiLoader.services['simpledb']['2009-04-15'].paginators = require('../apis/sdb-2009-04-15.paginators.json').pagination;
+apiLoader.services['simpledb']['2009-04-15'] = require('../apis/sdb-2009-04-15.min.json');
+apiLoader.services['simpledb']['2009-04-15'].paginators = require('../apis/sdb-2009-04-15.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SimpleDB')) {
+  AWS.SimpleDB = SimpleDB;
 }
 
-module.exports = AWS.SimpleDB;
+module.exports = SimpleDB;

--- a/clients/snowball.js
+++ b/clients/snowball.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Snowball')) {
-  apiLoader.services['snowball'] = {};
-  AWS.Snowball = Service.defineService('snowball', ['2016-06-30']);
+apiLoader.services['snowball'] = {};
+Snowball = Service.defineService('snowball', ['2016-06-30']);
 
-  apiLoader.services['snowball']['2016-06-30'] = require('../apis/snowball-2016-06-30.min.json');
-  apiLoader.services['snowball']['2016-06-30'].paginators = require('../apis/snowball-2016-06-30.paginators.json').pagination;
+apiLoader.services['snowball']['2016-06-30'] = require('../apis/snowball-2016-06-30.min.json');
+apiLoader.services['snowball']['2016-06-30'].paginators = require('../apis/snowball-2016-06-30.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Snowball')) {
+  AWS.Snowball = Snowball;
 }
 
-module.exports = AWS.Snowball;
+module.exports = Snowball;

--- a/clients/sns.js
+++ b/clients/sns.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SNS')) {
-  apiLoader.services['sns'] = {};
-  AWS.SNS = Service.defineService('sns', ['2010-03-31']);
+apiLoader.services['sns'] = {};
+SNS = Service.defineService('sns', ['2010-03-31']);
 
-  apiLoader.services['sns']['2010-03-31'] = require('../apis/sns-2010-03-31.min.json');
-  apiLoader.services['sns']['2010-03-31'].paginators = require('../apis/sns-2010-03-31.paginators.json').pagination;
+apiLoader.services['sns']['2010-03-31'] = require('../apis/sns-2010-03-31.min.json');
+apiLoader.services['sns']['2010-03-31'].paginators = require('../apis/sns-2010-03-31.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SNS')) {
+  AWS.SNS = SNS;
 }
 
-module.exports = AWS.SNS;
+module.exports = SNS;

--- a/clients/sqs.js
+++ b/clients/sqs.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SQS')) {
-  apiLoader.services['sqs'] = {};
-  AWS.SQS = Service.defineService('sqs', ['2012-11-05']);
-  require('../lib/services/sqs');
+apiLoader.services['sqs'] = {};
+SQS = Service.defineService('sqs', ['2012-11-05']);
+require('../lib/services/sqs')(SQS);
 
-  apiLoader.services['sqs']['2012-11-05'] = require('../apis/sqs-2012-11-05.min.json');
-  apiLoader.services['sqs']['2012-11-05'].paginators = require('../apis/sqs-2012-11-05.paginators.json').pagination;
+apiLoader.services['sqs']['2012-11-05'] = require('../apis/sqs-2012-11-05.min.json');
+apiLoader.services['sqs']['2012-11-05'].paginators = require('../apis/sqs-2012-11-05.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SQS')) {
+  AWS.SQS = SQS;
 }
 
-module.exports = AWS.SQS;
+module.exports = SQS;

--- a/clients/ssm.js
+++ b/clients/ssm.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SSM')) {
-  apiLoader.services['ssm'] = {};
-  AWS.SSM = Service.defineService('ssm', ['2014-11-06']);
+apiLoader.services['ssm'] = {};
+SSM = Service.defineService('ssm', ['2014-11-06']);
 
-  apiLoader.services['ssm']['2014-11-06'] = require('../apis/ssm-2014-11-06.min.json');
-  apiLoader.services['ssm']['2014-11-06'].paginators = require('../apis/ssm-2014-11-06.paginators.json').pagination;
+apiLoader.services['ssm']['2014-11-06'] = require('../apis/ssm-2014-11-06.min.json');
+apiLoader.services['ssm']['2014-11-06'].paginators = require('../apis/ssm-2014-11-06.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SSM')) {
+  AWS.SSM = SSM;
 }
 
-module.exports = AWS.SSM;
+module.exports = SSM;

--- a/clients/storagegateway.js
+++ b/clients/storagegateway.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'StorageGateway')) {
-  apiLoader.services['storagegateway'] = {};
-  AWS.StorageGateway = Service.defineService('storagegateway', ['2013-06-30']);
+apiLoader.services['storagegateway'] = {};
+StorageGateway = Service.defineService('storagegateway', ['2013-06-30']);
 
-  apiLoader.services['storagegateway']['2013-06-30'] = require('../apis/storagegateway-2013-06-30.min.json');
-  apiLoader.services['storagegateway']['2013-06-30'].paginators = require('../apis/storagegateway-2013-06-30.paginators.json').pagination;
+apiLoader.services['storagegateway']['2013-06-30'] = require('../apis/storagegateway-2013-06-30.min.json');
+apiLoader.services['storagegateway']['2013-06-30'].paginators = require('../apis/storagegateway-2013-06-30.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'StorageGateway')) {
+  AWS.StorageGateway = StorageGateway;
 }
 
-module.exports = AWS.StorageGateway;
+module.exports = StorageGateway;

--- a/clients/sts.js
+++ b/clients/sts.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'STS')) {
-  apiLoader.services['sts'] = {};
-  AWS.STS = Service.defineService('sts', ['2011-06-15']);
-  require('../lib/services/sts');
+apiLoader.services['sts'] = {};
+STS = Service.defineService('sts', ['2011-06-15']);
+require('../lib/services/sts')(STS);
 
-  apiLoader.services['sts']['2011-06-15'] = require('../apis/sts-2011-06-15.min.json');
+apiLoader.services['sts']['2011-06-15'] = require('../apis/sts-2011-06-15.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'STS')) {
+  AWS.STS = STS;
 }
 
-module.exports = AWS.STS;
+module.exports = STS;

--- a/clients/support.js
+++ b/clients/support.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'Support')) {
-  apiLoader.services['support'] = {};
-  AWS.Support = Service.defineService('support', ['2013-04-15']);
+apiLoader.services['support'] = {};
+Support = Service.defineService('support', ['2013-04-15']);
 
-  apiLoader.services['support']['2013-04-15'] = require('../apis/support-2013-04-15.min.json');
-  apiLoader.services['support']['2013-04-15'].paginators = require('../apis/support-2013-04-15.paginators.json').pagination;
+apiLoader.services['support']['2013-04-15'] = require('../apis/support-2013-04-15.min.json');
+apiLoader.services['support']['2013-04-15'].paginators = require('../apis/support-2013-04-15.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'Support')) {
+  AWS.Support = Support;
 }
 
-module.exports = AWS.Support;
+module.exports = Support;

--- a/clients/swf.js
+++ b/clients/swf.js
@@ -3,13 +3,14 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'SWF')) {
-  apiLoader.services['swf'] = {};
-  AWS.SWF = Service.defineService('swf', ['2012-01-25']);
-  require('../lib/services/swf');
+apiLoader.services['swf'] = {};
+SWF = Service.defineService('swf', ['2012-01-25']);
+require('../lib/services/swf')(SWF);
 
-  apiLoader.services['swf']['2012-01-25'] = require('../apis/swf-2012-01-25.min.json');
-  apiLoader.services['swf']['2012-01-25'].paginators = require('../apis/swf-2012-01-25.paginators.json').pagination;
+apiLoader.services['swf']['2012-01-25'] = require('../apis/swf-2012-01-25.min.json');
+apiLoader.services['swf']['2012-01-25'].paginators = require('../apis/swf-2012-01-25.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'SWF')) {
+  AWS.SWF = SWF;
 }
 
-module.exports = AWS.SWF;
+module.exports = SWF;

--- a/clients/waf.js
+++ b/clients/waf.js
@@ -3,11 +3,12 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'WAF')) {
-  apiLoader.services['waf'] = {};
-  AWS.WAF = Service.defineService('waf', ['2015-08-24']);
+apiLoader.services['waf'] = {};
+WAF = Service.defineService('waf', ['2015-08-24']);
 
-  apiLoader.services['waf']['2015-08-24'] = require('../apis/waf-2015-08-24.min.json');
+apiLoader.services['waf']['2015-08-24'] = require('../apis/waf-2015-08-24.min.json');
+if (!Object.prototype.hasOwnProperty.call(AWS, 'WAF')) {
+  AWS.WAF = WAF;
 }
 
-module.exports = AWS.WAF;
+module.exports = WAF;

--- a/clients/workspaces.js
+++ b/clients/workspaces.js
@@ -3,12 +3,13 @@ var AWS = require('../lib/core');
 var Service = require('../lib/service');
 var apiLoader = require('../lib/api_loader');
 
-if (!Object.prototype.hasOwnProperty.call(AWS, 'WorkSpaces')) {
-  apiLoader.services['workspaces'] = {};
-  AWS.WorkSpaces = Service.defineService('workspaces', ['2015-04-08']);
+apiLoader.services['workspaces'] = {};
+WorkSpaces = Service.defineService('workspaces', ['2015-04-08']);
 
-  apiLoader.services['workspaces']['2015-04-08'] = require('../apis/workspaces-2015-04-08.min.json');
-  apiLoader.services['workspaces']['2015-04-08'].paginators = require('../apis/workspaces-2015-04-08.paginators.json').pagination;
+apiLoader.services['workspaces']['2015-04-08'] = require('../apis/workspaces-2015-04-08.min.json');
+apiLoader.services['workspaces']['2015-04-08'].paginators = require('../apis/workspaces-2015-04-08.paginators.json').pagination;
+if (!Object.prototype.hasOwnProperty.call(AWS, 'WorkSpaces')) {
+  AWS.WorkSpaces = WorkSpaces;
 }
 
-module.exports = AWS.WorkSpaces;
+module.exports = WorkSpaces;

--- a/dist-tools/service-collector.js
+++ b/dist-tools/service-collector.js
@@ -37,7 +37,7 @@ function getServiceHeader(service) {
     service, metadata[service].name, service, util.inspect(versions));
   var svcPath = path.join(__dirname, '..', 'lib', 'services', service + '.js');
   if (fs.existsSync(svcPath)) {
-    file += '  require(\'./services/' + service + '\');\n';
+    file += '  require(\'./services/' + service + '\')(AWS.' + metadata[service].name + ');\n';
   }
   file += '}\n';
 

--- a/doc-custom/cloudfront/signer.js
+++ b/doc-custom/cloudfront/signer.js
@@ -1,0 +1,63 @@
+AWS.CloudFront.Signer = inherit({
+    /**
+     * A signer object can be used to generate signed URLs and cookies for granting
+     * access to content on restricted CloudFront distributions.
+     *
+     * @see http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html
+     *
+     * @param keyPairId [String]    (Required) The ID of the CloudFront key pair
+     *                              being used.
+     * @param privateKey [String]   (Required) A private key in RSA format.
+     */
+    constructor: function Signer(keyPairId, privateKey) {},
+
+    /**
+     * Create a signed Amazon CloudFront Cookie.
+     *
+     * @param options [Object]            The options to create a signed cookie.
+     * @option options url [String]     The URL to which the signature will grant
+     *                                  access. Required unless you pass in a full
+     *                                  policy.
+     * @option options expires [Number] A Unix UTC timestamp indicating when the
+     *                                  signature should expire. Required unless you
+     *                                  pass in a full policy.
+     * @option options policy [String]  A CloudFront JSON policy. Required unless
+     *                                  you pass in a url and an expiry time.
+     *
+     * @param cb [Function] if a callback is provided, this function will
+     *   pass the hash as the second parameter (after the error parameter) to
+     *   the callback function.
+     *
+     * @return [Object] if called synchronously (with no callback), returns the
+     *   signed cookie parameters.
+     * @return [null] nothing is returned if a callback is provided.
+     */
+    getSignedCookie: function (options, cb) {},
+
+    /**
+     * Create a signed Amazon CloudFront URL.
+     *
+     * Keep in mind that URLs meant for use in media/flash players may have
+     * different requirements for URL formats (e.g. some require that the
+     * extension be removed, some require the file name to be prefixed
+     * - mp4:<path>, some require you to add "/cfx/st" into your URL).
+     *
+     * @param options [Object]          The options to create a signed URL.
+     * @option options url [String]     The URL to which the signature will grant
+     *                                  access. Required.
+     * @option options expires [Number] A Unix UTC timestamp indicating when the
+     *                                  signature should expire. Required unless you
+     *                                  pass in a full policy.
+     * @option options policy [String]  A CloudFront JSON policy. Required unless
+     *                                  you pass in a url and an expiry time.
+     *
+     * @param cb [Function] if a callback is provided, this function will
+     *   pass the URL as the second parameter (after the error parameter) to
+     *   the callback function.
+     *
+     * @return [String] if called synchronously (with no callback), returns the
+     *   signed URL.
+     * @return [null] nothing is returned if a callback is provided.
+     */
+    getSignedUrl: function (options, cb) {}
+  });

--- a/doc-custom/dynamodb/document_client.js
+++ b/doc-custom/dynamodb/document_client.js
@@ -1,0 +1,326 @@
+/**
+ * The document client simplifies working with items in Amazon DynamoDB
+ * by abstracting away the notion of attribute values. This abstraction
+ * annotates native JavaScript types supplied as input parameters, as well
+ * as converts annotated response data to native JavaScript types.
+ *
+ * ## Marshalling Input and Unmarshalling Response Data
+ *
+ * The document client affords developers the use of native JavaScript types
+ * instead of `AttributeValue`s to simplify the JavaScript development
+ * experience with Amazon DynamoDB. JavaScript objects passed in as parameters
+ * are marshalled into `AttributeValue` shapes required by Amazon DynamoDB.
+ * Responses from DynamoDB are unmarshalled into plain JavaScript objects
+ * by the `DocumentClient`. The `DocumentClient`, does not accept
+ * `AttributeValue`s in favor of native JavaScript types.
+ *
+ * |                             JavaScript Type                            | DynamoDB AttributeValue |
+ * |:----------------------------------------------------------------------:|-------------------------|
+ * | String                                                                 | S                       |
+ * | Number                                                                 | N                       |
+ * | Boolean                                                                | BOOL                    |
+ * | null                                                                   | NULL                    |
+ * | Array                                                                  | L                       |
+ * | Object                                                                 | M                       |
+ * | Buffer, File, Blob, ArrayBuffer, DataView, and JavaScript typed arrays | B                       |
+ *
+ * ## Support for Sets
+ *
+ * The `DocumentClient` offers a convenient way to create sets from
+ * JavaScript Arrays. The type of set is inferred from the first element
+ * in the array. DynamoDB supports string, number, and binary sets. To
+ * learn more about supported types see the
+ * [Amazon DynamoDB Data Model Documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html)
+ * For more information see {AWS.DynamoDB.DocumentClient.createSet}
+ *
+ */
+AWS.DynamoDB.DocumentClient = AWS.util.inherit({
+    /**
+     * Creates a DynamoDB document client with a set of configuration options.
+     *
+     * @option options params [map] An optional map of parameters to bind to every
+     *   request sent by this service object.
+     * @option options service [AWS.DynamoDB] An optional pre-configured instance
+     *  of the AWS.DynamoDB service object to use for requests. The object may
+     *  bound parameters used by the document client.
+     * @see AWS.DynamoDB.constructor
+     *
+     */
+    constructor: function DocumentClient(options) {},
+    /**
+     * Returns the attributes of one or more items from one or more tables
+     * by delegating to `AWS.DynamoDB.batchGetItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.batchGetItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.batchGetItem
+     * @example Get items from multiple tables
+     *  var params = {
+     *    RequestItems: {
+     *      'Table-1': {
+     *        Keys: [
+     *          {
+     *             HashKey: 'haskey',
+     *             NumberRangeKey: 1
+     *          }
+     *        ]
+     *      },
+     *      'Table-2': {
+     *        Keys: [
+     *          { foo: 'bar' },
+     *        ]
+     *      }
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.batchGet(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    batchGet: function(params, callback) {},
+
+    /**
+     * Puts or deletes multiple items in one or more tables by delegating
+     * to `AWS.DynamoDB.batchWriteItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.batchWriteItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.batchWriteItem
+     * @example Write to and delete from a table
+     *  var params = {
+     *    RequestItems: {
+     *      'Table-1': [
+     *        {
+     *          DeleteRequest: {
+     *            Key: { HashKey: 'someKey' }
+     *          }
+     *        },
+     *        {
+     *          PutRequest: {
+     *            Item: {
+     *              HashKey: 'anotherKey',
+     *              NumAttribute: 1,
+     *              BoolAttribute: true,
+     *              ListAttribute: [1, 'two', false],
+     *              MapAttribute: { foo: 'bar' }
+     *            }
+     *          }
+     *        }
+     *      ]
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.batchWrite(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    batchWrite: function(params, callback) {},
+
+    /**
+     * Deletes a single item in a table by primary key by delegating to
+     * `AWS.DynamoDB.deleteItem()`
+     *
+     * Supply the same parameters as {AWS.DynamoDB.deleteItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.deleteItem
+     * @example Delete an item from a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Key: {
+     *      HashKey: 'hashkey',
+     *      NumberRangeKey: 1
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.delete(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    delete: function(params, callback) {},
+
+    /**
+     * Returns a set of attributes for the item with the given primary key
+     * by delegating to `AWS.DynamoDB.getItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.getItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.getItem
+     * @example Get an item from a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Key: {
+     *      HashKey: 'hashkey'
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.get(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    get: function(params, callback) {},
+
+    /**
+     * Creates a new item, or replaces an old item with a new item by
+     * delegating to `AWS.DynamoDB.putItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.putItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.putItem
+     * @example Create a new item in a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Item: {
+     *       HashKey: 'haskey',
+     *       NumAttribute: 1,
+     *       BoolAttribute: true,
+     *       ListAttribute: [1, 'two', false],
+     *       MapAttribute: { foo: 'bar'},
+     *       NullAttribute: null
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.put(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    put: function put(params, callback) {},
+
+    /**
+     * Edits an existing item's attributes, or adds a new item to the table if
+     * it does not already exist by delegating to `AWS.DynamoDB.updateItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.updateItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.updateItem
+     * @example Update an item with expressions
+     *  var params = {
+     *    TableName: 'Table',
+     *    Key: { HashKey : 'hashkey' },
+     *    UpdateExpression: 'set #a = :x + :y',
+     *    ConditionExpression: '#a < :MAX',
+     *    ExpressionAttributeNames: {'#a' : 'Sum'},
+     *    ExpressionAttributeValues: {
+     *      ':x' : 20,
+     *      ':y' : 45,
+     *      ':MAX' : 100,
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.update(params, function(err, data) {
+     *     if (err) console.log(err);
+     *     else console.log(data);
+     *  });
+     *
+     */
+    update: function(params, callback) {},
+
+    /**
+     * Returns one or more items and item attributes by accessing every item
+     * in a table or a secondary index.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.scan} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.scan
+     * @example Scan the table with a filter expression
+     *  var params = {
+     *    TableName : 'Table',
+     *    FilterExpression : 'Year = :this_year',
+     *    ExpressionAttributeValues : {':this_year' : 2015}
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.scan(params, function(err, data) {
+     *     if (err) console.log(err);
+     *     else console.log(data);
+     *  });
+     *
+     */
+    scan: function(params, callback) {},
+
+    /**
+      * Directly access items from a table by primary key or a secondary index.
+      *
+      * Supply the same parameters as {AWS.DynamoDB.query} with
+      * `AttributeValue`s substituted by native JavaScript types.
+      *
+      * @see AWS.DynamoDB.query
+      * @example Query an index
+      *  var params = {
+      *    TableName: 'Table',
+      *    IndexName: 'Index',
+      *    KeyConditionExpression: 'HashKey = :hkey and RangeKey > :rkey',
+      *    ExpressionAttributeValues: {
+      *      ':hkey': 'key',
+      *      ':rkey': 2015
+      *    }
+      *  };
+      *
+      *  var docClient = new AWS.DynamoDB.DocumentClient();
+      *
+      *  docClient.query(params, function(err, data) {
+      *     if (err) console.log(err);
+      *     else console.log(data);
+      *  });
+      *
+      */
+    query: function(params, callback) {},
+
+    /**
+     * Creates a set of elements inferring the type of set from
+     * the type of the first element. Amazon DynamoDB currently supports
+     * the number sets, string sets, and binary sets. For more information
+     * about DynamoDB data types see the documentation on the
+     * [Amazon DynamoDB Data Model](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes).
+     *
+     * @param list [Array] Collection to represent your DynamoDB Set
+     * @param options [map]
+     *  * **validate** [Boolean] set to true if you want to validate the type
+     *    of each element in the set. Defaults to `false`.
+     * @example Creating a number set
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  var params = {
+     *    Item: {
+     *      hashkey: 'hashkey'
+     *      numbers: docClient.createSet([1, 2, 3]);
+     *    }
+     *  };
+     *
+     *  docClient.put(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    createSet: function(list, options) {}
+});

--- a/doc-custom/s3/managed_upload.js
+++ b/doc-custom/s3/managed_upload.js
@@ -1,0 +1,123 @@
+/**
+ * The managed uploader allows for easy and efficient uploading of buffers,
+ * blobs, or streams, using a configurable amount of concurrency to perform
+ * multipart uploads where possible. This abstraction also enables uploading
+ * streams of unknown size due to the use of multipart uploads.
+ *
+ * To construct a managed upload object, see the {constructor} function.
+ *
+ * ## Tracking upload progress
+ *
+ * The managed upload object can also track progress by attaching an
+ * 'httpUploadProgress' listener to the upload manager. This event is similar
+ * to {AWS.Request~httpUploadProgress} but groups all concurrent upload progress
+ * into a single event. See {AWS.S3.ManagedUpload~httpUploadProgress} for more
+ * information.
+ *
+ * ## Handling Multipart Cleanup
+ *
+ * By default, this class will automatically clean up any multipart uploads
+ * when an individual part upload fails. This behavior can be disabled in order
+ * to manually handle failures by setting the `leavePartsOnError` configuration
+ * option to `true` when initializing the upload object.
+ *
+ * @!event httpUploadProgress(progress)
+ *   Triggered when the uploader has uploaded more data.
+ *   @note The `total` property may not be set if the stream being uploaded has
+ *     not yet finished chunking. In this case the `total` will be undefined
+ *     until the total stream size is known.
+ *   @note This event will not be emitted in Node.js 0.8.x.
+ *   @param progress [map] An object containing the `loaded` and `total` bytes
+ *     of the request and the `key` of the S3 object. Note that `total` may be undefined until the payload
+ *     size is known.
+ *   @context (see AWS.Request~send)
+ */
+AWS.S3.ManagedUpload = AWS.util.inherit({
+    /**
+     * Creates a managed upload object with a set of configuration options.
+     *
+     * @note A "Body" parameter is required to be set prior to calling {send}.
+     * @option options params [map] a map of parameters to pass to the upload
+     *   requests. The "Body" parameter is required to be specified either on
+     *   the service or in the params option.
+     * @note ContentMD5 should not be provided when using the managed upload object.
+     *   Instead, setting "computeChecksums" to true will enable automatic ContentMD5 generation
+     *   by the managed upload object.
+     * @option options queueSize [Number] (4) the size of the concurrent queue
+     *   manager to upload parts in parallel. Set to 1 for synchronous uploading
+     *   of parts. Note that the uploader will buffer at most queueSize * partSize
+     *   bytes into memory at any given time.
+     * @option options partSize [Number] (5mb) the size in bytes for each
+     *   individual part to be uploaded. Adjust the part size to ensure the number
+     *   of parts does not exceed {maxTotalParts}. See {minPartSize} for the
+     *   minimum allowed part size.
+     * @option options leavePartsOnError [Boolean] (false) whether to abort the
+     *   multipart upload if an error occurs. Set to true if you want to handle
+     *   failures manually.
+     * @option options service [AWS.S3] an optional S3 service object to use for
+     *   requests. This object might have bound parameters used by the uploader.
+     * @example Creating a default uploader for a stream object
+     *   var upload = new AWS.S3.ManagedUpload({
+     *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
+     *   });
+     * @example Creating an uploader with concurrency of 1 and partSize of 10mb
+     *   var upload = new AWS.S3.ManagedUpload({
+     *     partSize: 10 * 1024 * 1024, queueSize: 1,
+     *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
+     *   });
+     * @see send
+     */
+    constructor: function ManagedUpload(options) {},
+    /**
+     * @readonly
+     * @return [Number] the minimum number of bytes for an individual part
+     *   upload.
+     */
+    minPartSize: 1024 * 1024 * 5,
+    /**
+     * @readonly
+     * @return [Number] the maximum allowed number of parts in a multipart upload.
+     */
+    maxTotalParts: 10000,
+    /**
+     * Initiates the managed upload for the payload.
+     *
+     * @callback callback function(err, data)
+     *   @param err [Error] an error or null if no error occurred.
+     *   @param data [map] The response data from the successful upload:
+     *     * `Location` (String) the URL of the uploaded object
+     *     * `ETag` (String) the ETag of the uploaded object
+     *     * `Bucket` (String) the bucket to which the object was uploaded
+     *     * `Key` (String) the key to which the object was uploaded
+     * @example Sending a managed upload object
+     *   var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *   var upload = new AWS.S3.ManagedUpload({params: params});
+     *   upload.send(function(err, data) {
+     *     console.log(err, data);
+     *   });
+     */
+    send: function(callback) {},
+    /**
+     * Aborts a managed upload, including all concurrent upload requests.
+     * @note By default, calling this function will cleanup a multipart upload
+     *   if one was created. To leave the multipart upload around after aborting
+     *   a request, configure `leavePartsOnError` to `true` in the {constructor}.
+     * @note Calling {abort} in the browser environment will not abort any requests
+     *   that are already in flight. If a multipart upload was created, any parts
+     *   not yet uploaded will not be sent, and the multipart upload will be cleaned up.
+     * @example Aborting an upload
+     *   var params = {
+     *     Bucket: 'bucket', Key: 'key',
+     *     Body: new Buffer(1024 * 1024 * 25) // 25MB payload
+     *   };
+     *   var upload = s3.upload(params);
+     *   upload.send(function (err, data) {
+     *     if (err) console.log("Error:", err.code, err.message);
+     *     else console.log(data);
+     *   });
+     *
+     *   // abort request in 1 second
+     *   setTimeout(upload.abort.bind(upload), 1000);
+     */
+    abort: function() {}
+});

--- a/doc-custom/services/cloudsearchdomain.js
+++ b/doc-custom/services/cloudsearchdomain.js
@@ -1,0 +1,55 @@
+/**
+ * Constructs a service interface object. Each API operation is exposed as a
+ * function on service.
+ *
+ * ### Sending a Request Using CloudSearchDomain
+ *
+ * ```javascript
+ * var csd = new AWS.CloudSearchDomain({endpoint: 'my.host.tld'});
+ * csd.search(params, function (err, data) {
+ *   if (err) console.log(err, err.stack); // an error occurred
+ *   else     console.log(data);           // successful response
+ * });
+ * ```
+ *
+ * ### Locking the API Version
+ *
+ * In order to ensure that the CloudSearchDomain object uses this specific API,
+ * you can construct the object by passing the `apiVersion` option to the
+ * constructor:
+ *
+ * ```javascript
+ * var csd = new AWS.CloudSearchDomain({
+ *   endpoint: 'my.host.tld',
+ *   apiVersion: '2013-01-01'
+ * });
+ * ```
+ *
+ * You can also set the API version globally in `AWS.config.apiVersions` using
+ * the **cloudsearchdomain** service identifier:
+ *
+ * ```javascript
+ * AWS.config.apiVersions = {
+ *   cloudsearchdomain: '2013-01-01',
+ *   // other service API versions
+ * };
+ *
+ * var csd = new AWS.CloudSearchDomain({endpoint: 'my.host.tld'});
+ * ```
+ *
+ * @note You *must* provide an `endpoint` configuration parameter when
+ *   constructing this service. See {constructor} for more information.
+ *
+ * @!method constructor(options = {})
+ *   Constructs a service object. This object has one method for each
+ *   API operation.
+ *
+ *   @example Constructing a CloudSearchDomain object
+ *     var csd = new AWS.CloudSearchDomain({endpoint: 'my.host.tld'});
+ *   @note You *must* provide an `endpoint` when constructing this service.
+ *   @option (see AWS.Config.constructor)
+ *
+ * @service cloudsearchdomain
+ * @version 2013-01-01
+ */
+AWS.util.update(AWS.CloudSearchDomain.prototype, {});

--- a/doc-custom/services/glacier.js
+++ b/doc-custom/services/glacier.js
@@ -1,0 +1,25 @@
+AWS.util.update(AWS.Glacier.prototype, {
+    /**
+     * @!group Computing Checksums
+     */
+
+    /**
+     * Computes the SHA-256 linear and tree hash checksums for a given
+     * block of Buffer data. Pass the tree hash of the computed checksums
+     * as the checksum input to the {completeMultipartUpload} when performing
+     * a multi-part upload.
+     *
+     * @example Calculate checksum of 5.5MB data chunk
+     *   var glacier = new AWS.Glacier();
+     *   var data = new Buffer(5.5 * 1024 * 1024);
+     *   data.fill('0'); // fill with zeros
+     *   var results = glacier.computeChecksums(data);
+     *   // Result: { linearHash: '68aff0c5a9...', treeHash: '154e26c78f...' }
+     * @param data [Buffer, String] data to calculate the checksum for
+     * @return [map<linearHash:String,treeHash:String>] a map containing
+     *   the linearHash and treeHash properties representing hex based digests
+     *   of the respective checksums.
+     * @see completeMultipartUpload
+     */
+    computeChecksums: function computeChecksums(data) {}
+});

--- a/doc-custom/services/iotdata.js
+++ b/doc-custom/services/iotdata.js
@@ -1,0 +1,55 @@
+/**
+ * Constructs a service interface object. Each API operation is exposed as a
+ * function on service.
+ *
+ * ### Sending a Request Using IotData
+ *
+ * ```javascript
+ * var iotdata = new AWS.IotData({endpoint: 'my.host.tld'});
+ * iotdata.getThingShadow(params, function (err, data) {
+ *   if (err) console.log(err, err.stack); // an error occurred
+ *   else     console.log(data);           // successful response
+ * });
+ * ```
+ *
+ * ### Locking the API Version
+ *
+ * In order to ensure that the IotData object uses this specific API,
+ * you can construct the object by passing the `apiVersion` option to the
+ * constructor:
+ *
+ * ```javascript
+ * var iotdata = new AWS.IotData({
+ *   endpoint: 'my.host.tld',
+ *   apiVersion: '2015-05-28'
+ * });
+ * ```
+ *
+ * You can also set the API version globally in `AWS.config.apiVersions` using
+ * the **iotdata** service identifier:
+ *
+ * ```javascript
+ * AWS.config.apiVersions = {
+ *   iotdata: '2015-05-28',
+ *   // other service API versions
+ * };
+ *
+ * var iotdata = new AWS.IotData({endpoint: 'my.host.tld'});
+ * ```
+ *
+ * @note You *must* provide an `endpoint` configuration parameter when
+ *   constructing this service. See {constructor} for more information.
+ *
+ * @!method constructor(options = {})
+ *   Constructs a service object. This object has one method for each
+ *   API operation.
+ *
+ *   @example Constructing a IotData object
+ *     var iotdata = new AWS.IotData({endpoint: 'my.host.tld'});
+ *   @note You *must* provide an `endpoint` when constructing this service.
+ *   @option (see AWS.Config.constructor)
+ *
+ * @service iotdata
+ * @version 2015-05-28
+ */
+AWS.util.update(AWS.IotData.prototype, {});

--- a/doc-custom/services/s3.js
+++ b/doc-custom/services/s3.js
@@ -1,0 +1,76 @@
+AWS.util.update(AWS.S3.prototype, {
+    /**
+     * Get a pre-signed URL for a given operation name.
+     *
+     * @note You must ensure that you have static or previously resolved
+     *   credentials if you call this method synchronously (with no callback),
+     *   otherwise it may not properly sign the request. If you cannot guarantee
+     *   this (you are using an asynchronous credential provider, i.e., EC2
+     *   IAM roles), you should always call this method with an asynchronous
+     *   callback.
+     * @param operation [String] the name of the operation to call
+     * @param params [map] parameters to pass to the operation. See the given
+     *   operation for the expected operation parameters. In addition, you can
+     *   also pass the "Expires" parameter to inform S3 how long the URL should
+     *   work for.
+     * @option params Expires [Integer] (900) the number of seconds to expire
+     *   the pre-signed URL operation in. Defaults to 15 minutes.
+     * @param callback [Function] if a callback is provided, this function will
+     *   pass the URL as the second parameter (after the error parameter) to
+     *   the callback function.
+     * @return [String] if called synchronously (with no callback), returns the
+     *   signed URL.
+     * @return [null] nothing is returned if a callback is provided.
+     * @example Pre-signing a getObject operation (synchronously)
+     *   var params = {Bucket: 'bucket', Key: 'key'};
+     *   var url = s3.getSignedUrl('getObject', params);
+     *   console.log('The URL is', url);
+     * @example Pre-signing a putObject (asynchronously)
+     *   var params = {Bucket: 'bucket', Key: 'key'};
+     *   s3.getSignedUrl('putObject', params, function (err, url) {
+     *     console.log('The URL is', url);
+     *   });
+     * @example Pre-signing a putObject operation with a specific payload
+     *   var params = {Bucket: 'bucket', Key: 'key', Body: 'body'};
+     *   var url = s3.getSignedUrl('putObject', params);
+     *   console.log('The URL is', url);
+     * @example Passing in a 1-minute expiry time for a pre-signed URL
+     *   var params = {Bucket: 'bucket', Key: 'key', Expires: 60};
+     *   var url = s3.getSignedUrl('getObject', params);
+     *   console.log('The URL is', url); // expires in 60 seconds
+     */
+    getSignedUrl: function getSignedUrl(operation, params, callback) {},
+    /**
+     * @overload upload(params = {}, [options], [callback])
+     *   Uploads an arbitrarily sized buffer, blob, or stream, using intelligent
+     *   concurrent handling of parts if the payload is large enough. You can
+     *   configure the concurrent queue size by setting `options`. Note that this
+     *   is the only operation for which the SDK can retry requests with stream
+     *   bodies.
+     *
+     *   @param (see AWS.S3.putObject)
+     *   @option (see AWS.S3.ManagedUpload.constructor)
+     *   @return [AWS.S3.ManagedUpload] the managed upload object that can call
+     *     `send()` or track progress.
+     *   @example Uploading a stream object
+     *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *     s3.upload(params, function(err, data) {
+     *       console.log(err, data);
+     *     });
+     *   @example Uploading a stream with concurrency of 1 and partSize of 10mb
+     *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *     var options = {partSize: 10 * 1024 * 1024, queueSize: 1};
+     *     s3.upload(params, options, function(err, data) {
+     *       console.log(err, data);
+     *     });
+     * @callback callback function(err, data)
+     *   @param err [Error] an error or null if no error occurred.
+     *   @param data [map] The response data from the successful upload:
+     *     * `Location` (String) the URL of the uploaded object
+     *     * `ETag` (String) the ETag of the uploaded object
+     *     * `Bucket` (String) the bucket to which the object was uploaded
+     *     * `Key` (String) the key to which the object was uploaded
+     *   @see AWS.S3.ManagedUpload
+     */
+    upload: function upload(params, options, callback) {}
+});

--- a/doc-custom/services/sts.js
+++ b/doc-custom/services/sts.js
@@ -1,0 +1,28 @@
+AWS.util.update(AWS.STS.prototype, {
+    /**
+     * @overload credentialsFrom(data, credentials = null)
+     *   Creates a credentials object from STS response data containing
+     *   credentials information. Useful for quickly setting AWS credentials.
+     *
+     *   @note This is a low-level utility function. If you want to load temporary
+     *     credentials into your process for subsequent requests to AWS resources,
+     *     you should use {AWS.TemporaryCredentials} instead.
+     *   @param data [map] data retrieved from a call to {getFederatedToken},
+     *     {getSessionToken}, {assumeRole}, or {assumeRoleWithWebIdentity}.
+     *   @param credentials [AWS.Credentials] an optional credentials object to
+     *     fill instead of creating a new object. Useful when modifying an
+     *     existing credentials object from a refresh call.
+     *   @return [AWS.TemporaryCredentials] the set of temporary credentials
+     *     loaded from a raw STS operation response.
+     *   @example Using credentialsFrom to load global AWS credentials
+     *     var sts = new AWS.STS();
+     *     sts.getSessionToken(function (err, data) {
+     *       if (err) console.log("Error getting credentials");
+     *       else {
+     *         AWS.config.credentials = sts.credentialsFrom(data);
+     *       }
+     *     });
+     *   @see AWS.TemporaryCredentials
+     */
+    credentialsFrom: function credentialsFrom(data, credentials) {}
+});

--- a/doc-custom/services/swf.js
+++ b/doc-custom/services/swf.js
@@ -1,0 +1,6 @@
+/**
+   * @constant
+   * @readonly
+   * Backwards compatibility for access to the {AWS.SWF} service class.
+   */
+  AWS.SimpleWorkflow = AWS.SWF;

--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -91,7 +91,8 @@ var handleSuccess = function (result, callback) {
     callback(null, result);
 };
 
-AWS.CloudFront.Signer = inherit({
+module.exports = function attachSigner(CloudFront) {
+  CloudFront.Signer = inherit({
     /**
      * A signer object can be used to generate signed URLs and cookies for granting
      * access to content on restricted CloudFront distributions.
@@ -201,6 +202,5 @@ AWS.CloudFront.Signer = inherit({
 
         return handleSuccess(signedUrl, cb);
     }
-});
-
-module.exports = AWS.CloudFront.Signer;
+  });
+};

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -2,6 +2,7 @@ var AWS = require('../core');
 var Translator = require('./translator');
 var DynamoDBSet = require('./set');
 
+module.exports = function attachDocumentClient(DynamoDB) {
 /**
  * The document client simplifies working with items in Amazon DynamoDB
  * by abstracting away the notion of attribute values. This abstraction
@@ -38,482 +39,481 @@ var DynamoDBSet = require('./set');
  * For more information see {AWS.DynamoDB.DocumentClient.createSet}
  *
  */
-AWS.DynamoDB.DocumentClient = AWS.util.inherit({
+  DynamoDB.DocumentClient = AWS.util.inherit({
 
-  /**
-   * @api private
-   */
-  operations: {
-    batchGetItem: 'batchGet',
-    batchWriteItem: 'batchWrite',
-    putItem: 'put',
-    getItem: 'get',
-    deleteItem: 'delete',
-    updateItem: 'update',
-    scan: 'scan',
-    query: 'query'
-  },
+    /**
+     * @api private
+     */
+    operations: {
+      batchGetItem: 'batchGet',
+      batchWriteItem: 'batchWrite',
+      putItem: 'put',
+      getItem: 'get',
+      deleteItem: 'delete',
+      updateItem: 'update',
+      scan: 'scan',
+      query: 'query'
+    },
 
-  /**
-   * Creates a DynamoDB document client with a set of configuration options.
-   *
-   * @option options params [map] An optional map of parameters to bind to every
-   *   request sent by this service object.
-   * @option options service [AWS.DynamoDB] An optional pre-configured instance
-   *  of the AWS.DynamoDB service object to use for requests. The object may
-   *  bound parameters used by the document client.
-   * @see AWS.DynamoDB.constructor
-   *
-   */
-  constructor: function DocumentClient(options) {
-    var self = this;
-    self.options = options || {};
-    self.configure(self.options);
-  },
+    /**
+     * Creates a DynamoDB document client with a set of configuration options.
+     *
+     * @option options params [map] An optional map of parameters to bind to every
+     *   request sent by this service object.
+     * @option options service [AWS.DynamoDB] An optional pre-configured instance
+     *  of the AWS.DynamoDB service object to use for requests. The object may
+     *  bound parameters used by the document client.
+     * @see AWS.DynamoDB.constructor
+     *
+     */
+    constructor: function DocumentClient(options) {
+      var self = this;
+      self.options = options || {};
+      self.configure(self.options);
+    },
 
-  /**
-   * @api private
-   */
-  configure: function configure(options) {
-    var self = this;
-    self.service = options.service;
-    self.bindServiceObject(options);
-    self.attrValue =
-      self.service.api.operations.putItem.input.members.Item.value.shape;
-  },
+    /**
+     * @api private
+     */
+    configure: function configure(options) {
+      var self = this;
+      self.service = options.service;
+      self.bindServiceObject(options);
+      self.attrValue =
+        self.service.api.operations.putItem.input.members.Item.value.shape;
+    },
 
-  /**
-   * @api private
-   */
-  bindServiceObject: function bindServiceObject(options) {
-    var self = this;
-    options = options || {};
+    /**
+     * @api private
+     */
+    bindServiceObject: function bindServiceObject(options) {
+      var self = this;
+      options = options || {};
 
-    if (!self.service) {
-      self.service = new AWS.DynamoDB(options);
-    } else {
-      var config = AWS.util.copy(self.service.config);
-      self.service = new self.service.constructor.__super__(config);
-      self.service.config.params =
-        AWS.util.merge(self.service.config.params || {}, options.params);
-    }
-  },
-
-  /**
-   * Returns the attributes of one or more items from one or more tables
-   * by delegating to `AWS.DynamoDB.batchGetItem()`.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.batchGetItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.batchGetItem
-   * @example Get items from multiple tables
-   *  var params = {
-   *    RequestItems: {
-   *      'Table-1': {
-   *        Keys: [
-   *          {
-   *             HashKey: 'haskey',
-   *             NumberRangeKey: 1
-   *          }
-   *        ]
-   *      },
-   *      'Table-2': {
-   *        Keys: [
-   *          { foo: 'bar' },
-   *        ]
-   *      }
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.batchGet(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  batchGet: function(params, callback) {
-    var self = this;
-    var request = self.service.batchGetItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Puts or deletes multiple items in one or more tables by delegating
-   * to `AWS.DynamoDB.batchWriteItem()`.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.batchWriteItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.batchWriteItem
-   * @example Write to and delete from a table
-   *  var params = {
-   *    RequestItems: {
-   *      'Table-1': [
-   *        {
-   *          DeleteRequest: {
-   *            Key: { HashKey: 'someKey' }
-   *          }
-   *        },
-   *        {
-   *          PutRequest: {
-   *            Item: {
-   *              HashKey: 'anotherKey',
-   *              NumAttribute: 1,
-   *              BoolAttribute: true,
-   *              ListAttribute: [1, 'two', false],
-   *              MapAttribute: { foo: 'bar' }
-   *            }
-   *          }
-   *        }
-   *      ]
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.batchWrite(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  batchWrite: function(params, callback) {
-    var self = this;
-    var request = self.service.batchWriteItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Deletes a single item in a table by primary key by delegating to
-   * `AWS.DynamoDB.deleteItem()`
-   *
-   * Supply the same parameters as {AWS.DynamoDB.deleteItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.deleteItem
-   * @example Delete an item from a table
-   *  var params = {
-   *    TableName : 'Table',
-   *    Key: {
-   *      HashKey: 'hashkey',
-   *      NumberRangeKey: 1
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.delete(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  delete: function(params, callback) {
-    var self = this;
-    var request = self.service.deleteItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Returns a set of attributes for the item with the given primary key
-   * by delegating to `AWS.DynamoDB.getItem()`.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.getItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.getItem
-   * @example Get an item from a table
-   *  var params = {
-   *    TableName : 'Table',
-   *    Key: {
-   *      HashKey: 'hashkey'
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.get(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  get: function(params, callback) {
-    var self = this;
-    var request = self.service.getItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Creates a new item, or replaces an old item with a new item by
-   * delegating to `AWS.DynamoDB.putItem()`.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.putItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.putItem
-   * @example Create a new item in a table
-   *  var params = {
-   *    TableName : 'Table',
-   *    Item: {
-   *       HashKey: 'haskey',
-   *       NumAttribute: 1,
-   *       BoolAttribute: true,
-   *       ListAttribute: [1, 'two', false],
-   *       MapAttribute: { foo: 'bar'},
-   *       NullAttribute: null
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.put(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  put: function put(params, callback) {
-    var self = this;
-    var request = self.service.putItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Edits an existing item's attributes, or adds a new item to the table if
-   * it does not already exist by delegating to `AWS.DynamoDB.updateItem()`.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.updateItem} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.updateItem
-   * @example Update an item with expressions
-   *  var params = {
-   *    TableName: 'Table',
-   *    Key: { HashKey : 'hashkey' },
-   *    UpdateExpression: 'set #a = :x + :y',
-   *    ConditionExpression: '#a < :MAX',
-   *    ExpressionAttributeNames: {'#a' : 'Sum'},
-   *    ExpressionAttributeValues: {
-   *      ':x' : 20,
-   *      ':y' : 45,
-   *      ':MAX' : 100,
-   *    }
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.update(params, function(err, data) {
-   *     if (err) console.log(err);
-   *     else console.log(data);
-   *  });
-   *
-   */
-  update: function(params, callback) {
-    var self = this;
-    var request = self.service.updateItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Returns one or more items and item attributes by accessing every item
-   * in a table or a secondary index.
-   *
-   * Supply the same parameters as {AWS.DynamoDB.scan} with
-   * `AttributeValue`s substituted by native JavaScript types.
-   *
-   * @see AWS.DynamoDB.scan
-   * @example Scan the table with a filter expression
-   *  var params = {
-   *    TableName : 'Table',
-   *    FilterExpression : 'Year = :this_year',
-   *    ExpressionAttributeValues : {':this_year' : 2015}
-   *  };
-   *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  docClient.scan(params, function(err, data) {
-   *     if (err) console.log(err);
-   *     else console.log(data);
-   *  });
-   *
-   */
-  scan: function(params, callback) {
-    var self = this;
-    var request = self.service.scan(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-   /**
-    * Directly access items from a table by primary key or a secondary index.
-    *
-    * Supply the same parameters as {AWS.DynamoDB.query} with
-    * `AttributeValue`s substituted by native JavaScript types.
-    *
-    * @see AWS.DynamoDB.query
-    * @example Query an index
-    *  var params = {
-    *    TableName: 'Table',
-    *    IndexName: 'Index',
-    *    KeyConditionExpression: 'HashKey = :hkey and RangeKey > :rkey',
-    *    ExpressionAttributeValues: {
-    *      ':hkey': 'key',
-    *      ':rkey': 2015
-    *    }
-    *  };
-    *
-    *  var docClient = new AWS.DynamoDB.DocumentClient();
-    *
-    *  docClient.query(params, function(err, data) {
-    *     if (err) console.log(err);
-    *     else console.log(data);
-    *  });
-    *
-    */
-  query: function(params, callback) {
-    var self = this;
-    var request = self.service.query(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
-  },
-
-  /**
-   * Creates a set of elements inferring the type of set from
-   * the type of the first element. Amazon DynamoDB currently supports
-   * the number sets, string sets, and binary sets. For more information
-   * about DynamoDB data types see the documentation on the
-   * [Amazon DynamoDB Data Model](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes).
-   *
-   * @param list [Array] Collection to represent your DynamoDB Set
-   * @param options [map]
-   *  * **validate** [Boolean] set to true if you want to validate the type
-   *    of each element in the set. Defaults to `false`.
-   * @example Creating a number set
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
-   *
-   *  var params = {
-   *    Item: {
-   *      hashkey: 'hashkey'
-   *      numbers: docClient.createSet([1, 2, 3]);
-   *    }
-   *  };
-   *
-   *  docClient.put(params, function(err, data) {
-   *    if (err) console.log(err);
-   *    else console.log(data);
-   *  });
-   *
-   */
-  createSet: function(list, options) {
-    options = options || {};
-    return new DynamoDBSet(list, options);
-  },
-
-  /**
-   * @api private
-   */
-  getTranslator: function() {
-    return new Translator({attrValue: this.attrValue});
-  },
-
-  /**
-   * @api private
-   */
-  setupRequest: function setupRequest(request) {
-    var self = this;
-    var translator = self.getTranslator();
-    var operation = request.operation;
-    var inputShape = request.service.api.operations[operation].input;
-    request._events.validate.unshift(function(req) {
-      req.rawParams = AWS.util.copy(req.params);
-      req.params = translator.translateInput(req.rawParams, inputShape);
-    });
-  },
-
-  /**
-   * @api private
-   */
-  setupResponse: function setupResponse(request) {
-    var self = this;
-    var translator = self.getTranslator();
-    var outputShape = self.service.api.operations[request.operation].output;
-    request.on('extractData', function(response) {
-      response.data = translator.translateOutput(response.data, outputShape);
-    });
-
-    var response = request.response;
-    response.nextPage = function(cb) {
-      var resp = this;
-      var req = resp.request;
-      var config;
-      var service = req.service;
-      var operation = req.operation;
-      try {
-        config = service.paginationConfig(operation, true);
-      } catch (e) { resp.error = e; }
-
-      if (!resp.hasNextPage()) {
-        if (cb) cb(resp.error, null);
-        else if (resp.error) throw resp.error;
-        return null;
-      }
-
-      var params = AWS.util.copy(req.rawParams);
-      if (!resp.nextPageTokens) {
-        return cb ? cb(null, null) : null;
+      if (!self.service) {
+        self.service = new DynamoDB(options);
       } else {
-        var inputTokens = config.inputToken;
-        if (typeof inputTokens === 'string') inputTokens = [inputTokens];
-        for (var i = 0; i < inputTokens.length; i++) {
-          params[inputTokens[i]] = resp.nextPageTokens[i];
-        }
-        return self[operation](params, cb);
+        var config = AWS.util.copy(self.service.config);
+        self.service = new self.service.constructor.__super__(config);
+        self.service.config.params =
+          AWS.util.merge(self.service.config.params || {}, options.params);
       }
-    };
-  }
+    },
 
-});
+    /**
+     * Returns the attributes of one or more items from one or more tables
+     * by delegating to `AWS.DynamoDB.batchGetItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.batchGetItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.batchGetItem
+     * @example Get items from multiple tables
+     *  var params = {
+     *    RequestItems: {
+     *      'Table-1': {
+     *        Keys: [
+     *          {
+     *             HashKey: 'haskey',
+     *             NumberRangeKey: 1
+     *          }
+     *        ]
+     *      },
+     *      'Table-2': {
+     *        Keys: [
+     *          { foo: 'bar' },
+     *        ]
+     *      }
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.batchGet(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    batchGet: function(params, callback) {
+      var self = this;
+      var request = self.service.batchGetItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
 
-module.exports = AWS.DynamoDB.DocumentClient;
+    /**
+     * Puts or deletes multiple items in one or more tables by delegating
+     * to `AWS.DynamoDB.batchWriteItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.batchWriteItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.batchWriteItem
+     * @example Write to and delete from a table
+     *  var params = {
+     *    RequestItems: {
+     *      'Table-1': [
+     *        {
+     *          DeleteRequest: {
+     *            Key: { HashKey: 'someKey' }
+     *          }
+     *        },
+     *        {
+     *          PutRequest: {
+     *            Item: {
+     *              HashKey: 'anotherKey',
+     *              NumAttribute: 1,
+     *              BoolAttribute: true,
+     *              ListAttribute: [1, 'two', false],
+     *              MapAttribute: { foo: 'bar' }
+     *            }
+     *          }
+     *        }
+     *      ]
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.batchWrite(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    batchWrite: function(params, callback) {
+      var self = this;
+      var request = self.service.batchWriteItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Deletes a single item in a table by primary key by delegating to
+     * `AWS.DynamoDB.deleteItem()`
+     *
+     * Supply the same parameters as {AWS.DynamoDB.deleteItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.deleteItem
+     * @example Delete an item from a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Key: {
+     *      HashKey: 'hashkey',
+     *      NumberRangeKey: 1
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.delete(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    delete: function(params, callback) {
+      var self = this;
+      var request = self.service.deleteItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Returns a set of attributes for the item with the given primary key
+     * by delegating to `AWS.DynamoDB.getItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.getItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.getItem
+     * @example Get an item from a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Key: {
+     *      HashKey: 'hashkey'
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.get(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    get: function(params, callback) {
+      var self = this;
+      var request = self.service.getItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Creates a new item, or replaces an old item with a new item by
+     * delegating to `AWS.DynamoDB.putItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.putItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.putItem
+     * @example Create a new item in a table
+     *  var params = {
+     *    TableName : 'Table',
+     *    Item: {
+     *       HashKey: 'haskey',
+     *       NumAttribute: 1,
+     *       BoolAttribute: true,
+     *       ListAttribute: [1, 'two', false],
+     *       MapAttribute: { foo: 'bar'},
+     *       NullAttribute: null
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.put(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    put: function put(params, callback) {
+      var self = this;
+      var request = self.service.putItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Edits an existing item's attributes, or adds a new item to the table if
+     * it does not already exist by delegating to `AWS.DynamoDB.updateItem()`.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.updateItem} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.updateItem
+     * @example Update an item with expressions
+     *  var params = {
+     *    TableName: 'Table',
+     *    Key: { HashKey : 'hashkey' },
+     *    UpdateExpression: 'set #a = :x + :y',
+     *    ConditionExpression: '#a < :MAX',
+     *    ExpressionAttributeNames: {'#a' : 'Sum'},
+     *    ExpressionAttributeValues: {
+     *      ':x' : 20,
+     *      ':y' : 45,
+     *      ':MAX' : 100,
+     *    }
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.update(params, function(err, data) {
+     *     if (err) console.log(err);
+     *     else console.log(data);
+     *  });
+     *
+     */
+    update: function(params, callback) {
+      var self = this;
+      var request = self.service.updateItem(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Returns one or more items and item attributes by accessing every item
+     * in a table or a secondary index.
+     *
+     * Supply the same parameters as {AWS.DynamoDB.scan} with
+     * `AttributeValue`s substituted by native JavaScript types.
+     *
+     * @see AWS.DynamoDB.scan
+     * @example Scan the table with a filter expression
+     *  var params = {
+     *    TableName : 'Table',
+     *    FilterExpression : 'Year = :this_year',
+     *    ExpressionAttributeValues : {':this_year' : 2015}
+     *  };
+     *
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  docClient.scan(params, function(err, data) {
+     *     if (err) console.log(err);
+     *     else console.log(data);
+     *  });
+     *
+     */
+    scan: function(params, callback) {
+      var self = this;
+      var request = self.service.scan(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+      * Directly access items from a table by primary key or a secondary index.
+      *
+      * Supply the same parameters as {AWS.DynamoDB.query} with
+      * `AttributeValue`s substituted by native JavaScript types.
+      *
+      * @see AWS.DynamoDB.query
+      * @example Query an index
+      *  var params = {
+      *    TableName: 'Table',
+      *    IndexName: 'Index',
+      *    KeyConditionExpression: 'HashKey = :hkey and RangeKey > :rkey',
+      *    ExpressionAttributeValues: {
+      *      ':hkey': 'key',
+      *      ':rkey': 2015
+      *    }
+      *  };
+      *
+      *  var docClient = new AWS.DynamoDB.DocumentClient();
+      *
+      *  docClient.query(params, function(err, data) {
+      *     if (err) console.log(err);
+      *     else console.log(data);
+      *  });
+      *
+      */
+    query: function(params, callback) {
+      var self = this;
+      var request = self.service.query(params);
+      self.setupRequest(request);
+      self.setupResponse(request);
+      if (typeof callback === 'function') {
+        request.send(callback);
+      }
+      return request;
+    },
+
+    /**
+     * Creates a set of elements inferring the type of set from
+     * the type of the first element. Amazon DynamoDB currently supports
+     * the number sets, string sets, and binary sets. For more information
+     * about DynamoDB data types see the documentation on the
+     * [Amazon DynamoDB Data Model](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes).
+     *
+     * @param list [Array] Collection to represent your DynamoDB Set
+     * @param options [map]
+     *  * **validate** [Boolean] set to true if you want to validate the type
+     *    of each element in the set. Defaults to `false`.
+     * @example Creating a number set
+     *  var docClient = new AWS.DynamoDB.DocumentClient();
+     *
+     *  var params = {
+     *    Item: {
+     *      hashkey: 'hashkey'
+     *      numbers: docClient.createSet([1, 2, 3]);
+     *    }
+     *  };
+     *
+     *  docClient.put(params, function(err, data) {
+     *    if (err) console.log(err);
+     *    else console.log(data);
+     *  });
+     *
+     */
+    createSet: function(list, options) {
+      options = options || {};
+      return new DynamoDBSet(list, options);
+    },
+
+    /**
+     * @api private
+     */
+    getTranslator: function() {
+      return new Translator({attrValue: this.attrValue});
+    },
+
+    /**
+     * @api private
+     */
+    setupRequest: function setupRequest(request) {
+      var self = this;
+      var translator = self.getTranslator();
+      var operation = request.operation;
+      var inputShape = request.service.api.operations[operation].input;
+      request._events.validate.unshift(function(req) {
+        req.rawParams = AWS.util.copy(req.params);
+        req.params = translator.translateInput(req.rawParams, inputShape);
+      });
+    },
+
+    /**
+     * @api private
+     */
+    setupResponse: function setupResponse(request) {
+      var self = this;
+      var translator = self.getTranslator();
+      var outputShape = self.service.api.operations[request.operation].output;
+      request.on('extractData', function(response) {
+        response.data = translator.translateOutput(response.data, outputShape);
+      });
+
+      var response = request.response;
+      response.nextPage = function(cb) {
+        var resp = this;
+        var req = resp.request;
+        var config;
+        var service = req.service;
+        var operation = req.operation;
+        try {
+          config = service.paginationConfig(operation, true);
+        } catch (e) { resp.error = e; }
+
+        if (!resp.hasNextPage()) {
+          if (cb) cb(resp.error, null);
+          else if (resp.error) throw resp.error;
+          return null;
+        }
+
+        var params = AWS.util.copy(req.rawParams);
+        if (!resp.nextPageTokens) {
+          return cb ? cb(null, null) : null;
+        } else {
+          var inputTokens = config.inputToken;
+          if (typeof inputTokens === 'string') inputTokens = [inputTokens];
+          for (var i = 0; i < inputTokens.length; i++) {
+            params[inputTokens[i]] = resp.nextPageTokens[i];
+          }
+          return self[operation](params, cb);
+        }
+      };
+    }
+
+  });
+};

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -2,6 +2,7 @@ var AWS = require('../core');
 var byteLength = AWS.util.string.byteLength;
 var Buffer = AWS.util.Buffer;
 
+module.exports = function attachManagedUploader(S3) {
 /**
  * The managed uploader allows for easy and efficient uploading of buffers,
  * blobs, or streams, using a configurable amount of concurrency to perform
@@ -36,566 +37,566 @@ var Buffer = AWS.util.Buffer;
  *     size is known.
  *   @context (see AWS.Request~send)
  */
-AWS.S3.ManagedUpload = AWS.util.inherit({
-  /**
-   * Creates a managed upload object with a set of configuration options.
-   *
-   * @note A "Body" parameter is required to be set prior to calling {send}.
-   * @option options params [map] a map of parameters to pass to the upload
-   *   requests. The "Body" parameter is required to be specified either on
-   *   the service or in the params option.
-   * @note ContentMD5 should not be provided when using the managed upload object.
-   *   Instead, setting "computeChecksums" to true will enable automatic ContentMD5 generation
-   *   by the managed upload object.
-   * @option options queueSize [Number] (4) the size of the concurrent queue
-   *   manager to upload parts in parallel. Set to 1 for synchronous uploading
-   *   of parts. Note that the uploader will buffer at most queueSize * partSize
-   *   bytes into memory at any given time.
-   * @option options partSize [Number] (5mb) the size in bytes for each
-   *   individual part to be uploaded. Adjust the part size to ensure the number
-   *   of parts does not exceed {maxTotalParts}. See {minPartSize} for the
-   *   minimum allowed part size.
-   * @option options leavePartsOnError [Boolean] (false) whether to abort the
-   *   multipart upload if an error occurs. Set to true if you want to handle
-   *   failures manually.
-   * @option options service [AWS.S3] an optional S3 service object to use for
-   *   requests. This object might have bound parameters used by the uploader.
-   * @example Creating a default uploader for a stream object
-   *   var upload = new AWS.S3.ManagedUpload({
-   *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
-   *   });
-   * @example Creating an uploader with concurrency of 1 and partSize of 10mb
-   *   var upload = new AWS.S3.ManagedUpload({
-   *     partSize: 10 * 1024 * 1024, queueSize: 1,
-   *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
-   *   });
-   * @see send
-   */
-  constructor: function ManagedUpload(options) {
-    var self = this;
-    AWS.SequentialExecutor.call(self);
-    self.body = null;
-    self.sliceFn = null;
-    self.callback = null;
-    self.parts = {};
-    self.completeInfo = [];
-    self.fillQueue = function() {
-      self.callback(new Error('Unsupported body payload ' + typeof self.body));
-    };
+  S3.ManagedUpload = AWS.util.inherit({
+    /**
+     * Creates a managed upload object with a set of configuration options.
+     *
+     * @note A "Body" parameter is required to be set prior to calling {send}.
+     * @option options params [map] a map of parameters to pass to the upload
+     *   requests. The "Body" parameter is required to be specified either on
+     *   the service or in the params option.
+     * @note ContentMD5 should not be provided when using the managed upload object.
+     *   Instead, setting "computeChecksums" to true will enable automatic ContentMD5 generation
+     *   by the managed upload object.
+     * @option options queueSize [Number] (4) the size of the concurrent queue
+     *   manager to upload parts in parallel. Set to 1 for synchronous uploading
+     *   of parts. Note that the uploader will buffer at most queueSize * partSize
+     *   bytes into memory at any given time.
+     * @option options partSize [Number] (5mb) the size in bytes for each
+     *   individual part to be uploaded. Adjust the part size to ensure the number
+     *   of parts does not exceed {maxTotalParts}. See {minPartSize} for the
+     *   minimum allowed part size.
+     * @option options leavePartsOnError [Boolean] (false) whether to abort the
+     *   multipart upload if an error occurs. Set to true if you want to handle
+     *   failures manually.
+     * @option options service [AWS.S3] an optional S3 service object to use for
+     *   requests. This object might have bound parameters used by the uploader.
+     * @example Creating a default uploader for a stream object
+     *   var upload = new AWS.S3.ManagedUpload({
+     *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
+     *   });
+     * @example Creating an uploader with concurrency of 1 and partSize of 10mb
+     *   var upload = new AWS.S3.ManagedUpload({
+     *     partSize: 10 * 1024 * 1024, queueSize: 1,
+     *     params: {Bucket: 'bucket', Key: 'key', Body: stream}
+     *   });
+     * @see send
+     */
+    constructor: function ManagedUpload(options) {
+      var self = this;
+      AWS.SequentialExecutor.call(self);
+      self.body = null;
+      self.sliceFn = null;
+      self.callback = null;
+      self.parts = {};
+      self.completeInfo = [];
+      self.fillQueue = function() {
+        self.callback(new Error('Unsupported body payload ' + typeof self.body));
+      };
 
-    self.configure(options);
-  },
+      self.configure(options);
+    },
 
-  /**
-   * @api private
-   */
-  configure: function configure(options) {
-    options = options || {};
-    this.partSize = this.minPartSize;
+    /**
+     * @api private
+     */
+    configure: function configure(options) {
+      options = options || {};
+      this.partSize = this.minPartSize;
 
-    if (options.queueSize) this.queueSize = options.queueSize;
-    if (options.partSize) this.partSize = options.partSize;
-    if (options.leavePartsOnError) this.leavePartsOnError = true;
+      if (options.queueSize) this.queueSize = options.queueSize;
+      if (options.partSize) this.partSize = options.partSize;
+      if (options.leavePartsOnError) this.leavePartsOnError = true;
 
-    if (this.partSize < this.minPartSize) {
-      throw new Error('partSize must be greater than ' +
-                      this.minPartSize);
-    }
-
-    this.service = options.service;
-    this.bindServiceObject(options.params);
-    this.validateBody();
-    this.adjustTotalBytes();
-  },
-
-  /**
-   * @api private
-   */
-  leavePartsOnError: false,
-
-  /**
-   * @api private
-   */
-  queueSize: 4,
-
-  /**
-   * @api private
-   */
-  partSize: null,
-
-  /**
-   * @readonly
-   * @return [Number] the minimum number of bytes for an individual part
-   *   upload.
-   */
-  minPartSize: 1024 * 1024 * 5,
-
-  /**
-   * @readonly
-   * @return [Number] the maximum allowed number of parts in a multipart upload.
-   */
-  maxTotalParts: 10000,
-
-  /**
-   * Initiates the managed upload for the payload.
-   *
-   * @callback callback function(err, data)
-   *   @param err [Error] an error or null if no error occurred.
-   *   @param data [map] The response data from the successful upload:
-   *     * `Location` (String) the URL of the uploaded object
-   *     * `ETag` (String) the ETag of the uploaded object
-   *     * `Bucket` (String) the bucket to which the object was uploaded
-   *     * `Key` (String) the key to which the object was uploaded
-   * @example Sending a managed upload object
-   *   var params = {Bucket: 'bucket', Key: 'key', Body: stream};
-   *   var upload = new AWS.S3.ManagedUpload({params: params});
-   *   upload.send(function(err, data) {
-   *     console.log(err, data);
-   *   });
-   */
-  send: function(callback) {
-    var self = this;
-    self.failed = false;
-    self.callback = callback || function(err) { if (err) throw err; };
-
-    var runFill = true;
-    if (self.sliceFn) {
-      self.fillQueue = self.fillBuffer;
-    } else if (AWS.util.isNode()) {
-      var Stream = AWS.util.stream.Stream;
-      if (self.body instanceof Stream) {
-        runFill = false;
-        self.fillQueue = self.fillStream;
-        self.partBuffers = [];
-        self.body.
-          on('readable', function() { self.fillQueue(); }).
-          on('end', function() {
-            self.isDoneChunking = true;
-            self.numParts = self.totalPartNumbers;
-            self.fillQueue.call(self);
-          });
-      }
-    }
-
-    if (runFill) self.fillQueue.call(self);
-  },
-
-  /**
-   * Aborts a managed upload, including all concurrent upload requests.
-   * @note By default, calling this function will cleanup a multipart upload
-   *   if one was created. To leave the multipart upload around after aborting
-   *   a request, configure `leavePartsOnError` to `true` in the {constructor}.
-   * @note Calling {abort} in the browser environment will not abort any requests
-   *   that are already in flight. If a multipart upload was created, any parts
-   *   not yet uploaded will not be sent, and the multipart upload will be cleaned up.
-   * @example Aborting an upload
-   *   var params = {
-   *     Bucket: 'bucket', Key: 'key',
-   *     Body: new Buffer(1024 * 1024 * 25) // 25MB payload
-   *   };
-   *   var upload = s3.upload(params);
-   *   upload.send(function (err, data) {
-   *     if (err) console.log("Error:", err.code, err.message);
-   *     else console.log(data);
-   *   });
-   *
-   *   // abort request in 1 second
-   *   setTimeout(upload.abort.bind(upload), 1000);
-   */
-  abort: function() {
-    this.cleanup(AWS.util.error(new Error('Request aborted by user'), {
-      code: 'RequestAbortedError', retryable: false
-    }));
-  },
-
-  /**
-   * @api private
-   */
-  validateBody: function validateBody() {
-    var self = this;
-    self.body = self.service.config.params.Body;
-    if (!self.body) throw new Error('params.Body is required');
-    if (typeof self.body === 'string') {
-      self.body = new AWS.util.Buffer(self.body);
-    }
-    self.sliceFn = AWS.util.arraySliceFn(self.body);
-  },
-
-  /**
-   * @api private
-   */
-  bindServiceObject: function bindServiceObject(params) {
-    params = params || {};
-    var self = this;
-
-    // bind parameters to new service object
-    if (!self.service) {
-      self.service = new AWS.S3({params: params});
-    } else {
-      var config = AWS.util.copy(self.service.config);
-      self.service = new self.service.constructor.__super__(config);
-      self.service.config.params =
-        AWS.util.merge(self.service.config.params || {}, params);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  adjustTotalBytes: function adjustTotalBytes() {
-    var self = this;
-    try { // try to get totalBytes
-      self.totalBytes = byteLength(self.body);
-    } catch (e) { }
-
-    // try to adjust partSize if we know payload length
-    if (self.totalBytes) {
-      var newPartSize = Math.ceil(self.totalBytes / self.maxTotalParts);
-      if (newPartSize > self.partSize) self.partSize = newPartSize;
-    } else {
-      self.totalBytes = undefined;
-    }
-  },
-
-  /**
-   * @api private
-   */
-  isDoneChunking: false,
-
-  /**
-   * @api private
-   */
-  partPos: 0,
-
-  /**
-   * @api private
-   */
-  totalChunkedBytes: 0,
-
-  /**
-   * @api private
-   */
-  totalUploadedBytes: 0,
-
-  /**
-   * @api private
-   */
-  totalBytes: undefined,
-
-  /**
-   * @api private
-   */
-  numParts: 0,
-
-  /**
-   * @api private
-   */
-  totalPartNumbers: 0,
-
-  /**
-   * @api private
-   */
-  activeParts: 0,
-
-  /**
-   * @api private
-   */
-  doneParts: 0,
-
-  /**
-   * @api private
-   */
-  parts: null,
-
-  /**
-   * @api private
-   */
-  completeInfo: null,
-
-  /**
-   * @api private
-   */
-  failed: false,
-
-  /**
-   * @api private
-   */
-  multipartReq: null,
-
-  /**
-   * @api private
-   */
-  partBuffers: null,
-
-  /**
-   * @api private
-   */
-  partBufferLength: 0,
-
-  /**
-   * @api private
-   */
-  fillBuffer: function fillBuffer() {
-    var self = this;
-    var bodyLen = byteLength(self.body);
-
-    if (bodyLen === 0) {
-      self.isDoneChunking = true;
-      self.numParts = 1;
-      self.nextChunk(self.body);
-      return;
-    }
-
-    while (self.activeParts < self.queueSize && self.partPos < bodyLen) {
-      var endPos = Math.min(self.partPos + self.partSize, bodyLen);
-      var buf = self.sliceFn.call(self.body, self.partPos, endPos);
-      self.partPos += self.partSize;
-
-      if (byteLength(buf) < self.partSize || self.partPos === bodyLen) {
-        self.isDoneChunking = true;
-        self.numParts = self.totalPartNumbers + 1;
-      }
-      self.nextChunk(buf);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  fillStream: function fillStream() {
-    var self = this;
-    if (self.activeParts >= self.queueSize) return;
-
-    var buf = self.body.read(self.partSize - self.partBufferLength) ||
-              self.body.read();
-    if (buf) {
-      self.partBuffers.push(buf);
-      self.partBufferLength += buf.length;
-      self.totalChunkedBytes += buf.length;
-    }
-
-    if (self.partBufferLength >= self.partSize) {
-      // if we have single buffer we avoid copyfull concat
-      var pbuf = self.partBuffers.length === 1 ?
-        self.partBuffers[0] : Buffer.concat(self.partBuffers);
-      self.partBuffers = [];
-      self.partBufferLength = 0;
-
-      // if we have more than partSize, push the rest back on the queue
-      if (pbuf.length > self.partSize) {
-        var rest = pbuf.slice(self.partSize);
-        self.partBuffers.push(rest);
-        self.partBufferLength += rest.length;
-        pbuf = pbuf.slice(0, self.partSize);
+      if (this.partSize < this.minPartSize) {
+        throw new Error('partSize must be greater than ' +
+                        this.minPartSize);
       }
 
-      self.nextChunk(pbuf);
-    }
+      this.service = options.service;
+      this.bindServiceObject(options.params);
+      this.validateBody();
+      this.adjustTotalBytes();
+    },
 
-    if (self.isDoneChunking && !self.isDoneSending) {
-      // if we have single buffer we avoid copyfull concat
-      pbuf = self.partBuffers.length === 1 ?
-          self.partBuffers[0] : Buffer.concat(self.partBuffers);
-      self.partBuffers = [];
-      self.partBufferLength = 0;
-      self.totalBytes = self.totalChunkedBytes;
-      self.isDoneSending = true;
+    /**
+     * @api private
+     */
+    leavePartsOnError: false,
 
-      if (self.numParts === 0 || pbuf.length > 0) {
-        self.numParts++;
-        self.nextChunk(pbuf);
+    /**
+     * @api private
+     */
+    queueSize: 4,
+
+    /**
+     * @api private
+     */
+    partSize: null,
+
+    /**
+     * @readonly
+     * @return [Number] the minimum number of bytes for an individual part
+     *   upload.
+     */
+    minPartSize: 1024 * 1024 * 5,
+
+    /**
+     * @readonly
+     * @return [Number] the maximum allowed number of parts in a multipart upload.
+     */
+    maxTotalParts: 10000,
+
+    /**
+     * Initiates the managed upload for the payload.
+     *
+     * @callback callback function(err, data)
+     *   @param err [Error] an error or null if no error occurred.
+     *   @param data [map] The response data from the successful upload:
+     *     * `Location` (String) the URL of the uploaded object
+     *     * `ETag` (String) the ETag of the uploaded object
+     *     * `Bucket` (String) the bucket to which the object was uploaded
+     *     * `Key` (String) the key to which the object was uploaded
+     * @example Sending a managed upload object
+     *   var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *   var upload = new AWS.S3.ManagedUpload({params: params});
+     *   upload.send(function(err, data) {
+     *     console.log(err, data);
+     *   });
+     */
+    send: function(callback) {
+      var self = this;
+      self.failed = false;
+      self.callback = callback || function(err) { if (err) throw err; };
+
+      var runFill = true;
+      if (self.sliceFn) {
+        self.fillQueue = self.fillBuffer;
+      } else if (AWS.util.isNode()) {
+        var Stream = AWS.util.stream.Stream;
+        if (self.body instanceof Stream) {
+          runFill = false;
+          self.fillQueue = self.fillStream;
+          self.partBuffers = [];
+          self.body.
+            on('readable', function() { self.fillQueue(); }).
+            on('end', function() {
+              self.isDoneChunking = true;
+              self.numParts = self.totalPartNumbers;
+              self.fillQueue.call(self);
+            });
+        }
       }
-    }
 
-    self.body.read(0);
-  },
+      if (runFill) self.fillQueue.call(self);
+    },
 
-  /**
-   * @api private
-   */
-  nextChunk: function nextChunk(chunk) {
-    var self = this;
-    if (self.failed) return null;
+    /**
+     * Aborts a managed upload, including all concurrent upload requests.
+     * @note By default, calling this function will cleanup a multipart upload
+     *   if one was created. To leave the multipart upload around after aborting
+     *   a request, configure `leavePartsOnError` to `true` in the {constructor}.
+     * @note Calling {abort} in the browser environment will not abort any requests
+     *   that are already in flight. If a multipart upload was created, any parts
+     *   not yet uploaded will not be sent, and the multipart upload will be cleaned up.
+     * @example Aborting an upload
+     *   var params = {
+     *     Bucket: 'bucket', Key: 'key',
+     *     Body: new Buffer(1024 * 1024 * 25) // 25MB payload
+     *   };
+     *   var upload = s3.upload(params);
+     *   upload.send(function (err, data) {
+     *     if (err) console.log("Error:", err.code, err.message);
+     *     else console.log(data);
+     *   });
+     *
+     *   // abort request in 1 second
+     *   setTimeout(upload.abort.bind(upload), 1000);
+     */
+    abort: function() {
+      this.cleanup(AWS.util.error(new Error('Request aborted by user'), {
+        code: 'RequestAbortedError', retryable: false
+      }));
+    },
 
-    var partNumber = ++self.totalPartNumbers;
-    if (self.isDoneChunking && partNumber === 1) {
-      var req = self.service.putObject({Body: chunk});
-      req._managedUpload = self;
-      req.on('httpUploadProgress', self.progress).send(self.finishSinglePart);
-      return null;
-    } else if (self.service.config.params.ContentMD5) {
-      var err = AWS.util.error(new Error('The Content-MD5 you specified is invalid for multi-part uploads.'), {
-        code: 'InvalidDigest', retryable: false
-      });
+    /**
+     * @api private
+     */
+    validateBody: function validateBody() {
+      var self = this;
+      self.body = self.service.config.params.Body;
+      if (!self.body) throw new Error('params.Body is required');
+      if (typeof self.body === 'string') {
+        self.body = new AWS.util.Buffer(self.body);
+      }
+      self.sliceFn = AWS.util.arraySliceFn(self.body);
+    },
 
-      self.cleanup(err);
-      return null;
-    }
+    /**
+     * @api private
+     */
+    bindServiceObject: function bindServiceObject(params) {
+      params = params || {};
+      var self = this;
 
-    if (self.completeInfo[partNumber] && self.completeInfo[partNumber].ETag !== null) {
-      return null; // Already uploaded this part.
-    }
-
-    self.activeParts++;
-    if (!self.service.config.params.UploadId) {
-
-      if (!self.multipartReq) { // create multipart
-        self.multipartReq = self.service.createMultipartUpload();
-        self.multipartReq.on('success', function(resp) {
-          self.service.config.params.UploadId = resp.data.UploadId;
-          self.multipartReq = null;
-        });
-        self.queueChunks(chunk, partNumber);
-        self.multipartReq.on('error', function(err) {
-          self.cleanup(err);
-        });
-        self.multipartReq.send();
+      // bind parameters to new service object
+      if (!self.service) {
+        self.service = new S3({params: params});
       } else {
-        self.queueChunks(chunk, partNumber);
+        var config = AWS.util.copy(self.service.config);
+        self.service = new self.service.constructor.__super__(config);
+        self.service.config.params =
+          AWS.util.merge(self.service.config.params || {}, params);
       }
-    } else { // multipart is created, just send
-      self.uploadPart(chunk, partNumber);
-    }
-  },
+    },
 
-  /**
-   * @api private
-   */
-  uploadPart: function uploadPart(chunk, partNumber) {
-    var self = this;
+    /**
+     * @api private
+     */
+    adjustTotalBytes: function adjustTotalBytes() {
+      var self = this;
+      try { // try to get totalBytes
+        self.totalBytes = byteLength(self.body);
+      } catch (e) { }
 
-    var partParams = {
-      Body: chunk,
-      ContentLength: AWS.util.string.byteLength(chunk),
-      PartNumber: partNumber
-    };
+      // try to adjust partSize if we know payload length
+      if (self.totalBytes) {
+        var newPartSize = Math.ceil(self.totalBytes / self.maxTotalParts);
+        if (newPartSize > self.partSize) self.partSize = newPartSize;
+      } else {
+        self.totalBytes = undefined;
+      }
+    },
 
-    var partInfo = {ETag: null, PartNumber: partNumber};
-    self.completeInfo[partNumber] = partInfo;
+    /**
+     * @api private
+     */
+    isDoneChunking: false,
 
-    var req = self.service.uploadPart(partParams);
-    self.parts[partNumber] = req;
-    req._lastUploadedBytes = 0;
-    req._managedUpload = self;
-    req.on('httpUploadProgress', self.progress);
-    req.send(function(err, data) {
-      delete self.parts[partParams.PartNumber];
-      self.activeParts--;
+    /**
+     * @api private
+     */
+    partPos: 0,
 
-      if (!err && (!data || !data.ETag)) {
-        var message = 'No access to ETag property on response.';
-        if (AWS.util.isBrowser()) {
-          message += ' Check CORS configuration to expose ETag header.';
+    /**
+     * @api private
+     */
+    totalChunkedBytes: 0,
+
+    /**
+     * @api private
+     */
+    totalUploadedBytes: 0,
+
+    /**
+     * @api private
+     */
+    totalBytes: undefined,
+
+    /**
+     * @api private
+     */
+    numParts: 0,
+
+    /**
+     * @api private
+     */
+    totalPartNumbers: 0,
+
+    /**
+     * @api private
+     */
+    activeParts: 0,
+
+    /**
+     * @api private
+     */
+    doneParts: 0,
+
+    /**
+     * @api private
+     */
+    parts: null,
+
+    /**
+     * @api private
+     */
+    completeInfo: null,
+
+    /**
+     * @api private
+     */
+    failed: false,
+
+    /**
+     * @api private
+     */
+    multipartReq: null,
+
+    /**
+     * @api private
+     */
+    partBuffers: null,
+
+    /**
+     * @api private
+     */
+    partBufferLength: 0,
+
+    /**
+     * @api private
+     */
+    fillBuffer: function fillBuffer() {
+      var self = this;
+      var bodyLen = byteLength(self.body);
+
+      if (bodyLen === 0) {
+        self.isDoneChunking = true;
+        self.numParts = 1;
+        self.nextChunk(self.body);
+        return;
+      }
+
+      while (self.activeParts < self.queueSize && self.partPos < bodyLen) {
+        var endPos = Math.min(self.partPos + self.partSize, bodyLen);
+        var buf = self.sliceFn.call(self.body, self.partPos, endPos);
+        self.partPos += self.partSize;
+
+        if (byteLength(buf) < self.partSize || self.partPos === bodyLen) {
+          self.isDoneChunking = true;
+          self.numParts = self.totalPartNumbers + 1;
+        }
+        self.nextChunk(buf);
+      }
+    },
+
+    /**
+     * @api private
+     */
+    fillStream: function fillStream() {
+      var self = this;
+      if (self.activeParts >= self.queueSize) return;
+
+      var buf = self.body.read(self.partSize - self.partBufferLength) ||
+                self.body.read();
+      if (buf) {
+        self.partBuffers.push(buf);
+        self.partBufferLength += buf.length;
+        self.totalChunkedBytes += buf.length;
+      }
+
+      if (self.partBufferLength >= self.partSize) {
+        // if we have single buffer we avoid copyfull concat
+        var pbuf = self.partBuffers.length === 1 ?
+          self.partBuffers[0] : Buffer.concat(self.partBuffers);
+        self.partBuffers = [];
+        self.partBufferLength = 0;
+
+        // if we have more than partSize, push the rest back on the queue
+        if (pbuf.length > self.partSize) {
+          var rest = pbuf.slice(self.partSize);
+          self.partBuffers.push(rest);
+          self.partBufferLength += rest.length;
+          pbuf = pbuf.slice(0, self.partSize);
         }
 
-        err = AWS.util.error(new Error(message), {
-          code: 'ETagMissing', retryable: false
+        self.nextChunk(pbuf);
+      }
+
+      if (self.isDoneChunking && !self.isDoneSending) {
+        // if we have single buffer we avoid copyfull concat
+        pbuf = self.partBuffers.length === 1 ?
+            self.partBuffers[0] : Buffer.concat(self.partBuffers);
+        self.partBuffers = [];
+        self.partBufferLength = 0;
+        self.totalBytes = self.totalChunkedBytes;
+        self.isDoneSending = true;
+
+        if (self.numParts === 0 || pbuf.length > 0) {
+          self.numParts++;
+          self.nextChunk(pbuf);
+        }
+      }
+
+      self.body.read(0);
+    },
+
+    /**
+     * @api private
+     */
+    nextChunk: function nextChunk(chunk) {
+      var self = this;
+      if (self.failed) return null;
+
+      var partNumber = ++self.totalPartNumbers;
+      if (self.isDoneChunking && partNumber === 1) {
+        var req = self.service.putObject({Body: chunk});
+        req._managedUpload = self;
+        req.on('httpUploadProgress', self.progress).send(self.finishSinglePart);
+        return null;
+      } else if (self.service.config.params.ContentMD5) {
+        var err = AWS.util.error(new Error('The Content-MD5 you specified is invalid for multi-part uploads.'), {
+          code: 'InvalidDigest', retryable: false
         });
+
+        self.cleanup(err);
+        return null;
       }
-      if (err) return self.cleanup(err);
 
-      partInfo.ETag = data.ETag;
-      self.doneParts++;
-      if (self.isDoneChunking && self.doneParts === self.numParts) {
-        self.finishMultiPart();
-      } else {
-        self.fillQueue.call(self);
+      if (self.completeInfo[partNumber] && self.completeInfo[partNumber].ETag !== null) {
+        return null; // Already uploaded this part.
       }
-    });
-  },
 
-  /**
-   * @api private
-   */
-  queueChunks: function queueChunks(chunk, partNumber) {
-    var self = this;
-    self.multipartReq.on('success', function() {
-      self.uploadPart(chunk, partNumber);
-    });
-  },
+      self.activeParts++;
+      if (!self.service.config.params.UploadId) {
 
-  /**
-   * @api private
-   */
-  cleanup: function cleanup(err) {
-    var self = this;
-    if (self.failed) return;
+        if (!self.multipartReq) { // create multipart
+          self.multipartReq = self.service.createMultipartUpload();
+          self.multipartReq.on('success', function(resp) {
+            self.service.config.params.UploadId = resp.data.UploadId;
+            self.multipartReq = null;
+          });
+          self.queueChunks(chunk, partNumber);
+          self.multipartReq.on('error', function(err) {
+            self.cleanup(err);
+          });
+          self.multipartReq.send();
+        } else {
+          self.queueChunks(chunk, partNumber);
+        }
+      } else { // multipart is created, just send
+        self.uploadPart(chunk, partNumber);
+      }
+    },
 
-    // clean up stream
-    if (typeof self.body.removeAllListeners === 'function' &&
-        typeof self.body.resume === 'function') {
-      self.body.removeAllListeners('readable');
-      self.body.removeAllListeners('end');
-      self.body.resume();
-    }
+    /**
+     * @api private
+     */
+    uploadPart: function uploadPart(chunk, partNumber) {
+      var self = this;
 
-    if (self.service.config.params.UploadId && !self.leavePartsOnError) {
-      self.service.abortMultipartUpload().send();
-    }
-
-    AWS.util.each(self.parts, function(partNumber, part) {
-      part.removeAllListeners('complete');
-      part.abort();
-    });
-
-    self.activeParts = 0;
-    self.partPos = 0;
-    self.numParts = 0;
-    self.totalPartNumbers = 0;
-    self.parts = {};
-    self.failed = true;
-    self.callback(err);
-  },
-
-  /**
-   * @api private
-   */
-  finishMultiPart: function finishMultiPart() {
-    var self = this;
-    var completeParams = { MultipartUpload: { Parts: self.completeInfo.slice(1) } };
-    self.service.completeMultipartUpload(completeParams, function(err, data) {
-      if (err) return self.cleanup(err);
-      else self.callback(err, data);
-    });
-  },
-
-  /**
-   * @api private
-   */
-  finishSinglePart: function finishSinglePart(err, data) {
-    var upload = this.request._managedUpload;
-    var httpReq = this.request.httpRequest;
-    var endpoint = httpReq.endpoint;
-    if (err) return upload.callback(err);
-    data.Location =
-      [endpoint.protocol, '//', endpoint.host, httpReq.path].join('');
-    data.key = this.request.params.Key; // will stay undocumented
-    data.Key = this.request.params.Key;
-    data.Bucket = this.request.params.Bucket;
-    upload.callback(err, data);
-  },
-
-  /**
-   * @api private
-   */
-  progress: function progress(info) {
-    var upload = this._managedUpload;
-    if (this.operation === 'putObject') {
-      info.part = 1;
-      info.key = this.params.Key;
-    } else {
-      upload.totalUploadedBytes += info.loaded - this._lastUploadedBytes;
-      this._lastUploadedBytes = info.loaded;
-      info = {
-        loaded: upload.totalUploadedBytes,
-        total: upload.totalBytes,
-        part: this.params.PartNumber,
-        key: this.params.Key
+      var partParams = {
+        Body: chunk,
+        ContentLength: AWS.util.string.byteLength(chunk),
+        PartNumber: partNumber
       };
-    }
-    upload.emit('httpUploadProgress', [info]);
-  }
-});
 
-AWS.util.mixin(AWS.S3.ManagedUpload, AWS.SequentialExecutor);
-module.exports = AWS.S3.ManagedUpload;
+      var partInfo = {ETag: null, PartNumber: partNumber};
+      self.completeInfo[partNumber] = partInfo;
+
+      var req = self.service.uploadPart(partParams);
+      self.parts[partNumber] = req;
+      req._lastUploadedBytes = 0;
+      req._managedUpload = self;
+      req.on('httpUploadProgress', self.progress);
+      req.send(function(err, data) {
+        delete self.parts[partParams.PartNumber];
+        self.activeParts--;
+
+        if (!err && (!data || !data.ETag)) {
+          var message = 'No access to ETag property on response.';
+          if (AWS.util.isBrowser()) {
+            message += ' Check CORS configuration to expose ETag header.';
+          }
+
+          err = AWS.util.error(new Error(message), {
+            code: 'ETagMissing', retryable: false
+          });
+        }
+        if (err) return self.cleanup(err);
+
+        partInfo.ETag = data.ETag;
+        self.doneParts++;
+        if (self.isDoneChunking && self.doneParts === self.numParts) {
+          self.finishMultiPart();
+        } else {
+          self.fillQueue.call(self);
+        }
+      });
+    },
+
+    /**
+     * @api private
+     */
+    queueChunks: function queueChunks(chunk, partNumber) {
+      var self = this;
+      self.multipartReq.on('success', function() {
+        self.uploadPart(chunk, partNumber);
+      });
+    },
+
+    /**
+     * @api private
+     */
+    cleanup: function cleanup(err) {
+      var self = this;
+      if (self.failed) return;
+
+      // clean up stream
+      if (typeof self.body.removeAllListeners === 'function' &&
+          typeof self.body.resume === 'function') {
+        self.body.removeAllListeners('readable');
+        self.body.removeAllListeners('end');
+        self.body.resume();
+      }
+
+      if (self.service.config.params.UploadId && !self.leavePartsOnError) {
+        self.service.abortMultipartUpload().send();
+      }
+
+      AWS.util.each(self.parts, function(partNumber, part) {
+        part.removeAllListeners('complete');
+        part.abort();
+      });
+
+      self.activeParts = 0;
+      self.partPos = 0;
+      self.numParts = 0;
+      self.totalPartNumbers = 0;
+      self.parts = {};
+      self.failed = true;
+      self.callback(err);
+    },
+
+    /**
+     * @api private
+     */
+    finishMultiPart: function finishMultiPart() {
+      var self = this;
+      var completeParams = { MultipartUpload: { Parts: self.completeInfo.slice(1) } };
+      self.service.completeMultipartUpload(completeParams, function(err, data) {
+        if (err) return self.cleanup(err);
+        else self.callback(err, data);
+      });
+    },
+
+    /**
+     * @api private
+     */
+    finishSinglePart: function finishSinglePart(err, data) {
+      var upload = this.request._managedUpload;
+      var httpReq = this.request.httpRequest;
+      var endpoint = httpReq.endpoint;
+      if (err) return upload.callback(err);
+      data.Location =
+        [endpoint.protocol, '//', endpoint.host, httpReq.path].join('');
+      data.key = this.request.params.Key; // will stay undocumented
+      data.Key = this.request.params.Key;
+      data.Bucket = this.request.params.Bucket;
+      upload.callback(err, data);
+    },
+
+    /**
+     * @api private
+     */
+    progress: function progress(info) {
+      var upload = this._managedUpload;
+      if (this.operation === 'putObject') {
+        info.part = 1;
+        info.key = this.params.Key;
+      } else {
+        upload.totalUploadedBytes += info.loaded - this._lastUploadedBytes;
+        this._lastUploadedBytes = info.loaded;
+        info = {
+          loaded: upload.totalUploadedBytes,
+          total: upload.totalBytes,
+          part: this.params.PartNumber,
+          key: this.params.Key
+        };
+      }
+      upload.emit('httpUploadProgress', [info]);
+    }
+  });
+
+  AWS.util.mixin(S3.ManagedUpload, AWS.SequentialExecutor);
+};

--- a/lib/services/apigateway.js
+++ b/lib/services/apigateway.js
@@ -1,34 +1,37 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.APIGateway.prototype, {
-/**
- * Sets the Accept header to application/json.
- *
- * @api private
- */
-  setAcceptHeader: function setAcceptHeader(req) {
-    var httpRequest = req.httpRequest;
-    httpRequest.headers['Accept'] = 'application/json';
-  },
-
+module.exports = function decorateService(APIGateway) {
+  AWS.util.update(APIGateway.prototype, {
   /**
+   * Sets the Accept header to application/json.
+   *
    * @api private
    */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.addListener('build', this.setAcceptHeader);
-    if (request.operation === 'getSdk') {
-      request.addListener('extractData', this.useRawPayload);
-    }
-  },
+    setAcceptHeader: function setAcceptHeader(req) {
+      var httpRequest = req.httpRequest;
+      httpRequest.headers['Accept'] = 'application/json';
+    },
 
-  useRawPayload: function useRawPayload(resp) {
-    var req = resp.request;
-    var operation = req.operation;
-    var rules = req.service.api.operations[operation].output || {};
-    if (rules.payload) {
-      var body = resp.httpResponse.body;
-      resp.data[rules.payload] = body;
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.addListener('build', this.setAcceptHeader);
+      if (request.operation === 'getSdk') {
+        request.addListener('extractData', this.useRawPayload);
+      }
+    },
+
+    useRawPayload: function useRawPayload(resp) {
+      var req = resp.request;
+      var operation = req.operation;
+      var rules = req.service.api.operations[operation].output || {};
+      if (rules.payload) {
+        var body = resp.httpResponse.body;
+        resp.data[rules.payload] = body;
+      }
     }
-  }
-});
+  });
+};
+
 

--- a/lib/services/cloudfront.js
+++ b/lib/services/cloudfront.js
@@ -1,12 +1,12 @@
 var AWS = require('../core');
 
-// pull in CloudFront signer
-require('../cloudfront/signer');
+module.exports = function decorateService(CloudFront) {
+  // pull in CloudFront signer
+  require('../cloudfront/signer')(CloudFront);
+  AWS.util.update(CloudFront.prototype, {
 
-AWS.util.update(AWS.CloudFront.prototype, {
-
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.addListener('extractData', AWS.util.hoistPayloadMember);
-  }
-
-});
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.addListener('extractData', AWS.util.hoistPayloadMember);
+    }
+  });
+};

--- a/lib/services/cloudsearchdomain.js
+++ b/lib/services/cloudsearchdomain.js
@@ -54,67 +54,69 @@ var AWS = require('../core');
  * @service cloudsearchdomain
  * @version 2013-01-01
  */
-AWS.util.update(AWS.CloudSearchDomain.prototype, {
-  /**
-   * @api private
-   */
-  validateService: function validateService() {
-    if (!this.config.endpoint || this.config.endpoint.indexOf('{') >= 0) {
-      var msg = 'AWS.CloudSearchDomain requires an explicit ' +
-                '`endpoint\' configuration option.';
-      throw AWS.util.error(new Error(),
-        {name: 'InvalidEndpoint', message: msg});
-    }
-  },
-
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.removeListener('validate',
-      AWS.EventListeners.Core.VALIDATE_CREDENTIALS
-    );
-    request.onAsync('validate', this.validateCredentials);
-    request.addListener('validate', this.updateRegion);
-    if (request.operation === 'search') {
-      request.addListener('build', this.convertGetToPost);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  validateCredentials: function(req, done) {
-    if (!req.service.api.signatureVersion) return done(); // none
-    req.service.config.getCredentials(function(err) {
-      if (err) {
-        req.removeListener('sign', AWS.EventListeners.Core.SIGN);
+module.exports = function decorateService(CloudSearchDomain) {
+  AWS.util.update(CloudSearchDomain.prototype, {
+    /**
+     * @api private
+     */
+    validateService: function validateService() {
+      if (!this.config.endpoint || this.config.endpoint.indexOf('{') >= 0) {
+        var msg = 'AWS.CloudSearchDomain requires an explicit ' +
+                  '`endpoint\' configuration option.';
+        throw AWS.util.error(new Error(),
+          {name: 'InvalidEndpoint', message: msg});
       }
-      done();
-    });
-  },
+    },
 
-  /**
-   * @api private
-   */
-  convertGetToPost: function(request) {
-    var httpRequest = request.httpRequest
-    // convert queries to POST to avoid length restrictions
-    var path = httpRequest.path.split('?')
-    httpRequest.method = 'POST'
-    httpRequest.path = path[0]
-    httpRequest.body = path[1]
-    httpRequest.headers['Content-Length'] = httpRequest.body.length
-    httpRequest.headers['Content-Type'] = 'application/x-www-form-urlencoded'
-  },
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.removeListener('validate',
+        AWS.EventListeners.Core.VALIDATE_CREDENTIALS
+      );
+      request.onAsync('validate', this.validateCredentials);
+      request.addListener('validate', this.updateRegion);
+      if (request.operation === 'search') {
+        request.addListener('build', this.convertGetToPost);
+      }
+    },
 
-  /**
-   * @api private
-   */
-  updateRegion: function updateRegion(request) {
-    var endpoint = request.httpRequest.endpoint.hostname;
-    var zones = endpoint.split('.');
-    request.httpRequest.region = zones[1] || request.httpRequest.region;
-  }
+    /**
+     * @api private
+     */
+    validateCredentials: function(req, done) {
+      if (!req.service.api.signatureVersion) return done(); // none
+      req.service.config.getCredentials(function(err) {
+        if (err) {
+          req.removeListener('sign', AWS.EventListeners.Core.SIGN);
+        }
+        done();
+      });
+    },
 
-});
+    /**
+     * @api private
+     */
+    convertGetToPost: function(request) {
+      var httpRequest = request.httpRequest
+      // convert queries to POST to avoid length restrictions
+      var path = httpRequest.path.split('?')
+      httpRequest.method = 'POST'
+      httpRequest.path = path[0]
+      httpRequest.body = path[1]
+      httpRequest.headers['Content-Length'] = httpRequest.body.length
+      httpRequest.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    },
+
+    /**
+     * @api private
+     */
+    updateRegion: function updateRegion(request) {
+      var endpoint = request.httpRequest.endpoint.hostname;
+      var zones = endpoint.split('.');
+      request.httpRequest.region = zones[1] || request.httpRequest.region;
+    }
+
+  });
+};

--- a/lib/services/cognitoidentity.js
+++ b/lib/services/cognitoidentity.js
@@ -1,15 +1,17 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.CognitoIdentity.prototype, {
-  getOpenIdToken: function getOpenIdToken(params, callback) {
-    return this.makeUnauthenticatedRequest('getOpenIdToken', params, callback);
-  },
+module.exports = function decorateService(CognitoIdentity) {
+  AWS.util.update(CognitoIdentity.prototype, {
+    getOpenIdToken: function getOpenIdToken(params, callback) {
+      return this.makeUnauthenticatedRequest('getOpenIdToken', params, callback);
+    },
 
-  getId: function getId(params, callback) {
-    return this.makeUnauthenticatedRequest('getId', params, callback);
-  },
+    getId: function getId(params, callback) {
+      return this.makeUnauthenticatedRequest('getId', params, callback);
+    },
 
-  getCredentialsForIdentity: function getCredentialsForIdentity(params, callback) {
-    return this.makeUnauthenticatedRequest('getCredentialsForIdentity', params, callback);
-  }
-});
+    getCredentialsForIdentity: function getCredentialsForIdentity(params, callback) {
+      return this.makeUnauthenticatedRequest('getCredentialsForIdentity', params, callback);
+    }
+  });
+};

--- a/lib/services/dynamodb.js
+++ b/lib/services/dynamodb.js
@@ -1,53 +1,56 @@
 var AWS = require('../core');
 require('../dynamodb/document_client');
 
-AWS.util.update(AWS.DynamoDB.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    if (request.service.config.dynamoDbCrc32) {
-      request.removeListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
-      request.addListener('extractData', this.checkCrc32);
-      request.addListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
+module.exports = function decorateService(DynamoDB) {
+  require('../dynamodb/document_client')(DynamoDB);
+  AWS.util.update(DynamoDB.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      if (request.service.config.dynamoDbCrc32) {
+        request.removeListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
+        request.addListener('extractData', this.checkCrc32);
+        request.addListener('extractData', AWS.EventListeners.Json.EXTRACT_DATA);
+      }
+    },
+
+    /**
+     * @api private
+     */
+    checkCrc32: function checkCrc32(resp) {
+      if (!resp.httpResponse.streaming && !resp.request.service.crc32IsValid(resp)) {
+        resp.data = null;
+        resp.error = AWS.util.error(new Error(), {
+          code: 'CRC32CheckFailed',
+          message: 'CRC32 integrity check failed',
+          retryable: true
+        });
+        resp.request.haltHandlersOnError();
+        throw (resp.error);
+      }
+    },
+
+    /**
+     * @api private
+     */
+    crc32IsValid: function crc32IsValid(resp) {
+      var crc = resp.httpResponse.headers['x-amz-crc32'];
+      if (!crc) return true; // no (valid) CRC32 header
+      return parseInt(crc, 10) === AWS.util.crypto.crc32(resp.httpResponse.body);
+    },
+
+    /**
+     * @api private
+     */
+    defaultRetryCount: 10,
+
+    /**
+     * @api private
+     */
+    retryDelays: function retryDelays(retryCount) {
+      var delay = retryCount > 0 ? (50 * Math.pow(2, retryCount - 1)) : 0;
+      return delay;
     }
-  },
-
-  /**
-   * @api private
-   */
-  checkCrc32: function checkCrc32(resp) {
-    if (!resp.httpResponse.streaming && !resp.request.service.crc32IsValid(resp)) {
-      resp.data = null;
-      resp.error = AWS.util.error(new Error(), {
-        code: 'CRC32CheckFailed',
-        message: 'CRC32 integrity check failed',
-        retryable: true
-      });
-      resp.request.haltHandlersOnError();
-      throw (resp.error);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  crc32IsValid: function crc32IsValid(resp) {
-    var crc = resp.httpResponse.headers['x-amz-crc32'];
-    if (!crc) return true; // no (valid) CRC32 header
-    return parseInt(crc, 10) === AWS.util.crypto.crc32(resp.httpResponse.body);
-  },
-
-  /**
-   * @api private
-   */
-  defaultRetryCount: 10,
-
-  /**
-   * @api private
-   */
-  retryDelays: function retryDelays(retryCount) {
-    var delay = retryCount > 0 ? (50 * Math.pow(2, retryCount - 1)) : 0;
-    return delay;
-  }
-});
+  });
+};

--- a/lib/services/ec2.js
+++ b/lib/services/ec2.js
@@ -1,62 +1,64 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.EC2.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.removeListener('extractError', AWS.EventListeners.Query.EXTRACT_ERROR);
-    request.addListener('extractError', this.extractError);
+module.exports = function decorateService(EC2) {
+  AWS.util.update(EC2.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.removeListener('extractError', AWS.EventListeners.Query.EXTRACT_ERROR);
+      request.addListener('extractError', this.extractError);
 
-    if (request.operation === 'copySnapshot') {
-      request.onAsync('validate', this.buildCopySnapshotPresignedUrl);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  buildCopySnapshotPresignedUrl: function buildCopySnapshotPresignedUrl(req, done) {
-    if (req.params.PresignedUrl || req._subRequest) {
-      return done();
-    }
-
-    req.params = AWS.util.copy(req.params);
-    req.params.DestinationRegion = req.service.config.region;
-
-    var config = AWS.util.copy(req.service.config);
-    delete config.endpoint;
-    config.region = req.params.SourceRegion;
-    var svc = new req.service.constructor(config);
-    var newReq = svc[req.operation](req.params);
-    newReq._subRequest = true;
-    newReq.presign(function(err, url) {
-      if (err) done(err);
-      else {
-        req.params.PresignedUrl = url;
-        done();
+      if (request.operation === 'copySnapshot') {
+        request.onAsync('validate', this.buildCopySnapshotPresignedUrl);
       }
-    });
-  },
+    },
 
-  /**
-   * @api private
-   */
-  extractError: function extractError(resp) {
-    // EC2 nests the error code and message deeper than other AWS Query services.
-    var httpResponse = resp.httpResponse;
-    var data = new AWS.XML.Parser().parse(httpResponse.body.toString() || '');
-    if (data.Errors) {
-      resp.error = AWS.util.error(new Error(), {
-        code: data.Errors.Error.Code,
-        message: data.Errors.Error.Message
+    /**
+     * @api private
+     */
+    buildCopySnapshotPresignedUrl: function buildCopySnapshotPresignedUrl(req, done) {
+      if (req.params.PresignedUrl || req._subRequest) {
+        return done();
+      }
+
+      req.params = AWS.util.copy(req.params);
+      req.params.DestinationRegion = req.service.config.region;
+
+      var config = AWS.util.copy(req.service.config);
+      delete config.endpoint;
+      config.region = req.params.SourceRegion;
+      var svc = new req.service.constructor(config);
+      var newReq = svc[req.operation](req.params);
+      newReq._subRequest = true;
+      newReq.presign(function(err, url) {
+        if (err) done(err);
+        else {
+          req.params.PresignedUrl = url;
+          done();
+        }
       });
-    } else {
-      resp.error = AWS.util.error(new Error(), {
-        code: httpResponse.statusCode,
-        message: null
-      });
+    },
+
+    /**
+     * @api private
+     */
+    extractError: function extractError(resp) {
+      // EC2 nests the error code and message deeper than other AWS Query services.
+      var httpResponse = resp.httpResponse;
+      var data = new AWS.XML.Parser().parse(httpResponse.body.toString() || '');
+      if (data.Errors) {
+        resp.error = AWS.util.error(new Error(), {
+          code: data.Errors.Error.Code,
+          message: data.Errors.Error.Message
+        });
+      } else {
+        resp.error = AWS.util.error(new Error(), {
+          code: httpResponse.statusCode,
+          message: null
+        });
+      }
+      resp.error.requestId = data.RequestID || null;
     }
-    resp.error.requestId = data.RequestID || null;
-  }
-});
+  });
+};

--- a/lib/services/glacier.js
+++ b/lib/services/glacier.js
@@ -1,114 +1,116 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.Glacier.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    if (Array.isArray(request._events.validate)) {
-      request._events.validate.unshift(this.validateAccountId);
-    } else {
-      request.on('validate', this.validateAccountId);
-    }
-    request.removeListener('afterBuild',
-      AWS.EventListeners.Core.COMPUTE_SHA256);
-    request.on('build', this.addGlacierApiVersion);
-    request.on('build', this.addTreeHashHeaders);
-  },
-
-  /**
-   * @api private
-   */
-  validateAccountId: function validateAccountId(request) {
-    if (request.params.accountId !== undefined) return;
-    request.params = AWS.util.copy(request.params);
-    request.params.accountId = '-';
-  },
-
-  /**
-   * @api private
-   */
-  addGlacierApiVersion: function addGlacierApiVersion(request) {
-    var version = request.service.api.apiVersion;
-    request.httpRequest.headers['x-amz-glacier-version'] = version;
-  },
-
-  /**
-   * @api private
-   */
-  addTreeHashHeaders: function addTreeHashHeaders(request) {
-    if (request.params.body === undefined) return;
-
-    var hashes = request.service.computeChecksums(request.params.body);
-    request.httpRequest.headers['X-Amz-Content-Sha256'] = hashes.linearHash;
-
-    if (!request.httpRequest.headers['x-amz-sha256-tree-hash']) {
-      request.httpRequest.headers['x-amz-sha256-tree-hash'] = hashes.treeHash;
-    }
-  },
-
-  /**
-   * @!group Computing Checksums
-   */
-
-  /**
-   * Computes the SHA-256 linear and tree hash checksums for a given
-   * block of Buffer data. Pass the tree hash of the computed checksums
-   * as the checksum input to the {completeMultipartUpload} when performing
-   * a multi-part upload.
-   *
-   * @example Calculate checksum of 5.5MB data chunk
-   *   var glacier = new AWS.Glacier();
-   *   var data = new Buffer(5.5 * 1024 * 1024);
-   *   data.fill('0'); // fill with zeros
-   *   var results = glacier.computeChecksums(data);
-   *   // Result: { linearHash: '68aff0c5a9...', treeHash: '154e26c78f...' }
-   * @param data [Buffer, String] data to calculate the checksum for
-   * @return [map<linearHash:String,treeHash:String>] a map containing
-   *   the linearHash and treeHash properties representing hex based digests
-   *   of the respective checksums.
-   * @see completeMultipartUpload
-   */
-  computeChecksums: function computeChecksums(data) {
-    if (!AWS.util.Buffer.isBuffer(data)) data = new AWS.util.Buffer(data);
-
-    var mb = 1024 * 1024;
-    var hashes = [];
-    var hash = AWS.util.crypto.createHash('sha256');
-
-    // build leaf nodes in 1mb chunks
-    for (var i = 0; i < data.length; i += mb) {
-      var chunk = data.slice(i, Math.min(i + mb, data.length));
-      hash.update(chunk);
-      hashes.push(AWS.util.crypto.sha256(chunk));
-    }
-
-    return {
-      linearHash: hash.digest('hex'),
-      treeHash: this.buildHashTree(hashes)
-    };
-  },
-
-  /**
-   * @api private
-   */
-  buildHashTree: function buildHashTree(hashes) {
-    // merge leaf nodes
-    while (hashes.length > 1) {
-      var tmpHashes = [];
-      for (var i = 0; i < hashes.length; i += 2) {
-        if (hashes[i + 1]) {
-          var tmpHash = new AWS.util.Buffer(64);
-          tmpHash.write(hashes[i], 0, 32, 'binary');
-          tmpHash.write(hashes[i + 1], 32, 32, 'binary');
-          tmpHashes.push(AWS.util.crypto.sha256(tmpHash));
-        } else {
-          tmpHashes.push(hashes[i]);
-        }
+module.exports = function decorateService(Glacier) {
+  AWS.util.update(Glacier.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      if (Array.isArray(request._events.validate)) {
+        request._events.validate.unshift(this.validateAccountId);
+      } else {
+        request.on('validate', this.validateAccountId);
       }
-      hashes = tmpHashes;
-    }
+      request.removeListener('afterBuild',
+        AWS.EventListeners.Core.COMPUTE_SHA256);
+      request.on('build', this.addGlacierApiVersion);
+      request.on('build', this.addTreeHashHeaders);
+    },
 
-    return AWS.util.crypto.toHex(hashes[0]);
-  }
-});
+    /**
+     * @api private
+     */
+    validateAccountId: function validateAccountId(request) {
+      if (request.params.accountId !== undefined) return;
+      request.params = AWS.util.copy(request.params);
+      request.params.accountId = '-';
+    },
+
+    /**
+     * @api private
+     */
+    addGlacierApiVersion: function addGlacierApiVersion(request) {
+      var version = request.service.api.apiVersion;
+      request.httpRequest.headers['x-amz-glacier-version'] = version;
+    },
+
+    /**
+     * @api private
+     */
+    addTreeHashHeaders: function addTreeHashHeaders(request) {
+      if (request.params.body === undefined) return;
+
+      var hashes = request.service.computeChecksums(request.params.body);
+      request.httpRequest.headers['X-Amz-Content-Sha256'] = hashes.linearHash;
+
+      if (!request.httpRequest.headers['x-amz-sha256-tree-hash']) {
+        request.httpRequest.headers['x-amz-sha256-tree-hash'] = hashes.treeHash;
+      }
+    },
+
+    /**
+     * @!group Computing Checksums
+     */
+
+    /**
+     * Computes the SHA-256 linear and tree hash checksums for a given
+     * block of Buffer data. Pass the tree hash of the computed checksums
+     * as the checksum input to the {completeMultipartUpload} when performing
+     * a multi-part upload.
+     *
+     * @example Calculate checksum of 5.5MB data chunk
+     *   var glacier = new AWS.Glacier();
+     *   var data = new Buffer(5.5 * 1024 * 1024);
+     *   data.fill('0'); // fill with zeros
+     *   var results = glacier.computeChecksums(data);
+     *   // Result: { linearHash: '68aff0c5a9...', treeHash: '154e26c78f...' }
+     * @param data [Buffer, String] data to calculate the checksum for
+     * @return [map<linearHash:String,treeHash:String>] a map containing
+     *   the linearHash and treeHash properties representing hex based digests
+     *   of the respective checksums.
+     * @see completeMultipartUpload
+     */
+    computeChecksums: function computeChecksums(data) {
+      if (!AWS.util.Buffer.isBuffer(data)) data = new AWS.util.Buffer(data);
+
+      var mb = 1024 * 1024;
+      var hashes = [];
+      var hash = AWS.util.crypto.createHash('sha256');
+
+      // build leaf nodes in 1mb chunks
+      for (var i = 0; i < data.length; i += mb) {
+        var chunk = data.slice(i, Math.min(i + mb, data.length));
+        hash.update(chunk);
+        hashes.push(AWS.util.crypto.sha256(chunk));
+      }
+
+      return {
+        linearHash: hash.digest('hex'),
+        treeHash: this.buildHashTree(hashes)
+      };
+    },
+
+    /**
+     * @api private
+     */
+    buildHashTree: function buildHashTree(hashes) {
+      // merge leaf nodes
+      while (hashes.length > 1) {
+        var tmpHashes = [];
+        for (var i = 0; i < hashes.length; i += 2) {
+          if (hashes[i + 1]) {
+            var tmpHash = new AWS.util.Buffer(64);
+            tmpHash.write(hashes[i], 0, 32, 'binary');
+            tmpHash.write(hashes[i + 1], 32, 32, 'binary');
+            tmpHashes.push(AWS.util.crypto.sha256(tmpHash));
+          } else {
+            tmpHashes.push(hashes[i]);
+          }
+        }
+        hashes = tmpHashes;
+      }
+
+      return AWS.util.crypto.toHex(hashes[0]);
+    }
+  });
+};

--- a/lib/services/iotdata.js
+++ b/lib/services/iotdata.js
@@ -54,35 +54,37 @@ var AWS = require('../core');
  * @service iotdata
  * @version 2015-05-28
  */
-AWS.util.update(AWS.IotData.prototype, {
-    /**
-     * @api private
-     */
-    validateService: function validateService() {
-        if (!this.config.endpoint || this.config.endpoint.indexOf('{') >= 0) {
-            var msg = 'AWS.IotData requires an explicit ' +
-                '`endpoint\' configuration option.';
-            throw AWS.util.error(new Error(),
-                {name: 'InvalidEndpoint', message: msg});
+module.exports = function decorateService(IotData) {
+    AWS.util.update(IotData.prototype, {
+        /**
+         * @api private
+         */
+        validateService: function validateService() {
+            if (!this.config.endpoint || this.config.endpoint.indexOf('{') >= 0) {
+                var msg = 'AWS.IotData requires an explicit ' +
+                    '`endpoint\' configuration option.';
+                throw AWS.util.error(new Error(),
+                    {name: 'InvalidEndpoint', message: msg});
+            }
+        },
+
+        /**
+         * @api private
+         */
+        setupRequestListeners: function setupRequestListeners(request) {
+            request.addListener('validateResponse', this.validateResponseBody)
+        },
+
+        /**
+         * @api private
+         */
+        validateResponseBody: function validateResponseBody(resp) {
+            var body = resp.httpResponse.body.toString() || '{}';
+            var bodyCheck = body.trim();
+            if (!bodyCheck || bodyCheck.charAt(0) !== '{') {
+                resp.httpResponse.body = '';
+            }
         }
-    },
 
-    /**
-     * @api private
-     */
-    setupRequestListeners: function setupRequestListeners(request) {
-        request.addListener('validateResponse', this.validateResponseBody)
-    },
-
-    /**
-     * @api private
-     */
-    validateResponseBody: function validateResponseBody(resp) {
-        var body = resp.httpResponse.body.toString() || '{}';
-        var bodyCheck = body.trim();
-        if (!bodyCheck || bodyCheck.charAt(0) !== '{') {
-            resp.httpResponse.body = '';
-        }
-    }
-
-});
+    });
+};

--- a/lib/services/machinelearning.js
+++ b/lib/services/machinelearning.js
@@ -1,24 +1,27 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.MachineLearning.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    if (request.operation === 'predict') {
-      request.addListener('build', this.buildEndpoint);
-    }
-  },
+module.exports = function decorateService(MachineLearning) {
+  AWS.util.update(MachineLearning.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      if (request.operation === 'predict') {
+        request.addListener('build', this.buildEndpoint);
+      }
+    },
 
-  /**
-   * Updates request endpoint from PredictEndpoint
-   * @api private
-   */
-  buildEndpoint: function buildEndpoint(request) {
-    var url = request.params.PredictEndpoint;
-    if (url) {
-      request.httpRequest.endpoint = new AWS.Endpoint(url);
+    /**
+     * Updates request endpoint from PredictEndpoint
+     * @api private
+     */
+    buildEndpoint: function buildEndpoint(request) {
+      var url = request.params.PredictEndpoint;
+      if (url) {
+        request.httpRequest.endpoint = new AWS.Endpoint(url);
+      }
     }
-  }
 
-});
+  });
+};
+

--- a/lib/services/route53.js
+++ b/lib/services/route53.js
@@ -1,18 +1,20 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.Route53.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.on('build', this.sanitizeUrl);
-  },
+module.exports = function decorateService(Route53) {
+  AWS.util.update(Route53.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.on('build', this.sanitizeUrl);
+    },
 
-  /**
-   * @api private
-   */
-  sanitizeUrl: function sanitizeUrl(request) {
-    var path = request.httpRequest.path;
-    request.httpRequest.path = path.replace(/\/%2F\w+%2F/, '/');
-  }
-});
+    /**
+     * @api private
+     */
+    sanitizeUrl: function sanitizeUrl(request) {
+      var path = request.httpRequest.path;
+      request.httpRequest.path = path.replace(/\/%2F\w+%2F/, '/');
+    }
+  });
+};

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -1,8 +1,5 @@
 var AWS = require('../core');
 
-// Pull in managed upload extension
-require('../s3/managed_upload');
-
 /**
  * @api private
  */
@@ -22,811 +19,815 @@ var operationsWith200StatusCodeError = {
   301 // head operations on path-style or regional endpoints
  ];
 
-AWS.util.update(AWS.S3.prototype, {
-  /**
-   * @api private
-   */
-  getSignerClass: function getSignerClass(request) {
-    var defaultApiVersion = this.api.signatureVersion;
-    var userDefinedVersion = this._originalConfig ? this._originalConfig.signatureVersion : null;
-    var regionDefinedVersion = this.config.signatureVersion;
-    var isPresigned = request ? request.isPresigned() : false;
-    /*
-      1) User defined version specified:
-        a) always return user defined version
-      2) No user defined version specified:
-        a) default to lowest version the region supports
-    */
-    if (userDefinedVersion) {
-      userDefinedVersion = userDefinedVersion === 'v2' ? 's3' : userDefinedVersion;
-      return AWS.Signers.RequestSigner.getVersion(userDefinedVersion);
-    }
-    if (regionDefinedVersion) {
-      defaultApiVersion = regionDefinedVersion;
-    }
-
-    return AWS.Signers.RequestSigner.getVersion(defaultApiVersion);
-  },
-
-  /**
-   * @api private
-   */
-  validateService: function validateService() {
-    var msg;
-    var messages = [];
-
-    // default to us-east-1 when no region is provided
-    if (!this.config.region) this.config.region = 'us-east-1';
-
-    if (!this.config.endpoint && this.config.s3BucketEndpoint) {
-      messages.push('An endpoint must be provided when configuring ' +
-                    '`s3BucketEndpoint` to true.');
-    }
-    if (this.config.useAccelerateEndpoint && this.config.useDualstack) {
-      messages.push('`useAccelerateEndpoint` and `useDualstack` ' +
-                    'cannot both be configured to true.');
-    }
-    if (messages.length === 1) {
-      msg = messages[0];
-    } else if (messages.length > 1) {
-      msg = 'Multiple configuration errors:\n' + messages.join('\n');
-    }
-    if (msg) {
-      throw AWS.util.error(new Error(),
-        {name: 'InvalidEndpoint', message: msg});
-    }
-  },
-
-  /**
-   * @api private
-   */
-  shouldDisableBodySigning: function shouldDisableBodySigning(request) {
-    var signerClass = this.getSignerClass();
-    if (this.config.s3DisableBodySigning === true && signerClass === AWS.Signers.V4
-        && request.httpRequest.endpoint.protocol === 'https:') {
-      return true;
-    }
-    return false;
-  },
-
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.addListener('validate', this.validateScheme);
-    request.addListener('validate', this.validateBucketEndpoint);
-    request.addListener('validate', this.correctBucketRegionFromCache);
-    request.addListener('build', this.addContentType);
-    request.addListener('build', this.populateURI);
-    request.addListener('build', this.computeContentMd5);
-    request.addListener('build', this.computeSseCustomerKeyMd5);
-    request.addListener('afterBuild', this.addExpect100Continue);
-    request.removeListener('validate',
-      AWS.EventListeners.Core.VALIDATE_REGION);
-    request.addListener('extractError', this.extractError);
-    request.onAsync('extractError', this.requestBucketRegion);
-    request.addListener('extractData', this.extractData);
-    request.addListener('extractData', AWS.util.hoistPayloadMember);
-    request.addListener('beforePresign', this.prepareSignedUrl);
-    if (AWS.util.isBrowser()) {
-      request.onAsync('retry', this.reqRegionForNetworkingError);
-    }
-    if (this.shouldDisableBodySigning(request))  {
-      request.removeListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
-      request.addListener('afterBuild', this.disableBodySigning);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  validateScheme: function(req) {
-    var params = req.params,
-        scheme = req.httpRequest.endpoint.protocol,
-        sensitive = params.SSECustomerKey || params.CopySourceSSECustomerKey;
-    if (sensitive && scheme !== 'https:') {
-      var msg = 'Cannot send SSE keys over HTTP. Set \'sslEnabled\'' +
-        'to \'true\' in your configuration';
-      throw AWS.util.error(new Error(),
-        { code: 'ConfigError', message: msg });
-    }
-  },
-
-  /**
-   * @api private
-   */
-  validateBucketEndpoint: function(req) {
-    if (!req.params.Bucket && req.service.config.s3BucketEndpoint) {
-      var msg = 'Cannot send requests to root API with `s3BucketEndpoint` set.';
-      throw AWS.util.error(new Error(),
-        { code: 'ConfigError', message: msg });
-    }
-  },
-
-  /**
-   * @api private
-   */
-  isValidAccelerateOperation: function isValidAccelerateOperation(operation) {
-    var invalidOperations = [
-      'createBucket',
-      'deleteBucket',
-      'listBuckets'
-    ];
-    return invalidOperations.indexOf(operation) === -1;
-  },
-
-
-  /**
-   * S3 prefers dns-compatible bucket names to be moved from the uri path
-   * to the hostname as a sub-domain.  This is not possible, even for dns-compat
-   * buckets when using SSL and the bucket name contains a dot ('.').  The
-   * ssl wildcard certificate is only 1-level deep.
-   *
-   * @api private
-   */
-  populateURI: function populateURI(req) {
-    var httpRequest = req.httpRequest;
-    var b = req.params.Bucket;
-    var service = req.service;
-    var endpoint = httpRequest.endpoint;
-
-    if (b) {
-      if (!service.pathStyleBucketName(b)) {
-        if (service.config.useAccelerateEndpoint && service.isValidAccelerateOperation(req.operation)) {
-          endpoint.hostname = b + '.s3-accelerate.amazonaws.com';
-        } else if (!service.config.s3BucketEndpoint) {
-          endpoint.hostname =
-            b + '.' + endpoint.hostname;
-        }
-
-        var port = endpoint.port;
-        if (port !== 80 && port !== 443) {
-          endpoint.host = endpoint.hostname + ':' +
-            endpoint.port;
-        } else {
-          endpoint.host = endpoint.hostname;
-        }
-
-        httpRequest.virtualHostedBucket = b; // needed for signing the request
-        service.removeVirtualHostedBucketFromPath(req);
+module.exports = function decorateService(S3) {
+  // Pull in managed upload extension
+  require('../s3/managed_upload')(S3);
+  AWS.util.update(S3.prototype, {
+    /**
+     * @api private
+     */
+    getSignerClass: function getSignerClass(request) {
+      var defaultApiVersion = this.api.signatureVersion;
+      var userDefinedVersion = this._originalConfig ? this._originalConfig.signatureVersion : null;
+      var regionDefinedVersion = this.config.signatureVersion;
+      var isPresigned = request ? request.isPresigned() : false;
+      /*
+        1) User defined version specified:
+          a) always return user defined version
+        2) No user defined version specified:
+          a) default to lowest version the region supports
+      */
+      if (userDefinedVersion) {
+        userDefinedVersion = userDefinedVersion === 'v2' ? 's3' : userDefinedVersion;
+        return AWS.Signers.RequestSigner.getVersion(userDefinedVersion);
       }
-    }
-  },
-
-  /**
-   * Takes the bucket name out of the path if bucket is virtual-hosted
-   *
-   * @api private
-   */
-  removeVirtualHostedBucketFromPath: function removeVirtualHostedBucketFromPath(req) {
-    var httpRequest = req.httpRequest;
-    var bucket = httpRequest.virtualHostedBucket;
-    if (bucket && httpRequest.path) {
-      httpRequest.path = httpRequest.path.replace(new RegExp('/' + bucket), '');
-      if (httpRequest.path[0] !== '/') {
-        httpRequest.path = '/' + httpRequest.path;
+      if (regionDefinedVersion) {
+        defaultApiVersion = regionDefinedVersion;
       }
-    }
-  },
 
-  /**
-   * Adds Expect: 100-continue header if payload is greater-or-equal 1MB
-   * @api private
-   */
-  addExpect100Continue: function addExpect100Continue(req) {
-    var len = req.httpRequest.headers['Content-Length'];
-    if (AWS.util.isNode() && len >= 1024 * 1024) {
-      req.httpRequest.headers['Expect'] = '100-continue';
-    }
-  },
+      return AWS.Signers.RequestSigner.getVersion(defaultApiVersion);
+    },
 
-  /**
-   * Adds a default content type if none is supplied.
-   *
-   * @api private
-   */
-  addContentType: function addContentType(req) {
-    var httpRequest = req.httpRequest;
-    if (httpRequest.method === 'GET' || httpRequest.method === 'HEAD') {
-      // Content-Type is not set in GET/HEAD requests
-      delete httpRequest.headers['Content-Type'];
-      return;
-    }
+    /**
+     * @api private
+     */
+    validateService: function validateService() {
+      var msg;
+      var messages = [];
 
-    if (!httpRequest.headers['Content-Type']) { // always have a Content-Type
-      httpRequest.headers['Content-Type'] = 'application/octet-stream';
-    }
+      // default to us-east-1 when no region is provided
+      if (!this.config.region) this.config.region = 'us-east-1';
 
-    var contentType = httpRequest.headers['Content-Type'];
-    if (AWS.util.isBrowser()) {
-      if (typeof httpRequest.body === 'string' && !contentType.match(/;\s*charset=/)) {
-        var charset = '; charset=UTF-8';
-        httpRequest.headers['Content-Type'] += charset;
-      } else {
-        var replaceFn = function(_, prefix, charsetName) {
-          return prefix + charsetName.toUpperCase();
-        };
-
-        httpRequest.headers['Content-Type'] =
-          contentType.replace(/(;\s*charset=)(.+)$/, replaceFn);
+      if (!this.config.endpoint && this.config.s3BucketEndpoint) {
+        messages.push('An endpoint must be provided when configuring ' +
+                      '`s3BucketEndpoint` to true.');
       }
-    }
-  },
+      if (this.config.useAccelerateEndpoint && this.config.useDualstack) {
+        messages.push('`useAccelerateEndpoint` and `useDualstack` ' +
+                      'cannot both be configured to true.');
+      }
+      if (messages.length === 1) {
+        msg = messages[0];
+      } else if (messages.length > 1) {
+        msg = 'Multiple configuration errors:\n' + messages.join('\n');
+      }
+      if (msg) {
+        throw AWS.util.error(new Error(),
+          {name: 'InvalidEndpoint', message: msg});
+      }
+    },
 
-  /**
-   * @api private
-   */
-  computableChecksumOperations: {
-    putBucketCors: true,
-    putBucketLifecycle: true,
-    putBucketLifecycleConfiguration: true,
-    putBucketTagging: true,
-    deleteObjects: true,
-    putBucketReplication: true
-  },
-
-  /**
-   * Checks whether checksums should be computed for the request.
-   * If the request requires checksums to be computed, this will always
-   * return true, otherwise it depends on whether {AWS.Config.computeChecksums}
-   * is set.
-   *
-   * @param req [AWS.Request] the request to check against
-   * @return [Boolean] whether to compute checksums for a request.
-   * @api private
-   */
-  willComputeChecksums: function willComputeChecksums(req) {
-    if (this.computableChecksumOperations[req.operation]) return true;
-    if (!this.config.computeChecksums) return false;
-
-    // TODO: compute checksums for Stream objects
-    if (!AWS.util.Buffer.isBuffer(req.httpRequest.body) &&
-        typeof req.httpRequest.body !== 'string') {
-      return false;
-    }
-
-    var rules = req.service.api.operations[req.operation].input.members;
-
-    // Sha256 signing disabled, and not a presigned url
-    if (req.service.shouldDisableBodySigning(req) && !Object.prototype.hasOwnProperty.call(req.httpRequest.headers, 'presigned-expires')) {
-      if (rules.ContentMD5 && !req.params.ContentMD5) {
+    /**
+     * @api private
+     */
+    shouldDisableBodySigning: function shouldDisableBodySigning(request) {
+      var signerClass = this.getSignerClass();
+      if (this.config.s3DisableBodySigning === true && signerClass === AWS.Signers.V4
+          && request.httpRequest.endpoint.protocol === 'https:') {
         return true;
       }
-    }
-
-    // V4 signer uses SHA256 signatures so only compute MD5 if it is required
-    if (req.service.getSignerClass(req) === AWS.Signers.V4) {
-      if (rules.ContentMD5 && !rules.ContentMD5.required) return false;
-    }
-
-    if (rules.ContentMD5 && !req.params.ContentMD5) return true;
-  },
-
-  /**
-   * A listener that computes the Content-MD5 and sets it in the header.
-   * @see AWS.S3.willComputeChecksums
-   * @api private
-   */
-  computeContentMd5: function computeContentMd5(req) {
-    if (req.service.willComputeChecksums(req)) {
-      var md5 = AWS.util.crypto.md5(req.httpRequest.body, 'base64');
-      req.httpRequest.headers['Content-MD5'] = md5;
-    }
-  },
-
-  /**
-   * @api private
-   */
-  computeSseCustomerKeyMd5: function computeSseCustomerKeyMd5(req) {
-    var keys = {
-      SSECustomerKey: 'x-amz-server-side-encryption-customer-key-MD5',
-      CopySourceSSECustomerKey: 'x-amz-copy-source-server-side-encryption-customer-key-MD5'
-    };
-    AWS.util.each(keys, function(key, header) {
-      if (req.params[key]) {
-        var value = AWS.util.crypto.md5(req.params[key], 'base64');
-        req.httpRequest.headers[header] = value;
-      }
-    });
-  },
-
-  /**
-   * Returns true if the bucket name should be left in the URI path for
-   * a request to S3.  This function takes into account the current
-   * endpoint protocol (e.g. http or https).
-   *
-   * @api private
-   */
-  pathStyleBucketName: function pathStyleBucketName(bucketName) {
-    // user can force path style requests via the configuration
-    if (this.config.s3ForcePathStyle) return true;
-    if (this.config.s3BucketEndpoint) return false;
-
-    if (this.dnsCompatibleBucketName(bucketName)) {
-      return (this.config.sslEnabled && bucketName.match(/\./)) ? true : false;
-    } else {
-      return true; // not dns compatible names must always use path style
-    }
-  },
-
-  /**
-   * Returns true if the bucket name is DNS compatible.  Buckets created
-   * outside of the classic region MUST be DNS compatible.
-   *
-   * @api private
-   */
-  dnsCompatibleBucketName: function dnsCompatibleBucketName(bucketName) {
-    var b = bucketName;
-    var domain = new RegExp(/^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/);
-    var ipAddress = new RegExp(/(\d+\.){3}\d+/);
-    var dots = new RegExp(/\.\./);
-    return (b.match(domain) && !b.match(ipAddress) && !b.match(dots)) ? true : false;
-  },
-
-  /**
-   * @return [Boolean] whether response contains an error
-   * @api private
-   */
-  successfulResponse: function successfulResponse(resp) {
-    var req = resp.request;
-    var httpResponse = resp.httpResponse;
-    if (operationsWith200StatusCodeError[req.operation] &&
-        httpResponse.body.toString().match('<Error>')) {
       return false;
-    } else {
-      return httpResponse.statusCode < 300;
-    }
-  },
+    },
 
-  /**
-   * @return [Boolean] whether the error can be retried
-   * @api private
-   */
-  retryableError: function retryableError(error, request) {
-    if (operationsWith200StatusCodeError[request.operation] &&
-        error.statusCode === 200) {
-      return true;
-    } else if (request._requestRegionForBucket &&
-        request.service.bucketRegionCache[request._requestRegionForBucket]) {
-      return false;
-    } else if (error && error.code === 'RequestTimeout') {
-      return true;
-    } else if (error &&
-        regionRedirectErrorCodes.indexOf(error.code) != -1 &&
-        error.region && error.region != request.httpRequest.region) {
-      request.httpRequest.region = error.region;
-      if (error.statusCode === 301) {
-        request.service.updateReqBucketRegion(request);
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.addListener('validate', this.validateScheme);
+      request.addListener('validate', this.validateBucketEndpoint);
+      request.addListener('validate', this.correctBucketRegionFromCache);
+      request.addListener('build', this.addContentType);
+      request.addListener('build', this.populateURI);
+      request.addListener('build', this.computeContentMd5);
+      request.addListener('build', this.computeSseCustomerKeyMd5);
+      request.addListener('afterBuild', this.addExpect100Continue);
+      request.removeListener('validate',
+        AWS.EventListeners.Core.VALIDATE_REGION);
+      request.addListener('extractError', this.extractError);
+      request.onAsync('extractError', this.requestBucketRegion);
+      request.addListener('extractData', this.extractData);
+      request.addListener('extractData', AWS.util.hoistPayloadMember);
+      request.addListener('beforePresign', this.prepareSignedUrl);
+      if (AWS.util.isBrowser()) {
+        request.onAsync('retry', this.reqRegionForNetworkingError);
       }
-      return true;
-    } else {
-      var _super = AWS.Service.prototype.retryableError;
-      return _super.call(this, error, request);
-    }
-  },
+      if (this.shouldDisableBodySigning(request))  {
+        request.removeListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
+        request.addListener('afterBuild', this.disableBodySigning);
+      }
+    },
 
-  /**
-   * Updates httpRequest with region. If region is not provided, then
-   * the httpRequest will be updated based on httpRequest.region
-   *
-   * @api private
-   */
-  updateReqBucketRegion: function updateReqBucketRegion(request, region) {
-    var httpRequest = request.httpRequest;
-    if (typeof region === 'string' && region.length) {
-      httpRequest.region = region;
-    }
-    if (!httpRequest.endpoint.host.match(/s3(?!-accelerate).*\.amazonaws\.com$/)) {
-      return;
-    }
-    var service = request.service;
-    var s3Config = service.config;
-    var s3BucketEndpoint = s3Config.s3BucketEndpoint;
-    if (s3BucketEndpoint) {
-      delete s3Config.s3BucketEndpoint;
-    }
-    var newConfig = AWS.util.copy(s3Config);
-    delete newConfig.endpoint;
-    newConfig.region = httpRequest.region;
+    /**
+     * @api private
+     */
+    validateScheme: function(req) {
+      var params = req.params,
+          scheme = req.httpRequest.endpoint.protocol,
+          sensitive = params.SSECustomerKey || params.CopySourceSSECustomerKey;
+      if (sensitive && scheme !== 'https:') {
+        var msg = 'Cannot send SSE keys over HTTP. Set \'sslEnabled\'' +
+          'to \'true\' in your configuration';
+        throw AWS.util.error(new Error(),
+          { code: 'ConfigError', message: msg });
+      }
+    },
 
-    httpRequest.endpoint = (new AWS.S3(newConfig)).endpoint;
-    service.populateURI(request);
-    s3Config.s3BucketEndpoint = s3BucketEndpoint;
-    httpRequest.headers.Host = httpRequest.endpoint.host;
+    /**
+     * @api private
+     */
+    validateBucketEndpoint: function(req) {
+      if (!req.params.Bucket && req.service.config.s3BucketEndpoint) {
+        var msg = 'Cannot send requests to root API with `s3BucketEndpoint` set.';
+        throw AWS.util.error(new Error(),
+          { code: 'ConfigError', message: msg });
+      }
+    },
 
-    if (request._asm.currentState === 'validate') {
-      request.removeListener('build', service.populateURI);
-      request.addListener('build', service.removeVirtualHostedBucketFromPath);
-    }
-  },
+    /**
+     * @api private
+     */
+    isValidAccelerateOperation: function isValidAccelerateOperation(operation) {
+      var invalidOperations = [
+        'createBucket',
+        'deleteBucket',
+        'listBuckets'
+      ];
+      return invalidOperations.indexOf(operation) === -1;
+    },
 
-  /**
-   * Provides a specialized parser for getBucketLocation -- all other
-   * operations are parsed by the super class.
-   *
-   * @api private
-   */
-  extractData: function extractData(resp) {
-    var req = resp.request;
-    if (req.operation === 'getBucketLocation') {
-      var match = resp.httpResponse.body.toString().match(/>(.+)<\/Location/);
-      delete resp.data['_'];
-      if (match) {
-        resp.data.LocationConstraint = match[1];
+
+    /**
+     * S3 prefers dns-compatible bucket names to be moved from the uri path
+     * to the hostname as a sub-domain.  This is not possible, even for dns-compat
+     * buckets when using SSL and the bucket name contains a dot ('.').  The
+     * ssl wildcard certificate is only 1-level deep.
+     *
+     * @api private
+     */
+    populateURI: function populateURI(req) {
+      var httpRequest = req.httpRequest;
+      var b = req.params.Bucket;
+      var service = req.service;
+      var endpoint = httpRequest.endpoint;
+
+      if (b) {
+        if (!service.pathStyleBucketName(b)) {
+          if (service.config.useAccelerateEndpoint && service.isValidAccelerateOperation(req.operation)) {
+            endpoint.hostname = b + '.s3-accelerate.amazonaws.com';
+          } else if (!service.config.s3BucketEndpoint) {
+            endpoint.hostname =
+              b + '.' + endpoint.hostname;
+          }
+
+          var port = endpoint.port;
+          if (port !== 80 && port !== 443) {
+            endpoint.host = endpoint.hostname + ':' +
+              endpoint.port;
+          } else {
+            endpoint.host = endpoint.hostname;
+          }
+
+          httpRequest.virtualHostedBucket = b; // needed for signing the request
+          service.removeVirtualHostedBucketFromPath(req);
+        }
+      }
+    },
+
+    /**
+     * Takes the bucket name out of the path if bucket is virtual-hosted
+     *
+     * @api private
+     */
+    removeVirtualHostedBucketFromPath: function removeVirtualHostedBucketFromPath(req) {
+      var httpRequest = req.httpRequest;
+      var bucket = httpRequest.virtualHostedBucket;
+      if (bucket && httpRequest.path) {
+        httpRequest.path = httpRequest.path.replace(new RegExp('/' + bucket), '');
+        if (httpRequest.path[0] !== '/') {
+          httpRequest.path = '/' + httpRequest.path;
+        }
+      }
+    },
+
+    /**
+     * Adds Expect: 100-continue header if payload is greater-or-equal 1MB
+     * @api private
+     */
+    addExpect100Continue: function addExpect100Continue(req) {
+      var len = req.httpRequest.headers['Content-Length'];
+      if (AWS.util.isNode() && len >= 1024 * 1024) {
+        req.httpRequest.headers['Expect'] = '100-continue';
+      }
+    },
+
+    /**
+     * Adds a default content type if none is supplied.
+     *
+     * @api private
+     */
+    addContentType: function addContentType(req) {
+      var httpRequest = req.httpRequest;
+      if (httpRequest.method === 'GET' || httpRequest.method === 'HEAD') {
+        // Content-Type is not set in GET/HEAD requests
+        delete httpRequest.headers['Content-Type'];
+        return;
+      }
+
+      if (!httpRequest.headers['Content-Type']) { // always have a Content-Type
+        httpRequest.headers['Content-Type'] = 'application/octet-stream';
+      }
+
+      var contentType = httpRequest.headers['Content-Type'];
+      if (AWS.util.isBrowser()) {
+        if (typeof httpRequest.body === 'string' && !contentType.match(/;\s*charset=/)) {
+          var charset = '; charset=UTF-8';
+          httpRequest.headers['Content-Type'] += charset;
+        } else {
+          var replaceFn = function(_, prefix, charsetName) {
+            return prefix + charsetName.toUpperCase();
+          };
+
+          httpRequest.headers['Content-Type'] =
+            contentType.replace(/(;\s*charset=)(.+)$/, replaceFn);
+        }
+      }
+    },
+
+    /**
+     * @api private
+     */
+    computableChecksumOperations: {
+      putBucketCors: true,
+      putBucketLifecycle: true,
+      putBucketLifecycleConfiguration: true,
+      putBucketTagging: true,
+      deleteObjects: true,
+      putBucketReplication: true
+    },
+
+    /**
+     * Checks whether checksums should be computed for the request.
+     * If the request requires checksums to be computed, this will always
+     * return true, otherwise it depends on whether {AWS.Config.computeChecksums}
+     * is set.
+     *
+     * @param req [AWS.Request] the request to check against
+     * @return [Boolean] whether to compute checksums for a request.
+     * @api private
+     */
+    willComputeChecksums: function willComputeChecksums(req) {
+      if (this.computableChecksumOperations[req.operation]) return true;
+      if (!this.config.computeChecksums) return false;
+
+      // TODO: compute checksums for Stream objects
+      if (!AWS.util.Buffer.isBuffer(req.httpRequest.body) &&
+          typeof req.httpRequest.body !== 'string') {
+        return false;
+      }
+
+      var rules = req.service.api.operations[req.operation].input.members;
+
+      // Sha256 signing disabled, and not a presigned url
+      if (req.service.shouldDisableBodySigning(req) && !Object.prototype.hasOwnProperty.call(req.httpRequest.headers, 'presigned-expires')) {
+        if (rules.ContentMD5 && !req.params.ContentMD5) {
+          return true;
+        }
+      }
+
+      // V4 signer uses SHA256 signatures so only compute MD5 if it is required
+      if (req.service.getSignerClass(req) === AWS.Signers.V4) {
+        if (rules.ContentMD5 && !rules.ContentMD5.required) return false;
+      }
+
+      if (rules.ContentMD5 && !req.params.ContentMD5) return true;
+    },
+
+    /**
+     * A listener that computes the Content-MD5 and sets it in the header.
+     * @see AWS.S3.willComputeChecksums
+     * @api private
+     */
+    computeContentMd5: function computeContentMd5(req) {
+      if (req.service.willComputeChecksums(req)) {
+        var md5 = AWS.util.crypto.md5(req.httpRequest.body, 'base64');
+        req.httpRequest.headers['Content-MD5'] = md5;
+      }
+    },
+
+    /**
+     * @api private
+     */
+    computeSseCustomerKeyMd5: function computeSseCustomerKeyMd5(req) {
+      var keys = {
+        SSECustomerKey: 'x-amz-server-side-encryption-customer-key-MD5',
+        CopySourceSSECustomerKey: 'x-amz-copy-source-server-side-encryption-customer-key-MD5'
+      };
+      AWS.util.each(keys, function(key, header) {
+        if (req.params[key]) {
+          var value = AWS.util.crypto.md5(req.params[key], 'base64');
+          req.httpRequest.headers[header] = value;
+        }
+      });
+    },
+
+    /**
+     * Returns true if the bucket name should be left in the URI path for
+     * a request to S3.  This function takes into account the current
+     * endpoint protocol (e.g. http or https).
+     *
+     * @api private
+     */
+    pathStyleBucketName: function pathStyleBucketName(bucketName) {
+      // user can force path style requests via the configuration
+      if (this.config.s3ForcePathStyle) return true;
+      if (this.config.s3BucketEndpoint) return false;
+
+      if (this.dnsCompatibleBucketName(bucketName)) {
+        return (this.config.sslEnabled && bucketName.match(/\./)) ? true : false;
       } else {
-        resp.data.LocationConstraint = '';
+        return true; // not dns compatible names must always use path style
       }
-    }
-    var bucket = req.params.Bucket || null;
-    if (req.operation === 'deleteBucket' && typeof bucket === 'string' && !resp.error) {
-      req.service.clearBucketRegionCache(bucket);
-    } else {
+    },
+
+    /**
+     * Returns true if the bucket name is DNS compatible.  Buckets created
+     * outside of the classic region MUST be DNS compatible.
+     *
+     * @api private
+     */
+    dnsCompatibleBucketName: function dnsCompatibleBucketName(bucketName) {
+      var b = bucketName;
+      var domain = new RegExp(/^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/);
+      var ipAddress = new RegExp(/(\d+\.){3}\d+/);
+      var dots = new RegExp(/\.\./);
+      return (b.match(domain) && !b.match(ipAddress) && !b.match(dots)) ? true : false;
+    },
+
+    /**
+     * @return [Boolean] whether response contains an error
+     * @api private
+     */
+    successfulResponse: function successfulResponse(resp) {
+      var req = resp.request;
+      var httpResponse = resp.httpResponse;
+      if (operationsWith200StatusCodeError[req.operation] &&
+          httpResponse.body.toString().match('<Error>')) {
+        return false;
+      } else {
+        return httpResponse.statusCode < 300;
+      }
+    },
+
+    /**
+     * @return [Boolean] whether the error can be retried
+     * @api private
+     */
+    retryableError: function retryableError(error, request) {
+      if (operationsWith200StatusCodeError[request.operation] &&
+          error.statusCode === 200) {
+        return true;
+      } else if (request._requestRegionForBucket &&
+          request.service.bucketRegionCache[request._requestRegionForBucket]) {
+        return false;
+      } else if (error && error.code === 'RequestTimeout') {
+        return true;
+      } else if (error &&
+          regionRedirectErrorCodes.indexOf(error.code) != -1 &&
+          error.region && error.region != request.httpRequest.region) {
+        request.httpRequest.region = error.region;
+        if (error.statusCode === 301) {
+          request.service.updateReqBucketRegion(request);
+        }
+        return true;
+      } else {
+        var _super = AWS.Service.prototype.retryableError;
+        return _super.call(this, error, request);
+      }
+    },
+
+    /**
+     * Updates httpRequest with region. If region is not provided, then
+     * the httpRequest will be updated based on httpRequest.region
+     *
+     * @api private
+     */
+    updateReqBucketRegion: function updateReqBucketRegion(request, region) {
+      var httpRequest = request.httpRequest;
+      if (typeof region === 'string' && region.length) {
+        httpRequest.region = region;
+      }
+      if (!httpRequest.endpoint.host.match(/s3(?!-accelerate).*\.amazonaws\.com$/)) {
+        return;
+      }
+      var service = request.service;
+      var s3Config = service.config;
+      var s3BucketEndpoint = s3Config.s3BucketEndpoint;
+      if (s3BucketEndpoint) {
+        delete s3Config.s3BucketEndpoint;
+      }
+      var newConfig = AWS.util.copy(s3Config);
+      delete newConfig.endpoint;
+      newConfig.region = httpRequest.region;
+
+      httpRequest.endpoint = (new S3(newConfig)).endpoint;
+      service.populateURI(request);
+      s3Config.s3BucketEndpoint = s3BucketEndpoint;
+      httpRequest.headers.Host = httpRequest.endpoint.host;
+
+      if (request._asm.currentState === 'validate') {
+        request.removeListener('build', service.populateURI);
+        request.addListener('build', service.removeVirtualHostedBucketFromPath);
+      }
+    },
+
+    /**
+     * Provides a specialized parser for getBucketLocation -- all other
+     * operations are parsed by the super class.
+     *
+     * @api private
+     */
+    extractData: function extractData(resp) {
+      var req = resp.request;
+      if (req.operation === 'getBucketLocation') {
+        var match = resp.httpResponse.body.toString().match(/>(.+)<\/Location/);
+        delete resp.data['_'];
+        if (match) {
+          resp.data.LocationConstraint = match[1];
+        } else {
+          resp.data.LocationConstraint = '';
+        }
+      }
+      var bucket = req.params.Bucket || null;
+      if (req.operation === 'deleteBucket' && typeof bucket === 'string' && !resp.error) {
+        req.service.clearBucketRegionCache(bucket);
+      } else {
+        var headers = resp.httpResponse.headers || {};
+        var region = headers['x-amz-bucket-region'] || null;
+        if (!region && req.operation === 'createBucket' && !resp.error) {
+          var createBucketConfiguration = req.params.CreateBucketConfiguration;
+          if (!createBucketConfiguration) {
+            region = 'us-east-1';
+          } else if (createBucketConfiguration.LocationConstraint === 'EU') {
+            region = 'eu-west-1';
+          } else {
+            region = createBucketConfiguration.LocationConstraint;
+          }
+        }
+        if (region) {
+            if (bucket && region !== req.service.bucketRegionCache[bucket]) {
+              req.service.bucketRegionCache[bucket] = region;
+            }
+        }
+      }
+      req.service.extractRequestIds(resp);
+    },
+
+    /**
+     * Extracts an error object from the http response.
+     *
+     * @api private
+     */
+    extractError: function extractError(resp) {
+      var codes = {
+        304: 'NotModified',
+        403: 'Forbidden',
+        400: 'BadRequest',
+        404: 'NotFound'
+      };
+
+      var req = resp.request;
+      var code = resp.httpResponse.statusCode;
+      var body = resp.httpResponse.body || '';
+
       var headers = resp.httpResponse.headers || {};
       var region = headers['x-amz-bucket-region'] || null;
-      if (!region && req.operation === 'createBucket' && !resp.error) {
-        var createBucketConfiguration = req.params.CreateBucketConfiguration;
-        if (!createBucketConfiguration) {
-          region = 'us-east-1';
-        } else if (createBucketConfiguration.LocationConstraint === 'EU') {
-          region = 'eu-west-1';
-        } else {
-          region = createBucketConfiguration.LocationConstraint;
-        }
+      var bucket = req.params.Bucket || null;
+      var bucketRegionCache = req.service.bucketRegionCache;
+      if (region && bucket && region !== bucketRegionCache[bucket]) {
+        bucketRegionCache[bucket] = region;
       }
-      if (region) {
-          if (bucket && region !== req.service.bucketRegionCache[bucket]) {
-            req.service.bucketRegionCache[bucket] = region;
+
+      var cachedRegion;
+      if (codes[code] && body.length === 0) {
+        if (bucket && !region) {
+          cachedRegion = bucketRegionCache[bucket] || null;
+          if (cachedRegion !== req.httpRequest.region) {
+            region = cachedRegion;
           }
-      }
-    }
-    req.service.extractRequestIds(resp);
-  },
-
-  /**
-   * Extracts an error object from the http response.
-   *
-   * @api private
-   */
-  extractError: function extractError(resp) {
-    var codes = {
-      304: 'NotModified',
-      403: 'Forbidden',
-      400: 'BadRequest',
-      404: 'NotFound'
-    };
-
-    var req = resp.request;
-    var code = resp.httpResponse.statusCode;
-    var body = resp.httpResponse.body || '';
-
-    var headers = resp.httpResponse.headers || {};
-    var region = headers['x-amz-bucket-region'] || null;
-    var bucket = req.params.Bucket || null;
-    var bucketRegionCache = req.service.bucketRegionCache;
-    if (region && bucket && region !== bucketRegionCache[bucket]) {
-      bucketRegionCache[bucket] = region;
-    }
-
-    var cachedRegion;
-    if (codes[code] && body.length === 0) {
-      if (bucket && !region) {
-        cachedRegion = bucketRegionCache[bucket] || null;
-        if (cachedRegion !== req.httpRequest.region) {
-          region = cachedRegion;
         }
-      }
-      resp.error = AWS.util.error(new Error(), {
-        code: codes[code],
-        message: null,
-        region: region
-      });
-    } else {
-      var data = new AWS.XML.Parser().parse(body.toString());
+        resp.error = AWS.util.error(new Error(), {
+          code: codes[code],
+          message: null,
+          region: region
+        });
+      } else {
+        var data = new AWS.XML.Parser().parse(body.toString());
 
-      if (data.Region && !region) {
-        region = data.Region;
-        if (bucket && region !== bucketRegionCache[bucket]) {
-          bucketRegionCache[bucket] = region;
+        if (data.Region && !region) {
+          region = data.Region;
+          if (bucket && region !== bucketRegionCache[bucket]) {
+            bucketRegionCache[bucket] = region;
+          }
+        } else if (bucket && !region && !data.Region) {
+          cachedRegion = bucketRegionCache[bucket] || null;
+          if (cachedRegion !== req.httpRequest.region) {
+            region = cachedRegion;
+          }
         }
-      } else if (bucket && !region && !data.Region) {
-        cachedRegion = bucketRegionCache[bucket] || null;
-        if (cachedRegion !== req.httpRequest.region) {
-          region = cachedRegion;
-        }
+
+        resp.error = AWS.util.error(new Error(), {
+          code: data.Code || code,
+          message: data.Message || null,
+          region: region
+        });
       }
+      req.service.extractRequestIds(resp);
+    },
 
-      resp.error = AWS.util.error(new Error(), {
-        code: data.Code || code,
-        message: data.Message || null,
-        region: region
-      });
-    }
-    req.service.extractRequestIds(resp);
-  },
+    /**
+     * If region was not obtained synchronously, then send async request
+     * to get bucket region for errors resulting from wrong region.
+     *
+     * @api private
+     */
+    requestBucketRegion: function requestBucketRegion(resp, done) {
+      var error = resp.error;
+      var req = resp.request;
+      var bucket = req.params.Bucket || null;
 
-  /**
-   * If region was not obtained synchronously, then send async request
-   * to get bucket region for errors resulting from wrong region.
-   *
-   * @api private
-   */
-  requestBucketRegion: function requestBucketRegion(resp, done) {
-    var error = resp.error;
-    var req = resp.request;
-    var bucket = req.params.Bucket || null;
-
-    if (!error || !bucket || error.region || req.operation === 'listObjects' ||
-        (AWS.util.isNode() && req.operation === 'headBucket') ||
-        (error.statusCode === 400 && req.operation !== 'headObject') ||
-        regionRedirectErrorCodes.indexOf(error.code) === -1) {
-      return done();
-    }
-    var reqOperation = AWS.util.isNode() ? 'headBucket' : 'listObjects';
-    var reqParams = {Bucket: bucket};
-    if (reqOperation === 'listObjects') reqParams.MaxKeys = 0;
-    var regionReq = req.service[reqOperation](reqParams);
-    regionReq._requestRegionForBucket = bucket;
-    regionReq.send(function() {
-      var region = req.service.bucketRegionCache[bucket] || null;
-      error.region = region;
-      done();
-    });
-  },
-
-   /**
-   * For browser only. If NetworkingError received, will attempt to obtain
-   * the bucket region.
-   *
-   * @api private
-   */
-   reqRegionForNetworkingError: function reqRegionForNetworkingError(resp, done) {
-    if (!AWS.util.isBrowser()) {
-      return done();
-    }
-    var error = resp.error;
-    var request = resp.request;
-    var bucket = request.params.Bucket;
-    if (!error || error.code !== 'NetworkingError' || !bucket ||
-        request.httpRequest.region === 'us-east-1') {
-      return done();
-    }
-    var service = request.service;
-    var bucketRegionCache = service.bucketRegionCache;
-    var cachedRegion = bucketRegionCache[bucket] || null;
-
-    if (cachedRegion && cachedRegion !== request.httpRequest.region) {
-      service.updateReqBucketRegion(request, cachedRegion);
-      done();
-    } else if (!service.dnsCompatibleBucketName(bucket)) {
-      service.updateReqBucketRegion(request, 'us-east-1');
-      if (bucketRegionCache[bucket] !== 'us-east-1') {
-        bucketRegionCache[bucket] = 'us-east-1';
+      if (!error || !bucket || error.region || req.operation === 'listObjects' ||
+          (AWS.util.isNode() && req.operation === 'headBucket') ||
+          (error.statusCode === 400 && req.operation !== 'headObject') ||
+          regionRedirectErrorCodes.indexOf(error.code) === -1) {
+        return done();
       }
-      done();
-    } else if (request.httpRequest.virtualHostedBucket) {
-      var getRegionReq = service.listObjects({Bucket: bucket, MaxKeys: 0});
-      service.updateReqBucketRegion(getRegionReq, 'us-east-1');
-      getRegionReq._requestRegionForBucket = bucket;
-
-      getRegionReq.send(function() {
-        var region = service.bucketRegionCache[bucket] || null;
-        if (region && region !== request.httpRequest.region) {
-          service.updateReqBucketRegion(request, region);
-        }
+      var reqOperation = AWS.util.isNode() ? 'headBucket' : 'listObjects';
+      var reqParams = {Bucket: bucket};
+      if (reqOperation === 'listObjects') reqParams.MaxKeys = 0;
+      var regionReq = req.service[reqOperation](reqParams);
+      regionReq._requestRegionForBucket = bucket;
+      regionReq.send(function() {
+        var region = req.service.bucketRegionCache[bucket] || null;
+        error.region = region;
         done();
       });
-    } else {
-      // DNS-compatible path-style
-      // (s3ForcePathStyle or bucket name with dot over https)
-      // Cannot obtain region information for this case
-      done();
-    }
-   },
+    },
 
-  /**
-   * Cache for bucket region.
-   *
-   * @api private
-   */
-   bucketRegionCache: {},
-
-  /**
-   * Clears bucket region cache.
-   *
-   * @api private
-   */
-   clearBucketRegionCache: function(buckets) {
-    var bucketRegionCache = this.bucketRegionCache;
-    if (!buckets) {
-      buckets = Object.keys(bucketRegionCache);
-    } else if (typeof buckets === 'string') {
-      buckets = [buckets];
-    }
-    for (var i = 0; i < buckets.length; i++) {
-      delete bucketRegionCache[buckets[i]];
-    }
-    return bucketRegionCache;
-   },
-
-   /**
-    * Corrects request region if bucket's cached region is different
-    *
-    * @api private
-    */
-  correctBucketRegionFromCache: function correctBucketRegionFromCache(req) {
-    var bucket = req.params.Bucket || null;
-    if (bucket) {
-      var service = req.service;
-      var requestRegion = req.httpRequest.region;
-      var cachedRegion = service.bucketRegionCache[bucket];
-      if (cachedRegion && cachedRegion !== requestRegion) {
-        service.updateReqBucketRegion(req, cachedRegion);
+    /**
+     * For browser only. If NetworkingError received, will attempt to obtain
+     * the bucket region.
+     *
+     * @api private
+     */
+    reqRegionForNetworkingError: function reqRegionForNetworkingError(resp, done) {
+      if (!AWS.util.isBrowser()) {
+        return done();
       }
+      var error = resp.error;
+      var request = resp.request;
+      var bucket = request.params.Bucket;
+      if (!error || error.code !== 'NetworkingError' || !bucket ||
+          request.httpRequest.region === 'us-east-1') {
+        return done();
+      }
+      var service = request.service;
+      var bucketRegionCache = service.bucketRegionCache;
+      var cachedRegion = bucketRegionCache[bucket] || null;
+
+      if (cachedRegion && cachedRegion !== request.httpRequest.region) {
+        service.updateReqBucketRegion(request, cachedRegion);
+        done();
+      } else if (!service.dnsCompatibleBucketName(bucket)) {
+        service.updateReqBucketRegion(request, 'us-east-1');
+        if (bucketRegionCache[bucket] !== 'us-east-1') {
+          bucketRegionCache[bucket] = 'us-east-1';
+        }
+        done();
+      } else if (request.httpRequest.virtualHostedBucket) {
+        var getRegionReq = service.listObjects({Bucket: bucket, MaxKeys: 0});
+        service.updateReqBucketRegion(getRegionReq, 'us-east-1');
+        getRegionReq._requestRegionForBucket = bucket;
+
+        getRegionReq.send(function() {
+          var region = service.bucketRegionCache[bucket] || null;
+          if (region && region !== request.httpRequest.region) {
+            service.updateReqBucketRegion(request, region);
+          }
+          done();
+        });
+      } else {
+        // DNS-compatible path-style
+        // (s3ForcePathStyle or bucket name with dot over https)
+        // Cannot obtain region information for this case
+        done();
+      }
+    },
+
+    /**
+     * Cache for bucket region.
+     *
+     * @api private
+     */
+    bucketRegionCache: {},
+
+    /**
+     * Clears bucket region cache.
+     *
+     * @api private
+     */
+    clearBucketRegionCache: function(buckets) {
+      var bucketRegionCache = this.bucketRegionCache;
+      if (!buckets) {
+        buckets = Object.keys(bucketRegionCache);
+      } else if (typeof buckets === 'string') {
+        buckets = [buckets];
+      }
+      for (var i = 0; i < buckets.length; i++) {
+        delete bucketRegionCache[buckets[i]];
+      }
+      return bucketRegionCache;
+    },
+
+    /**
+      * Corrects request region if bucket's cached region is different
+      *
+      * @api private
+      */
+    correctBucketRegionFromCache: function correctBucketRegionFromCache(req) {
+      var bucket = req.params.Bucket || null;
+      if (bucket) {
+        var service = req.service;
+        var requestRegion = req.httpRequest.region;
+        var cachedRegion = service.bucketRegionCache[bucket];
+        if (cachedRegion && cachedRegion !== requestRegion) {
+          service.updateReqBucketRegion(req, cachedRegion);
+        }
+      }
+    },
+
+    /**
+     * Extracts S3 specific request ids from the http response.
+     *
+     * @api private
+     */
+    extractRequestIds: function extractRequestIds(resp) {
+      var extendedRequestId = resp.httpResponse.headers ? resp.httpResponse.headers['x-amz-id-2'] : null;
+      var cfId = resp.httpResponse.headers ? resp.httpResponse.headers['x-amz-cf-id'] : null;
+      resp.extendedRequestId = extendedRequestId;
+      resp.cfId = cfId;
+
+      if (resp.error) {
+        resp.error.requestId = resp.requestId || null;
+        resp.error.extendedRequestId = extendedRequestId;
+        resp.error.cfId = cfId;
+      }
+    },
+
+    /**
+     * Get a pre-signed URL for a given operation name.
+     *
+     * @note You must ensure that you have static or previously resolved
+     *   credentials if you call this method synchronously (with no callback),
+     *   otherwise it may not properly sign the request. If you cannot guarantee
+     *   this (you are using an asynchronous credential provider, i.e., EC2
+     *   IAM roles), you should always call this method with an asynchronous
+     *   callback.
+     * @param operation [String] the name of the operation to call
+     * @param params [map] parameters to pass to the operation. See the given
+     *   operation for the expected operation parameters. In addition, you can
+     *   also pass the "Expires" parameter to inform S3 how long the URL should
+     *   work for.
+     * @option params Expires [Integer] (900) the number of seconds to expire
+     *   the pre-signed URL operation in. Defaults to 15 minutes.
+     * @param callback [Function] if a callback is provided, this function will
+     *   pass the URL as the second parameter (after the error parameter) to
+     *   the callback function.
+     * @return [String] if called synchronously (with no callback), returns the
+     *   signed URL.
+     * @return [null] nothing is returned if a callback is provided.
+     * @example Pre-signing a getObject operation (synchronously)
+     *   var params = {Bucket: 'bucket', Key: 'key'};
+     *   var url = s3.getSignedUrl('getObject', params);
+     *   console.log('The URL is', url);
+     * @example Pre-signing a putObject (asynchronously)
+     *   var params = {Bucket: 'bucket', Key: 'key'};
+     *   s3.getSignedUrl('putObject', params, function (err, url) {
+     *     console.log('The URL is', url);
+     *   });
+     * @example Pre-signing a putObject operation with a specific payload
+     *   var params = {Bucket: 'bucket', Key: 'key', Body: 'body'};
+     *   var url = s3.getSignedUrl('putObject', params);
+     *   console.log('The URL is', url);
+     * @example Passing in a 1-minute expiry time for a pre-signed URL
+     *   var params = {Bucket: 'bucket', Key: 'key', Expires: 60};
+     *   var url = s3.getSignedUrl('getObject', params);
+     *   console.log('The URL is', url); // expires in 60 seconds
+     */
+    getSignedUrl: function getSignedUrl(operation, params, callback) {
+      params = AWS.util.copy(params || {});
+      var expires = params.Expires || 900;
+      delete params.Expires; // we can't validate this
+      var request = this.makeRequest(operation, params);
+      return request.presign(expires, callback);
+    },
+
+    /**
+     * @api private
+     */
+    prepareSignedUrl: function prepareSignedUrl(request) {
+      request.addListener('validate', request.service.noPresignedContentLength);
+      request.removeListener('build', request.service.addContentType);
+      if (!request.params.Body) {
+        // no Content-MD5/SHA-256 if body is not provided
+        request.removeListener('build', request.service.computeContentMd5);
+      } else {
+        request.addListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
+      }
+    },
+
+    /**
+     * @api private
+     * @param request
+     */
+    disableBodySigning: function disableBodySigning(request) {
+      var headers = request.httpRequest.headers;
+      // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
+      if (!Object.prototype.hasOwnProperty.call(headers, 'presigned-expires')) {
+        headers['X-Amz-Content-Sha256'] = 'UNSIGNED-PAYLOAD';
+      }
+    },
+
+    /**
+     * @api private
+     */
+    noPresignedContentLength: function noPresignedContentLength(request) {
+      if (request.params.ContentLength !== undefined) {
+        throw AWS.util.error(new Error(), {code: 'UnexpectedParameter',
+          message: 'ContentLength is not supported in pre-signed URLs.'});
+      }
+    },
+
+    createBucket: function createBucket(params, callback) {
+      // When creating a bucket *outside* the classic region, the location
+      // constraint must be set for the bucket and it must match the endpoint.
+      // This chunk of code will set the location constraint param based
+      // on the region (when possible), but it will not override a passed-in
+      // location constraint.
+      if (typeof params === 'function' || !params) {
+        callback = callback || params;
+        params = {};
+      }
+      var hostname = this.endpoint.hostname;
+      if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
+        params.CreateBucketConfiguration = { LocationConstraint: this.config.region };
+      }
+      return this.makeRequest('createBucket', params, callback);
+    },
+
+    /**
+     * @overload upload(params = {}, [options], [callback])
+     *   Uploads an arbitrarily sized buffer, blob, or stream, using intelligent
+     *   concurrent handling of parts if the payload is large enough. You can
+     *   configure the concurrent queue size by setting `options`. Note that this
+     *   is the only operation for which the SDK can retry requests with stream
+     *   bodies.
+     *
+     *   @param (see AWS.S3.putObject)
+     *   @option (see AWS.S3.ManagedUpload.constructor)
+     *   @return [AWS.S3.ManagedUpload] the managed upload object that can call
+     *     `send()` or track progress.
+     *   @example Uploading a stream object
+     *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *     s3.upload(params, function(err, data) {
+     *       console.log(err, data);
+     *     });
+     *   @example Uploading a stream with concurrency of 1 and partSize of 10mb
+     *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
+     *     var options = {partSize: 10 * 1024 * 1024, queueSize: 1};
+     *     s3.upload(params, options, function(err, data) {
+     *       console.log(err, data);
+     *     });
+     * @callback callback function(err, data)
+     *   @param err [Error] an error or null if no error occurred.
+     *   @param data [map] The response data from the successful upload:
+     *     * `Location` (String) the URL of the uploaded object
+     *     * `ETag` (String) the ETag of the uploaded object
+     *     * `Bucket` (String) the bucket to which the object was uploaded
+     *     * `Key` (String) the key to which the object was uploaded
+     *   @see AWS.S3.ManagedUpload
+     */
+    upload: function upload(params, options, callback) {
+      if (typeof options === 'function' && callback === undefined) {
+        callback = options;
+        options = null;
+      }
+
+      options = options || {};
+      options = AWS.util.merge(options || {}, {service: this, params: params});
+
+      var uploader = new S3.ManagedUpload(options);
+      if (typeof callback === 'function') uploader.send(callback);
+      return uploader;
     }
-  },
-
-  /**
-   * Extracts S3 specific request ids from the http response.
-   *
-   * @api private
-   */
-  extractRequestIds: function extractRequestIds(resp) {
-    var extendedRequestId = resp.httpResponse.headers ? resp.httpResponse.headers['x-amz-id-2'] : null;
-    var cfId = resp.httpResponse.headers ? resp.httpResponse.headers['x-amz-cf-id'] : null;
-    resp.extendedRequestId = extendedRequestId;
-    resp.cfId = cfId;
-
-    if (resp.error) {
-      resp.error.requestId = resp.requestId || null;
-      resp.error.extendedRequestId = extendedRequestId;
-      resp.error.cfId = cfId;
-    }
-  },
-
-  /**
-   * Get a pre-signed URL for a given operation name.
-   *
-   * @note You must ensure that you have static or previously resolved
-   *   credentials if you call this method synchronously (with no callback),
-   *   otherwise it may not properly sign the request. If you cannot guarantee
-   *   this (you are using an asynchronous credential provider, i.e., EC2
-   *   IAM roles), you should always call this method with an asynchronous
-   *   callback.
-   * @param operation [String] the name of the operation to call
-   * @param params [map] parameters to pass to the operation. See the given
-   *   operation for the expected operation parameters. In addition, you can
-   *   also pass the "Expires" parameter to inform S3 how long the URL should
-   *   work for.
-   * @option params Expires [Integer] (900) the number of seconds to expire
-   *   the pre-signed URL operation in. Defaults to 15 minutes.
-   * @param callback [Function] if a callback is provided, this function will
-   *   pass the URL as the second parameter (after the error parameter) to
-   *   the callback function.
-   * @return [String] if called synchronously (with no callback), returns the
-   *   signed URL.
-   * @return [null] nothing is returned if a callback is provided.
-   * @example Pre-signing a getObject operation (synchronously)
-   *   var params = {Bucket: 'bucket', Key: 'key'};
-   *   var url = s3.getSignedUrl('getObject', params);
-   *   console.log('The URL is', url);
-   * @example Pre-signing a putObject (asynchronously)
-   *   var params = {Bucket: 'bucket', Key: 'key'};
-   *   s3.getSignedUrl('putObject', params, function (err, url) {
-   *     console.log('The URL is', url);
-   *   });
-   * @example Pre-signing a putObject operation with a specific payload
-   *   var params = {Bucket: 'bucket', Key: 'key', Body: 'body'};
-   *   var url = s3.getSignedUrl('putObject', params);
-   *   console.log('The URL is', url);
-   * @example Passing in a 1-minute expiry time for a pre-signed URL
-   *   var params = {Bucket: 'bucket', Key: 'key', Expires: 60};
-   *   var url = s3.getSignedUrl('getObject', params);
-   *   console.log('The URL is', url); // expires in 60 seconds
-   */
-  getSignedUrl: function getSignedUrl(operation, params, callback) {
-    params = AWS.util.copy(params || {});
-    var expires = params.Expires || 900;
-    delete params.Expires; // we can't validate this
-    var request = this.makeRequest(operation, params);
-    return request.presign(expires, callback);
-  },
-
-  /**
-   * @api private
-   */
-  prepareSignedUrl: function prepareSignedUrl(request) {
-    request.addListener('validate', request.service.noPresignedContentLength);
-    request.removeListener('build', request.service.addContentType);
-    if (!request.params.Body) {
-      // no Content-MD5/SHA-256 if body is not provided
-      request.removeListener('build', request.service.computeContentMd5);
-    } else {
-      request.addListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
-    }
-  },
-
-  /**
-   * @api private
-   * @param request
-   */
-  disableBodySigning: function disableBodySigning(request) {
-    var headers = request.httpRequest.headers;
-    // Add the header to anything that isn't a presigned url, unless that presigned url had a body defined
-    if (!Object.prototype.hasOwnProperty.call(headers, 'presigned-expires')) {
-      headers['X-Amz-Content-Sha256'] = 'UNSIGNED-PAYLOAD';
-    }
-  },
-
-  /**
-   * @api private
-   */
-  noPresignedContentLength: function noPresignedContentLength(request) {
-    if (request.params.ContentLength !== undefined) {
-      throw AWS.util.error(new Error(), {code: 'UnexpectedParameter',
-        message: 'ContentLength is not supported in pre-signed URLs.'});
-    }
-  },
-
-  createBucket: function createBucket(params, callback) {
-    // When creating a bucket *outside* the classic region, the location
-    // constraint must be set for the bucket and it must match the endpoint.
-    // This chunk of code will set the location constraint param based
-    // on the region (when possible), but it will not override a passed-in
-    // location constraint.
-    if (typeof params === 'function' || !params) {
-      callback = callback || params;
-      params = {};
-    }
-    var hostname = this.endpoint.hostname;
-    if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
-      params.CreateBucketConfiguration = { LocationConstraint: this.config.region };
-    }
-    return this.makeRequest('createBucket', params, callback);
-  },
-
-  /**
-   * @overload upload(params = {}, [options], [callback])
-   *   Uploads an arbitrarily sized buffer, blob, or stream, using intelligent
-   *   concurrent handling of parts if the payload is large enough. You can
-   *   configure the concurrent queue size by setting `options`. Note that this
-   *   is the only operation for which the SDK can retry requests with stream
-   *   bodies.
-   *
-   *   @param (see AWS.S3.putObject)
-   *   @option (see AWS.S3.ManagedUpload.constructor)
-   *   @return [AWS.S3.ManagedUpload] the managed upload object that can call
-   *     `send()` or track progress.
-   *   @example Uploading a stream object
-   *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
-   *     s3.upload(params, function(err, data) {
-   *       console.log(err, data);
-   *     });
-   *   @example Uploading a stream with concurrency of 1 and partSize of 10mb
-   *     var params = {Bucket: 'bucket', Key: 'key', Body: stream};
-   *     var options = {partSize: 10 * 1024 * 1024, queueSize: 1};
-   *     s3.upload(params, options, function(err, data) {
-   *       console.log(err, data);
-   *     });
-   * @callback callback function(err, data)
-   *   @param err [Error] an error or null if no error occurred.
-   *   @param data [map] The response data from the successful upload:
-   *     * `Location` (String) the URL of the uploaded object
-   *     * `ETag` (String) the ETag of the uploaded object
-   *     * `Bucket` (String) the bucket to which the object was uploaded
-   *     * `Key` (String) the key to which the object was uploaded
-   *   @see AWS.S3.ManagedUpload
-   */
-  upload: function upload(params, options, callback) {
-    if (typeof options === 'function' && callback === undefined) {
-      callback = options;
-      options = null;
-    }
-
-    options = options || {};
-    options = AWS.util.merge(options || {}, {service: this, params: params});
-
-    var uploader = new AWS.S3.ManagedUpload(options);
-    if (typeof callback === 'function') uploader.send(callback);
-    return uploader;
-  }
-});
+  });
+};

--- a/lib/services/sqs.js
+++ b/lib/services/sqs.js
@@ -1,131 +1,133 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.SQS.prototype, {
-  /**
-   * @api private
-   */
-  setupRequestListeners: function setupRequestListeners(request) {
-    request.addListener('build', this.buildEndpoint);
+module.exports = function decorateService(SQS) {
+  AWS.util.update(SQS.prototype, {
+    /**
+     * @api private
+     */
+    setupRequestListeners: function setupRequestListeners(request) {
+      request.addListener('build', this.buildEndpoint);
 
-    if (request.service.config.computeChecksums) {
-      if (request.operation === 'sendMessage') {
-        request.addListener('extractData', this.verifySendMessageChecksum);
-      } else if (request.operation === 'sendMessageBatch') {
-        request.addListener('extractData', this.verifySendMessageBatchChecksum);
-      } else if (request.operation === 'receiveMessage') {
-        request.addListener('extractData', this.verifyReceiveMessageChecksum);
-      }
-    }
-  },
-
-  /**
-   * @api private
-   */
-  verifySendMessageChecksum: function verifySendMessageChecksum(response) {
-    if (!response.data) return;
-
-    var md5 = response.data.MD5OfMessageBody;
-    var body = this.params.MessageBody;
-    var calculatedMd5 = this.service.calculateChecksum(body);
-    if (calculatedMd5 !== md5) {
-      var msg = 'Got "' + response.data.MD5OfMessageBody +
-        '", expecting "' + calculatedMd5 + '".';
-      this.service.throwInvalidChecksumError(response,
-        [response.data.MessageId], msg);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  verifySendMessageBatchChecksum: function verifySendMessageBatchChecksum(response) {
-    if (!response.data) return;
-
-    var service = this.service;
-    var entries = {};
-    var errors = [];
-    var messageIds = [];
-    AWS.util.arrayEach(response.data.Successful, function (entry) {
-      entries[entry.Id] = entry;
-    });
-    AWS.util.arrayEach(this.params.Entries, function (entry) {
-      if (entries[entry.Id]) {
-        var md5 = entries[entry.Id].MD5OfMessageBody;
-        var body = entry.MessageBody;
-        if (!service.isChecksumValid(md5, body)) {
-          errors.push(entry.Id);
-          messageIds.push(entries[entry.Id].MessageId);
+      if (request.service.config.computeChecksums) {
+        if (request.operation === 'sendMessage') {
+          request.addListener('extractData', this.verifySendMessageChecksum);
+        } else if (request.operation === 'sendMessageBatch') {
+          request.addListener('extractData', this.verifySendMessageBatchChecksum);
+        } else if (request.operation === 'receiveMessage') {
+          request.addListener('extractData', this.verifyReceiveMessageChecksum);
         }
       }
-    });
+    },
 
-    if (errors.length > 0) {
-      service.throwInvalidChecksumError(response, messageIds,
-        'Invalid messages: ' + errors.join(', '));
-    }
-  },
+    /**
+     * @api private
+     */
+    verifySendMessageChecksum: function verifySendMessageChecksum(response) {
+      if (!response.data) return;
 
-  /**
-   * @api private
-   */
-  verifyReceiveMessageChecksum: function verifyReceiveMessageChecksum(response) {
-    if (!response.data) return;
-
-    var service = this.service;
-    var messageIds = [];
-    AWS.util.arrayEach(response.data.Messages, function(message) {
-      var md5 = message.MD5OfBody;
-      var body = message.Body;
-      if (!service.isChecksumValid(md5, body)) {
-        messageIds.push(message.MessageId);
+      var md5 = response.data.MD5OfMessageBody;
+      var body = this.params.MessageBody;
+      var calculatedMd5 = this.service.calculateChecksum(body);
+      if (calculatedMd5 !== md5) {
+        var msg = 'Got "' + response.data.MD5OfMessageBody +
+          '", expecting "' + calculatedMd5 + '".';
+        this.service.throwInvalidChecksumError(response,
+          [response.data.MessageId], msg);
       }
-    });
+    },
 
-    if (messageIds.length > 0) {
-      service.throwInvalidChecksumError(response, messageIds,
-        'Invalid messages: ' + messageIds.join(', '));
+    /**
+     * @api private
+     */
+    verifySendMessageBatchChecksum: function verifySendMessageBatchChecksum(response) {
+      if (!response.data) return;
+
+      var service = this.service;
+      var entries = {};
+      var errors = [];
+      var messageIds = [];
+      AWS.util.arrayEach(response.data.Successful, function (entry) {
+        entries[entry.Id] = entry;
+      });
+      AWS.util.arrayEach(this.params.Entries, function (entry) {
+        if (entries[entry.Id]) {
+          var md5 = entries[entry.Id].MD5OfMessageBody;
+          var body = entry.MessageBody;
+          if (!service.isChecksumValid(md5, body)) {
+            errors.push(entry.Id);
+            messageIds.push(entries[entry.Id].MessageId);
+          }
+        }
+      });
+
+      if (errors.length > 0) {
+        service.throwInvalidChecksumError(response, messageIds,
+          'Invalid messages: ' + errors.join(', '));
+      }
+    },
+
+    /**
+     * @api private
+     */
+    verifyReceiveMessageChecksum: function verifyReceiveMessageChecksum(response) {
+      if (!response.data) return;
+
+      var service = this.service;
+      var messageIds = [];
+      AWS.util.arrayEach(response.data.Messages, function(message) {
+        var md5 = message.MD5OfBody;
+        var body = message.Body;
+        if (!service.isChecksumValid(md5, body)) {
+          messageIds.push(message.MessageId);
+        }
+      });
+
+      if (messageIds.length > 0) {
+        service.throwInvalidChecksumError(response, messageIds,
+          'Invalid messages: ' + messageIds.join(', '));
+      }
+    },
+
+    /**
+     * @api private
+     */
+    throwInvalidChecksumError: function throwInvalidChecksumError(response, ids, message) {
+      response.error = AWS.util.error(new Error(), {
+        retryable: true,
+        code: 'InvalidChecksum',
+        messageIds: ids,
+        message: response.request.operation +
+                ' returned an invalid MD5 response. ' + message
+      });
+    },
+
+    /**
+     * @api private
+     */
+    isChecksumValid: function isChecksumValid(checksum, data) {
+      return this.calculateChecksum(data) === checksum;
+    },
+
+    /**
+     * @api private
+     */
+    calculateChecksum: function calculateChecksum(data) {
+      return AWS.util.crypto.md5(data, 'hex');
+    },
+
+    /**
+     * @api private
+     */
+    buildEndpoint: function buildEndpoint(request) {
+      var url = request.httpRequest.params.QueueUrl;
+      if (url) {
+        request.httpRequest.endpoint = new AWS.Endpoint(url);
+
+        // signature version 4 requires the region name to be set,
+        // sqs queue urls contain the region name
+        var matches = request.httpRequest.endpoint.host.match(/^sqs\.(.+?)\./);
+        if (matches) request.httpRequest.region = matches[1];
+      }
     }
-  },
-
-  /**
-   * @api private
-   */
-  throwInvalidChecksumError: function throwInvalidChecksumError(response, ids, message) {
-    response.error = AWS.util.error(new Error(), {
-      retryable: true,
-      code: 'InvalidChecksum',
-      messageIds: ids,
-      message: response.request.operation +
-               ' returned an invalid MD5 response. ' + message
-    });
-  },
-
-  /**
-   * @api private
-   */
-  isChecksumValid: function isChecksumValid(checksum, data) {
-    return this.calculateChecksum(data) === checksum;
-  },
-
-  /**
-   * @api private
-   */
-  calculateChecksum: function calculateChecksum(data) {
-    return AWS.util.crypto.md5(data, 'hex');
-  },
-
-  /**
-   * @api private
-   */
-  buildEndpoint: function buildEndpoint(request) {
-    var url = request.httpRequest.params.QueueUrl;
-    if (url) {
-      request.httpRequest.endpoint = new AWS.Endpoint(url);
-
-      // signature version 4 requires the region name to be set,
-      // sqs queue urls contain the region name
-      var matches = request.httpRequest.endpoint.host.match(/^sqs\.(.+?)\./);
-      if (matches) request.httpRequest.region = matches[1];
-    }
-  }
-});
+  });
+};

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -1,47 +1,49 @@
 var AWS = require('../core');
 
-AWS.util.update(AWS.STS.prototype, {
-  /**
-   * @overload credentialsFrom(data, credentials = null)
-   *   Creates a credentials object from STS response data containing
-   *   credentials information. Useful for quickly setting AWS credentials.
-   *
-   *   @note This is a low-level utility function. If you want to load temporary
-   *     credentials into your process for subsequent requests to AWS resources,
-   *     you should use {AWS.TemporaryCredentials} instead.
-   *   @param data [map] data retrieved from a call to {getFederatedToken},
-   *     {getSessionToken}, {assumeRole}, or {assumeRoleWithWebIdentity}.
-   *   @param credentials [AWS.Credentials] an optional credentials object to
-   *     fill instead of creating a new object. Useful when modifying an
-   *     existing credentials object from a refresh call.
-   *   @return [AWS.TemporaryCredentials] the set of temporary credentials
-   *     loaded from a raw STS operation response.
-   *   @example Using credentialsFrom to load global AWS credentials
-   *     var sts = new AWS.STS();
-   *     sts.getSessionToken(function (err, data) {
-   *       if (err) console.log("Error getting credentials");
-   *       else {
-   *         AWS.config.credentials = sts.credentialsFrom(data);
-   *       }
-   *     });
-   *   @see AWS.TemporaryCredentials
-   */
-  credentialsFrom: function credentialsFrom(data, credentials) {
-    if (!data) return null;
-    if (!credentials) credentials = new AWS.TemporaryCredentials();
-    credentials.expired = false;
-    credentials.accessKeyId = data.Credentials.AccessKeyId;
-    credentials.secretAccessKey = data.Credentials.SecretAccessKey;
-    credentials.sessionToken = data.Credentials.SessionToken;
-    credentials.expireTime = data.Credentials.Expiration;
-    return credentials;
-  },
+module.exports = function decorateService(STS) {
+  AWS.util.update(STS.prototype, {
+    /**
+     * @overload credentialsFrom(data, credentials = null)
+     *   Creates a credentials object from STS response data containing
+     *   credentials information. Useful for quickly setting AWS credentials.
+     *
+     *   @note This is a low-level utility function. If you want to load temporary
+     *     credentials into your process for subsequent requests to AWS resources,
+     *     you should use {AWS.TemporaryCredentials} instead.
+     *   @param data [map] data retrieved from a call to {getFederatedToken},
+     *     {getSessionToken}, {assumeRole}, or {assumeRoleWithWebIdentity}.
+     *   @param credentials [AWS.Credentials] an optional credentials object to
+     *     fill instead of creating a new object. Useful when modifying an
+     *     existing credentials object from a refresh call.
+     *   @return [AWS.TemporaryCredentials] the set of temporary credentials
+     *     loaded from a raw STS operation response.
+     *   @example Using credentialsFrom to load global AWS credentials
+     *     var sts = new AWS.STS();
+     *     sts.getSessionToken(function (err, data) {
+     *       if (err) console.log("Error getting credentials");
+     *       else {
+     *         AWS.config.credentials = sts.credentialsFrom(data);
+     *       }
+     *     });
+     *   @see AWS.TemporaryCredentials
+     */
+    credentialsFrom: function credentialsFrom(data, credentials) {
+      if (!data) return null;
+      if (!credentials) credentials = new AWS.TemporaryCredentials();
+      credentials.expired = false;
+      credentials.accessKeyId = data.Credentials.AccessKeyId;
+      credentials.secretAccessKey = data.Credentials.SecretAccessKey;
+      credentials.sessionToken = data.Credentials.SessionToken;
+      credentials.expireTime = data.Credentials.Expiration;
+      return credentials;
+    },
 
-  assumeRoleWithWebIdentity: function assumeRoleWithWebIdentity(params, callback) {
-    return this.makeUnauthenticatedRequest('assumeRoleWithWebIdentity', params, callback);
-  },
+    assumeRoleWithWebIdentity: function assumeRoleWithWebIdentity(params, callback) {
+      return this.makeUnauthenticatedRequest('assumeRoleWithWebIdentity', params, callback);
+    },
 
-  assumeRoleWithSAML: function assumeRoleWithSAML(params, callback) {
-    return this.makeUnauthenticatedRequest('assumeRoleWithSAML', params, callback);
-  }
-});
+    assumeRoleWithSAML: function assumeRoleWithSAML(params, callback) {
+      return this.makeUnauthenticatedRequest('assumeRoleWithSAML', params, callback);
+    }
+  });
+};

--- a/lib/services/swf.js
+++ b/lib/services/swf.js
@@ -1,10 +1,18 @@
 var AWS = require('../core');
 
-AWS.util.hideProperties(AWS, ['SimpleWorkflow']);
+module.exports = function addReferenceTo(SWF) {
+  AWS.util.hideProperties(AWS, ['SimpleWorkflow']);
 
-/**
- * @constant
- * @readonly
- * Backwards compatibility for access to the {AWS.SWF} service class.
- */
-AWS.SimpleWorkflow = AWS.SWF;
+  /**
+   * @constant
+   * @readonly
+   * Backwards compatibility for access to the {AWS.SWF} service class.
+   */
+  Object.defineProperty(AWS, 'SimpleWorkflow', {
+    get: function get() {
+      return SWF;
+    },
+    enumerable: false,
+    configurable: true
+  });
+};


### PR DESCRIPTION
Service clients will now be lazy loaded when importing the SDK using: `require('aws-sdk')`
This fixes #1124 which noted that all services were loaded into memory when the SDK was imported, as a result of the changes to support webpack introduced in version `2.6.0` of the SDK.

Notes:
`doc-custom` was added to contain documentation for service customizations.
Service customizations now accept their Service constructor rather than grabbing it from the AWS namespace. Doing this allowed these customizations to be lazy-loaded as well, and doesn't require the service clients to exist on the AWS namespace anymore.

/cc @LiuJoyceC 