### PR TITLE
Add the execution environment to the SDK user agent if specified

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -20,7 +20,11 @@ var util = {
     if (util.isBrowser() && typeof navigator !== 'undefined') {
       return navigator.userAgent;
     } else {
-      return process.platform + '/' + process.version;
+      var engine = process.platform + '/' + process.version;
+      if (process.env.AWS_EXECUTION_ENV) {
+        engine += ' exec-env/' + process.env.AWS_EXECUTION_ENV;
+      }
+      return engine;
     }
   },
 

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -1,9 +1,6 @@
 helpers = require('../helpers')
 AWS = helpers.AWS
 
-beforeEach ->
-  helpers.spyOn(AWS.util, 'userAgent').andReturn('aws-sdk-js/0.1')
-
 buildRequest = ->
   ddb = new AWS.DynamoDB({region: 'region', endpoint: 'localhost', apiVersion: '2011-12-05'})
   req = ddb.makeRequest('listTables', {ExclusiveStartTableName: 'bår'})
@@ -35,6 +32,7 @@ describe 'AWS.Signers.V4', ->
   signer = null
 
   beforeEach ->
+    helpers.spyOn(AWS.util, 'userAgent').andReturn('aws-sdk-js/0.1')
     creds = accessKeyId: 'akid', secretAccessKey: 'secret', sessionToken: 'session'
     signer = buildSigner()
     signer.addAuthorization(creds, date)


### PR DESCRIPTION
This change adds the execution environment specified in the `AWS_EXECUTION_ENV` environment variable to the user agent in a node process.

@chrisradek 