### PR TITLE
Add ReadableStream type to Body

### DIFF
--- a/clients/s3.d.ts
+++ b/clients/s3.d.ts
@@ -741,7 +741,7 @@ declare namespace S3 {
     Prefix?: Prefix;
   }
   export type AnalyticsS3ExportFileFormat = "CSV"|string;
-  export type Body = Buffer|Uint8Array|Blob|string;
+  export type Body = Buffer|Uint8Array|Blob|ReadableStream|string;
   export interface Bucket {
     /**
      * The name of the bucket.

--- a/clients/s3.d.ts
+++ b/clients/s3.d.ts
@@ -741,7 +741,7 @@ declare namespace S3 {
     Prefix?: Prefix;
   }
   export type AnalyticsS3ExportFileFormat = "CSV"|string;
-  export type Body = Buffer|Uint8Array|Blob|ReadableStream|string;
+  export type Body = Buffer|Uint8Array|Blob|Readable|string;
   export interface Bucket {
     /**
      * The name of the bucket.


### PR DESCRIPTION
Addresses #1225, allowing the body in S3 requests to be a ReadableStream when using TypeScript.