### PR TITLE
Signal Initial Validity

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -142,6 +142,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
+    this.roleArn = roleArn;
+
     var sourceCredentials = {
       accessKeyId: sourceProfile['aws_access_key_id'],
       secretAccessKey: sourceProfile['aws_secret_access_key'],

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -362,6 +362,7 @@ if AWS.util.isNode()
       </AssumeRoleResponse>
       '''
       creds = new AWS.SharedIniFileCredentials()
+      expect(creds.roleArn).to.equal('arn')
       creds.refresh (err) ->
         expect(creds.accessKeyId).to.equal('KEY')
         expect(creds.secretAccessKey).to.equal('SECRET')


### PR DESCRIPTION
Signal that the credentials have passed initial validation checks (i.e. the role_arn and source_profiles values were set and the source_profile was successfully loaded for use in invoking STS).  This is a small change to resolve #1243 by exposing the `role_arn` value on the attribute `roleArn` after the initial validation of the settings.

Alter unit tests to validate at least once that the roleArn attribute is created and available in a valid configuration unit test.

See #1243 for more background on the issue and reproduction steps.