### PR TITLE
Ensure config is loaded before trying to load credential helpers

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -71,6 +71,7 @@ AWS.util.update(AWS, {
 });
 
 require('./service');
+require('./config');
 
 require('./credentials');
 require('./credentials/credential_provider_chain');
@@ -79,7 +80,6 @@ require('./credentials/web_identity_credentials');
 require('./credentials/cognito_identity_credentials');
 require('./credentials/saml_credentials');
 
-require('./config');
 require('./http');
 require('./sequential_executor');
 require('./event_listeners');


### PR DESCRIPTION
I've created this due to https://github.com/dwyl/aws-lambda-deploy/issues/56 which shows that AWS SDKs since v2.6.0 have been having an error whilst running their test suite.

I picked out the stack trace for the error as you can see:

```
Trace: Config
    at Object.<anonymous> (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/node_loader.js:19:9)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/clients/sts.js:1:63)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/credentials/temporary_credentials.js:2:11)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/core.js:78:1)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.userAgent (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/util.js:29:43)
    at HttpRequest.setUserAgent (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/http.js:115:52)
    at new HttpRequest (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/http.js:103:10)
    at new Request (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/request.js:317:24)
    at makeRequest (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/service.js:190:19)
    at svc.(anonymous function) [as getFunction] (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/aws-sdk/lib/service.js:451:23)
    at upload (/Users/sidebc01/workspace/aws-lambda-deploy/lib/upload.js:27:10)
    at Context.<anonymous> (/Users/sidebc01/workspace/aws-lambda-deploy/test/05_upload.test.js:21:5)
    at callFnAsync (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runnable.js:368:21)
    at Test.Runnable.run (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runnable.js:318:7)
    at Runner.runTest (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:444:10)
    at /Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:550:12
    at next (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:361:14)
    at /Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:371:7
    at next (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:295:14)
    at Immediate._onImmediate (/Users/sidebc01/workspace/aws-lambda-deploy/node_modules/mocha/lib/runner.js:339:5)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

Which is summarized as:

```
at Object.<anonymous> (aws-sdk/lib/node_loader.js:19:9)
at Object.<anonymous> (aws-sdk/clients/sts.js:1:63)
at Object.<anonymous> (aws-sdk/lib/credentials/temporary_credentials.js:2:11)
at Object.<anonymous> (aws-sdk/lib/core.js:78:1)
at Object.userAgent (aws-sdk/lib/util.js:29:43)
at HttpRequest.setUserAgent (aws-sdk/lib/http.js:115:52)
at new HttpRequest (aws-sdk/lib/http.js:103:10)
at new Request (aws-sdk/lib/request.js:317:24)
at makeRequest (aws-sdk/lib/service.js:190:19)
at svc.(anonymous function) [as getFunction] (aws-sdk/lib/service.js:451:23)
```

You can see that `lib/core` tries to include the `temporary_credentials` on line 78 and this eventually calls `node_loader` which tries to use `AWS.Config` which isn't loaded in `lib/core` until line 82. By moving the config require above the credentials require this appears to be fixed and would seem to make sense if it's a dependency of the credentials.