### PR TITLE
Update contribute guide to call out importance of adding tests and not breaking the build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ npm test
 To run a particular test subset e.g. just the unit tests:
 
 ```
-npm run-script unit
+npm run unit
 ```
 
 See the implementation of the `test` script in `package.json` for more options.
@@ -95,7 +95,7 @@ Our goal with the changelog is to document all changes made with each version of
 When submitting a pull request, please run the `add-change` script and commit the resulting JSON file so that your change gets added to the changelog.
 From SDK root:
 ```
-npm run-script add-change
+npm run add-change
 ```
 
 See the [add-change cli notes](./scripts/changelog/README.md) for more information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,16 @@ Please be aware of the following notes prior to opening a pull request:
    yet available in the SDK, please talk to us beforehand to avoid any
    duplication of effort.
 
+3. Wherever possible, pull requests should contain tests as appropriate.
+   Bugfixes should contain tests that exercise the corrected behavior (i.e., the
+   test should fail without the bugfix and pass with it), and new features 
+   should be accompanied by tests exercising the feature.
+
+4. Pull requests that contain failing tests will not be merged until the test
+   failures are addressed. Pull requests that cause a significant drop in the
+   SDK's test coverage percentage are unlikely to be merged until tests have
+   been added.
+
 ### Testing
 
 To run the tests locally, install `phantomjs`. You can do so using [Homebrew][homebrew]:
@@ -85,7 +95,7 @@ Our goal with the changelog is to document all changes made with each version of
 When submitting a pull request, please run the `add-change` script and commit the resulting JSON file so that your change gets added to the changelog.
 From SDK root:
 ```
-node ./scripts/changelog/add-change.js
+npm run-script add-change
 ```
 
 See the [add-change cli notes](./scripts/changelog/README.md) for more information.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 AWS SDK for JavaScript
-Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed at
 Amazon Web Services, Inc. (http://aws.amazon.com/).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ There are a few known limitations with the bundled TypeScript definitions at thi
  * Service client typings reflect the latest `apiVersion`, regardless of which `apiVersion` is specified when creating a client.
  * Service-bound parameters use the `any` type.
 
+## Getting Help
+Please use these community resources for getting help. We use the GitHub issues for tracking bugs and feature requests and have limited bandwidth to address them.
+ * Ask a question on [StackOverflow](https://stackoverflow.com/) and tag it with `aws-sdk-js`
+ * Come join the AWS JavaScript community on [gitter](https://gitter.im/aws/aws-sdk-js?source=orgpage)
+ * Open a support ticket with [AWS Support](https://console.aws.amazon.com/support/home#/)
+ * If it turns out that you may have found a bug, please [open an issue](https://github.com/aws/aws-sdk-js/issues/new)
+
+## Opening Issues
+If you encounter a bug with the AWS SDK for JavaScript we would like to hear
+about it. Search the [existing issues](https://github.com/aws/aws-sdk-js/issues)
+and try to make sure your problem doesn’t already exist before opening a new
+issue. It’s helpful if you include the version of the SDK, Node.js or browser
+environment and OS you’re using. Please include a stack trace and reduced repro
+case when appropriate, too.
+
+The GitHub issues are intended for bug reports and feature requests. For help
+and questions with using the AWS SDK for JavaScript please make use of the
+resources listed in the [Getting Help](https://github.com/aws/aws-sdk-js#getting-help)
+section. There are limited resources available for handling issues and by
+keeping the list of open issues lean we can respond in a timely manner.
+
 ## Supported Services
 
 <p class="note"><strong>Note</strong>:

--- a/dist/BUNDLE_LICENSE.txt
+++ b/dist/BUNDLE_LICENSE.txt
@@ -1,7 +1,7 @@
 The bundled package of the AWS SDK for JavaScript is available under the
 Apache License, Version 2.0:
 
-  Copyright 2012-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License"). You
   may not use this file except in compliance with the License. A copy of

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "lint": "eslint lib dist-tools/*.js",
     "console": "./scripts/console",
     "testfiles": "istanbul `[ $COVERAGE ] && echo 'cover _mocha' || echo 'test mocha'`",
-    "tstest": "tsc -p ./ts"
+    "tstest": "tsc -p ./ts",
+    "add-change": "node ./scripts/changelog/add-change.js"
   }
 }


### PR DESCRIPTION
This PR adds the changelog entry generation script as an npm run target and updates the contributing guide. It's a low-priority update.