### PR TITLE
Fixes regression introduced in v2.44.0 around hoisted payloads when using promises

### DIFF
--- a/.changes/next-release/bugfix-Promise-ef153c9f.json
+++ b/.changes/next-release/bugfix-Promise-ef153c9f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Promise",
+  "description": "Fixes an issue introduced in v2.44.0 where payload members on some CloudFront and S3 operations weren't hoisted when using promises. This issue was introduced in and could affect users that were accessing fields on a response that weren't documented, but were available for backwards compatibility."
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -769,8 +769,10 @@ AWS.Request.addPromisesToClass = function addPromisesToClass(PromiseDependency) 
         if (resp.error) {
           reject(resp.error);
         } else {
+          // define $response property so that it is not enumberable
+          // this prevents circular reference errors when stringifying the JSON object
           resolve(Object.defineProperty(
-            AWS.util.copy(resp.data),
+            resp.data || {},
             '$response',
             {value: resp}
           ));


### PR DESCRIPTION
[`AWS.util.hoistPayloadMember`](https://github.com/aws/aws-sdk-js/blob/master/lib/util.js#L674-L694) hoists payload members to the root of the parsed `data` object returned by CloudFront and S3 operations. This was done to maintain backwards compatibility. 

These hoisted fields are marked as not enumerable, so `AWS.util.copy` ignored them when copying the `resp.data` object in [`lib/request.js`](https://github.com/aws/aws-sdk-js/compare/master...chrisradek:fix-payload-hoist-w-promises?expand=1#diff-96d9811cb2296e877edf463c6cfc57bdR775)

We were copying `resp.data` to prevent circular references when we added the `$response` member to the `data` object. Now that we define `$response` as a property on the `data` object, it is not enumerable, so it is ignored when iterating over the object (e.g. JSON.stringify, console.log). We no longer need to copy the `resp.data` object due to this previous change.

Fixes #1476 