### PR TITLE
AWS.config.setPromisesDependency(null) forces use of native promises

### DIFF
--- a/.changes/next-release/bugfix-Promises-cb5d283f.json
+++ b/.changes/next-release/bugfix-Promises-cb5d283f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Promises",
+  "description": "Fixes issue introduced in v2.6.12. Calling AWS.config.setPromisesDependency(null) will once again force the SDK to use native promises if they are available."
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -497,6 +497,8 @@ AWS.Config = AWS.util.inherit({
 
   /**
    * Sets the promise dependency the SDK will use wherever Promises are returned.
+   * Passing `null` will force the SDK to use native Promises if they are available.
+   * If native Promises are not available, passing `null` will have no effect.
    * @param [Constructor] dep A reference to a Promise constructor
    */
   setPromisesDependency: function setPromisesDependency(dep) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -501,9 +501,13 @@ AWS.Config = AWS.util.inherit({
    */
   setPromisesDependency: function setPromisesDependency(dep) {
     PromisesDependency = dep;
+    // if null was passed in, we should try to use native promises
+    if (dep === null && typeof Promise === 'function') {
+      PromisesDependency = Promise;
+    }
     var constructors = [AWS.Request, AWS.Credentials, AWS.CredentialProviderChain];
     if (AWS.S3 && AWS.S3.ManagedUpload) constructors.push(AWS.S3.ManagedUpload);
-    AWS.util.addPromises(constructors, dep);
+    AWS.util.addPromises(constructors, PromisesDependency);
   },
 
   /**

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -256,6 +256,18 @@ describe 'AWS.config', ->
       expect(utilSpy.calls.length).to.equal(1)
       expect(Array.isArray(utilSpy.calls[0].arguments[0])).to.be.true
       expect(utilSpy.calls[0].arguments[0].length).to.equal(4)
+    
+    if typeof Promise != 'undefined'
+      it 'reverts to native promises when null is passed', ->
+        # create fake promise constructor
+        P = ->
+        utilSpy = helpers.spyOn(AWS.util, 'addPromises')
+        AWS.config.setPromisesDependency(P);
+        expect(utilSpy.calls[0].arguments[1] == P).to.be.true
+        # revert promise
+        AWS.config.setPromisesDependency(null);
+        expect(utilSpy.calls[1].arguments[1] == Promise).to.be.true
+        expect(utilSpy.calls[1].arguments[1] == P).to.be.false
 
   describe 'getPromisesDependency', ->
     it 'returns PromisesDependency if set', ->


### PR DESCRIPTION
Calling AWS.config.setPromisesDependency with null now reverts to native promises. 

Fixes #1274 

/cc @jeskew 