### PR TITLE
Fix localStorage check for Safari private browsing

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -333,8 +333,8 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
     try {
       window.localStorage.setItem('aws.test-storage', 'foobar');
       window.localStorage.removeItem('aws.test-storage');
-      return AWS.util.isBrowser() && window.localStorage !== null && typeof window.localStorage === 'object' ?
-             window.localStorage : {};
+
+      return AWS.util.isBrowser() ? window.localStorage : {};
     } catch (_) {
       return {};
     }

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -331,6 +331,8 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   storage: (function() {
     try {
+      window.localStorage.setItem('aws.test-storage', 'foobar');
+      window.localStorage.removeItem('aws.test-storage');
       return AWS.util.isBrowser() && window.localStorage !== null && typeof window.localStorage === 'object' ?
              window.localStorage : {};
     } catch (_) {

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -331,10 +331,14 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   storage: (function() {
     try {
-      window.localStorage.setItem('aws.test-storage', 'foobar');
-      window.localStorage.removeItem('aws.test-storage');
+      var storage = AWS.util.isBrowser() && window.localStorage !== null && typeof window.localStorage === 'object' ?
+          window.localStorage : {};
 
-      return AWS.util.isBrowser() ? window.localStorage : {};
+      // Test set/remove which would throw an error in Safari's private browsing
+      storage['aws.test-storage'] = 'foobar';
+      delete storage['aws.test-storage'];
+
+      return storage;
     } catch (_) {
       return {};
     }


### PR DESCRIPTION
This PR adds a step to ensure a proper fallback is achieved when in private browsing mode on Safari. 

In private browsing, Safari restricts the localStorage quota at 0, so while `window.localStorage` is a valid object in the browser, any attempt to set data throws an exception.