### PR TITLE
Removes reference to node typings and stubs dom interfaces

### DIFF
--- a/clients/acm.d.ts
+++ b/clients/acm.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ACM extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/apigateway.d.ts
+++ b/clients/apigateway.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class APIGateway extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/applicationautoscaling.d.ts
+++ b/clients/applicationautoscaling.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ApplicationAutoScaling extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/autoscaling.d.ts
+++ b/clients/autoscaling.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class AutoScaling extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/budgets.d.ts
+++ b/clients/budgets.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Budgets extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudformation.d.ts
+++ b/clients/cloudformation.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudFormation extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudfront.d.ts
+++ b/clients/cloudfront.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {CloudFrontCustomizations} from '../lib/services/cloudfront';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudFront extends CloudFrontCustomizations {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudhsm.d.ts
+++ b/clients/cloudhsm.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudHSM extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudsearch.d.ts
+++ b/clients/cloudsearch.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudSearch extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudsearchdomain.d.ts
+++ b/clients/cloudsearchdomain.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudSearchDomain extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudtrail.d.ts
+++ b/clients/cloudtrail.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudTrail extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudwatch.d.ts
+++ b/clients/cloudwatch.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudWatch extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudwatchevents.d.ts
+++ b/clients/cloudwatchevents.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudWatchEvents extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cloudwatchlogs.d.ts
+++ b/clients/cloudwatchlogs.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CloudWatchLogs extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/codecommit.d.ts
+++ b/clients/codecommit.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CodeCommit extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/codedeploy.d.ts
+++ b/clients/codedeploy.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CodeDeploy extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/codepipeline.d.ts
+++ b/clients/codepipeline.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CodePipeline extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cognitoidentity.d.ts
+++ b/clients/cognitoidentity.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CognitoIdentity extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cognitoidentityserviceprovider.d.ts
+++ b/clients/cognitoidentityserviceprovider.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CognitoIdentityServiceProvider extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/cognitosync.d.ts
+++ b/clients/cognitosync.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class CognitoSync extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/configservice.d.ts
+++ b/clients/configservice.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ConfigService extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/datapipeline.d.ts
+++ b/clients/datapipeline.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DataPipeline extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/devicefarm.d.ts
+++ b/clients/devicefarm.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DeviceFarm extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/directconnect.d.ts
+++ b/clients/directconnect.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DirectConnect extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/directoryservice.d.ts
+++ b/clients/directoryservice.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DirectoryService extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/discovery.d.ts
+++ b/clients/discovery.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Discovery extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/dms.d.ts
+++ b/clients/dms.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DMS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/dynamodb.d.ts
+++ b/clients/dynamodb.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {DynamoDBCustomizations} from '../lib/services/dynamodb';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DynamoDB extends DynamoDBCustomizations {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/dynamodbstreams.d.ts
+++ b/clients/dynamodbstreams.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class DynamoDBStreams extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/ec2.d.ts
+++ b/clients/ec2.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class EC2 extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/ecr.d.ts
+++ b/clients/ecr.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ECR extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/ecs.d.ts
+++ b/clients/ecs.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ECS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/efs.d.ts
+++ b/clients/efs.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class EFS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/elasticache.d.ts
+++ b/clients/elasticache.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ElastiCache extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/elasticbeanstalk.d.ts
+++ b/clients/elasticbeanstalk.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ElasticBeanstalk extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/elastictranscoder.d.ts
+++ b/clients/elastictranscoder.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ElasticTranscoder extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/elb.d.ts
+++ b/clients/elb.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ELB extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/elbv2.d.ts
+++ b/clients/elbv2.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ELBv2 extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/emr.d.ts
+++ b/clients/emr.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class EMR extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/es.d.ts
+++ b/clients/es.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ES extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/firehose.d.ts
+++ b/clients/firehose.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Firehose extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/gamelift.d.ts
+++ b/clients/gamelift.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class GameLift extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/glacier.d.ts
+++ b/clients/glacier.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {GlacierCustomizations} from '../lib/services/glacier';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Glacier extends GlacierCustomizations {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/iam.d.ts
+++ b/clients/iam.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class IAM extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/importexport.d.ts
+++ b/clients/importexport.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ImportExport extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/inspector.d.ts
+++ b/clients/inspector.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Inspector extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/iot.d.ts
+++ b/clients/iot.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Iot extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/iotdata.d.ts
+++ b/clients/iotdata.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class IotData extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/kinesis.d.ts
+++ b/clients/kinesis.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Kinesis extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/kinesisanalytics.d.ts
+++ b/clients/kinesisanalytics.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class KinesisAnalytics extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/kms.d.ts
+++ b/clients/kms.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class KMS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/lambda.d.ts
+++ b/clients/lambda.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Lambda extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/machinelearning.d.ts
+++ b/clients/machinelearning.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class MachineLearning extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/marketplacecommerceanalytics.d.ts
+++ b/clients/marketplacecommerceanalytics.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class MarketplaceCommerceAnalytics extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/marketplacemetering.d.ts
+++ b/clients/marketplacemetering.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class MarketplaceMetering extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/mobileanalytics.d.ts
+++ b/clients/mobileanalytics.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class MobileAnalytics extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/opsworks.d.ts
+++ b/clients/opsworks.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class OpsWorks extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/rds.d.ts
+++ b/clients/rds.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class RDS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/redshift.d.ts
+++ b/clients/redshift.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Redshift extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/route53.d.ts
+++ b/clients/route53.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Route53 extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/route53domains.d.ts
+++ b/clients/route53domains.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Route53Domains extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/s3.d.ts
+++ b/clients/s3.d.ts
@@ -1,11 +1,12 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
+import * as stream from 'stream';
 import {S3Customizations} from '../lib/services/s3';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
 import {UseDualstackConfigOptions} from '../lib/config_use_dualstack';
+interface Blob {}
 declare class S3 extends S3Customizations {
   /**
    * Constructs a service object. This object has one method for each API operation.
@@ -1284,7 +1285,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body;
+    Body?: Body|stream.Readable;
     /**
      * Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.
      */
@@ -1448,7 +1449,7 @@ declare namespace S3.Types {
     PartNumber?: PartNumber;
   }
   export interface GetObjectTorrentOutput {
-    Body?: Body;
+    Body?: Body|stream.Readable;
     RequestCharged?: RequestCharged;
   }
   export interface GetObjectTorrentRequest {
@@ -2387,7 +2388,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body;
+    Body?: Body|stream.Readable;
     /**
      * Name of the bucket to which the PUT operation was initiated.
      */
@@ -2813,7 +2814,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body;
+    Body?: Body|stream.Readable;
     /**
      * Name of the bucket to which the multipart upload was initiated.
      */

--- a/clients/s3.d.ts
+++ b/clients/s3.d.ts
@@ -1,7 +1,6 @@
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
-import * as stream from 'stream';
 import {S3Customizations} from '../lib/services/s3';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
@@ -1285,7 +1284,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body|stream.Readable;
+    Body?: Body;
     /**
      * Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If false, this response header does not appear in the response.
      */
@@ -1449,7 +1448,7 @@ declare namespace S3.Types {
     PartNumber?: PartNumber;
   }
   export interface GetObjectTorrentOutput {
-    Body?: Body|stream.Readable;
+    Body?: Body;
     RequestCharged?: RequestCharged;
   }
   export interface GetObjectTorrentRequest {
@@ -2388,7 +2387,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body|stream.Readable;
+    Body?: Body;
     /**
      * Name of the bucket to which the PUT operation was initiated.
      */
@@ -2814,7 +2813,7 @@ declare namespace S3.Types {
     /**
      * Object data.
      */
-    Body?: Body|stream.Readable;
+    Body?: Body;
     /**
      * Name of the bucket to which the multipart upload was initiated.
      */

--- a/clients/servicecatalog.d.ts
+++ b/clients/servicecatalog.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class ServiceCatalog extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/ses.d.ts
+++ b/clients/ses.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SES extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/simpledb.d.ts
+++ b/clients/simpledb.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SimpleDB extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/sms.d.ts
+++ b/clients/sms.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SMS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/snowball.d.ts
+++ b/clients/snowball.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Snowball extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/sns.d.ts
+++ b/clients/sns.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SNS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/sqs.d.ts
+++ b/clients/sqs.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SQS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/ssm.d.ts
+++ b/clients/ssm.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SSM extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/storagegateway.d.ts
+++ b/clients/storagegateway.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class StorageGateway extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/sts.d.ts
+++ b/clients/sts.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class STS extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/support.d.ts
+++ b/clients/support.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class Support extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/swf.d.ts
+++ b/clients/swf.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class SWF extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/waf.d.ts
+++ b/clients/waf.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class WAF extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/clients/workspaces.d.ts
+++ b/clients/workspaces.d.ts
@@ -1,10 +1,10 @@
-///<reference types="node" />
 import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
+interface Blob {}
 declare class WorkSpaces extends Service {
   /**
    * Constructs a service object. This object has one method for each API operation.

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import {Agent as httpAgent} from 'http';
 import {Agent as httpsAgent} from 'https';
 import {AWSError} from './error';

--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -1,9 +1,12 @@
-/// <reference types="node" />
 import DynamoDB = require('../../clients/dynamodb');
 import * as DCInterfaces from './document_client_interfaces';
 import * as stream from 'stream';
 import {Request} from '../request';
 import {AWSError} from '../error';
+
+interface File {}
+interface Blob {}
+
 /**
  * The document client simplifies working with items in Amazon DynamoDB
  * by abstracting away the notion of attribute values. This abstraction

--- a/lib/dynamodb/document_client_interfaces.d.ts
+++ b/lib/dynamodb/document_client_interfaces.d.ts
@@ -1,4 +1,4 @@
-///<reference types="node" />
+interface Blob {}
 export type AttributeAction = "ADD"|"PUT"|"DELETE"|string;
 export interface AttributeDefinition {
   /**

--- a/lib/http_response.d.ts
+++ b/lib/http_response.d.ts
@@ -1,5 +1,6 @@
-/// <reference types="node" />
 import * as stream from 'stream';
+
+interface XMLHttpRequest {}
 /**
  * The low level HTTP response object, encapsulating all HTTP header and body data returned from the request.
  */

--- a/lib/request.d.ts
+++ b/lib/request.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import * as stream from 'stream';
 import {Service} from './service';
 import {Response} from './response';

--- a/lib/services/glacier.d.ts
+++ b/lib/services/glacier.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node" />
-
 import {Service} from '../service';
 
 export class GlacierCustomizations extends Service {

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -246,9 +246,6 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
                 memberType = '_' + memberType;
             }
             code += tabs(tabCount + 1) + memberKey + required + ': ' + memberType + '';
-            if (member.streaming) {
-                code += '|stream.Readable';
-            }
             code += ';\n';
         });
         code += tabs(tabCount) + '}\n';
@@ -272,9 +269,6 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
         code += tabs(tabCount) + 'export type ' + shapeKey + ' = boolean;\n';
     } else if (type === 'blob' || type === 'binary') {
         code += tabs(tabCount) + 'export type ' + shapeKey + ' = Buffer|Uint8Array|Blob|string';
-        if (shape.streaming) {
-            code += '|stream.Readable';
-        }
         code += ';\n';
     }
     return code;
@@ -397,7 +391,6 @@ TSGenerator.prototype.processServiceModel = function processServiceModel(service
     code += 'import {Request} from \'../lib/request\';\n';
     code += 'import {Response} from \'../lib/response\';\n';
     code += 'import {AWSError} from \'../lib/error\';\n';
-    code += 'import * as stream from \'stream\';\n';
     var hasCustomizations = this.includeCustomService(serviceIdentifier);
     var parentClass = hasCustomizations ? className + 'Customizations' : 'Service';
     if (hasCustomizations) {

--- a/ts/s3.ts
+++ b/ts/s3.ts
@@ -1,4 +1,5 @@
 import S3 = require('../clients/s3');
+import fs = require('fs');
 
 // Instantiate S3 without options
 var s3 = new S3();
@@ -24,7 +25,7 @@ s3.listObjects({
 }, function(err, data) {
     if (err) {
         console.log(err.extendedRequstId);
-    } else {
+    } else if (data && data.Contents) {
         data.Contents.forEach(function(content) {
             console.log(content.Key);
         });
@@ -39,7 +40,7 @@ s3.listObjects({
 s3.listObjects(function(err, data) {
     if (err) {
         console.log(err.code);
-    } else {
+    } else if (data && data.Contents) {
         data.Contents.forEach(function(content) {
             console.log(content.Key);
         });
@@ -58,7 +59,7 @@ listObjectsReq.on('error', function(err, resp) {
     console.log(resp.error);
 });
 listObjectsReq.on('success', function(resp) {
-    if (resp.data) {
+    if (resp.data && resp.data.Contents) {
         resp.data.Contents.forEach(function(content) {
             console.log(content.Key);
         });
@@ -68,7 +69,7 @@ listObjectsReq.on('success', function(resp) {
 listObjectsReq.on('complete', function(resp) {
     if (resp.error) {
         console.log(resp.error.code);
-    } else if (resp.data) {
+    } else if (resp.data && resp.data.Contents) {
         resp.data.Contents.forEach(function(content) {
             console.log(content.Key);
         });
@@ -78,7 +79,7 @@ listObjectsReq.on('complete', function(resp) {
 listObjectsReq.send(function(err, data) {
     if (err) {
         console.log(err.code);
-    } else {
+    } else if (data && data.Contents) {
         data.Contents.forEach(function(content) {
             console.log(content.Key);
         });
@@ -86,6 +87,7 @@ listObjectsReq.send(function(err, data) {
 });
 // test promise support
 listObjectsReq.promise().then(function(data) {
+    data.Contents = data.Contents || [];
     data.Contents.forEach(function(content) {
         console.log(content.Key);
     });
@@ -97,3 +99,22 @@ var s3GetObjectStream = s3.getObject({
     Bucket: 'BUCKET',
     Key: 'KEY'
 }).createReadStream();
+
+// test putObject
+s3.putObject({
+    Bucket: 'BUCKET',
+    Key: 'Test',
+    Body: 'text'
+});
+
+s3.putObject({
+    Bucket: 'BUCKET',
+    Key: 'Test',
+    Body: new Buffer('text')
+});
+
+s3.putObject({
+    Bucket: 'BUCKET',
+    Key: 'Test',
+    Body: fs.createReadStream('/fake/path')
+});

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -7,8 +7,7 @@
         "module": "commonjs",
         "lib": [
             "es5",
-            "es2015.promise",
-            "dom"
+            "es2015.promise"
         ],
         "noEmit": true
     }


### PR DESCRIPTION
@blakeembry
I'm only posting a few of the updated service models here since they are updated so frequently.
I removed all instances of
```javascript
///<reference types="node" />
```

I tried to include a `tsconfig.json` with the SDK that specified `dom` in `compilerOptions.lib`, but I still got XMLHttpRequest (and related) errors in my test app if I excluded `dom`.

It looks like the route some libraries have taken is to create empty interfaces. Then, if the user includes `dom` the interfaces are merged. I've done this, however this also reduces the effectiveness of type-checking. Short of creating separate definitions for the browser (difficult since this is a combined project), I'm not sure there's a better way to do this.

Anyway, would love to get some feedback if you have time.

Note: The first commit has most of the changes (I reverted the streams one for now), I uploaded all the updated definitions in case anyone wanted to test against their existing projects.