### PR TITLE
Ensure $HOME is used when present on all platforms

### DIFF
--- a/.changes/next-release/bugfix-SharedIniFileCredentials-fd68c2f5.json
+++ b/.changes/next-release/bugfix-SharedIniFileCredentials-fd68c2f5.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SharedIniFileCredentials",
+  "description": "This fix reverts a regression introduced in version 2.44.0 in which the value returned by os.homedir would be used in preference over the value of the HOME environment variable"
+}

--- a/lib/shared_ini.js
+++ b/lib/shared_ini.js
@@ -30,10 +30,6 @@ module.exports = AWS.util.inherit({
   },
 
   getHomeDir: function getHomeDir() {
-    if (typeof os.homedir === 'function') {
-      return os.homedir();
-    }
-
     var env = process.env;
     var home = env.HOME ||
       env.USERPROFILE ||
@@ -41,6 +37,10 @@ module.exports = AWS.util.inherit({
 
     if (home) {
       return home;
+    }
+
+    if (typeof os.homedir === 'function') {
+      return os.homedir();
     }
 
     throw AWS.util.error(

--- a/test/credentials.spec.coffee
+++ b/test/credentials.spec.coffee
@@ -191,6 +191,16 @@ if AWS.util.isNode()
         expect(AWS.util.readFileSync.calls[0].arguments[0]).to
           .match(/[\/\\]foo[\/\\]bar[\/\\]baz[\/\\].aws[\/\\]credentials/)
 
+      it 'should prefer $HOME to os.homedir', ->
+        process.env.HOME = '/home/user'
+        helpers.spyOn(os, 'homedir').andReturn(process.env.HOME + '/foo/bar')
+
+        new AWS.SharedIniFileCredentials()
+        expect(os.homedir.calls.length).to.equal(0)
+        expect(AWS.util.readFileSync.calls.length).to.equal(1)
+        expect(AWS.util.readFileSync.calls[0].arguments[0]).to
+          .match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/)
+
       it 'throws an error if HOME/HOMEPATH/USERPROFILE are not set', ->
         expect(-> new AWS.SharedIniFileCredentials().refresh()).
           to.throw('Cannot load credentials, HOME path not set')


### PR DESCRIPTION
os.homedir uses USERPROFILE over HOME on Windows systems, which caused
the default behavior of AWS.SharedIniFileCredentials to change from
2.43.0 to 2.44.0

This should resolve #1483 