### PR TITLE
Fix ManagedUpload never finishes when stream size == part size

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -173,7 +173,11 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
           on('end', function() {
             self.isDoneChunking = true;
             self.numParts = self.totalPartNumbers;
-            self.fillQueue.call(self);
+            if (self.isDoneChunking && self.totalPartNumbers >= 1 && self.doneParts === self.numParts) {
+              self.finishMultiPart();
+            } else {
+              self.fillQueue.call(self);
+            }
           });
       }
     }


### PR DESCRIPTION
When uploading a stream with an unknown initial length and a total length
exactly equal to a multiple of the part size and a queueSize of `1`, the upload callback is
never finished.

This is caused by only checking whether the upload finished after uploading
the last part, but not when the end event is received.

In our case the end event is received after the last part has been uploaded,
but there is also no more data to be uploaded, resulting in a hanging upload.

I would love to add a test, but couldn't figure out how to trigger receiving the end event after the stream was read, any hints?