### PR TITLE
fix typo in the documentation of retryDelayOptions.base

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -100,7 +100,7 @@ var PromisesDependency;
  *     Currently supported options are:
  *
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
- *       exponential backoff for operation retries. Defaults to 100 ms for all services accept
+ *       exponential backoff for operation retries. Defaults to 100 ms for all services except
  *       DynamoDB, where it defaults to 50ms.
  *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
  *       and returns the amount of time to delay in milliseconds. The `base` option will be
@@ -217,7 +217,7 @@ AWS.Config = AWS.util.inherit({
    *
    *   * **base** [Integer] &mdash; The base number of milliseconds to use in the
    *     exponential backoff for operation retries. Defaults to 100 ms for all
-   *     services accept DynamoDB, where it defaults to 50ms.
+   *     services except DynamoDB, where it defaults to 50ms.
    *   * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
    *     and returns the amount of time to delay in milliseconds. The `base` option will be
    *     ignored if this option is supplied.


### PR DESCRIPTION
I think there is a typo in the documentation of `retryDelayOptions.base`, it says:

> The base number of milliseconds to use in the exponential backoff for operation retries. Defaults to 100 ms for all services **accept** DynamoDB, where it defaults to 50ms

I think it should be "except". 

Please note that I am not a native speaker and I could be wrong.