### PR TITLE
Ensure MultipartUpload locations returned by the managed uploader are URI-decoded to match single part upload locations

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -618,10 +618,20 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
         return self.cleanup(err);
       }
 
+      if (data && typeof data.Location === 'string') {
+        data.Location = data.Location.replace(/%2F/g, '/');
+      }
+
       if (Array.isArray(self.tags)) {
         self.service.putObjectTagging(
           {Tagging: {TagSet: self.tags}},
-          self.callback
+          function(err, data) {
+            if (err) {
+              self.callback(err);
+            } else {
+              self.callback(null, data);
+            }
+          }
         );
       } else {
         self.callback(err, data);

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -625,11 +625,11 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       if (Array.isArray(self.tags)) {
         self.service.putObjectTagging(
           {Tagging: {TagSet: self.tags}},
-          function(err, data) {
-            if (err) {
-              self.callback(err);
+          function(e, d) {
+            if (e) {
+              self.callback(e);
             } else {
-              self.callback(null, data);
+              self.callback(e, data);
             }
           }
         );

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -337,6 +337,54 @@ describe 'AWS.S3.ManagedUpload', ->
         expect(data.Bucket).to.equal('bucket')
         done()
 
+    describe 'Location', ->
+      it 'returns paths with simple string keys for single part uploads', (done) ->
+        reqs = helpers.mockResponses [
+          data: ETag: 'ETAG'
+        ]
+        send {Body: smallbody, ContentEncoding: 'encoding', Key: 'file.ext'}, ->
+          expect(err).not.to.exist
+          expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/file.ext')
+          done()
+
+      it 'returns paths with simple string keys for multipart uploads', (done) ->
+        reqs = helpers.mockResponses [
+          { data: UploadId: 'uploadId' }
+          { data: ETag: 'ETAG1' }
+          { data: ETag: 'ETAG2' }
+          { data: ETag: 'ETAG3' }
+          { data: ETag: 'ETAG4' }
+          { data: ETag: 'FINAL_ETAG', Location: 'https://bucket.s3.mock-region.amazonaws.com/file.ext' }
+        ]
+        send {Body: bigbody, ContentEncoding: 'encoding', Key: 'file.ext'}, ->
+          expect(err).not.to.exist
+          expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/file.ext')
+          done()
+
+      it 'returns paths with subfolder keys for single part uploads', (done) ->
+        reqs = helpers.mockResponses [
+          data: ETag: 'ETAG'
+        ]
+        send {Body: smallbody, ContentEncoding: 'encoding', Key: 'directory/subdirectory/file.ext'}, ->
+          expect(err).not.to.exist
+          expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/directory/subdirectory/file.ext')
+          done()
+
+      it 'returns paths with subfolder keys for multipart uploads', (done) ->
+        reqs = helpers.mockResponses [
+          { data: UploadId: 'uploadId' }
+          { data: ETag: 'ETAG1' }
+          { data: ETag: 'ETAG2' }
+          { data: ETag: 'ETAG3' }
+          { data: ETag: 'ETAG4' }
+          { data: ETag: 'FINAL_ETAG', Location: 'https://bucket.s3.mock-region.amazonaws.com/directory%2Fsubdirectory%2Ffile.ext' }
+        ]
+        send {Body: bigbody, ContentEncoding: 'encoding', Key: 'folder/file.ext'}, ->
+          expect(err).not.to.exist
+          expect(data.Location).to.equal('https://bucket.s3.mock-region.amazonaws.com/directory/subdirectory/file.ext')
+          done()
+
+
     if AWS.util.isNode()
       describe 'streaming', ->
         it 'sends a small stream in a single putObject', (done) ->

--- a/test/s3/managed_upload.spec.coffee
+++ b/test/s3/managed_upload.spec.coffee
@@ -632,6 +632,7 @@ describe 'AWS.S3.ManagedUpload', ->
             's3.putObjectTagging'
           ]
           expect(err).not.to.exist
+          expect(data.Location).to.equal('FINAL_LOCATION')
           expect(reqs[6].params.Tagging).to.deep.equal({
             TagSet: [
               {Key: 'tag1', Value: 'value1'}


### PR DESCRIPTION
This PR replaces `%2F` in the location returned by `CompletedMultipartUpload` with `/` inside of the managed uploader so that the encoding of the location doesn't change depending on whether a multipart or single-part upload was undertaken.

This would resolve #1158 

/cc @chrisradek 