### PR TITLE
Bump "buffer" module version to support old Android Browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "uglify-js": "2.x"
   },
   "dependencies": {
-    "buffer": "4.9.1",
+    "buffer": "5.0.6",
     "crypto-browserify": "1.0.9",
     "jmespath": "0.15.0",
     "querystring": "0.2.0",


### PR DESCRIPTION
With old Android Browser (ex. Android 4.4.2),  [s3.upload](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) fails with undefined method error on ArrayBuffer.

This is because old Android Browser supports ArrayBuffer but not ArrayBuffer.isView.
The issue seems to be fixed on buffer@v5.0.6. 
https://github.com/feross/buffer/commit/2ac965b088d5e9019930c3d9016c7a213994e2fb

I tried `npm run unit` and `npm run browsertest` on aws-js-sdk with buffer v5.0.6 and there was no failure.