### PR TITLE
Propagate an error from a stream to s3.upload callback

### DIFF
--- a/.changes/next-release/bugfix-s3-20314e6c.json
+++ b/.changes/next-release/bugfix-s3-20314e6c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Propagate an error from a stream to s3.upload callback #1169"
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -168,6 +168,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
         self.fillQueue = self.fillStream;
         self.partBuffers = [];
         self.body.
+          on('error', function(err) { self.cleanup(err); }).
           on('readable', function() { self.fillQueue(); }).
           on('end', function() {
             self.isDoneChunking = true;

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -356,3 +356,14 @@ describe 'AWS.S3.ManagedUpload', ->
             expect(helpers.operationsForRequests(reqs)).to.eql ['s3.putObject']
             expect(err).not.to.exist
             done()
+
+        it 'propagates an error from a stream', (done) ->
+          errorStream = new require('stream').Readable()
+          errorStream._read = -> this.emit('error', new Error('message'))
+
+          upload = new AWS.S3.ManagedUpload params: { Body: errorStream }
+          upload.send (e, d) ->
+            expect(e).to.exist
+            expect(d).not.to.exist
+            expect(e.message).to.equal('message')
+            done()


### PR DESCRIPTION
When using `s3.upload` to upload a stream, the AWS SDK currently does not handle `error` events raised by the input stream. The user has two options [1]:

1. Handle the error, in which case `s3.upload` **does not call back**
2. Do not handle the error, in which case the process will crash

This PR makes it so that an error raised by an input stream will propagate to the `s3.upload` callback as an error.

`s3.putObject` also doesn't handle errors on the input stream, but it's not clear how or where to modify that behavior.

By the way, it looks like a few tests in test/s3/managed_upload.spec.coffee are using `upload.send` instead of the wrapper `send`, but then checking the global variable `err` (which is not being updated because it's managed by the `send` wrapper). Those tests may be giving false positives.

[1] Here's a sample program demonstrating the behavior I describe. Comment out the `on('error', ...` line to switch between the cases.

```js
var aws = require('aws-sdk');
var stream = require('stream');

var s3 = new aws.S3({ ... });

var errorStream = new stream.Readable(
  { read: () => { errorStream.emit('error', new Error('message')); } }
);

errorStream.on('error', (error) => { console.log('caught error:', error); });

s3.upload(
  { Bucket: '<bucket>', Key: 'abc', Body: errorStream },
  (error, result) => {
    console.log('s3.upload error:', error);
    console.log('s3.upload result:', result);
  }
);
```