### PR TITLE
Fixes issue with binary response bodies being empty in react native

### DIFF
--- a/.changes/next-release/bugfix-ReactNative-1c146c4d.json
+++ b/.changes/next-release/bugfix-ReactNative-1c146c4d.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ReactNative",
+  "description": "Fixes issue where binary responses were empty in iOS (e.g. s3.getObject)"
+}

--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -25,7 +25,6 @@ AWS.XHRClient = AWS.util.inherit({
       } catch (e) { return; }
 
       if (this.readyState >= this.HEADERS_RECEIVED && !headersEmitted) {
-        try { xhr.responseType = 'arraybuffer'; } catch (e) {}
         emitter.statusCode = xhr.status;
         emitter.headers = self.parseHeaders(xhr.getAllResponseHeaders());
         emitter.emit(
@@ -75,6 +74,7 @@ AWS.XHRClient = AWS.util.inherit({
     if (httpOptions.xhrWithCredentials) {
       xhr.withCredentials = true;
     }
+    try { xhr.responseType = 'arraybuffer'; } catch (e) {}
 
     try {
       if (httpRequest.body) {

--- a/test/browser.spec.js
+++ b/test/browser.spec.js
@@ -202,6 +202,24 @@
         }).send();
         return done();
       });
+      it('sets responseType to arraybuffer', function(done) {
+        var key, opts, req, svc;
+        key = uniqueName('test');
+        opts = AWS.util.merge(config, config.s3);
+        svc = new AWS.S3(opts);
+        req = svc.putObject({
+          Key: key,
+          Body: 'body'
+        }, function(err, data) {
+          expect(req.httpRequest.stream.responseType).to.equal('arraybuffer');
+          // cleanup
+          svc.deleteObject({
+            Key: key
+          }, function(err, data) {
+            done();
+          });
+        });
+      });
       return it('lower cases HTTP headers', function() {
         var client, headers, rawHeaders;
         rawHeaders = "x-amzn-Foo: foo\nx-amzn-Bar: bar";


### PR DESCRIPTION
Fixes #1503 

React Native doesn't allow for setting the `responseType` when the request has already been sent. Other browsers have issues when the responseType is set before `xhr.open()` is called.

This change properly changes the responseType to `arraybuffer` to handle binary data. The SDK already converts response data to a Buffer type today, so there shouldn't be any change from the user's perspective.

/cc @jeskew 