### PR TITLE
change first selection value of request.httpRequest.region in updateRegion

### DIFF
--- a/lib/services/cloudsearchdomain.js
+++ b/lib/services/cloudsearchdomain.js
@@ -114,7 +114,7 @@ AWS.util.update(AWS.CloudSearchDomain.prototype, {
   updateRegion: function updateRegion(request) {
     var endpoint = request.httpRequest.endpoint.hostname;
     var zones = endpoint.split('.');
-    request.httpRequest.region = zones[1] || request.httpRequest.region;
+    request.httpRequest.region = request.httpRequest.region || zones[1];
   }
 
 });


### PR DESCRIPTION
I think that request.httpRequest.region shouldn't change value if it have a value. If request.httpRequest.region is undefined, then request.httpRequest.region initialize zones[1] from endpoint domain.