### PR TITLE
Declare and export the promise resolution type instead of declaring it inline

### DIFF
--- a/lib/request.d.ts
+++ b/lib/request.d.ts
@@ -161,7 +161,7 @@ export class Request<D, E> {
     /**
      * Returns a 'thenable' promise.
      */
-    promise(): Promise<D & {$response: Response<D, E>}>
+    promise(): Promise<PromiseResult<D, E>>
     /**
      * The time that the request started.
      */
@@ -172,6 +172,8 @@ export class Request<D, E> {
     httpRequest: HttpRequest;
 
 }
+
+export type PromiseResult<D, E> = D & {$response: Response<D, E>};
 
 export interface Progress {
     loaded: number;

--- a/lib/request.js
+++ b/lib/request.js
@@ -769,9 +769,11 @@ AWS.Request.addPromisesToClass = function addPromisesToClass(PromiseDependency) 
         if (resp.error) {
           reject(resp.error);
         } else {
-          var data = AWS.util.copy(resp.data);
-          data.$response = resp;
-          resolve(data);
+          resolve(Object.defineProperty(
+            AWS.util.copy(resp.data),
+            '$response',
+            {value: resp}
+          ));
         }
       });
       self.runTo();

--- a/test/request.spec.coffee
+++ b/test/request.spec.coffee
@@ -287,6 +287,7 @@ describe 'AWS.Request', ->
         helpers.mockHttpResponse 200, {}, ['FOO', 'BAR', 'BAZ', 'QUX']
         service.makeRequest('mockMethod').promise().then (data) ->
           expect(data.$response.httpResponse.statusCode).to.equal(200)
+          expect(JSON.stringify(data)).to.be.ok;
 
     it 'appends \'promise\' to the user agent', ->
       P = ->


### PR DESCRIPTION
This change would let functions returning promises from requests to explicitly support the new `$response` property on the resolved value.

It would also make declarations look cleaner in case any is running tsc with `"declaration": true` with implicit return types.