### PR TITLE
Fix/stop stringing payload blobs

### DIFF
--- a/.changes/next-release/bugfix-Parser-d7e3b2f2.json
+++ b/.changes/next-release/bugfix-Parser-d7e3b2f2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Parser",
+  "description": "Makes casting payload blobs to strings an exceptional behavior rather than the default"
+}

--- a/clients/lambda.js
+++ b/clients/lambda.js
@@ -5,6 +5,7 @@ var apiLoader = require('../lib/api_loader');
 
 apiLoader.services['lambda'] = {};
 AWS.Lambda = Service.defineService('lambda', ['2014-11-11', '2015-03-31']);
+require('../lib/services/lambda');
 Object.defineProperty(apiLoader.services['lambda'], '2014-11-11', {
   get: function get() {
     var model = require('../apis/lambda-2014-11-11.min.json');

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -287,7 +287,12 @@ function StringShape() {
   this.toType = function(value) {
     value = this.api && nullLessProtocols.indexOf(this.api.protocol) > -1 ?
       value || '' : value;
-    return this.isJsonValue ? JSON.parse(value) : value;
+    if (this.isJsonValue) {
+      return JSON.parse(value);
+    }
+
+    return value && typeof value.toString === 'function' ?
+      value.toString() : value;
   };
 
   this.toWireFormat = function(value) {

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -45,13 +45,13 @@ function extractData(resp) {
   if (rules.payload) {
     var payloadMember = rules.members[rules.payload];
     var body = resp.httpResponse.body;
-    if (payloadMember.isStreaming) {
-      resp.data[rules.payload] = body;
-    } else if (payloadMember.type === 'structure' || payloadMember.type === 'list') {
+    if (payloadMember.type === 'structure' || payloadMember.type === 'list') {
       var parser = new JsonParser();
       resp.data[rules.payload] = parser.parse(body, payloadMember);
+    } else if (payloadMember.type === 'binary' || payloadMember.isStreaming) {
+      resp.data[rules.payload] = body;
     } else {
-      resp.data[rules.payload] = body.toString();
+      resp.data[rules.payload] = payloadMember.toType(body);
     }
   } else {
     var data = resp.data;

--- a/lib/protocol/rest_xml.js
+++ b/lib/protocol/rest_xml.js
@@ -74,13 +74,13 @@ function extractData(resp) {
   var payload = output.payload;
   if (payload) {
     var payloadMember = output.members[payload];
-    if (payloadMember.isStreaming) {
-      resp.data[payload] = body;
-    } else if (payloadMember.type === 'structure') {
+    if (payloadMember.type === 'structure') {
       parser = new AWS.XML.Parser();
       resp.data[payload] = parser.parse(body.toString(), payloadMember);
+    } else if (payloadMember.type === 'binary' || payloadMember.isStreaming) {
+      resp.data[payload] = body;
     } else {
-      resp.data[payload] = body.toString();
+      resp.data[payload] = payloadMember.toType(body);
     }
   } else if (body.length > 0) {
     parser = new AWS.XML.Parser();

--- a/lib/services/apigateway.js
+++ b/lib/services/apigateway.js
@@ -19,20 +19,8 @@ AWS.util.update(AWS.APIGateway.prototype, {
     if (request.operation === 'getExport') {
       var params = request.params || {};
       if (params.exportType === 'swagger') {
-        request.addListener('extractData', this.parsePayload);
+        request.addListener('extractData', AWS.util.convertPayloadToString);
       }
-    }
-  },
-
-  /**
-   * @api private
-   */
-  parsePayload: function parsePayload(resp) {
-    var req = resp.request;
-    var operation = req.operation;
-    var rules = req.service.api.operations[operation].output || {};
-    if (rules.payload && resp.data[rules.payload]) {
-      resp.data[rules.payload] = resp.data[rules.payload].toString();
     }
   }
 });

--- a/lib/services/apigateway.js
+++ b/lib/services/apigateway.js
@@ -16,18 +16,23 @@ AWS.util.update(AWS.APIGateway.prototype, {
    */
   setupRequestListeners: function setupRequestListeners(request) {
     request.addListener('build', this.setAcceptHeader);
-    if (request.operation === 'getSdk') {
-      request.addListener('extractData', this.useRawPayload);
+    if (request.operation === 'getExport') {
+      var params = request.params || {};
+      if (params.exportType === 'swagger') {
+        request.addListener('extractData', this.parsePayload);
+      }
     }
   },
 
-  useRawPayload: function useRawPayload(resp) {
+  /**
+   * @api private
+   */
+  parsePayload: function parsePayload(resp) {
     var req = resp.request;
     var operation = req.operation;
     var rules = req.service.api.operations[operation].output || {};
-    if (rules.payload) {
-      var body = resp.httpResponse.body;
-      resp.data[rules.payload] = body;
+    if (rules.payload && resp.data[rules.payload]) {
+      resp.data[rules.payload] = resp.data[rules.payload].toString();
     }
   }
 });

--- a/lib/services/iotdata.js
+++ b/lib/services/iotdata.js
@@ -1,5 +1,8 @@
 var AWS = require('../core');
 
+/**
+ * @api private
+ */
 var blobPayloadOutputOps = [
   'deleteThingShadow',
   'getThingShadow',
@@ -79,7 +82,7 @@ AWS.util.update(AWS.IotData.prototype, {
     setupRequestListeners: function setupRequestListeners(request) {
         request.addListener('validateResponse', this.validateResponseBody);
         if (blobPayloadOutputOps.indexOf(request.operation) > -1) {
-            request.addListener('extractData', this.parsePayload);
+            request.addListener('extractData', AWS.util.convertPayloadToString);
         }
     },
 
@@ -91,18 +94,6 @@ AWS.util.update(AWS.IotData.prototype, {
         var bodyCheck = body.trim();
         if (!bodyCheck || bodyCheck.charAt(0) !== '{') {
             resp.httpResponse.body = '';
-        }
-    },
-
-    /**
-    * @api private
-    */
-    parsePayload: function parsePayload(resp) {
-        var req = resp.request;
-        var operation = req.operation;
-        var rules = req.service.api.operations[operation].output || {};
-        if (rules.payload && resp.data[rules.payload]) {
-            resp.data[rules.payload] = resp.data[rules.payload].toString();
         }
     }
 

--- a/lib/services/iotdata.js
+++ b/lib/services/iotdata.js
@@ -1,5 +1,11 @@
 var AWS = require('../core');
 
+var blobPayloadOutputOps = [
+  'deleteThingShadow',
+  'getThingShadow',
+  'updateThingShadow'
+];
+
 /**
  * Constructs a service interface object. Each API operation is exposed as a
  * function on service.
@@ -71,7 +77,10 @@ AWS.util.update(AWS.IotData.prototype, {
      * @api private
      */
     setupRequestListeners: function setupRequestListeners(request) {
-        request.addListener('validateResponse', this.validateResponseBody)
+        request.addListener('validateResponse', this.validateResponseBody);
+        if (blobPayloadOutputOps.indexOf(request.operation) > -1) {
+            request.addListener('extractData', this.parsePayload);
+        }
     },
 
     /**
@@ -82,6 +91,18 @@ AWS.util.update(AWS.IotData.prototype, {
         var bodyCheck = body.trim();
         if (!bodyCheck || bodyCheck.charAt(0) !== '{') {
             resp.httpResponse.body = '';
+        }
+    },
+
+    /**
+    * @api private
+    */
+    parsePayload: function parsePayload(resp) {
+        var req = resp.request;
+        var operation = req.operation;
+        var rules = req.service.api.operations[operation].output || {};
+        if (rules.payload && resp.data[rules.payload]) {
+            resp.data[rules.payload] = resp.data[rules.payload].toString();
         }
     }
 

--- a/lib/services/lambda.js
+++ b/lib/services/lambda.js
@@ -1,0 +1,25 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.Lambda.prototype, {
+  /**
+   * @api private
+   */
+  setupRequestListeners: function setupRequestListeners(request) {
+    if (request.operation === 'invoke') {
+      request.addListener('extractData', this.parsePayload);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  parsePayload: function parsePayload(resp) {
+    var req = resp.request;
+    var operation = req.operation;
+    var rules = req.service.api.operations[operation].output || {};
+    if (rules.payload && resp.data[rules.payload]) {
+      resp.data[rules.payload] = resp.data[rules.payload].toString();
+    }
+  }
+});
+

--- a/lib/services/lambda.js
+++ b/lib/services/lambda.js
@@ -6,19 +6,7 @@ AWS.util.update(AWS.Lambda.prototype, {
    */
   setupRequestListeners: function setupRequestListeners(request) {
     if (request.operation === 'invoke') {
-      request.addListener('extractData', this.parsePayload);
-    }
-  },
-
-  /**
-   * @api private
-   */
-  parsePayload: function parsePayload(resp) {
-    var req = resp.request;
-    var operation = req.operation;
-    var rules = req.service.api.operations[operation].output || {};
-    if (rules.payload && resp.data[rules.payload]) {
-      resp.data[rules.payload] = resp.data[rules.payload].toString();
+      request.addListener('extractData', AWS.util.convertPayloadToString);
     }
   }
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -880,6 +880,18 @@ var util = {
     v4: function uuidV4() {
       return require('uuid').v4();
     }
+  },
+
+  /**
+   * @api private
+   */
+  convertPayloadToString: function convertPayloadToString(resp) {
+    var req = resp.request;
+    var operation = req.operation;
+    var rules = req.service.api.operations[operation].output || {};
+    if (rules.payload && resp.data[rules.payload]) {
+      resp.data[rules.payload] = resp.data[rules.payload].toString();
+    }
   }
 
 };

--- a/test/fixtures/protocol/output/json.json
+++ b/test/fixtures/protocol/output/json.json
@@ -231,7 +231,7 @@
         }
       },
       "MapType": {
-        "type": "string",
+        "type": "map",
         "key": { "shape": "StringType" },
         "value": { "shape": "StringType" }
       }

--- a/test/json/parser.spec.coffee
+++ b/test/json/parser.spec.coffee
@@ -17,7 +17,10 @@ describe 'AWS.JSON.Parser', ->
   describe 'parse', ->
 
     it 'returns an empty document when there are no params', ->
-      expect(parse({}, '{}')).to.eql({})
+      rules =
+        type: 'structure'
+        members: {}
+      expect(parse(rules, '{}')).to.eql({})
 
     describe 'structures', ->
       rules =

--- a/test/protocol/rest_json.spec.coffee
+++ b/test/protocol/rest_json.spec.coffee
@@ -223,6 +223,11 @@ describe 'AWS.Protocol.RestJson', ->
       svc.extractData(response)
 
     it 'JSON parses http response bodies', ->
+      defop output:
+        type: 'structure'
+        members:
+          a: type: 'integer'
+          b: type: 'string'
       extractData '{"a":1, "b":"xyz"}'
       expect(response.error).to.equal(null)
       expect(response.data).to.eql({a:1, b:'xyz'})
@@ -245,7 +250,7 @@ describe 'AWS.Protocol.RestJson', ->
         type: 'structure'
         payload: 'Body'
         members:
-          Body: location: 'body', type: 'binary'
+          Body: location: 'body', type: 'string'
 
       extractData 'foobar'
       expect(response.error).to.equal(null)

--- a/test/services/apigateway.spec.coffee
+++ b/test/services/apigateway.spec.coffee
@@ -21,11 +21,35 @@ describe 'AWS.APIGateway', ->
         expect(req.headers['Accept']).to.equal('application/json')
         req = build('updateApiKey', apiKey: 'apiKey')
         expect(req.headers['Accept']).to.equal('application/json')
-        
+
+  describe 'response parsing', ->
     describe 'getSdk', ->
       it 'returns the raw payload as the body', (done) ->
         body = new Buffer('∂ƒ©∆')
         helpers.mockHttpResponse 200, {}, body
         apigateway.getSdk (err, data) ->
           expect(data.body).to.eql(body)
-          done()        
+          done()
+
+    describe 'getExport', ->
+      it 'converts the body to a string when the exportType is "swagger"', (done) ->
+        swaggerDoc = JSON.stringify({swagger: "2.0", host: "foo.amazonaws.com"})
+        body = new Buffer(swaggerDoc)
+        helpers.mockHttpResponse 200, {}, body
+        apigateway.getExport {exportType: 'swagger'}, (err, data) ->
+          expect(Buffer.isBuffer(data.body)).to.be.false
+          expect(data.body).to.eql(swaggerDoc)
+          done()
+
+      it 'returns the raw payload when the exportType is not "swagger"', (done) ->
+        swaggerDoc = JSON.stringify({notSwagger: "2.0", host: "foo.amazonaws.com"})
+        body = new Buffer(swaggerDoc)
+        helpers.mockHttpResponse 200, {}, body
+        apigateway.getExport {exportType: 'notSwagger'}, (err, data) ->
+          expect(Buffer.isBuffer(data.body)).to.be.true
+          if typeof body.equals == 'function'
+            expect(body.equals(data.body)).to.be.true
+          else
+            expect(body.toString()).to.equal(data.body.toString())
+          expect(data.body.toString()).to.eql(swaggerDoc)
+          done()

--- a/test/services/iotdata.spec.js
+++ b/test/services/iotdata.spec.js
@@ -1,0 +1,29 @@
+var AWS = require('../../index');
+var helpers = require('../helpers');
+var Buffer = AWS.util.Buffer;
+
+describe('AWS.IotData', function() {
+  var blobPayloadOutputOps = [
+    'deleteThingShadow',
+    'getThingShadow',
+    'updateThingShadow'
+  ];
+
+  for (var i = 0; i < blobPayloadOutputOps.length; i++) {
+    describe(blobPayloadOutputOps[i], (function(operation) {
+      return function() {
+        it('converts the body to a string', function(done) {
+          var client = new AWS.IotData({endpoint: 'localhost'});
+          var shadow = JSON.stringify({foo: 'bar', fizz: ['buzz', 'pop']});
+          var body = new Buffer(shadow);
+          helpers.mockHttpResponse(200, {}, body);
+          client[operation]({thingName: 'thing'}, function(err, data) {
+            expect(Buffer.isBuffer(data.payload)).to.be.false;
+            expect(data.payload).to.eql(shadow);
+            done();
+          });
+        });
+      };
+    })(blobPayloadOutputOps[i]));
+  }
+});

--- a/test/services/lambda.spec.js
+++ b/test/services/lambda.spec.js
@@ -1,0 +1,19 @@
+var AWS = require('../../index');
+var helpers = require('../helpers');
+var Buffer = AWS.util.Buffer;
+
+describe('AWS.IotData', function() {
+  describe('invoke', function() {
+    it('converts the body to a string', function(done) {
+      var client = new AWS.Lambda();
+      var payload = JSON.stringify({foo: 'bar', fizz: ['buzz', 'pop']});
+      var body = new Buffer(payload);
+      helpers.mockHttpResponse(200, {}, body);
+      client.invoke({FunctionName: 'function'}, function(err, data) {
+        expect(Buffer.isBuffer(data.Payload)).to.be.false;
+        expect(data.Payload).to.eql(payload);
+        done();
+      });
+    });
+  });
+});

--- a/test/services/s3.spec.coffee
+++ b/test/services/s3.spec.coffee
@@ -1620,3 +1620,13 @@ describe 'AWS.S3', ->
           expect(data.fields[key]).to.equal(conditions[key])
         )
         done()
+
+  describe 'getBucketPolicy', ->
+    it 'converts the body to a string', (done) ->
+      policy = JSON.stringify({key: 'value', foo: 'bar', fizz: 1})
+      body = new Buffer(policy)
+      helpers.mockHttpResponse 200, {}, body
+      s3.getBucketPolicy (err, data) ->
+        expect(Buffer.isBuffer(data.Policy)).to.be.false;
+        expect(data.Policy).to.eql(policy)
+        done()

--- a/test/util.spec.coffee
+++ b/test/util.spec.coffee
@@ -566,10 +566,10 @@ describe 'AWS.util.base64', ->
       catch e
         err = e
       expect(err.message).to.equal('Cannot base64 encode number 3.14')
-    
+
     it 'does not encode null', ->
       expect(base64.encode(null)).to.eql(null)
-    
+
     it 'does not encode undefined', ->
       expect(base64.encode(undefined)).to.eql(undefined)
 
@@ -592,7 +592,7 @@ describe 'AWS.util.base64', ->
 
     it 'does not decode null', ->
       expect(base64.decode(null)).to.eql(null)
-    
+
     it 'does not decode undefined', ->
       expect(base64.decode(undefined)).to.eql(undefined)
 
@@ -639,7 +639,7 @@ describe 'AWS.util.hoistPayloadMember', ->
           'payload': 'Stream'
           'members': 'Stream': 'shape': 'BlobStream'
         'BlobStream':
-          'type': 'blob'
+          'type': 'binary'
           'streaming': true
     httpResp =
       'status_code': 200


### PR DESCRIPTION
The SDK is currently converting members of output structures that represent the entire response payload to strings (unless the member is tagged as "streaming" in the model). This is unwanted behavior in APIGateway's `getSdk` method, where the payload is a binary blob that would be corrupted by being converted to a string, and the SDK therefore has a customization to use the raw payload instead for that operation. It is, however, behavior on which customers might be relying for `AWS.Lambda.invoke`, `AWS.IotData.deleteThingShadow`, `AWS.IotData.getThingShadow`, and `AWS.IotData.updateThingShadow`. 

This PR flips that setup so that the latter operations have a customization and returning the raw payload for operations like `AWS.APIGateway.getSdk` is the default. That way, any future operation that returns binary data will expose it safely to customers (i.e., as a buffer) rather than casting it to a string.