### PR TITLE
[TypeScript] Add endpoint property to AWS.S3 instances

### DIFF
--- a/.changes/next-release/bugfix-TypeScript-5a92a366.json
+++ b/.changes/next-release/bugfix-TypeScript-5a92a366.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TypeScript",
+  "description": "Add `endpoint` property to AWS.S3 instance declaration."
+}

--- a/lib/service.d.ts
+++ b/lib/service.d.ts
@@ -1,6 +1,7 @@
 import {Request} from './request';
 import {AWSError} from './error';
 import {ConfigurationOptions, ConfigBase} from './config';
+import {Endpoint} from './endpoint';
 export class Service {
     /**
      * Creates a new service object with a configuration object.
@@ -45,6 +46,11 @@ export class Service {
     apiVersions: string[];
 
     config: ConfigBase & ServiceConfigurationOptions;
+
+    /**
+     * An Endpoint object representing the endpoint URL for service requests.
+     */
+    endpoint: Endpoint;
 }
 
 export interface ServiceConfigurationOptions extends ConfigurationOptions {

--- a/ts/s3.ts
+++ b/ts/s3.ts
@@ -1,5 +1,6 @@
 import S3 = require('../clients/s3');
 import fs = require('fs');
+import {Endpoint} from '../lib/endpoint';
 
 // Instantiate S3 without options
 var s3 = new S3();
@@ -161,3 +162,5 @@ var uploader2: S3.ManagedUpload = new S3.ManagedUpload(<S3.ManagedUpload.Managed
 uploader2.send((err, data) => {
 
 });
+
+var endpoint: Endpoint = s3.endpoint;


### PR DESCRIPTION
The documentation for `AWS.S3` states that it exposes a property, [`endpoint`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#endpoint-property), which is an [`AWS.Endpoint`](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Endpoint.html) object.

However, the declaration for `AWS.S3` does not expose the property.

This patch resolves that issue.

I tried to copy all the things I did for #1339.