### PR TITLE
Allow conversion of objects with inheritance chains via DocumentClient converter

### DIFF
--- a/.changes/next-release/feature-DynamoDb-3a53558c.json
+++ b/.changes/next-release/feature-DynamoDb-3a53558c.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "DynamoDb",
+  "description": "Allow objects with inheritance chains to be converted to MapAttributeValues instead of undefined"
+}

--- a/lib/dynamodb/converter.js
+++ b/lib/dynamodb/converter.js
@@ -7,6 +7,7 @@ var DynamoDBSet = require('./set');
  * Convert a JavaScript value to its equivalent DynamoDB AttributeValue type
  *
  * @param data [any] The data to convert to a DynamoDB AttributeValue
+ * @param options [map]
  * @option options convertEmptyValues [Boolean] Whether to automatically convert
  *                                              empty strings, blobs, and sets
  *                                              to `null`
@@ -16,17 +17,9 @@ function convertInput(data, options) {
   options = options || {};
   var type = typeOf(data);
   if (type === 'Object') {
-    var map = {M: {}};
-    for (var key in data) {
-      map['M'][key] = convertInput(data[key], options);
-    }
-    return map;
+    return formatMap(data, options);
   } else if (type === 'Array') {
-    var list = {L: []};
-    for (var i = 0; i < data.length; i++) {
-      list['L'].push(convertInput(data[i], options));
-    }
-    return list;
+    return formatList(data, options);
   } else if (type === 'Set') {
     return formatSet(data, options);
   } else if (type === 'String') {
@@ -45,7 +38,39 @@ function convertInput(data, options) {
     return { BOOL: data };
   } else if (type === 'null') {
     return { NULL: true };
+  } else if (type !== 'undefined' && type !== 'Function') {
+    // this value has a custom constructor
+    return formatMap(data, options);
   }
+}
+
+/**
+ * @api private
+ * @param data [Array]
+ * @param options [map]
+ */
+function formatList(data, options) {
+  var list = {L: []};
+  for (var i = 0; i < data.length; i++) {
+    list['L'].push(convertInput(data[i], options));
+  }
+  return list;
+}
+
+/**
+ * @api private
+ * @param data [map]
+ * @param options [map]
+ */
+function formatMap(data, options) {
+  var map = {M: {}};
+  for (var key in data) {
+    var formatted = convertInput(data[key], options);
+    if (formatted !== void 0) {
+      map['M'][key] = formatted;
+    }
+  }
+  return map;
 }
 
 /**


### PR DESCRIPTION
The DynamoDB Document Client converter currently omits any objects with extended prototype chains from the serialized format. I couldn't find a good way to test this with ES6 classes, but I added tests for the prototypical inheritance pattern that classes use behind the curtain.

This would resolve #1378