### PR TITLE
Use the name of a map key shape instead of "someKey" in data type examples

### DIFF
--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -399,10 +399,10 @@ class ExampleShapeVisitor
   end
 
   def visit_map(node, required = false)
-    data = indent("someKey: " + traverse(node['value']))
+    data = indent("'<#{node['key']['shape']}>': " + traverse(node['value']))
     lines = ["{" + mark_rec_shape(node) + (required ? " /* required */" : "")]
     lines << data + ","
-    lines << "  /* anotherKey: ... */"
+    lines << "  /* '<#{node['key']['shape']}>': ... */"
     lines << "}"
     lines.join("\n")
   end


### PR DESCRIPTION
This provides a bit more context when the map key has a specific meaning (like ['RoleType' in Cognito Identity](https://github.com/aws/aws-sdk-js/blob/master/apis/cognito-identity-2014-06-30.normal.json#L1208), ['TableName' in DynamoDB](https://github.com/aws/aws-sdk-js/blob/master/apis/dynamodb-2011-12-05.normal.json#L356), ['EnvironmentVariableName' in Lambda](https://github.com/aws/aws-sdk-js/blob/master/apis/lambda-2015-03-31.normal.json#L898), etc).