### PR TITLE
Updates url and querystring dependencies for the browser version of the SDK

### DIFF
--- a/.changes/next-release/bugfix-Browser-9f045858.json
+++ b/.changes/next-release/bugfix-Browser-9f045858.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Browser",
+  "description": "Updates `url` and `querystring` dependencies to be controlled by the SDK instead of tools like browserify or webpack."
+}

--- a/lib/browser_loader.js
+++ b/lib/browser_loader.js
@@ -3,6 +3,8 @@ var util = require('./util');
 // browser specific modules
 util.crypto.lib = require('crypto-browserify');
 util.Buffer = require('buffer/').Buffer;
+util.url = require('url/');
+util.querystring = require('querystring/');
 
 var AWS = require('./core');
 

--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -1,5 +1,5 @@
-var url = require('url'),
-    AWS = require('../core'),
+var AWS = require('../core'),
+    url = AWS.util.url,
     crypto = AWS.util.crypto.lib,
     base64Encode = AWS.util.base64.encode,
     inherit = AWS.util.inherit;

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -5,6 +5,8 @@ util.crypto.lib = require('crypto');
 util.Buffer = require('buffer').Buffer;
 util.domain = require('domain');
 util.stream = require('stream');
+util.url = require('url');
+util.querystring = require('querystring');
 
 var AWS = require('./core');
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,15 +54,15 @@ var util = {
   },
 
   urlParse: function urlParse(url) {
-    return require('url').parse(url);
+    return util.url.parse(url);
   },
 
   urlFormat: function urlFormat(url) {
-    return require('url').format(url);
+    return util.url.format(url);
   },
 
   queryStringParse: function queryStringParse(qs) {
-    return require('querystring').parse(qs);
+    return util.querystring.parse(qs);
   },
 
   queryParamsToString: function queryParamsToString(params) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
       "buffer": "4.9.1",
       "crypto-browserify": "1.0.9",
       "jmespath": "0.15.0",
+      "querystring": "0.2.0",
       "sax": "1.1.5",
+      "url": "0.10.3",
       "xml2js": "0.4.15",
       "xmlbuilder": "2.6.2"
     },


### PR DESCRIPTION
Previously, relied on tools like webpack/browserify to see these native node modules and supply a 3rd party library version.

This caused an issue with some versions of the url library breaking in projects that used AMD for module loading.

Fixes #1148

/cc @LiuJoyceC 