### PR TITLE
Updates smoke tests to work with temporary credentials

### DIFF
--- a/features/importexport/importexport.feature
+++ b/features/importexport/importexport.feature
@@ -1,5 +1,5 @@
 # language: en
-@importexport @requiresakid
+@importexport @requiresakid @nosession
 Feature: AWS Import/Export
 
   I want to use AWS Import/Export

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -102,8 +102,11 @@ module.exports = function () {
   });
 
   this.When(/^I get a pre\-signed URL to GET the key "([^"]*)"$/, function(key, callback) {
-    this.signedUrl = this.s3.getSignedUrl('getObject', {Bucket: this.sharedBucket, Key: key});
-    callback();
+    var world = this;
+    this.s3.getSignedUrl('getObject', {Bucket: this.sharedBucket, Key: key}, function(err, url) {
+      world.signedUrl = url;
+      callback();
+    });
   });
 
   this.When(/^I access the URL via HTTP GET$/, function(callback) {
@@ -117,10 +120,13 @@ module.exports = function () {
   });
 
   this.Given(/^I get a pre\-signed URL to PUT the key "([^"]*)"(?: with data "([^"]*)")?$/, function(key, body, callback) {
+    var world = this;
     var params = {Bucket: this.sharedBucket, Key: key};
     if (body) params.Body = body;
-    this.signedUrl = this.s3.getSignedUrl('putObject', params);
-    callback();
+    this.s3.getSignedUrl('putObject', params, function(err, url) {
+      world.signedUrl = url;
+      callback();
+    });
   });
 
   this.Given(/^I access the URL via HTTP PUT with data "([^"]*)"$/, function(body, callback) {
@@ -142,6 +148,7 @@ module.exports = function () {
   this.Given(
     /^I create a presigned form to POST the key "([^"]*)" with the data "([^"]*)"$/,
     function (key, data, callback) {
+      var world = this;
       var boundary = this.postBoundary = '----WebKitFormBoundaryLL0mBKIuuLUKr7be';
       var conditions = [
           ['content-length-range', data.length - 1, data.length + 1]
@@ -151,24 +158,25 @@ module.exports = function () {
           Fields: {key: key},
           Conditions: conditions
         };
-      var postData = this.s3.createPresignedPost(params);
-      var body = Object.keys(postData.fields).reduce(function(body, fieldName) {
-        body += '--' + boundary + '\r\n';
-        body += 'Content-Disposition: form-data; name="' + fieldName + '"\r\n\r\n';
-        return body + postData.fields[fieldName] + '\r\n';
-      }, '');
-      body += '--' + this.postBoundary + '\r\n';
-      body += 'Content-Disposition: form-data; name="file"; filename="' + key + '"\r\n';
-      body += 'Content-Type: text/plain\r\n\r\n';
-      body += data + '\r\n';
-      body += '--' + this.postBoundary + '\r\n';
-      body += 'Content-Disposition: form-data; name="submit"\r\n';
-      body += 'Content-Type: text/plain\r\n\r\n';
-      body += 'submit\r\n';
-      body += '--' + this.postBoundary + '--\r\n';
-      this.postBody = body;
-      this.postAction = postData.url;
-      callback();
+      this.s3.createPresignedPost(params, function(err, postData) {
+        var body = Object.keys(postData.fields).reduce(function(body, fieldName) {
+          body += '--' + boundary + '\r\n';
+          body += 'Content-Disposition: form-data; name="' + fieldName + '"\r\n\r\n';
+            return body + postData.fields[fieldName] + '\r\n';
+          }, '');
+          body += '--' + world.postBoundary + '\r\n';
+          body += 'Content-Disposition: form-data; name="file"; filename="' + key + '"\r\n';
+          body += 'Content-Type: text/plain\r\n\r\n';
+          body += data + '\r\n';
+          body += '--' + world.postBoundary + '\r\n';
+          body += 'Content-Disposition: form-data; name="submit"\r\n';
+          body += 'Content-Type: text/plain\r\n\r\n';
+          body += 'submit\r\n';
+          body += '--' + world.postBoundary + '--\r\n';
+          world.postBody = body;
+          world.postAction = postData.url;
+          callback();
+      });
     }
   );
 

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -162,20 +162,20 @@ module.exports = function () {
         var body = Object.keys(postData.fields).reduce(function(body, fieldName) {
           body += '--' + boundary + '\r\n';
           body += 'Content-Disposition: form-data; name="' + fieldName + '"\r\n\r\n';
-            return body + postData.fields[fieldName] + '\r\n';
-          }, '');
-          body += '--' + world.postBoundary + '\r\n';
-          body += 'Content-Disposition: form-data; name="file"; filename="' + key + '"\r\n';
-          body += 'Content-Type: text/plain\r\n\r\n';
-          body += data + '\r\n';
-          body += '--' + world.postBoundary + '\r\n';
-          body += 'Content-Disposition: form-data; name="submit"\r\n';
-          body += 'Content-Type: text/plain\r\n\r\n';
-          body += 'submit\r\n';
-          body += '--' + world.postBoundary + '--\r\n';
-          world.postBody = body;
-          world.postAction = postData.url;
-          callback();
+          return body + postData.fields[fieldName] + '\r\n';
+        }, '');
+        body += '--' + world.postBoundary + '\r\n';
+        body += 'Content-Disposition: form-data; name="file"; filename="' + key + '"\r\n';
+        body += 'Content-Type: text/plain\r\n\r\n';
+        body += data + '\r\n';
+        body += '--' + world.postBoundary + '\r\n';
+        body += 'Content-Disposition: form-data; name="submit"\r\n';
+        body += 'Content-Type: text/plain\r\n\r\n';
+        body += 'submit\r\n';
+        body += '--' + world.postBoundary + '--\r\n';
+        world.postBody = body;
+        world.postAction = postData.url;
+        callback();
       });
     }
   );

--- a/features/sts/sts.feature
+++ b/features/sts/sts.feature
@@ -4,7 +4,7 @@ Feature: AWS Security Token Service
 
   I want to use AWS Security Token Service
 
-  @requiresakid
+  @requiresakid @nosession
   Scenario: Get a session token
     Given I get an STS session token with a duration of 900 seconds
     Then the result should contain an access key ID and secret access key


### PR DESCRIPTION
Some of our tests just won't work using temporary credentials, so they are tagged with `@nosession`.

We can skip running those tests by typing: `cucumber.js -t ~@nosession`

Some of the S3 tests were also failing when using temporary credentials since they were relying on credentials being resolved prior to running them.

/cc @jeskew 