### PR TITLE
Fix intermittently failing unit test and allows running individual unit test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       "buildertest": "mocha --compilers coffee:coffee-script -s 1000 -t 10000 dist-tools/test",
       "integration": "cucumber.js",
       "lint" : "eslint lib dist-tools/*.js",
-      "console": "./scripts/console"
+      "console": "./scripts/console",
+      "testfiles" : "istanbul `[ $COVERAGE ] && echo 'cover _mocha' || echo 'test mocha'`"      
     }
 }

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -284,10 +284,10 @@ describe 'AWS.Request', ->
       server = require('http').createServer (req, resp) ->
         app(req, resp)
 
-      server.setTimeout(1)
-
       beforeEach (done) ->
         data = ''; error = null
+
+        server.setTimeout(1)
 
         app = (req, resp) ->
           resp.writeHead(200, {})
@@ -530,6 +530,7 @@ describe 'AWS.Request', ->
             console.log(e.stack)
 
       it 'retries temporal errors and streams resulting successful response', (done) ->
+        server.setTimeout(1000)
         errs = 0
         app = (req, resp) ->
           status = if errs < 2 then 500 else 200


### PR DESCRIPTION
Increases timeout on unit test that intermittently failed due to server timeout.Also adds an npm script to allow running only specified unit test files. To use it, simply run `npm run testfiles [names of unit tests files/directories separated by space]`. For example, running `npm run testfiles test/request.spec.coffee test/services` will run only the unit tests in the test/request.spec.coffee file and the toplevel files in the directory test/services. Works only with NPM version 2 or higher.

/cc: @chrisradek 