### PR TITLE
Update dependencies to versions that use lodash 4 and are still compatible with node 0.8

### DIFF
--- a/features/s3/managed_upload.feature
+++ b/features/s3/managed_upload.feature
@@ -23,12 +23,14 @@ Feature: S3 Managed Upload
     And the object "large_upload_buffer" should exist
     And the ContentLength should equal 20971520
 
+  @streaming
   Scenario: Uploading an empty stream
     When I use S3 managed upload to upload an empty stream to the key "empty_upload_stream"
     Then the multipart upload should succeed
     Then the object "empty_upload_stream" should exist
     And the ContentLength should equal 0
 
+  @streaming
   Scenario: Uploading a small stream
     When I use S3 managed upload to upload a small stream to the key "small_upload_stream"
     Then the multipart upload should succeed
@@ -36,6 +38,7 @@ Feature: S3 Managed Upload
     Then the object "small_upload_stream" should exist
     And the ContentLength should equal 1048576
 
+  @streaming
   Scenario: Uploading a large stream
     When I use S3 managed upload to upload a large stream to the key "large_upload_stream"
     Then the multipart upload should succeed

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "crypto-browserify": "1.0.9",
     "jmespath": "0.15.0",
     "querystring": "0.2.0",
-    "sax": "1.1.5",
+    "sax": "1.2.1",
     "url": "0.10.3",
-    "uuid": "3.0.0",
-    "xml2js": "0.4.15",
-    "xmlbuilder": "2.6.2"
+    "uuid": "3.0.1",
+    "xml2js": "0.4.17",
+    "xmlbuilder": "4.2.1"
   },
   "main": "lib/aws.js",
   "browser": {


### PR DESCRIPTION
Tested on a few versions of Node 0.8; updating to these dependencies does not cause any new test failures.

Resolves #1428
Resolves #1143

/cc @chrisradek 