### PR TITLE
Add support for loading shared config

### DIFF
--- a/.changes/next-release/feature-EnvironmentVariable-6754fae2.json
+++ b/.changes/next-release/feature-EnvironmentVariable-6754fae2.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EnvironmentVariable",
+  "description": "Load config from ~/.aws/config if AWS_SDK_LOAD_CONFIG is set"
+}

--- a/.changes/next-release/feature-EnvironmentVariable-99ebc879.json
+++ b/.changes/next-release/feature-EnvironmentVariable-99ebc879.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EnvironmentVariable",
+  "description": "Add support for specifying the location of the shared config file via the AWS_CONFIG_FILE environment variable. This variable is only honored if AWS_SDK_LOAD_CONFIG is set to a truthy value."
+}

--- a/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
+++ b/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
@@ -1,5 +1,5 @@
 {
   "type": "feature",
   "category": "EnvironmentVariable",
-  "description": "Add AWS_CREDENTIAL_PROFILES_FILE Environment Variable as defined in the Java AWS_SDK"
+  "description": "Add support for the AWS_SHARED_CREDENTIALS_FILE environment variable if AWS_SDK_LOAD_CONFIG is set"
 }

--- a/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
+++ b/.changes/next-release/feature-EnvironmentVariable-ce9cbf48.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EnvironmentVariable",
+  "description": "Add AWS_CREDENTIAL_PROFILES_FILE Environment Variable as defined in the Java AWS_SDK"
+}

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,7 +1,7 @@
 var AWS = require('../core');
 var path = require('path');
 var SharedIniFile = require('../shared_ini');
-var STS = require('../../clients/sts');
+require('../../clients/sts');
 
 /**
  * Represents credentials loaded from shared credentials file
@@ -176,7 +176,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sts = new STS({
+    var sts = new AWS.STS({
       credentials: new AWS.Credentials(sourceCredentials)
     });
 

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,10 +1,7 @@
 var AWS = require('../core');
 var path = require('path');
+var SharedIniFile = require('../shared_ini');
 var STS = require('../../clients/sts');
-
-var configOptInEnv = 'AWS_SDK_LOAD_CONFIG';
-var sharedFileEnv = 'AWS_SHARED_CREDENTIALS_FILE';
-var defaultProfile = 'default';
 
 /**
  * Represents credentials loaded from shared credentials file
@@ -57,7 +54,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     options = options || {};
 
     this.filename = options.filename;
-    this.profile = options.profile || process.env.AWS_PROFILE || defaultProfile;
+    this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
     this.disableAssumeRole = Boolean(options.disableAssumeRole);
     this.get(function() {});
   },
@@ -76,19 +73,27 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   refresh: function refresh(callback) {
     if (!callback) callback = function(err) { if (err) throw err; };
     try {
-      var profile = {};
-      if (process.env[configOptInEnv]) {
-        var config = new AWS.SharedIniFile({
+      var profiles = {};
+      if (process.env[AWS.util.configOptInEnv]) {
+        var config = new SharedIniFile({
           isConfig: true,
-          filename: process.env.AWS_CONFIG_FILE
+          filename: process.env[AWS.util.sharedConfigFileEnv]
         });
-        profile = AWS.util.merge(profile, config.getProfile(this.profile));
+        for (var i = 0, availableProfiles = config.getProfiles(); i < availableProfiles.length; i++) {
+          profiles[availableProfiles[i]] = config.getProfile(availableProfiles[i]);
+        }
       }
-      var creds = new AWS.SharedIniFile({
+      var creds = new SharedIniFile({
         filename: this.filename ||
-          (process.env[configOptInEnv] && process.env[sharedFileEnv])
+          (process.env[AWS.util.configOptInEnv] && process.env[AWS.util.sharedCredentialsFileEnv])
       });
-      profile = AWS.util.merge(profile, creds.getProfile(this.profile));
+      for (var i = 0, availableProfiles = creds.getProfiles(); i < availableProfiles.length; i++) {
+        profiles[availableProfiles[i]] = AWS.util.merge(
+          profiles[availableProfiles[i]] || {},
+          creds.getProfile(availableProfiles[i])
+        );
+      }
+      var profile = profiles[this.profile] || {};
 
       if (Object.keys(profile).length === 0) {
         throw AWS.util.error(
@@ -98,7 +103,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       }
 
       if (profile['role_arn']) {
-        this.loadRoleProfile(creds, profile, callback);
+        this.loadRoleProfile(profiles, profile, callback);
         return;
       }
 
@@ -126,7 +131,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     if (this.disableAssumeRole) {
       throw AWS.util.error(
         new Error('Role assumption profiles are disabled. ' +
-                  'Failed to load profile ' + this.profile),
+                  'Failed to load profile ' + this.profile +
+                  ' from ' + creds.filename),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
@@ -144,7 +150,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sourceProfile = creds.getProfile(sourceProfileName);
+    var sourceProfile = creds[sourceProfileName];
 
     if (typeof sourceProfile !== 'object') {
       throw AWS.util.error(

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -3,12 +3,13 @@ var path = require('path');
 var STS = require('../../clients/sts');
 
 var configOptInEnv = 'AWS_SDK_LOAD_CONFIG';
+var sharedFileEnv = 'AWS_SHARED_CREDENTIALS_FILE';
 var defaultProfile = 'default';
 
 /**
  * Represents credentials loaded from shared credentials file
  * (defaulting to ~/.aws/credentials or defined by the
- * `AWS_CREDENTIAL_PROFILES_FILE` environment variable).
+ * `AWS_SHARED_CREDENTIALS_FILE` environment variable).
  *
  * ## Using the shared credentials file
  *
@@ -44,7 +45,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    * @option options profile [String] (AWS_PROFILE env var or 'default')
    *   the name of the profile to load.
    * @option options filename [String] ('~/.aws/credentials' or defined by
-   *   AWS_CREDENTIAL_PROFILES_FILE process env var)
+   *   AWS_SHARED_CREDENTIALS_FILE process env var)
    *   the filename to use when loading credentials.
    * @option options disableAssumeRole [Boolean] (false) True to disable
    *   support for profiles that assume an IAM role. If true, and an assume
@@ -75,21 +76,23 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   refresh: function refresh(callback) {
     if (!callback) callback = function(err) { if (err) throw err; };
     try {
-      if (!this.filename) this.loadDefaultFilename();
       var profile = {};
       if (process.env[configOptInEnv]) {
-        var configProfileName = this.profile === defaultProfile ?
-          'default' : 'profile ' + this.profile;
-        var config = AWS.util.ini
-          .parse(AWS.util.readFileSync(this.configFilename));
-        profile = AWS.util.merge(profile, config[configProfileName]);
+        var config = new AWS.SharedIniFile({
+          isConfig: true,
+          filename: process.env.AWS_CONFIG_FILE
+        });
+        profile = AWS.util.merge(profile, config.getProfile(this.profile));
       }
-      var creds = AWS.util.ini.parse(AWS.util.readFileSync(this.filename));
-      profile = AWS.util.merge(profile, creds[this.profile]);
+      var creds = new AWS.SharedIniFile({
+        filename: this.filename ||
+          (process.env[configOptInEnv] && process.env[sharedFileEnv])
+      });
+      profile = AWS.util.merge(profile, creds.getProfile(this.profile));
 
       if (Object.keys(profile).length === 0) {
         throw AWS.util.error(
-          new Error('Profile ' + this.profile + ' not found in ' + this.filename),
+          new Error('Profile ' + this.profile + ' not found'),
           { code: 'SharedIniFileCredentialsProviderFailure' }
         );
       }
@@ -105,8 +108,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
       if (!this.accessKeyId || !this.secretAccessKey) {
         throw AWS.util.error(
-          new Error('Credentials not set in ' + this.filename +
-                    ' using profile ' + this.profile),
+          new Error('Credentials not set for profile ' + this.profile),
           { code: 'SharedIniFileCredentialsProviderFailure' }
         );
       }
@@ -124,8 +126,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     if (this.disableAssumeRole) {
       throw AWS.util.error(
         new Error('Role assumption profiles are disabled. ' +
-                  'Failed to load profile ' + this.profile + ' from ' +
-                  this.filename),
+                  'Failed to load profile ' + this.profile),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
@@ -138,19 +139,17 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     if (!sourceProfileName) {
       throw AWS.util.error(
-        new Error('source_profile is not set in ' + this.filename +
-                  ' using profile ' + this.profile),
+        new Error('source_profile is not set using profile ' + this.profile),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
 
-    var sourceProfile = creds[sourceProfileName];
+    var sourceProfile = creds.getProfile(sourceProfileName);
 
     if (typeof sourceProfile !== 'object') {
       throw AWS.util.error(
-        new Error('source_profile ' + sourceProfileName + ' set in ' +
-                  this.filename + ' using profile ' + this.profile +
-                  ' does not exist'),
+        new Error('source_profile ' + sourceProfileName + ' using profile '
+          + this.profile + ' does not exist'),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
@@ -166,8 +165,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     if (!sourceCredentials.accessKeyId || !sourceCredentials.secretAccessKey) {
       throw AWS.util.error(
         new Error('Credentials not set in source_profile ' +
-                  sourceProfileName + ' set in ' + this.filename +
-                  ' using profile ' + this.profile),
+                  sourceProfileName + ' using profile ' + this.profile),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
@@ -197,30 +195,5 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       self.expireTime = data.Credentials.Expiration;
       callback();
     });
-  },
-
-  /**
-   * @api private
-   */
-  loadDefaultFilename: function loadDefaultFilename() {
-    var env = process.env;
-
-    var home = env.HOME ||
-               env.USERPROFILE ||
-               (env.HOMEPATH ? ((env.HOMEDRIVE || 'C:/') + env.HOMEPATH) : null);
-    if (!home) {
-      throw AWS.util.error(
-        new Error('Cannot load credentials, HOME path not set'),
-        { code: 'SharedIniFileCredentialsProviderFailure' }
-      );
-    }
-
-    this.filename = path.join(home, '.aws', 'credentials');
-
-    if (env[configOptInEnv]) {
-      this.filename = env.AWS_SHARED_CREDENTIALS_FILE || this.filename;
-      this.configFilename = env.AWS_CONFIG_FILE ||
-        path.join(home, '.aws', 'config');
-    }
   }
 });

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,7 +1,7 @@
 var AWS = require('../core');
 var path = require('path');
 var SharedIniFile = require('../shared_ini');
-require('../../clients/sts');
+var STS = require('../../clients/sts');
 
 /**
  * Represents credentials loaded from shared credentials file
@@ -74,12 +74,13 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     if (!callback) callback = function(err) { if (err) throw err; };
     try {
       var profiles = {};
+      var i, availableProfiles;
       if (process.env[AWS.util.configOptInEnv]) {
         var config = new SharedIniFile({
           isConfig: true,
           filename: process.env[AWS.util.sharedConfigFileEnv]
         });
-        for (var i = 0, availableProfiles = config.getProfiles(); i < availableProfiles.length; i++) {
+        for (i = 0, availableProfiles = config.getProfiles(); i < availableProfiles.length; i++) {
           profiles[availableProfiles[i]] = config.getProfile(availableProfiles[i]);
         }
       }
@@ -87,11 +88,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         filename: this.filename ||
           (process.env[AWS.util.configOptInEnv] && process.env[AWS.util.sharedCredentialsFileEnv])
       });
-      for (var i = 0, availableProfiles = creds.getProfiles(); i < availableProfiles.length; i++) {
-        profiles[availableProfiles[i]] = AWS.util.merge(
-          profiles[availableProfiles[i]] || {},
-          creds.getProfile(availableProfiles[i])
-        );
+      for (i = 0, availableProfiles = creds.getProfiles(); i < availableProfiles.length; i++) {
+        profiles[availableProfiles[i]] = creds.getProfile(availableProfiles[i]);
       }
       var profile = profiles[this.profile] || {};
 
@@ -176,7 +174,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sts = new AWS.STS({
+    var sts = new STS({
       credentials: new AWS.Credentials(sourceCredentials)
     });
 

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -4,7 +4,8 @@ var STS = require('../../clients/sts');
 
 /**
  * Represents credentials loaded from shared credentials file
- * (defaulting to ~/.aws/credentials).
+ * (defaulting to ~/.aws/credentials or defined by the
+ * `AWS_CREDENTIAL_PROFILES_FILE` environment variable).
  *
  * ## Using the shared credentials file
  *
@@ -39,8 +40,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    * @param options [map] a set of options
    * @option options profile [String] (AWS_PROFILE env var or 'default')
    *   the name of the profile to load.
-   * @option options filename [String] ('~/.aws/credentials') the filename
-   *   to use when loading credentials.
+   * @option options filename [String] ('~/.aws/credentials' or defined by
+   *   AWS_CREDENTIAL_PROFILES_FILE process env var)
+   *   the filename to use when loading credentials.
    * @option options disableAssumeRole [Boolean] (false) True to disable
    *   support for profiles that assume an IAM role. If true, and an assume
    *   role profile is selected, an error is raised.
@@ -50,7 +52,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     options = options || {};
 
-    this.filename = options.filename;
+    this.filename = options.filename || process.env.AWS_CREDENTIAL_PROFILES_FILE;
     this.profile = options.profile || process.env.AWS_PROFILE || 'default';
     this.disableAssumeRole = !!options.disableAssumeRole;
     this.get(function() {});

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -2,6 +2,9 @@ var AWS = require('../core');
 var path = require('path');
 var STS = require('../../clients/sts');
 
+var configOptInEnv = 'AWS_SDK_LOAD_CONFIG';
+var defaultProfile = 'default';
+
 /**
  * Represents credentials loaded from shared credentials file
  * (defaulting to ~/.aws/credentials or defined by the
@@ -52,9 +55,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     options = options || {};
 
-    this.filename = options.filename || process.env.AWS_CREDENTIAL_PROFILES_FILE;
-    this.profile = options.profile || process.env.AWS_PROFILE || 'default';
-    this.disableAssumeRole = !!options.disableAssumeRole;
+    this.filename = options.filename;
+    this.profile = options.profile || process.env.AWS_PROFILE || defaultProfile;
+    this.disableAssumeRole = Boolean(options.disableAssumeRole);
     this.get(function() {});
   },
 
@@ -73,10 +76,18 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     if (!callback) callback = function(err) { if (err) throw err; };
     try {
       if (!this.filename) this.loadDefaultFilename();
+      var profile = {};
+      if (process.env[configOptInEnv]) {
+        var configProfileName = this.profile === defaultProfile ?
+          'default' : 'profile ' + this.profile;
+        var config = AWS.util.ini
+          .parse(AWS.util.readFileSync(this.configFilename));
+        profile = AWS.util.merge(profile, config[configProfileName]);
+      }
       var creds = AWS.util.ini.parse(AWS.util.readFileSync(this.filename));
-      var profile = creds[this.profile];
+      profile = AWS.util.merge(profile, creds[this.profile]);
 
-      if (typeof profile !== 'object') {
+      if (Object.keys(profile).length === 0) {
         throw AWS.util.error(
           new Error('Profile ' + this.profile + ' not found in ' + this.filename),
           { code: 'SharedIniFileCredentialsProviderFailure' }
@@ -193,6 +204,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   loadDefaultFilename: function loadDefaultFilename() {
     var env = process.env;
+
     var home = env.HOME ||
                env.USERPROFILE ||
                (env.HOMEPATH ? ((env.HOMEDRIVE || 'C:/') + env.HOMEPATH) : null);
@@ -204,5 +216,11 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     }
 
     this.filename = path.join(home, '.aws', 'credentials');
+
+    if (env[configOptInEnv]) {
+      this.filename = env.AWS_SHARED_CREDENTIALS_FILE || this.filename;
+      this.configFilename = env.AWS_CONFIG_FILE ||
+        path.join(home, '.aws', 'config');
+    }
   }
 });

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -19,6 +19,9 @@ AWS.XML.Parser = require('./xml/node_parser');
 // Load Node HTTP client
 require('./http/node');
 
+// Load Node shared ini file loader
+require('./shared_ini');
+
 // Load custom credential providers
 require('./credentials/ec2_metadata_credentials');
 require('./credentials/ecs_credentials');
@@ -59,7 +62,19 @@ AWS.util.update(AWS.Config.prototype.keys, {
     return new AWS.CredentialProviderChain();
   },
   region: function() {
-    return process.env.AWS_REGION || process.env.AMAZON_REGION;
+    var env = process.env;
+    var region = env.AWS_REGION || env.AMAZON_REGION;
+    if (!region && env.AWS_SDK_LOAD_CONFIG) {
+      var configFile = new AWS.SharedIniFile({
+        isConfig: true,
+        filename: process.env.AWS_CONFIG_FILE
+      });
+      var profile = configFile.getProfile(
+        env.AWS_PROFILE || AWS.util.defaultProfile
+      );
+      region = profile && profile.region;
+    }
+    return region;
   }
 });
 

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -19,15 +19,14 @@ AWS.XML.Parser = require('./xml/node_parser');
 // Load Node HTTP client
 require('./http/node');
 
-// Load Node shared ini file loader
-require('./shared_ini');
-
 // Load custom credential providers
 require('./credentials/ec2_metadata_credentials');
 require('./credentials/ecs_credentials');
 require('./credentials/environment_credentials');
 require('./credentials/file_system_credentials');
 require('./credentials/shared_ini_file_credentials');
+
+var SharedIniFile = require('./shared_ini');
 
 // Setup default chain providers
 // If this changes, please update documentation for
@@ -64,15 +63,18 @@ AWS.util.update(AWS.Config.prototype.keys, {
   region: function() {
     var env = process.env;
     var region = env.AWS_REGION || env.AMAZON_REGION;
-    if (!region && env.AWS_SDK_LOAD_CONFIG) {
-      var configFile = new AWS.SharedIniFile({
-        isConfig: true,
-        filename: process.env.AWS_CONFIG_FILE
-      });
-      var profile = configFile.getProfile(
-        env.AWS_PROFILE || AWS.util.defaultProfile
-      );
-      region = profile && profile.region;
+    if (env[AWS.util.configOptInEnv]) {
+      var toCheck = [
+        {filename: env[AWS.util.sharedCredentialsFileEnv]},
+        {isConfig: true, filename: env[AWS.util.sharedConfigFileEnv]}
+      ];
+      while (!region && toCheck.length) {
+        var configFile = new SharedIniFile(toCheck.shift());
+        var profile = configFile.getProfile(
+          env.AWS_PROFILE || AWS.util.defaultProfile
+        );
+        region = profile && profile.region;
+      }
     }
     return region;
   }

--- a/lib/shared_ini.js
+++ b/lib/shared_ini.js
@@ -1,0 +1,59 @@
+var AWS = require('./core');
+var os = require('os');
+var path = require('path');
+
+/**
+ * @api private
+ */
+AWS.SharedIniFile = AWS.util.inherit({
+  constructor: function SharedIniFile(options) {
+    options = options || {};
+
+    this.filename = options.filename;
+    this.isConfig = options.isConfig === true;
+  },
+
+  ensureFileLoaded: function loadFile() {
+    if (!this.parsedContents) {
+      this.parsedContents = AWS.util.ini.parse(
+        AWS.util.readFileSync(this.filename || this.getDefaultFilepath())
+      );
+    }
+  },
+
+  getDefaultFilepath: function getDefaultFilepath() {
+    return path.join(
+      this.getHomeDir(),
+      '.aws',
+      this.isConfig ? 'config' : 'credentials'
+    );
+  },
+
+  getHomeDir: function getHomeDir() {
+    if (typeof os.homedir === 'function') {
+      return os.homedir();
+    }
+
+    var env = process.env;
+    var home = env.HOME ||
+      env.USERPROFILE ||
+      (env.HOMEPATH ? ((env.HOMEDRIVE || 'C:/') + env.HOMEPATH) : null);
+
+    if (home) {
+      return home;
+    }
+
+    throw AWS.util.error(
+      new Error('Cannot load credentials, HOME path not set')
+    );
+  },
+
+  getProfile: function loadProfile(profile) {
+    this.ensureFileLoaded();
+
+    var profileIndex = profile !== AWS.util.defaultProfile && this.isConfig ?
+      'profile ' + profile : profile;
+
+    return this.parsedContents[profileIndex];
+  }
+});

--- a/lib/shared_ini.js
+++ b/lib/shared_ini.js
@@ -5,18 +5,18 @@ var path = require('path');
 /**
  * @api private
  */
-AWS.SharedIniFile = AWS.util.inherit({
+module.exports = AWS.util.inherit({
   constructor: function SharedIniFile(options) {
     options = options || {};
 
-    this.filename = options.filename;
     this.isConfig = options.isConfig === true;
+    this.filename = options.filename || this.getDefaultFilepath();
   },
 
   ensureFileLoaded: function loadFile() {
     if (!this.parsedContents) {
       this.parsedContents = AWS.util.ini.parse(
-        AWS.util.readFileSync(this.filename || this.getDefaultFilepath())
+        AWS.util.readFileSync(this.filename)
       );
     }
   },
@@ -55,5 +55,18 @@ AWS.SharedIniFile = AWS.util.inherit({
       'profile ' + profile : profile;
 
     return this.parsedContents[profileIndex];
+  },
+
+  getProfiles: function loadProfileNames() {
+    this.ensureFileLoaded();
+    var isConfig = this.isConfig;
+
+    return Object.keys(this.parsedContents).map(function(profileName) {
+      if (isConfig) {
+        return profileName.replace(/^profile\s/, '');
+      }
+
+      return profileName;
+    });
   }
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -897,7 +897,22 @@ var util = {
   /**
    * @api private
    */
-  defaultProfile: 'default'
+  defaultProfile: 'default',
+
+  /**
+   * @api private
+   */
+  configOptInEnv: 'AWS_SDK_LOAD_CONFIG',
+
+  /**
+   * @api private
+   */
+  sharedCredentialsFileEnv: 'AWS_SHARED_CREDENTIALS_FILE',
+
+  /**
+   * @api private
+   */
+  sharedConfigFileEnv: 'AWS_CONFIG_FILE'
 };
 
 module.exports = util;

--- a/lib/util.js
+++ b/lib/util.js
@@ -892,8 +892,12 @@ var util = {
     if (rules.payload && resp.data[rules.payload]) {
       resp.data[rules.payload] = resp.data[rules.payload].toString();
     }
-  }
+  },
 
+  /**
+   * @api private
+   */
+  defaultProfile: 'default'
 };
 
 module.exports = util;

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -1,5 +1,6 @@
 helpers = require('./helpers')
 AWS = helpers.AWS
+SharedIniFile = require('../lib/shared_ini')
 
 configure = (options) -> new AWS.Config(options)
 
@@ -55,46 +56,98 @@ describe 'AWS.Config', ->
           os = require('os')
           helpers.spyOn(os, 'homedir').andReturn('/home/user')
 
-        it 'grabs region from shared config if AWS_SDK_LOAD_CONFIG is set', ->
+        it 'grabs region from shared credentials file if AWS_SDK_LOAD_CONFIG is set', ->
           process.env.AWS_SDK_LOAD_CONFIG = '1'
-          mock = '''
-          [default]
-          region = us-west-2
-          '''
-          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+            if (path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/))
+              '''
+              [default]
+              region = us-west-2
+              '''
+            else
+              '''
+              [default]
+              region = eu-east-1
+              '''
 
           config = new AWS.Config()
           expect(config.region).to.equal('us-west-2')
-          expect(AWS.util.readFileSync.calls[0].arguments[0]).to.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/)
+
+        it 'loads file from path specified in AWS_SHARED_CREDENTIALS_FILE if AWS_SDK_LOAD_CONFIG is set', ->
+          process.env.AWS_SDK_LOAD_CONFIG = '1'
+          process.env.AWS_SHARED_CREDENTIALS_FILE = '/path/to/user/config/file'
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+            if (path == '/path/to/user/config/file')
+              '''
+              [default]
+              region = us-west-2
+              '''
+            else
+              '''
+              [default]
+              region = eu-east-1
+              '''
+
+          config = new AWS.Config()
+          expect(config.region).to.equal('us-west-2')
+
+        it 'grabs region from shared config if AWS_SDK_LOAD_CONFIG is set', ->
+          process.env.AWS_SDK_LOAD_CONFIG = '1'
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+            if (path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/))
+              '''
+              [default]
+              region = us-west-2
+              '''
+            else
+              '''
+              [default]
+              aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+              aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              '''
+
+          config = new AWS.Config()
+          expect(config.region).to.equal('us-west-2')
 
         it 'loads file from path specified in AWS_CONFIG_FILE if AWS_SDK_LOAD_CONFIG is set', ->
           process.env.AWS_SDK_LOAD_CONFIG = '1'
           process.env.AWS_CONFIG_FILE = '/path/to/user/config/file'
-          mock = '''
-          [default]
-          region = us-west-2
-          '''
-          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+            if (path == '/path/to/user/config/file')
+              '''
+              [default]
+              region = us-west-2
+              '''
+            else
+              '''
+              [default]
+              aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+              aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+              '''
 
           config = new AWS.Config()
           expect(config.region).to.equal('us-west-2')
-          expect(AWS.util.readFileSync.calls[0].arguments[0]).to.equal('/path/to/user/config/file')
 
         it 'uses the profile specified in AWS_PROFILE', ->
           process.env.AWS_SDK_LOAD_CONFIG = '1'
           process.env.AWS_PROFILE = 'foo'
-          mock = '''
-          [default]
-          region = us-west-1
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+            if (path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/))
+              '''
+              [default]
+              region = us-west-1
 
-          [profile foo]
-          region = us-west-2
-          '''
-          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
+              [profile foo]
+              region = us-west-2
+              '''
+            else
+              '''
+              [default]
+              region = eu-east-1
+              '''
 
           config = new AWS.Config()
           expect(config.region).to.equal('us-west-2')
-          expect(AWS.util.readFileSync.calls[0].arguments[0]).to.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/)
 
         it 'prefers AWS_REGION to the shared config file', ->
           process.env.AWS_REGION = 'us-east-1'

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -295,6 +295,23 @@ if AWS.util.isNode()
         expect(creds.secretAccessKey).to.equal('secret')
         expect(creds.sessionToken).to.equal('session')
 
+      it 'will not merge profiles across the config and credentials file', ->
+        process.env.AWS_SDK_LOAD_CONFIG = '1'
+        helpers.spyOn(AWS.util, 'readFileSync').andCallFake (path) ->
+          if path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/)
+            '''
+            [default]
+            aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+            '''
+          else
+            '''
+            [default]
+            aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+            '''
+
+        creds = new AWS.SharedIniFileCredentials()
+        creds.get((err, data) -> expect(err).to.be.defined);
+
       it 'loads credentials from ~/.aws/credentials if AWS_SDK_LOAD_CONFIG is not set', ->
         process.env.AWS_SHARED_CREDENTIALS_FILE = '/path/to/aws/credentials'
         mock = '''
@@ -514,11 +531,11 @@ if AWS.util.isNode()
       </AssumeRoleResponse>
       '''
       creds = new AWS.SharedIniFileCredentials()
-      stsCtorSpy = helpers.spyOn(AWS, 'STS').andCallThrough()
+      credsCtorSpy = helpers.spyOn(AWS, 'Credentials').andCallThrough()
       expect(creds.roleArn).to.equal('arn')
       creds.refresh (err) ->
-        expect(stsCtorSpy.calls.length).to.equal(1)
-        sourceCreds = stsCtorSpy.calls[0].arguments[0].credentials
+        expect(credsCtorSpy.calls.length).to.equal(1)
+        sourceCreds = credsCtorSpy.calls[0].arguments[0]
         expect(sourceCreds.accessKeyId).to.equal('akid')
         expect(sourceCreds.secretAccessKey).to.equal('secret')
 
@@ -556,11 +573,11 @@ if AWS.util.isNode()
       </AssumeRoleResponse>
       '''
       creds = new AWS.SharedIniFileCredentials()
-      stsCtorSpy = helpers.spyOn(AWS, 'STS').andCallThrough()
+      credsCtorSpy = helpers.spyOn(AWS, 'Credentials').andCallThrough()
       expect(creds.roleArn).to.equal('arn')
       creds.refresh (err) ->
-        expect(stsCtorSpy.calls.length).to.equal(1)
-        sourceCreds = stsCtorSpy.calls[0].arguments[0].credentials
+        expect(credsCtorSpy.calls.length).to.equal(1)
+        sourceCreds = credsCtorSpy.calls[0].arguments[0]
         expect(sourceCreds.accessKeyId).to.equal('akid')
         expect(sourceCreds.secretAccessKey).to.equal('secret')
 

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -158,6 +158,7 @@ if AWS.util.isNode()
   describe 'AWS.SharedIniFileCredentials', ->
     beforeEach ->
       delete process.env.AWS_PROFILE
+      delete process.env.AWS_CREDENTIAL_PROFILES_FILE
       delete process.env.HOME
       delete process.env.HOMEPATH
       delete process.env.HOMEDRIVE
@@ -208,6 +209,21 @@ if AWS.util.isNode()
         creds.get();
         validateCredentials(creds)
         expect(AWS.util.readFileSync.calls[0].arguments[0]).to.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/)
+
+      it 'loads credentials from path defined in AWS_CREDENTIAL_PROFILES_FILE', ->
+        process.env.AWS_CREDENTIAL_PROFILES_FILE = '/path/to/aws/credentials'
+        mock = '''
+        [default]
+        aws_access_key_id = akid
+        aws_secret_access_key = secret
+        aws_session_token = session
+        '''
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock)
+
+        creds = new AWS.SharedIniFileCredentials()
+        creds.get();
+        validateCredentials(creds)
+        expect(AWS.util.readFileSync.calls[0].arguments[0]).to.equal('/path/to/aws/credentials')
 
       it 'loads the default profile if AWS_PROFILE is empty', ->
         process.env.AWS_PROFILE = ''

--- a/test/services/cloudsearchdomain.spec.coffee
+++ b/test/services/cloudsearchdomain.spec.coffee
@@ -46,6 +46,7 @@ describe 'AWS.CloudSearchDomain', ->
 
     it 'does NOT sign request if credentials are NOT provided', ->
       cds.config.credentials = null
+      cds.config.credentialProvider = null
       params = { query: 'foo' }
       req = build('search', params)
       expect(req.headers).not.to.have.property('Authorization')


### PR DESCRIPTION
This PR adds support for loading configuration from `~/.aws/config`, including credentials, the default region to use, and role assumption metadata. This is an opt-in feature and will only take effect if the `AWS_SDK_LOAD_CONFIG` environment variable is set to something truthy.

I also added support for some configuration environment variables that we do not currently support, namely `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE`, both of which will only be used if `AWS_SDK_LOAD_CONFIG` is set.

This should resolve #1196 as well (via `AWS_SHARED_CREDENTIALS_FILE`).

Resolves #1296 
Resolves #1093 
Resolves #993 