### PR TITLE
Ensure master credentials are refreshed before refreshing temporary credentials

### DIFF
--- a/.changes/next-release/bugfix-TemporaryCredentials-685384e2.json
+++ b/.changes/next-release/bugfix-TemporaryCredentials-685384e2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "TemporaryCredentials",
+  "description": "Ensure master credentials are not expired before using them to refresh temporary credentials"
+}

--- a/lib/credentials.d.ts
+++ b/lib/credentials.d.ts
@@ -36,26 +36,26 @@ export class Credentials {
     /**
      * AWS access key ID.
      */
-    accessKeyId: string
+    accessKeyId: string;
     /**
      * Whether the credentials have been expired and require a refresh.
      * Used in conjunction with expireTime.
      */
-    expired: boolean
+    expired: boolean;
     /**
      * Time when credentials should be considered expired.
      * Used in conjunction with expired.
      */
-    expireTime: Date
-    static expiryWindow: number
+    expireTime: Date;
+    static expiryWindow: number;
     /**
      * AWS secret access key.
      */
-    secretAccessKey: string
+    secretAccessKey: string;
     /**
      * AWS session token.
      */
-    sessionToken: string
+    sessionToken: string;
 }
 
 interface CredentialsOptions {

--- a/lib/credentials/temporary_credentials.js
+++ b/lib/credentials/temporary_credentials.js
@@ -83,14 +83,16 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
     self.createClients();
     if (!callback) callback = function(err) { if (err) throw err; };
 
-    self.service.config.credentials = self.masterCredentials;
-    var operation = self.params.RoleArn ?
-      self.service.assumeRole : self.service.getSessionToken;
-    operation.call(self.service, function (err, data) {
-      if (!err) {
-        self.service.credentialsFrom(data, self);
-      }
-      callback(err);
+    self.masterCredentials.get(function() {
+      self.service.config.credentials = self.masterCredentials;
+      var operation = self.params.RoleArn ?
+        self.service.assumeRole : self.service.getSessionToken;
+      operation.call(self.service, function (err, data) {
+        if (!err) {
+          self.service.credentialsFrom(data, self);
+        }
+        callback(err);
+      });
     });
   },
 
@@ -101,6 +103,10 @@ AWS.TemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
     this.masterCredentials = masterCredentials || AWS.config.credentials;
     while (this.masterCredentials.masterCredentials) {
       this.masterCredentials = this.masterCredentials.masterCredentials;
+    }
+
+    if (typeof this.masterCredentials.get !== 'function') {
+      this.masterCredentials = new AWS.Credentials(this.masterCredentials);
     }
   },
 

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -664,6 +664,18 @@ describe 'AWS.TemporaryCredentials', ->
           creds.refresh ->
             expect(spy.calls.length).to.equal(4)
 
+    it 'should refresh expired master credentials when refreshing self', ->
+      masterCreds = new AWS.Credentials('akid', 'secret')
+      masterCreds.expired = true;
+      refreshSpy = helpers.spyOn(masterCreds, 'refresh')
+
+      creds = new AWS.TemporaryCredentials({RoleArn: 'ARN'}, masterCreds);
+      creds.createClients()
+      mockSTS(new Date(AWS.util.date.getDate().getTime() + 100000),
+        RoleArn: 'ARN', RoleSessionName: 'temporary-credentials')
+      creds.refresh(->)
+      expect(refreshSpy.calls.length).to.equal(1)
+
 describe 'AWS.WebIdentityCredentials', ->
   creds = null
 


### PR DESCRIPTION
This PR should resolve a rough edge with temporary credentials for which the master credentials are themselves temporary. A user pointed out that [they needed to manually refresh Ec2 metadata credentials](https://github.com/aws/aws-sdk-js/issues/1064#issuecomment-282610182) used as the master credentials for an assumed role, which is not an ideal experience.

/cc @chrisradek 