### PR TITLE
upgrade xmlbuilder and xml2js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "sax": "1.1.5",
     "url": "0.10.3",
     "uuid": "3.0.0",
-    "xml2js": "0.4.15",
-    "xmlbuilder": "2.6.2"
+    "xml2js": "^0.4.17",
+    "xmlbuilder": "^8.2.0"
   },
   "main": "lib/aws.js",
   "browser": {


### PR DESCRIPTION
While looking for older versions of lodash, I'd noticed you were using an older version of xmlbuilder that transitively includes lodash ~3.5.0.

This can cause any project relying on the aws-sdk to gain about 2M of dependencies if they're using Lodash 4 or above:

```
➜  ember.js git:(master) du -sh ./node_modules/xmlbuilder/node_modules/lodash
1.8M    ./node_modules/xmlbuilder/node_modules/lodash
```