### PR TITLE
Ensure codecov runs after any job completes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    after_n_builds: 1
+
 coverage:
   status:
     project:


### PR DESCRIPTION
CodeCov seems to get stuck in a "waiting for CI to complete" loop pretty frequently. This change will have CodeCov comment after the first build job completes.

/cc @chrisradek 