### PR TITLE
Cast string bodies to buffers to ensure correct encoding used

### DIFF
--- a/.changes/next-release/bugfix-S3-3a275bd9.json
+++ b/.changes/next-release/bugfix-S3-3a275bd9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Convert string bodies to buffers to ensure correct encoding is used"
+}

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -28,6 +28,20 @@ Feature: Working with Objects in S3
     And the object "contentlength" should contain "foo"
 
   @multi-byte
+  Scenario: Putting multi-byte metadata
+    When I put a buffer containing "foo" to the key "mbmd" with the metadata key "mdkey" and value "voilà ça marche"
+    Then the object "mbmd" should exist
+    Then I get the object "mbmd"
+    And the object "mbmd" should contain "foo"
+
+  @multi-byte
+  Scenario: Putting multi-byte metadata
+    When I put "foo" to the key "mbmd" with the metadata key "mdkey" and value "voilà ça marche"
+    Then the object "mbmd" should exist
+    Then I get the object "mbmd"
+    And the object "mbmd" should contain "foo"
+
+  @multi-byte
   Scenario: Putting a multi-byte string to an object
     When I put "åß∂ƒ©" to the key "multi"
     Then the object "multi" should exist

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -29,6 +29,22 @@ module.exports = function () {
     this.request('s3nochecksums', 'putObject', params, next);
   });
 
+  this.When(/^I put "([^"]*)" to the key "([^"]*)" with the metadata key "([^"]*)" and value "([^"]*)"$/, function(contents, key, mdKey, mdValue, next) {
+    var metadata = {};
+    metadata[mdKey] = mdValue;
+    var params = {Bucket: this.sharedBucket, Key: key, Body: contents, Metadata: metadata };
+    this.s3nochecksums = new this.AWS.S3({computeChecksums: false});
+    this.request('s3nochecksums', 'putObject', params, next);
+  });
+
+  this.When(/^I put a buffer containing "([^"]*)" to the key "([^"]*)" with the metadata key "([^"]*)" and value "([^"]*)"$/, function(contents, key, mdKey, mdValue, next) {
+    var metadata = {};
+    metadata[mdKey] = mdValue;
+    var params = {Bucket: this.sharedBucket, Key: key, Body: new Buffer(contents), Metadata: metadata };
+    this.s3nochecksums = new this.AWS.S3({computeChecksums: false});
+    this.request('s3nochecksums', 'putObject', params, next);
+  });
+
   this.Then(/^the object "([^"]*)" should contain "([^"]*)"$/, function(key, contents, next) {
     this.assert.equal(this.data.Body.toString().replace('\n', ''), contents);
     next();

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -100,6 +100,9 @@ AWS.NodeHttpClient = AWS.util.inherit({
           total: totalBytes
         });
       });
+      if (typeof body === 'string') {
+        body = new Buffer(body);
+      }
       stream.end(body);
     } else {
       // no request body

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -101,7 +101,8 @@ AWS.NodeHttpClient = AWS.util.inherit({
         });
       });
       if (typeof body === 'string') {
-        body = new Buffer(body);
+        body = typeof Buffer.from === 'function' ?
+          Buffer.from(body) : new Buffer(body);
       }
       stream.end(body);
     } else {


### PR DESCRIPTION
This change ensures that bodies are always converted to byte buffers before being passed to an `http.ClientRequest`. It looks like the code that packs headers and short bodies into the same outgoing HTTP packet has a slightly different codepath for non-binary strings, which this change lets the SDK avoid.

Resolves #1297.