### PR TITLE
Add a connectTimeout option to the node httpOptions config parameter

### DIFF
--- a/.changes/next-release/feature-Http-018eab1b.json
+++ b/.changes/next-release/feature-Http-018eab1b.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Http",
+  "description": "Adds a connectTimeout option that allows slow-to-establish socket connections to be quickly abandoned"
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -91,6 +91,7 @@ export interface HTTPOptions {
      * The maximum time in milliseconds that the connection phase of the request
      * should be allowed to take. This only limits the connection phase and has
      * no impact once the socket has established a connection.
+     * Used in node.js environments only.
      */
     connectTimeout?: number;
     /**

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -15,20 +15,20 @@ export class ConfigBase extends ConfigurationOptions{
      * Loads configuration data from a JSON file into this config object.
      * Loading configuration willr eset all existing configuration on the object.
      * This feature is not supported in the browser environment of the SDK.
-     * 
+     *
      * @param {string} path - the path relative to your process's current working directory to load configuration from.
      */
     loadFromPath(path: string): ConfigBase;
     /**
      * Updates the current configuration object with new options.
-     * 
+     *
      * @param {ConfigurationOptions} options - a map of option keys and values.
      * @param {boolean} allowUnknownKeys - Whether unknown keys can be set on the configuration object.
      */
     update(options: ConfigurationOptions & {[key: string]: any}, allowUnknownKeys: true): void;
     /**
      * Updates the current configuration object with new options.
-     * 
+     *
      * @param {ConfigurationOptions} options - a map of option keys and values.
      * @param {boolean} allowUnknownKeys - Defaults to false. Whether unknown keys can be set on the configuration object.
      */
@@ -54,20 +54,20 @@ export class Config extends ConfigBase {
      * Loads configuration data from a JSON file into this config object.
      * Loading configuration willr eset all existing configuration on the object.
      * This feature is not supported in the browser environment of the SDK.
-     * 
+     *
      * @param {string} path - the path relative to your process's current working directory to load configuration from.
      */
     loadFromPath(path: string): Config & ConfigurationServicePlaceholders & APIVersions;
     /**
      * Updates the current configuration object with new options.
-     * 
+     *
      * @param {ConfigurationOptions} options - a map of option keys and values.
      * @param {boolean} allowUnknownKeys - Whether unknown keys can be set on the configuration object.
      */
     update(options: ConfigurationOptions & ConfigurationServicePlaceholders & APIVersions & {[key: string]: any}, allowUnknownKeys: true): void;
     /**
      * Updates the current configuration object with new options.
-     * 
+     *
      * @param {ConfigurationOptions} options - a map of option keys and values.
      * @param {boolean} allowUnknownKeys - Defaults to false. Whether unknown keys can be set on the configuration object.
      */
@@ -80,31 +80,37 @@ export interface HTTPOptions {
     /**
      * the URL to proxy requests through.
      */
-    proxy?: string
+    proxy?: string;
     /**
      * the Agent object to perform HTTP requests with.
      * Used for connection pooling.
      * Defaults to the global agent (http.globalAgent) for non-SSL connections.
      */
-    agent?: httpAgent | httpsAgent
+    agent?: httpAgent | httpsAgent;
+    /**
+     * The maximum time in milliseconds that the connection phase of the request
+     * should be allowed to take. This only limits the connection phase and has
+     * no impact once the socket has established a connection.
+     */
+    connectTimeout?: number;
     /**
      * The number of milliseconds to wait before giving up on a connection attempt.
      * Defaults to two minutes (120000).
      */
-    timeout?: number
+    timeout?: number;
     /**
      * Whether the SDK will send asynchronous HTTP requests.
      * Used in the browser environment only.
      * Set to false to send requests synchronously.
      * Defaults to true (async on).
      */
-    xhrAsync?: boolean
+    xhrAsync?: boolean;
     /**
      * Sets the 'withCredentials' property of an XMLHttpRequest object.
      * Used in the browser environment only.
      * Defaults to false.
      */
-    xhrWithCredentials?: boolean
+    xhrWithCredentials?: boolean;
 }
 export interface Logger {
     write?: (chunk: any, encoding?: string, callback?: () => void) => void
@@ -112,7 +118,7 @@ export interface Logger {
 }
 export interface ParamValidation {
     /**
-     * Validates that a value meets the min constraint. 
+     * Validates that a value meets the min constraint.
      * This is enabled by default when paramValidation is set to true.
      */
     min?: boolean
@@ -131,12 +137,12 @@ export interface ParamValidation {
 }
 export interface RetryDelayOptions {
     /**
-     * The base number of milliseconds to use in the exponential backoff for operation retries. 
+     * The base number of milliseconds to use in the exponential backoff for operation retries.
      * Defaults to 100 ms.
      */
     base?: number
     /**
-     * A custom function that accepts a retry count and returns the amount of time to delay in milliseconds. 
+     * A custom function that accepts a retry count and returns the amount of time to delay in milliseconds.
      * The base option will be ignored if this option is supplied.
      */
     customBackoff?: (retryCount: number) => number
@@ -178,19 +184,19 @@ export abstract class ConfigurationOptions {
     credentialProvider?: CredentialProviderChain
     /**
      * AWS access key ID.
-     * 
+     *
      * @deprecated
      */
     accessKeyId?: string
     /**
      * AWS secret access key.
-     * 
+     *
      * @deprecated
      */
     secretAccessKey?: string
     /**
      * AWS session token.
-     * 
+     *
      * @deprecated
      */
     sessionToken?: string
@@ -211,8 +217,8 @@ export abstract class ConfigurationOptions {
      */
     maxRetries?: number
     /**
-     * Returns whether input parameters should be validated against the operation description before sending the request. 
-     * Defaults to true. 
+     * Returns whether input parameters should be validated against the operation description before sending the request.
+     * Defaults to true.
      * Pass a map to enable any of the following specific validation features: min|max|pattern|enum
      */
     paramValidation?: ParamValidation|boolean

--- a/lib/config.js
+++ b/lib/config.js
@@ -231,6 +231,10 @@ AWS.Config = AWS.util.inherit({
    *     SSL connections, a special Agent object is used in order to enable
    *     peer certificate verification. This feature is only available in the
    *     Node.js environment.
+   *   * **connectTimeout** [Integer] &mdash; Sets the socket to timeout after
+   *     failing to establish a connection with the server after
+   *     `connectTimeout` milliseconds. This timeout has no effect once a socket
+   *     connection has been established.
    *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
    *     milliseconds of inactivity on the socket. Defaults to two minutes
    *     (120000).

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -53,6 +53,28 @@ AWS.NodeHttpClient = AWS.util.inherit({
     });
     httpRequest.stream = stream; // attach stream to httpRequest
 
+    // connection timeout support
+    if (httpOptions.connectTimeout) {
+      stream.on('socket', function(socket) {
+        if (socket.connecting) {
+          var timeoutId = setTimeout(function connectTimeout() {
+            if (cbAlreadyCalled) return; cbAlreadyCalled = true;
+
+            stream.abort();
+            errCallback(AWS.util.error(
+              new Error('Socket timed out without establishing a connection'),
+              {code: 'TimeoutError'}
+            ));
+          }, httpOptions.connectTimeout);
+          socket.on('connect', (function(tId) {
+            return function () {
+              clearTimeout(tId);
+            };
+          })(timeoutId));
+        }
+      });
+    }
+
     // timeout support
     stream.setTimeout(httpOptions.timeout || 0, function() {
       if (cbAlreadyCalled) return; cbAlreadyCalled = true;

--- a/test/node_http_client.spec.coffee
+++ b/test/node_http_client.spec.coffee
@@ -1,5 +1,7 @@
 helpers = require('./helpers')
 AWS = helpers.AWS
+EventEmitter = require('events').EventEmitter
+httpModule = require('http')
 
 if AWS.util.isNode()
   describe 'AWS.NodeHttpClient', ->
@@ -60,30 +62,33 @@ if AWS.util.isNode()
         setTimeoutSpy = null
         clearTimeoutSpy = null
 
+        oldRequest = httpModule.request
+        requestSpy = null
+        mockClientRequest = null
+
         beforeEach ->
           setTimeoutSpy = helpers.spyOn(global, 'setTimeout')
             .andReturn(timeoutId)
           clearTimeoutSpy = helpers.spyOn(global, 'clearTimeout')
             .andCallFake(() -> {})
+          mockClientRequest = new EventEmitter()
+          mockClientRequest.setTimeout = () -> {}
+          mockClientRequest.end = () -> {}
+          requestSpy = helpers.spyOn(httpModule, 'request')
+            .andReturn(mockClientRequest)
 
         afterEach ->
           global.setTimeout = oldSetTimeout
           global.clearTimeout = oldClearTimeout
+          httpModule.request = oldRequest
 
         it 'clears timeouts once the connection has been established', ->
-          EventEmitter = require('events')
-          mockStream = new EventEmitter()
-          mockStream.setTimeout = () -> {}
-          mockStream.end = () -> {}
-          httpModule = require('http')
-          helpers.spyOn(httpModule, 'request').andReturn(mockStream)
-
           req = new AWS.HttpRequest 'http://1.1.1.1'
           http.handleRequest req, {connectTimeout: 120000}, null, () -> {}
 
           mockSocket = new EventEmitter()
           mockSocket.connecting = true;
-          mockStream.emit('socket', mockSocket)
+          mockClientRequest.emit('socket', mockSocket)
           expect(setTimeoutSpy.calls.length).to.equal(1)
           mockSocket.emit('connect')
           expect(clearTimeoutSpy.calls.length).to.equal(1)

--- a/test/node_http_client.spec.coffee
+++ b/test/node_http_client.spec.coffee
@@ -43,3 +43,12 @@ if AWS.util.isNode()
           expect(err.code).to.equal('TimeoutError')
           expect(err.message).to.equal('Connection timed out after 1ms')
           expect(numCalls).to.equal(1)
+
+      it 'supports connectTimeout in httpOptions', ->
+        numCalls = 0
+        req = new AWS.HttpRequest 'http://1.1.1.1'
+        http.handleRequest req, {connectTimeout: 1}, null, (err) ->
+          numCalls += 1
+          expect(err.code).to.equal('TimeoutError')
+          expect(err.message).to.equal('Socket timed out without establishing a connection')
+          expect(numCalls).to.equal(1)

--- a/test/node_http_client.spec.coffee
+++ b/test/node_http_client.spec.coffee
@@ -48,7 +48,7 @@ if AWS.util.isNode()
 
       it 'supports connectTimeout in httpOptions', ->
         numCalls = 0
-        req = new AWS.HttpRequest 'http://1.1.1.1'
+        req = new AWS.HttpRequest 'http://10.255.255.255'
         http.handleRequest req, {connectTimeout: 1}, null, (err) ->
           numCalls += 1
           expect(err.code).to.equal('TimeoutError')
@@ -83,7 +83,7 @@ if AWS.util.isNode()
           httpModule.request = oldRequest
 
         it 'clears timeouts once the connection has been established', ->
-          req = new AWS.HttpRequest 'http://1.1.1.1'
+          req = new AWS.HttpRequest 'http://10.255.255.255'
           http.handleRequest req, {connectTimeout: 120000}, null, () -> {}
 
           mockSocket = new EventEmitter()


### PR DESCRIPTION
This PR adds a `connectTimeout` option to the parameters passed in as `httpOptions` when configuring a client in a node.js environment. The connectTimeout will abort a connection if a socket has not successfully established a connection within `n` milliseconds of it being assigned to a request; after the connection is established, the only timeout that applies is the `timeout` option already available in the SDK.

/cc @chrisradek 