### PR TITLE
Account for objects with null prototype in `typeOf` function

### DIFF
--- a/lib/dynamodb/types.js
+++ b/lib/dynamodb/types.js
@@ -7,6 +7,10 @@ function typeOf(data) {
     return 'Binary';
   } else if (data !== undefined && data.constructor) {
     return util.typeName(data.constructor);
+  } else if (data !== undefined && typeof data === 'object') {
+    // this object is the result of Object.create(null), hence the absence of a
+    // defined constructor
+    return 'Object';
   } else {
     return 'undefined';
   }

--- a/test/dynamodb/types.js
+++ b/test/dynamodb/types.js
@@ -29,7 +29,7 @@ describe('DynamoDb document client typeOf (internal)', function() {
     });
 
     it('should return "Binary" for buffers', function() {
-        expect(typeOf(Buffer.from('foo'))).to.equal('Binary');
+        expect(typeOf(new Buffer('foo'))).to.equal('Binary');
     });
 
     it('should return "Boolean" for booleans', function() {

--- a/test/dynamodb/types.js
+++ b/test/dynamodb/types.js
@@ -1,0 +1,42 @@
+var typeOf = require('../../lib/dynamodb/types').typeOf,
+    helpers = require('../helpers'),
+    AWS = helpers.AWS;
+
+describe('DynamoDb document client typeOf (internal)', function() {
+    it('should return "Array" for arrays', function() {
+        expect(typeOf([])).to.equal('Array');
+    });
+
+    it('should return "Object" for objects', function() {
+        expect(typeOf({})).to.equal('Object');
+    });
+
+    it('should return "Object" for null-prototype objects', function() {
+        expect(typeOf(Object.create(null))).to.equal('Object');
+    });
+
+    it('should return "Set" for sets', function() {
+        var client = new AWS.DynamoDB.DocumentClient();
+        expect(typeOf(client.createSet(['a']))).to.equal('Set');
+    });
+
+    it('should return "String" for strings', function() {
+        expect(typeOf('foo')).to.equal('String');
+    });
+
+    it('should return "Number" for numbers', function() {
+        expect(typeOf(42)).to.equal('Number');
+    });
+
+    it('should return "Binary" for buffers', function() {
+        expect(typeOf(Buffer.from('foo'))).to.equal('Binary');
+    });
+
+    it('should return "Boolean" for booleans', function() {
+        expect(typeOf(true)).to.equal('Boolean');
+    });
+
+    it('should return "null" for null', function() {
+        expect(typeOf(null)).to.equal('null');
+    });
+});


### PR DESCRIPTION
This change will allow objects created using `Object.create(null)` to be properly serialized by the DDB document client. Resolves #1298.