### PR TITLE
Move documentation for convertEmptyValues option from `createSet` to constructor

### DIFF
--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -62,6 +62,10 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    * @option options service [AWS.DynamoDB] An optional pre-configured instance
    *  of the AWS.DynamoDB service object to use for requests. The object may
    *  bound parameters used by the document client.
+   * @option options convertEmptyValues [Boolean] set to true if you would like
+   *  the document client to convert empty values (0-length strings, binary
+   *  buffers, and sets) to be converted to NULL types when persisting to
+   *  DynamoDB.
    * @see AWS.DynamoDB.constructor
    *
    */
@@ -430,10 +434,6 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    * @param options [map]
    *  * **validate** [Boolean] set to true if you want to validate the type
    *    of each element in the set. Defaults to `false`.
-   *  * **convertEmptyValues** [Boolean] set to true if you would like the
-   *    document client to convert empty values (0-length strings, binary
-   *    buffers, and sets) to be converted to NULL types when persisting to
-   *    DynamoDB.
    * @example Creating a number set
    *  var docClient = new AWS.DynamoDB.DocumentClient();
    *


### PR DESCRIPTION
The documentation for the `convertEmptyValues` option on the document client should appear on the constructor, not on `createSet`. This change should aid in the discoverability of this feature.