### PR TITLE
add AWSError to exports

### DIFF
--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -18,3 +18,4 @@ export {MetadataService} from './metadata_service';
 export {Request} from './request';
 export {Response} from './response';
 export {Service} from './service';
+export {AWSError} from './error';


### PR DESCRIPTION
AWSError is missing from exports. 
I don't like using 'any' 