### PR TITLE
[DynamoDB] Clarify TypeScript typings for item attributes.

### DIFF
--- a/.changes/next-release/feature-dynamodb-09a8b087.json
+++ b/.changes/next-release/feature-dynamodb-09a8b087.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "dynamodb",
+  "description": "Add specific TypeScript typings for item attributes."
+}

--- a/clients/dynamodb.d.ts
+++ b/clients/dynamodb.d.ts
@@ -185,48 +185,69 @@ declare namespace DynamoDB {
   export type AttributeName = string;
   export type AttributeNameList = AttributeName[];
   export type AttributeUpdates = {[key: string]: AttributeValueUpdate};
-  export interface AttributeValue {
     /**
-     * An attribute of type String. For example:  "S": "Hello" 
-     */
-    S?: StringAttributeValue;
-    /**
-     * An attribute of type Number. For example:  "N": "123.45"  Numbers are sent across the network to DynamoDB as strings, to maximize compatibility across languages and libraries. However, DynamoDB treats them as number type attributes for mathematical operations.
-     */
-    N?: NumberAttributeValue;
-    /**
-     * An attribute of type Binary. For example:  "B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk" 
-     */
-    B?: BinaryAttributeValue;
-    /**
-     * An attribute of type String Set. For example:  "SS": ["Giraffe", "Hippo" ,"Zebra"] 
-     */
-    SS?: StringSetAttributeValue;
-    /**
-     * An attribute of type Number Set. For example:  "NS": ["42.2", "-19", "7.5", "3.14"]  Numbers are sent across the network to DynamoDB as strings, to maximize compatibility across languages and libraries. However, DynamoDB treats them as number type attributes for mathematical operations.
-     */
-    NS?: NumberSetAttributeValue;
-    /**
-     * An attribute of type Binary Set. For example:  "BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="] 
-     */
-    BS?: BinarySetAttributeValue;
-    /**
-     * An attribute of type Map. For example:  "M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}} 
-     */
-    M?: MapAttributeValue;
-    /**
-     * An attribute of type List. For example:  "L": ["Cookies", "Coffee", 3.14159] 
-     */
-    L?: ListAttributeValue;
-    /**
-     * An attribute of type Null. For example:  "NULL": true 
-     */
-    NULL?: NullAttributeValue;
-    /**
-     * An attribute of type Boolean. For example:  "BOOL": true 
-     */
-    BOOL?: BooleanAttributeValue;
+   * An attribute of type String. For example:  "S": "Hello"
+   */
+  export interface StringAttribute {
+    S: StringAttributeValue;
   }
+  /**
+   * An attribute of type Number. For example:  "N": "123.45"  Numbers are sent across the network to DynamoDB as strings, to maximize compatibility across languages and libraries. However, DynamoDB treats them as number type attributes for mathematical operations.
+   */
+  export interface NumberAttribute {
+    N: NumberAttributeValue;
+  }
+  /**
+   * An attribute of type Binary. For example:  "B": "dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk"
+   */
+  export interface BinaryAttribute {
+    B: BinaryAttributeValue;
+  }
+  /**
+   * An attribute of type String Set. For example:  "SS": ["Giraffe", "Hippo" ,"Zebra"]
+   */
+  export interface StringSetAttribute {
+    SS: StringSetAttributeValue;
+  }
+  /**
+   * An attribute of type Number Set. For example:  "NS": ["42.2", "-19", "7.5", "3.14"]  Numbers are sent across the network to DynamoDB as strings, to maximize compatibility across languages and libraries. However, DynamoDB treats them as number type attributes for mathematical operations.
+   */
+  export interface NumberSetAttribute {
+    NS: NumberSetAttributeValue;
+  }
+  /**
+   * An attribute of type Binary Set. For example:  "BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
+   */
+  export interface BinarySetAttribute {
+    BS: BinarySetAttributeValue;
+  }
+  /**
+   * An attribute of type Map. For example:  "M": {"Name": {"S": "Joe"}, "Age": {"N": "35"}}
+   */
+  export interface MapAttribute {
+    M: MapAttributeValue;
+  }
+  /**
+   * An attribute of type List. For example:  "L": ["Cookies", "Coffee", 3.14159]
+   */
+  export interface ListAttribute {
+    L: ListAttributeValue;
+  }
+  /**
+   * An attribute of type Null. For example:  "NULL": true
+   */
+  export interface NullAttribute {
+    NULL: NullAttributeValue;
+  }
+  /**
+   * An attribute of type Boolean. For example:  "BOOL": true
+   */
+  export interface BooleanAttribute {
+    BOOL: BooleanAttributeValue;
+  }
+  export type AttributeValue = StringAttribute | NumberAttribute | BinaryAttribute |
+                                StringSetAttribute | NumberSetAttribute | BinarySetAttribute |
+                                MapAttribute | ListAttribute | NullAttribute | BooleanAttribute;
   export type AttributeValueList = AttributeValue[];
   export interface AttributeValueUpdate {
     /**


### PR DESCRIPTION
The TypeScript typings for DynamoDB's `AttributeValue` are too loose. Here's a subset:

```
export interface AttributeValue {
  S?: StringAttributeValue;
  N?: NumberAttributeValue;
  ...
}
```

This typing documents that if I have an object that conforms to the `AttributeValue` interface that it can have none, one, some, or all of the specific attribute value types. This is not true. An object that is an `AttributeValue` should have one and only one of the specific attribute value types.

This pull request rectifies this by making each specific attribute value type its own interface and transforms the overloaded `AttributeValue` interface into a type that can be any one of these new interfaces. Here's a subset:

```
export interface StringAttribute {
  S: StringAttributeValue;
}
export interface NumberAttribute {
  N: NumberAttributeValue;
}
...
export type AttributeValue = StringAttribute | NumberAttribute | ...
```

This PR is the minimum needed to add the new clarified typings while not breaking existing consumers of the `AttributeValue` interface.

If you'd like I can add a use case that demonstrates why the loose typing is problematic.