### PR TITLE
Fixes missing last part on managed uploads

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -173,10 +173,10 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
           on('end', function() {
             self.isDoneChunking = true;
             self.numParts = self.totalPartNumbers;
+            self.fillQueue.call(self);
+
             if (self.isDoneChunking && self.totalPartNumbers >= 1 && self.doneParts === self.numParts) {
               self.finishMultiPart();
-            } else {
-              self.fillQueue.call(self);
             }
           });
       }

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -393,6 +393,35 @@ describe 'AWS.S3.ManagedUpload', ->
               ]
               done()
 
+        it 'can send a stream that is larger then the part size', (done) ->
+          partSize = 5 * 1024 * 1024
+          streamSize = 1024 + partSize
+          require('crypto').randomBytes streamSize, (err, buf) ->
+            return done(err) if err
+
+            stream = AWS.util.buffer.toStream buf
+            reqs = helpers.mockResponses [
+              { data: UploadId: 'uploadId' }
+              { data: ETag: 'ETAG1' }
+              { data: ETag: 'ETAG2' }
+              { data: ETag: 'FINAL_ETAG', Location: 'FINAL_LOCATION' }
+            ]
+            upload = new AWS.S3.ManagedUpload({
+              partSize: partSize,
+              queueSize: 1,
+              params: { Body: stream }
+            })
+            upload.send (err) ->
+              return done(err) if err
+
+              expect(helpers.operationsForRequests(reqs)).to.eql [
+                's3.createMultipartUpload',
+                's3.uploadPart',
+                's3.uploadPart',
+                's3.completeMultipartUpload'
+              ]
+              done()
+
         it 'can send a stream that is exactly divisible by part size', (done) ->
           partSize = 5 * 1024 * 1024
           streamSize = 2 * partSize


### PR DESCRIPTION
When using queueSize 1 and receiving an end event before the last part
was read, the last part wasn't uploaded and the upload corrupted.