### PR TITLE
Add X-Amzn-Trace-Id to list of unsigned headers

### DIFF
--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -224,8 +224,15 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     }
   },
 
-  unsignableHeaders: ['authorization', 'content-type', 'content-length',
-                      'user-agent', expiresHeader, 'expect'],
+  unsignableHeaders: [
+    'authorization',
+    'content-type',
+    'content-length',
+    'user-agent',
+    expiresHeader,
+    'expect',
+    'x-amzn-trace-id'
+  ],
 
   isSignableHeader: function isSignableHeader(key) {
     if (key.toLowerCase().indexOf('x-amz-') === 0) return true;

--- a/test/signers/v4.spec.coffee
+++ b/test/signers/v4.spec.coffee
@@ -194,6 +194,10 @@ describe 'AWS.Signers.V4', ->
       signer.request.headers = {'Authorization': 'foo'}
       expect(signer.canonicalHeaders()).to.equal('')
 
+    it 'should ignore X-Amzn-Trace-Id header', ->
+      signer.request.headers = {'X-Amzn-Trace-Id': 'foo'}
+      expect(signer.canonicalHeaders()).to.equal('')
+
     it 'should lowercase all header names (not values)', ->
       signer.request.headers = {'FOO': 'BAR'}
       expect(signer.canonicalHeaders()).to.equal('foo:BAR')


### PR DESCRIPTION
This header [can be set or altered by a load balancer](http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html) and is therefore unsafe to sign. Should a user provide this header before the SDK signs the request, there's a chance the header value (and thus the expected signature) could be changed in-flight.

/cc @chrisradek 