### PR TITLE
Add AWS_CREDENTIAL_PROFILES_FILE Environment Variable

### DIFF
--- a/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
+++ b/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EnvironmentVariable",
+  "description": "Add AWS_CREDENTIAL_PROFILES_FILE Environment Variable as defined in the Java AWS_SDK"
+}

--- a/doc-src/guide/node-configuring.md
+++ b/doc-src/guide/node-configuring.md
@@ -79,6 +79,9 @@ You may configure credentials for multiple access keys in the same shared
 configuration file using *profiles*. This is discussed in the last part of
 this section.
 
+You can specify a different location for the shared credentials file
+by using the `AWS_CREDENTIAL_PROFILES_FILE` environment variable.
+
 ##### Creating the Shared Credentials File
 
 If you do not already have a shared credentials file, you can create one in

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -4,7 +4,8 @@ var STS = require('../../clients/sts');
 
 /**
  * Represents credentials loaded from shared credentials file
- * (defaulting to ~/.aws/credentials).
+ * (defaulting to ~/.aws/credentials or defined by the
+ * `AWS_CREDENTIAL_PROFILES_FILE` environment variable).
  *
  * ## Using the shared credentials file
  *
@@ -39,8 +40,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    * @param options [map] a set of options
    * @option options profile [String] (AWS_PROFILE env var or 'default')
    *   the name of the profile to load.
-   * @option options filename [String] ('~/.aws/credentials') the filename
-   *   to use when loading credentials.
+   * @option options filename [String] ('~/.aws/credentials' or defined by
+   *   AWS_CREDENTIAL_PROFILES_FILE process env var)
+   *   the filename to use when loading credentials.
    * @option options disableAssumeRole [Boolean] (false) True to disable
    *   support for profiles that assume an IAM role. If true, and an assume
    *   role profile is selected, an error is raised.
@@ -50,7 +52,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     options = options || {};
 
-    this.filename = options.filename;
+    this.filename = options.filename || process.env.AWS_CREDENTIAL_PROFILES_FILE;
     this.profile = options.profile || process.env.AWS_PROFILE || 'default';
     this.disableAssumeRole = !!options.disableAssumeRole;
     this.get(function() {});

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -158,6 +158,7 @@ if AWS.util.isNode()
   describe 'AWS.SharedIniFileCredentials', ->
     beforeEach ->
       delete process.env.AWS_PROFILE
+      delete process.env.AWS_CREDENTIAL_PROFILES_FILE
       delete process.env.HOME
       delete process.env.HOMEPATH
       delete process.env.HOMEDRIVE
@@ -208,6 +209,21 @@ if AWS.util.isNode()
         creds.get();
         validateCredentials(creds)
         expect(AWS.util.readFileSync.calls[0].arguments[0]).to.equal('/home/user/.aws/credentials')
+
+      it 'loads credentials from path defined in AWS_CREDENTIAL_PROFILES_FILE', ->
+        process.env.AWS_CREDENTIAL_PROFILES_FILE = '/path/to/aws/credentials'
+        mock = '''
+        [default]
+        aws_access_key_id = akid
+        aws_secret_access_key = secret
+        aws_session_token = session
+        '''
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
+
+        creds = new AWS.SharedIniFileCredentials()
+        creds.get();
+        validateCredentials(creds)
+        expect(AWS.util.readFileSync.calls[0].arguments[0]).to.equal('/path/to/aws/credentials')
 
       it 'loads the default profile if AWS_PROFILE is empty', ->
         process.env.AWS_PROFILE = ''


### PR DESCRIPTION
Adding the AWS_CREDENTIAL_PROFILES_FILE Environment Variable, that is for example used in the Java and Python AWS_SDK . Using this variable you can specify a different location of the shared credential file.
