### PR TITLE
support custom delay and maxAttempts in ResourceWaiter

### DIFF
--- a/lib/resource_waiter.js
+++ b/lib/resource_waiter.js
@@ -136,6 +136,15 @@ AWS.ResourceWaiter = inherit({
       callback = params; params = undefined;
     }
 
+    if (params && params.delay) {
+      this.config.delay = params.delay;
+      delete params.delay;
+    }
+    if (params && params.maxAttempts) {
+      this.config.maxAttempts = params.maxAttempts;
+      delete params.maxAttempts;
+    }
+
     var request = this.service.makeRequest(this.config.operation, params);
     request._waiter = this;
     request.response.maxRetries = this.config.maxAttempts;
@@ -173,6 +182,6 @@ AWS.ResourceWaiter = inherit({
       });
     }
 
-    this.config = this.service.api.waiters[state];
+    this.config = AWS.util.copy(this.service.api.waiters[state]);
   }
 });

--- a/test/resource_waiter.spec.coffee
+++ b/test/resource_waiter.spec.coffee
@@ -190,3 +190,24 @@ describe 'AWS.ResourceWaiter', ->
       expect(err).to.equal(null)
       expect(data).to.not.eql(null)
       expect(resp.retryCount).to.equal(2)
+
+    it 'supports custom delay and maxAttempts', ->
+      err = null; data = null; resp = null
+      db = new AWS.DynamoDB
+      maxAttempts = 50
+      delay = 5
+      resps = ({data: {Table: {TableStatus: 'LOADING'}}} for _ in [1..maxAttempts+1])
+      resps.push({data: {Table: {TableStatus: 'ACTIVE'}}})
+      helpers.mockResponses resps
+
+      waiter = new AWS.ResourceWaiter(db, 'tableExists')
+      waiter.wait {delay: delay, maxAttempts: maxAttempts}, (e, d) -> resp = this; err = e; data = d
+      expect(data).to.equal(null)
+      expect(err.code).to.equal('ResourceNotReady')
+      expect(resp.retryCount).to.equal(maxAttempts)
+      expect(resp.error.retryDelay).to.equal(delay * 1000)
+
+      # Ensure custom settings aren't persisted in future waiters
+      waiter = new AWS.ResourceWaiter(db, 'tableExists')
+      expect(waiter.config.maxAttempts).to.equal(25);
+      expect(waiter.config.delay).to.equal(20);


### PR DESCRIPTION
fixes #881.

This PR would allow `delay` and `maxAttempts` parameters to be passed within the `params` object of `ResourceWaiter.wait` (used by the `waitFor` service methods) to override the default settings in the waiter service API definition.

Sample syntax using the example [discussed](https://github.com/aws/aws-sdk-js/issues/1018#issuecomment-227914203) in #1018:

```
var req = route53.waitFor('resourceRecordSetsChanged', {
  Id: "ID",
  delay: 40,
  maxAttempts: 100
}, function (err, data){ /* etc.. */});
```