### PR TITLE
Overwrite the name of errors thrown by underlying credential providers in AWS.Config.getCredentials

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -310,7 +310,9 @@ AWS.Config = AWS.util.inherit({
 
     function credError(msg, err) {
       return new AWS.util.error(err || new Error(), {
-        code: 'CredentialsError', message: msg
+        code: 'CredentialsError',
+        message: msg,
+        name: 'CredentialsError'
       });
     }
 

--- a/test/config.spec.coffee
+++ b/test/config.spec.coffee
@@ -146,7 +146,7 @@ describe 'AWS.Config', ->
       config = new AWS.Config()
       config.update(foo: 10)
       expect(config.foo).to.equal(undefined)
-    
+
     describe 'should allow', ->
       allServices = require('../clients/all')
       for own className, ctor of allServices
@@ -208,6 +208,7 @@ describe 'AWS.Config', ->
       config.getCredentials(spy)
       expect(spy.calls.length).not.to.equal(0)
       expect(spy.calls[0].arguments[0].code).to.equal('CredentialsError')
+      expect(spy.calls[0].arguments[0].name).to.equal('CredentialsError')
       expect(spy.calls[0].arguments[0].message).to.equal(message)
 
     it 'should check credentials for static object first', ->
@@ -220,9 +221,12 @@ describe 'AWS.Config', ->
       expectValid credentials: get: (cb) -> cb()
 
     it 'should error if credentials.get() cannot resolve', ->
+      error = new Error('Error!')
+      error.code = 'FooError'
+      error.name = 'BarError'
       options = credentials:
         constructor: name: 'CustomCredentials'
-        get: (cb) -> cb(new Error('Error!'), null)
+        get: (cb) -> cb(error, null)
       expectError options, 'Could not load credentials from CustomCredentials'
 
     it 'should check credentialProvider if no credentials', ->
@@ -230,8 +234,11 @@ describe 'AWS.Config', ->
         resolve: (cb) -> cb(null, accessKeyId: 'key', secretAccessKey: 'secret')
 
     it 'should error if credentialProvider fails to resolve', ->
+      error = new Error('Error!')
+      error.code = 'FooError'
+      error.name = 'BarError'
       options = credentials: null, credentialProvider:
-        resolve: (cb) -> cb(new Error('Error!'), null)
+        resolve: (cb) -> cb(error, null)
       expectError options, 'Could not load credentials from any providers'
 
     it 'should error if no credentials or credentialProvider', ->
@@ -256,7 +263,7 @@ describe 'AWS.config', ->
       expect(utilSpy.calls.length).to.equal(1)
       expect(Array.isArray(utilSpy.calls[0].arguments[0])).to.be.true
       expect(utilSpy.calls[0].arguments[0].length).to.equal(4)
-    
+
     if typeof Promise != 'undefined'
       it 'reverts to native promises when null is passed', ->
         # create fake promise constructor

--- a/test/event_listeners.spec.coffee
+++ b/test/event_listeners.spec.coffee
@@ -71,6 +71,7 @@ describe 'AWS.EventListeners', ->
       AWS.util.arrayEach errorHandler.calls, (call) ->
         expect(call.arguments[0]).to.be.instanceOf(Error)
         expect(call.arguments[0].code).to.equal('CredentialsError')
+        expect(call.arguments[0].name).to.equal('CredentialsError')
         expect(call.arguments[0].message).to.match(/Missing credentials/)
 
     it 'sends error event if credentials are not set', ->
@@ -82,6 +83,7 @@ describe 'AWS.EventListeners', ->
       AWS.util.arrayEach errorHandler.calls, (call) ->
         expect(call.arguments[0] ).to.be.instanceOf(Error)
         expect(call.arguments[0].code).to.equal('CredentialsError')
+        expect(call.arguments[0].name).to.equal('CredentialsError')
         expect(call.arguments[0].message).to.match(/Missing credentials/)
 
     it 'does not validate credentials if request is not signed', ->


### PR DESCRIPTION
This is a fairly narrow fix to #849 along the lines proposed in [this comment](https://github.com/aws/aws-sdk-js/issues/849#issuecomment-247725567). We're already overwriting the code and message of the errors intercepted in `AWS.Config.getCredentials`, and this PR would overwrite the name as well.

I'm not 100% sure this is a backwards compatible change. Obviously, the error situation reported in #849 is not a `TimeoutError`, but replacing the name of the underlying error (`TimeoutError`) with something appropriate might be a breaking change if someone is explicitly matching those timeout errors by name.

/cc @chrisradek 