### PR TITLE
[TypeScript] Allow the service configuration credentials to be nulled

### DIFF
--- a/.changes/next-release/bugfix-TypeScript-b03c57a6.json
+++ b/.changes/next-release/bugfix-TypeScript-b03c57a6.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TypeScript",
+  "description": "Enable the configuration credentials to be nulled so that the global config is not used."
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -171,7 +171,7 @@ export abstract class ConfigurationOptions {
     /**
      * The AWS credentials to sign requests with.
      */
-    credentials?: Credentials|CredentialsOptions
+    credentials?: Credentials|CredentialsOptions|null
     /**
      * The provider chain used to resolve credentials if no static credentials property is set.
      */

--- a/ts/s3.ts
+++ b/ts/s3.ts
@@ -5,6 +5,11 @@ import {Endpoint} from '../lib/endpoint';
 // Instantiate S3 without options
 var s3 = new S3();
 
+// Instantiate S3 without using the global credentials
+new S3({
+    credentials: null
+});
+
 // Instantiate S3 with config
 var s3Config: S3.Types.ClientConfiguration = {
     apiVersion: '2006-03-01',


### PR DESCRIPTION
This enables the service to use a supplied credential provider chain and to ignore those resolved by the global configuration.

As discussed in #1366.