### PR TITLE
Expose DynamoDB set and converter

### DIFF
--- a/clients/dynamodb.d.ts
+++ b/clients/dynamodb.d.ts
@@ -5,6 +5,7 @@ import {DynamoDBCustomizations} from '../lib/services/dynamodb';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
 import {DocumentClient as document_client} from '../lib/dynamodb/document_client';
+import {Converter as converter} from '../lib/dynamodb/converter';
 interface Blob {}
 declare class DynamoDB extends DynamoDBCustomizations {
   /**
@@ -167,6 +168,7 @@ declare class DynamoDB extends DynamoDBCustomizations {
 }
 declare namespace DynamoDB {
   export import DocumentClient = document_client;
+  export import Converter = converter;
 }
 declare namespace DynamoDB {
   export type AttributeAction = "ADD"|"PUT"|"DELETE"|string;

--- a/lib/dynamodb/converter.d.ts
+++ b/lib/dynamodb/converter.d.ts
@@ -1,0 +1,9 @@
+import DynamoDB = require('../../clients/dynamodb');
+
+export class Converter {
+    static input(data: any, options?: DynamoDB.DocumentClient.ConverterOptions): DynamoDB.AttributeValue;
+
+    static output(data: DynamoDB.AttributeValue): any;
+}
+
+export namespace Converter {}

--- a/lib/dynamodb/converter.d.ts
+++ b/lib/dynamodb/converter.d.ts
@@ -1,9 +1,11 @@
 import DynamoDB = require('../../clients/dynamodb');
 
 export class Converter {
-    static input(data: any, options?: DynamoDB.DocumentClient.ConverterOptions): DynamoDB.AttributeValue;
+    static input(data: any, options?: Converter.ConverterOptions): DynamoDB.AttributeValue;
 
     static output(data: DynamoDB.AttributeValue): any;
 }
 
-export namespace Converter {}
+export namespace Converter {
+    export type ConverterOptions = DynamoDB.DocumentClient.ConverterOptions;
+}

--- a/lib/dynamodb/converter.js
+++ b/lib/dynamodb/converter.js
@@ -1,7 +1,17 @@
-var util = require('../core').util;
+var AWS = require('../core');
+var util = AWS.util;
 var typeOf = require('./types').typeOf;
 var DynamoDBSet = require('./set');
 
+/**
+ * Convert a JavaScript value to its equivalent DynamoDB AttributeValue type
+ *
+ * @param data [any] The data to convert to a DynamoDB AttributeValue
+ * @option options convertEmptyValues [Boolean] Whether to automatically convert
+ *                                              empty strings, blobs, and sets
+ *                                              to `null`
+ * @returns [AWS.DynamoDB.AttributeValue]
+ */
 function convertInput(data, options) {
   options = options || {};
   var type = typeOf(data);
@@ -23,21 +33,24 @@ function convertInput(data, options) {
     if (data.length === 0 && options.convertEmptyValues) {
       return convertInput(null);
     }
-    return { 'S': data };
+    return { S: data };
   } else if (type === 'Number') {
-    return { 'N': data.toString() };
+    return { N: data.toString() };
   } else if (type === 'Binary') {
     if (data.length === 0 && options.convertEmptyValues) {
       return convertInput(null);
     }
-    return { 'B': data };
+    return { B: data };
   } else if (type === 'Boolean') {
-    return {'BOOL': data};
+    return { BOOL: data };
   } else if (type === 'null') {
-    return {'NULL': true};
+    return { NULL: true };
   }
 }
 
+/**
+ * @api private
+ */
 function formatSet(data, options) {
   options = options || {};
   var values = data.values;
@@ -59,6 +72,9 @@ function formatSet(data, options) {
   return map;
 }
 
+/**
+ * @api private
+ */
 function filterEmptySetValues(set) {
     var nonEmptyValues = [];
     var potentiallyEmptyTypes = {
@@ -80,6 +96,12 @@ function filterEmptySetValues(set) {
     return set.values;
 }
 
+/**
+ * Convert a DynamoDB AttributeValue object to its equivalent JavaScript type.
+ *
+ * @param data [AWS.DynamoDB.AttributeValue]
+ * @returns [Object|Array|String|Number|Boolean|null]
+ */
 function convertOutput(data) {
   var list, map, i;
   for (var type in data) {
@@ -128,7 +150,9 @@ function convertOutput(data) {
   }
 }
 
-module.exports = {
+AWS.DynamoDB.Converter = {
   input: convertInput,
   output: convertOutput
 };
+
+module.exports = AWS.DynamoDB.Converter;

--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -57,7 +57,15 @@ export class DocumentClient {
 }
 
 export namespace DocumentClient {
-    export interface DocumentClientOptions {
+    interface ConverterOptions {
+        /**
+         * An optional flag indicating that the document client should cast
+         * empty strings, buffers, and sets to NULL shapes
+         */
+        convertEmptyValues?: boolean;
+    }
+
+    export interface DocumentClientOptions extends ConverterOptions{
         /**
          * An optional map of parameters to bind to every request sent by this service object. 
          */
@@ -66,10 +74,6 @@ export namespace DocumentClient {
          * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client. 
          */
         service?: DynamoDB
-        /**
-         * An optional flag indicating that the document client should cast empty strings, buffers, and sets to NULL shapes
-         */
-        convertEmptyValues?: boolean
     }
 
     export interface CreateSetOptions {

--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -21,7 +21,7 @@ export class DocumentClient {
     /**
      * Creates a set of elements inferring the type of set from the type of the first element. Amazon DynamoDB currently supports the number sets, string sets, and binary sets. For more information about DynamoDB data types see the documentation on the Amazon DynamoDB Data Model.
      */
-    createSet(list: number[]|string[]|DocumentClient.binaryType[], options: DocumentClient.CreateSetOptions): void
+    createSet(list: number[]|string[]|DocumentClient.binaryType[], options?: DocumentClient.CreateSetOptions): DocumentClient.DynamoDbSet;
     /**
      * Returns the attributes of one or more items from one or more tables by delegating to AWS.DynamoDB.batchGetItem().
      */
@@ -78,7 +78,25 @@ export namespace DocumentClient {
          */
         validate?: boolean
     }
+
     export type binaryType = Buffer|File|Blob|ArrayBuffer|DataView|Int8Array|Uint8Array|Uint8ClampedArray|Int16Array|Uint16Array|Int32Array|Uint32Array|Float32Array|Float64Array|stream.Stream;
+
+    interface StringSet {
+        type: 'String';
+        values: Array<string>;
+    }
+
+    interface NumberSet {
+        type: 'Number';
+        values: Array<number>;
+    }
+
+    interface BinarySet {
+        type: 'Binary';
+        values: Array<binaryType>;
+    }
+
+    export type DynamoDbSet = StringSet|NumberSet|BinarySet;
 }
 
 export namespace DocumentClient {

--- a/lib/dynamodb/set.js
+++ b/lib/dynamodb/set.js
@@ -1,6 +1,9 @@
 var util = require('../core').util;
 var typeOf = require('./types').typeOf;
 
+/**
+ * @api private
+ */
 var DynamoDBSet = util.inherit({
 
   constructor: function Set(list, options) {

--- a/scripts/lib/ts-customizations.json
+++ b/scripts/lib/ts-customizations.json
@@ -19,6 +19,15 @@
           "alias": "document_client"
         }
       ]
+    },
+    {
+      "path": "lib/dynamodb/converter",
+      "imports": [
+        {
+          "name": "Converter",
+          "alias": "converter"
+        }
+      ]
     }
   ],
   "polly": [

--- a/test/dynamodb/converter.js
+++ b/test/dynamodb/converter.js
@@ -1,0 +1,316 @@
+var DynamoDBSet = require('../../lib/dynamodb/set'),
+  helpers = require('../helpers'),
+  AWS = helpers.AWS,
+  input = helpers.AWS.DynamoDB.Converter.input,
+  output = helpers.AWS.DynamoDB.Converter.output;
+
+describe('AWS.DynamoDB.Converter', function() {
+  describe('.input', function() {
+    describe('strings', function() {
+      it('should convert strings to StringAttributeValues', function() {
+        expect(input('string')).to.deep.equal({S: 'string'});
+      });
+
+      it(
+        'should convert strings to null when convertEmptyValues option set',
+        function() {
+          expect(input('', {convertEmptyValues: true}))
+            .to.deep.equal({NULL: true});
+        }
+      );
+
+      it(
+        'should convert empty strings to StringAttributeValues otherwise',
+        function() {
+          expect(input('')).to.deep.equal({S: ''});
+        }
+      );
+    });
+
+    describe('binary values', function() {
+      it('should convert binary values to BinaryAttributeValues', function() {
+        var b64String = 'deadbeef';
+        var converted = input(AWS.util.base64.decode(b64String));
+        expect(converted).to.have.keys('B');
+        expect(converted.B.toString('base64')).to.equal(b64String);
+      });
+
+      it(
+        'should convert binary values to null when convertEmptyValues option set',
+        function() {
+          expect(input(AWS.util.base64.decode(''), {convertEmptyValues: true}))
+            .to.deep.equal({NULL: true});
+        }
+      );
+
+      it(
+        'should convert empty strings to StringAttributeValues otherwise',
+        function() {
+          var converted = input(AWS.util.base64.decode(''));
+          expect(converted).to.have.keys('B');
+          expect(converted.B.toString('base64')).to.equal('');
+        }
+      );
+    });
+
+    describe('numbers', function() {
+      it('should convert numbers to NumberAttributeValues', function() {
+        expect(input(42)).to.deep.equal({N: '42'});
+      });
+    });
+
+    describe('null', function() {
+      it('should convert nulls to NullAttributeValues', function() {
+        expect(input(null)).to.deep.equal({NULL: true});
+      });
+    });
+
+    describe('boolean', function() {
+      it('should convert booleans to BooleanAttributeValues', function() {
+        expect(input(true)).to.deep.equal({BOOL: true});
+        expect(input(false)).to.deep.equal({BOOL: false});
+      });
+    });
+
+    describe('lists', function() {
+      it('should convert lists to ListAttributeValues', function() {
+        expect(input([])).to.deep.equal({L: []});
+      });
+
+      it('should convert list members to AttributeValues', function() {
+        expect(input(['a', 1, true, null, {}])).to.deep.equal({L: [
+          {S: 'a'},
+          {N: '1'},
+          {BOOL: true},
+          {NULL: true},
+          {M: {}}
+        ]});
+      });
+
+      it(
+        'should remove empty list members when convertEmptyValues option is set',
+        function() {
+          expect(input(
+            ['', AWS.util.base64.decode(''), true],
+            {convertEmptyValues: true}
+          )).to.deep.equal({L: [
+            {NULL: true},
+            {NULL: true},
+            {BOOL: true}
+          ]});
+        }
+      );
+    });
+
+    describe('maps', function() {
+      it('should convert maps to MapAttributeValues', function() {
+        expect(input({})).to.deep.equal({M: {}});
+      });
+
+      it('should convert map members to AttributeValues', function() {
+        expect(input({a: 'a', b: 1, c: true, d: null, e: ['s']})).to.deep.equal({
+          M: {
+            a: {S: 'a'},
+            b: {N: '1'},
+            c: {BOOL: true},
+            d: {NULL: true},
+            e: {L: [{S: 's'}]}
+          }
+        });
+      });
+
+      it(
+        'should remove empty map members when convertEmptyValues option is set',
+        function() {
+          expect(input(
+            {a: '', b: AWS.util.base64.decode(''), c: true},
+            {convertEmptyValues: true}
+          )).to.deep.equal({M: {
+            a: {NULL: true},
+            b: {NULL: true},
+            c: {BOOL: true}
+          }});
+        }
+      );
+    });
+
+    describe('string sets', function() {
+      it(
+        'should convert sets with strings into StringSetAttributeValues',
+        function() {
+          expect(input(new DynamoDBSet(['a', 'b', 'c'])))
+            .to.deep.equal({SS: ['a', 'b', 'c']});
+        }
+      );
+
+      it(
+        'should drop empty members when convertEmptyValues option is set',
+        function() {
+          expect(input(new DynamoDBSet(['a', '', 'c']), {convertEmptyValues: true}))
+            .to.deep.equal({SS: ['a', 'c']});
+        }
+      );
+
+      it(
+        'should keep empty members when convertEmptyValues option is not set',
+        function() {
+          expect(input(new DynamoDBSet(['a', '', 'c'])))
+            .to.deep.equal({SS: ['a', '', 'c']});
+        }
+      );
+    });
+
+    describe('number sets', function() {
+      it(
+        'should convert sets with numbers into NumberSetAttributeValues',
+        function() {
+          expect(input(new DynamoDBSet([1, 2, 3])))
+            .to.deep.equal({NS: ['1', '2', '3']});
+        }
+      );
+    });
+
+    describe('binary sets', function() {
+      var b64Strings = ['dead', 'beef', 'face'];
+
+      it(
+        'should convert sets with strings into StringSetAttributeValues',
+        function() {
+          var converted = input(new DynamoDBSet(b64Strings.map(AWS.util.base64.decode)));
+          expect(converted).to.have.keys('BS');
+          expect(converted.BS.map(AWS.util.base64.encode)).to.deep.equal(b64Strings);
+        }
+      );
+
+      it(
+        'should drop empty members when convertEmptyValues option is set',
+        function() {
+          var converted = input(
+            new DynamoDBSet(b64Strings.concat('').map(AWS.util.base64.decode)),
+            {convertEmptyValues: true}
+          );
+          expect(converted).to.have.keys('BS');
+          expect(converted.BS.map(AWS.util.base64.encode)).to.deep.equal(b64Strings);
+        }
+      );
+
+      it(
+        'should drop empty members when convertEmptyValues option is set',
+        function() {
+          var converted = input(
+            new DynamoDBSet(b64Strings.concat('').map(AWS.util.base64.decode))
+          );
+          expect(converted).to.have.keys('BS');
+          expect(converted.BS.map(AWS.util.base64.encode))
+            .to.deep.equal(b64Strings.concat(''));
+        }
+      );
+    });
+  });
+
+  describe('.output', function() {
+    describe('strings', function() {
+      it('should convert StringAttributeValues to strings', function() {
+        expect(output({S: 'string'})).to.equal('string');
+      });
+    });
+
+    describe('binary values', function() {
+      it('should convert binary values to BinaryAttributeValues', function() {
+        var b64String = 'deadbeef';
+        expect(AWS.util.base64.encode(output({B: AWS.util.base64.decode(b64String)}))).to.equal(b64String);
+      });
+    });
+
+    describe('numbers', function() {
+      it('should convert numbers to NumberAttributeValues', function() {
+        expect(output({N: '42'})).to.equal(42);
+      });
+    });
+
+    describe('null', function() {
+      it('should convert nulls to NullAttributeValues', function() {
+        expect(output({NULL: true})).to.equal(null);
+      });
+    });
+
+    describe('boolean', function() {
+      it('should convert booleans to BooleanAttributeValues', function() {
+        expect(output({BOOL: true})).to.equal(true);
+        expect(output({BOOL: false})).to.equal(false);
+      });
+    });
+
+    describe('lists', function() {
+      it('should convert lists to ListAttributeValues', function() {
+        expect(output({L: []})).to.deep.equal([]);
+      });
+
+      it('should convert list members to AttributeValues', function() {
+        expect(output({L: [
+          {S: 'a'},
+          {N: '1'},
+          {BOOL: true},
+          {NULL: true},
+          {M: {}}
+        ]})).to.deep.equal(['a', 1, true, null, {}]);
+      });
+    });
+
+    describe('maps', function() {
+      it('should convert maps to MapAttributeValues', function() {
+        expect(output({M: {}})).to.deep.equal({});
+      });
+
+      it('should convert map members to AttributeValues', function() {
+        expect(output({
+          M: {
+            a: {S: 'a'},
+            b: {N: '1'},
+            c: {BOOL: true},
+            d: {NULL: true},
+            e: {L: [{S: 's'}]}
+          }
+        })).to.deep.equal({a: 'a', b: 1, c: true, d: null, e: ['s']});
+      });
+    });
+
+    describe('string sets', function() {
+      it(
+        'should convert sets with strings into StringSetAttributeValues',
+        function() {
+          var converted = output({SS: ['a', 'b', 'c']});
+          expect(converted).to.have.keys('values', 'type');
+          expect(converted.type).to.equal('String');
+          expect(converted.values).to.deep.equal(['a', 'b', 'c']);
+        }
+      );
+    });
+
+    describe('number sets', function() {
+      it(
+        'should convert sets with numbers into NumberSetAttributeValues',
+        function() {
+          var converted = output({NS: ['1', '2', '3']});
+          expect(converted).to.have.keys('values', 'type');
+          expect(converted.type).to.equal('Number');
+          expect(converted.values).to.deep.equal([1, 2, 3]);
+        }
+      );
+    });
+
+    describe('binary sets', function() {
+      it(
+        'should convert sets with strings into StringSetAttributeValues',
+        function() {
+          var b64Strings = ['dead', 'beef', 'face'];
+          var converted = output({BS: b64Strings.map(AWS.util.base64.decode)});
+          expect(converted).to.have.keys('values', 'type');
+          expect(converted.type).to.equal('Binary');
+          expect(converted.values.map(AWS.util.base64.encode))
+            .to.deep.equal(b64Strings);
+        }
+      );
+    });
+  });
+});

--- a/ts/dynamodb.ts
+++ b/ts/dynamodb.ts
@@ -19,7 +19,12 @@ if (set.type === 'String') {
     const binary: DynamoDB.DocumentClient.binaryType|undefined = set.values.pop();
 }
 
-const av: DynamoDB.AttributeValue = DynamoDB.Converter.input('string');
+const converter: DynamoDB.Converter = DynamoDB.Converter;
+const options: DynamoDB.Converter.ConverterOptions = {
+    convertEmptyValues: true,
+};
+
+const av: DynamoDB.AttributeValue = DynamoDB.Converter.input('string', options);
 const jsType: any = DynamoDB.Converter.output('string');
 client.get(params, (err, data) => {
     

--- a/ts/dynamodb.ts
+++ b/ts/dynamodb.ts
@@ -9,6 +9,16 @@ const params: DynamoDB.DocumentClient.GetItemInput = {
     }
 };
 
+const set: DynamoDB.DocumentClient.DynamoDbSet = client.createSet(['string']);
+
+if (set.type === 'String') {
+    const string: string|undefined = set.values.pop();
+} else if (set.type === 'Number') {
+    const number: number|undefined = set.values.pop();
+} else {
+    const binary: DynamoDB.DocumentClient.binaryType|undefined = set.values.pop();
+}
+
 client.get(params, (err, data) => {
     
 });

--- a/ts/dynamodb.ts
+++ b/ts/dynamodb.ts
@@ -19,6 +19,8 @@ if (set.type === 'String') {
     const binary: DynamoDB.DocumentClient.binaryType|undefined = set.values.pop();
 }
 
+const av: DynamoDB.AttributeValue = DynamoDB.Converter.input('string');
+const jsType: any = DynamoDB.Converter.output('string');
 client.get(params, (err, data) => {
     
 });


### PR DESCRIPTION
This PR exposes the DynamoDB DocumentClient converter and set functionality. It also adds unit and TS tests.

/cc @chrisradek 