### PR TITLE
Add credentialProvider as an optional parameter of ConfigurationOptions

### DIFF
--- a/.changes/next-release/bugfix-TypeScript-5f321e6b.json
+++ b/.changes/next-release/bugfix-TypeScript-5f321e6b.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TypeScript",
+  "description": "Add `credentialProvider` as an optional parameter of `ConfigurationOptions`."
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -2,6 +2,7 @@ import {Agent as httpAgent} from 'http';
 import {Agent as httpsAgent} from 'https';
 import {AWSError} from './error';
 import {Credentials, CredentialsOptions} from './credentials';
+import {CredentialProviderChain} from './credentials/credential_provider_chain';
 import {ConfigurationServicePlaceholders, ConfigurationServiceApiVersions} from './config_service_placeholders';
 
 export class ConfigBase extends ConfigurationOptions{
@@ -171,6 +172,10 @@ export abstract class ConfigurationOptions {
      * The AWS credentials to sign requests with.
      */
     credentials?: Credentials|CredentialsOptions
+    /**
+     * The provider chain used to resolve credentials if no static credentials property is set.
+     */
+    credentialProvider?: CredentialProviderChain
     /**
      * AWS access key ID.
      * 

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -94,3 +94,12 @@ var config = AWS.config.loadFromPath('/to/path');
 AWS.config.update({
    fake: 'fake' 
 }, true);
+
+// Test constructing with a CredentialProviderChain
+var options = {
+    credentialProvider: new AWS.CredentialProviderChain([
+        () => new AWS.EC2MetadataCredentials()
+    ])
+};
+var s3 = new AWS.S3(options);
+var ses = new AWS.SES(options);


### PR DESCRIPTION
As discussed in #1338, the documentation for [`AWS.S3`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property) and [`AWS.SES`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#constructor-property) both state that they accept `credentialProvider`, which is an instance of [`AWS.CredentialProviderChain`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html), as part of the configuration options.

However, the declaration for [`ConfigurationOptions`](https://github.com/aws/aws-sdk-js/blob/67f8e309fb2ab748880a826911573beaa0e7986c/lib/config.d.ts#L155) did not expose such a parameter. This patch resolves that issue.

Fixes #1338