### PR TITLE
Fixes XHR abort issue

### DIFF
--- a/.changes/next-release/bugfix-XHR-0cc94ff1.json
+++ b/.changes/next-release/bugfix-XHR-0cc94ff1.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "XHR",
+  "description": "Fixes an issue where the callback provided to an operation would not fire if a request was aborted after being sent. The bug only affected the browser SDK."
+}

--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -49,6 +49,11 @@ AWS.XHRClient = AWS.util.inherit({
         code: 'NetworkingError'
       }));
     }, false);
+    xhr.addEventListener('abort', function () {
+      errCallback(AWS.util.error(new Error('Request aborted'), {
+        code: 'RequestAbortedError'
+      }));
+    }, false);
 
     callback(emitter);
     xhr.open(httpRequest.method, href, httpOptions.xhrAsync !== false);

--- a/test/browser.spec.coffee
+++ b/test/browser.spec.coffee
@@ -94,7 +94,7 @@ integrationTests ->
   describe 'Request.abort', ->
     it 'can abort a request', (done) ->
       req = s3.putObject Key: 'key', Body: 'body'
-      req.on 'send', (resp) -> resp.request.abort()
+      req.on 'httpHeaders', () -> this.abort()
       req.send (err) ->
         expect(err.name).to.equal('RequestAbortedError')
         done()


### PR DESCRIPTION
I changed the XHR abort test to abort once headers are received. Calling `abort` on `send` always created the error and triggered the callback, however it did not appear to actually abort a request.

/cc @jeskew 