### PR TITLE
Fix doc example gen

### DIFF
--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -104,7 +104,6 @@ class MethodDocumentor
 
     @lines << "@param params [Object]"
     @lines += shapes(api, operation['input'], options).map {|line| "  " + line }
-
     if examples
       examples.each do |example|
         begin
@@ -113,7 +112,7 @@ class MethodDocumentor
           @lines << ""
           @lines << " /* #{example['description']} */"
           @lines << ""
-          @lines << generate_shared_example(api, example, klass, method_name(operation_name)).split("\n").map {|line| "  " + line}  
+          @lines << sharedExample
         rescue => exception
           puts "[warn]: Error encountered generating example for #{klass}.#{operation_name}: #{exception}"
         end

--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -107,11 +107,16 @@ class MethodDocumentor
 
     if examples
       examples.each do |example|
-        @lines << "@example #{example['title']}"
-        @lines << ""
-        @lines << " /* #{example['description']} */"
-        @lines << ""
-        @lines << generate_shared_example(api, example, klass, method_name(operation_name)).split("\n").map {|line| "  " + line}
+        begin
+          sharedExample = generate_shared_example(api, example, klass, method_name(operation_name)).split("\n").map {|line| "  " + line}
+          @lines << "@example #{example['title']}"
+          @lines << ""
+          @lines << " /* #{example['description']} */"
+          @lines << ""
+          @lines << generate_shared_example(api, example, klass, method_name(operation_name)).split("\n").map {|line| "  " + line}  
+        rescue => exception
+          puts "[warn]: Error encountered generating example for #{klass}.#{operation_name}: #{exception}"
+        end
       end
     end
 

--- a/doc-src/templates/api-versions/plugin.rb
+++ b/doc-src/templates/api-versions/plugin.rb
@@ -276,7 +276,9 @@ eof
   end
 
   def load_examples(name, version)
-    paths = Dir[File.join($APIS_DIR, "#{name}-#{version}.examples.json")]
+    @info ||= JSON.parse(File.read(File.join($APIS_DIR, 'metadata.json')))
+    prefix = @info[name]['prefix'] || name
+    paths = Dir[File.join($APIS_DIR, "#{prefix}-#{version}.examples.json")]
     unless paths.empty?
       json = JSON.parse(File.read(paths[0]))
       json['examples']


### PR DESCRIPTION
This update now treats example doc generation errors as a warning instead of a hard failure. A helpful message will be outputted to aide in troubleshooting.

I also discovered that services with a `prefix` field in the `metadata.json` file were not being represented by the example doc generator. Fixed that as well.

/cc @jeskew 