### PR TITLE
Fixed TypeScript compile error

### DIFF
--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -36,7 +36,7 @@ export class ConfigBase extends ConfigurationOptions{
     /**
      * Gets the promise dependency the SDK will use wherever Promises are returned.
      */
-    getPromisesDependency(): typeof Promise | void;
+    getPromisesDependency(): Promise<any> | void;
     /**
      * Sets the promise dependency the SDK will use wherever Promises are returned.
      * @param {function} dep - a reference to a Promise constructor


### PR DESCRIPTION
When attempting to compile a simple TypeScript project that uses aws-sdk, I was getting the following error:

node_modules/aws-sdk/lib/config.d.ts(39,37): error TS2693: 'Promise' only refers to a type, but is being used as a value here.

This change has resolved the error but I'm not 100% confident it is correct.

...also I hope master is the correct branch to be submitting the request for...