### PR TITLE
Customize waiter configuration

### DIFF
--- a/.changes/next-release/feature-Waiter-0b39468f.json
+++ b/.changes/next-release/feature-Waiter-0b39468f.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Waiter",
+  "description": "Allow customization of a waiter using a special `$waiter` key"
+}

--- a/lib/resource_waiter.js
+++ b/lib/resource_waiter.js
@@ -136,13 +136,15 @@ AWS.ResourceWaiter = inherit({
       callback = params; params = undefined;
     }
 
-    if (params && params.delay) {
-      this.config.delay = params.delay;
-      delete params.delay;
-    }
-    if (params && params.maxAttempts) {
-      this.config.maxAttempts = params.maxAttempts;
-      delete params.maxAttempts;
+    if (params && params.$waiter) {
+      params = AWS.util.copy(params);
+      if (typeof params.$waiter.delay === 'number') {
+        this.config.delay = params.$waiter.delay;
+      }
+      if (typeof params.$waiter.maxAttempts === 'number') {
+        this.config.maxAttempts = params.$waiter.maxAttempts;
+      }
+      delete params.$waiter;
     }
 
     var request = this.service.makeRequest(this.config.operation, params);

--- a/lib/resource_waiter.js
+++ b/lib/resource_waiter.js
@@ -136,6 +136,15 @@ AWS.ResourceWaiter = inherit({
       callback = params; params = undefined;
     }
 
+    if (params && params.delay) {
+      this.config.delay = params.delay;
+      delete params.delay;
+    }
+    if (params && params.maxAttempts) {
+      this.config.maxAttempts = params.maxAttempts;
+      delete params.maxAttempts;
+    }
+
     var request = this.service.makeRequest(this.config.operation, params);
     request._waiter = this;
     request.response.maxRetries = this.config.maxAttempts;
@@ -173,6 +182,6 @@ AWS.ResourceWaiter = inherit({
       });
     }
 
-    this.config = this.service.api.waiters[state];
+    this.config = AWS.util.copy(this.service.api.waiters[state]);
   }
 });

--- a/lib/service.d.ts
+++ b/lib/service.d.ts
@@ -2,6 +2,19 @@ import {Request} from './request';
 import {AWSError} from './error';
 import {ConfigurationOptions, ConfigBase} from './config';
 import {Endpoint} from './endpoint';
+
+interface WaiterConfiguration {
+    /**
+     * The number of seconds to wait between requests
+     */
+    delay?: number;
+
+    /**
+     * The maximum number of requests to send while waiting
+     */
+    maxAttempts?: number;
+}
+
 export class Service {
     /**
      * Creates a new service object with a configuration object.
@@ -37,7 +50,7 @@ export class Service {
     /**
      * Waits for a given state.
      */
-    waitFor(state: string, params?: {[key: string]: any}, callback?: (err: AWSError, data: any) => void): Request<any, AWSError>;
+    waitFor(state: string, params?: {[key: string]: any, $waiter?: WaiterConfiguration}, callback?: (err: AWSError, data: any) => void): Request<any, AWSError>;
     waitFor(state: string, callback?: (err: AWSError, data: any) => void): Request<any, AWSError>;
 
     /**

--- a/lib/service.js
+++ b/lib/service.js
@@ -223,6 +223,11 @@ AWS.Service = inherit({
    *
    * @param state [String] the state on the service to wait for
    * @param params [map] a map of parameters to pass with each request
+   * @option params $waiter [map] a map of configuration options for the waiter
+   * @option params $waiter.delay [Number] The number of seconds to wait between
+   *                                       requests
+   * @option params $waiter.maxAttempts [Number] The maximum number of requests
+   *                                             to send while waiting
    * @callback callback function(err, data)
    *   If a callback is supplied, it is called when a response is returned
    *   from the service.

--- a/test/resource_waiter.spec.coffee
+++ b/test/resource_waiter.spec.coffee
@@ -190,3 +190,24 @@ describe 'AWS.ResourceWaiter', ->
       expect(err).to.equal(null)
       expect(data).to.not.eql(null)
       expect(resp.retryCount).to.equal(2)
+
+    it 'supports custom delay and maxAttempts', ->
+      err = null; data = null; resp = null
+      db = new AWS.DynamoDB
+      maxAttempts = 50
+      delay = 5
+      resps = ({data: {Table: {TableStatus: 'LOADING'}}} for _ in [1..maxAttempts+1])
+      resps.push({data: {Table: {TableStatus: 'ACTIVE'}}})
+      helpers.mockResponses resps
+
+      waiter = new AWS.ResourceWaiter(db, 'tableExists')
+      waiter.wait {delay: delay, maxAttempts: maxAttempts}, (e, d) -> resp = this; err = e; data = d
+      expect(data).to.equal(null)
+      expect(err.code).to.equal('ResourceNotReady')
+      expect(resp.retryCount).to.equal(maxAttempts)
+      expect(resp.error.retryDelay).to.equal(delay * 1000)
+
+      # Ensure custom settings aren't persisted in future waiters
+      waiter = new AWS.ResourceWaiter(db, 'tableExists')
+      expect(waiter.config.maxAttempts).to.equal(25);
+      expect(waiter.config.delay).to.equal(20);

--- a/test/resource_waiter.spec.coffee
+++ b/test/resource_waiter.spec.coffee
@@ -201,7 +201,7 @@ describe 'AWS.ResourceWaiter', ->
       helpers.mockResponses resps
 
       waiter = new AWS.ResourceWaiter(db, 'tableExists')
-      waiter.wait {delay: delay, maxAttempts: maxAttempts}, (e, d) -> resp = this; err = e; data = d
+      waiter.wait {$waiter: {delay: delay, maxAttempts: maxAttempts}}, (e, d) -> resp = this; err = e; data = d
       expect(data).to.equal(null)
       expect(err.code).to.equal('ResourceNotReady')
       expect(resp.retryCount).to.equal(maxAttempts)

--- a/ts/service.ts
+++ b/ts/service.ts
@@ -1,0 +1,22 @@
+import {AWSError} from '../lib/error';
+import {DescribeTableOutput} from '../clients/dynamodb';
+import {Service} from '../lib/service';
+
+const service: Service = new Service({
+    endpoint: 'http://localhost:3000',
+    params: {
+        BucketName: 'mybucket1337',
+    },
+});
+
+service.waitFor('BucketExists', (err: AWSError, data: any) => {
+    // The bucket exists!
+});
+
+service.waitFor(
+    'TableExists',
+    {$waiter: {delay: 20, maxAttempts: 4}},
+    (err: AWSError, data: DescribeTableOutput) => {
+        // The table exists!
+    }
+);


### PR DESCRIPTION
This PR is a continuation of #1206. Rather than keep `delay` and `maxAttempts` as top-level members of the hash passed to `ResourceWaiter`, the waiter will look for them in a key (`@waiter`) that won't collide with any operation arguments.

/cc @chrisradek  

Resolves #1206 
Resolves #881 