### PR TITLE
Standardize the documentClient variable name in examples

### DIFF
--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -130,9 +130,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.batchGet(params, function(err, data) {
+   *  documentClient.batchGet(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
@@ -181,9 +181,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.batchWrite(params, function(err, data) {
+   *  documentClient.batchWrite(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
@@ -217,9 +217,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.delete(params, function(err, data) {
+   *  documentClient.delete(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
@@ -252,9 +252,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.get(params, function(err, data) {
+   *  documentClient.get(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
@@ -292,9 +292,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.put(params, function(err, data) {
+   *  documentClient.put(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
@@ -333,9 +333,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    }
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.update(params, function(err, data) {
+   *  documentClient.update(params, function(err, data) {
    *     if (err) console.log(err);
    *     else console.log(data);
    *  });
@@ -367,9 +367,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *    ExpressionAttributeValues : {':this_year' : 2015}
    *  };
    *
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
-   *  docClient.scan(params, function(err, data) {
+   *  documentClient.scan(params, function(err, data) {
    *     if (err) console.log(err);
    *     else console.log(data);
    *  });
@@ -404,9 +404,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
     *    }
     *  };
     *
-    *  var docClient = new AWS.DynamoDB.DocumentClient();
+    *  var documentClient = new AWS.DynamoDB.DocumentClient();
     *
-    *  docClient.query(params, function(err, data) {
+    *  documentClient.query(params, function(err, data) {
     *     if (err) console.log(err);
     *     else console.log(data);
     *  });
@@ -435,16 +435,16 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *  * **validate** [Boolean] set to true if you want to validate the type
    *    of each element in the set. Defaults to `false`.
    * @example Creating a number set
-   *  var docClient = new AWS.DynamoDB.DocumentClient();
+   *  var documentClient = new AWS.DynamoDB.DocumentClient();
    *
    *  var params = {
    *    Item: {
    *      hashkey: 'hashkey'
-   *      numbers: docClient.createSet([1, 2, 3]);
+   *      numbers: documentClient.createSet([1, 2, 3]);
    *    }
    *  };
    *
-   *  docClient.put(params, function(err, data) {
+   *  documentClient.put(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });


### PR DESCRIPTION
The examples that are automatically generated by yarddoc use `var documentClient`, whereas the hand-curated ones use `var docClient`. This PR gets rid of the latter in favor of the former.