### PR TITLE
Fixes issue found in React Native on Android when sending request bodies without a Content-Type

### DIFF
--- a/.changes/next-release/bugfix-ReactNative-c7e6ea73.json
+++ b/.changes/next-release/bugfix-ReactNative-c7e6ea73.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ReactNative",
+  "description": "Requests will always have a Content-Type header if they also have a body. Works around an issue caused by React Native's Android XMLHttpRequest implementation that requires the Content-Type header to be present if there is a request body."
+}

--- a/lib/react-native-loader.js
+++ b/lib/react-native-loader.js
@@ -1,11 +1,11 @@
 var util = require('./util');
 
-// browser specific modules
+// react-native specific modules
 util.crypto.lib = require('crypto-browserify');
 util.Buffer = require('buffer/').Buffer;
 util.url = require('url/');
 util.querystring = require('querystring/');
-util.environment = 'react-native';
+util.environment = 'js-react-native';
 
 var AWS = require('./core');
 
@@ -17,6 +17,12 @@ AWS.XML.Parser = require('./xml/node_parser');
 
 // Load the XHR HttpClient
 require('./http/xhr');
+
+// add custom request event handlers
+var addContentType = require('./react-native/add-content-type').addContentType;
+AWS.EventListeners.Core.addNamedListeners(function(add) {
+  add('ADD_CONTENT_TYPE', 'afterBuild', addContentType);
+});
 
 if (typeof process === 'undefined') {
   process = {};

--- a/lib/react-native/add-content-type.js
+++ b/lib/react-native/add-content-type.js
@@ -1,0 +1,15 @@
+function addContentType(req) {
+  var httpRequest = req.httpRequest || {};
+  var headers = httpRequest.headers;
+  // We don't want to force a content type on presigned urls
+  if (headers && !req.isPresigned()) {
+    if (httpRequest.body && !headers['Content-Type']) {
+      // React Native's android XHR requires Content-Type to be defined if there is a body
+      headers['Content-Type'] = '';
+    }
+  }
+}
+
+module.exports = {
+    addContentType: addContentType
+};

--- a/tasks/browser.rake
+++ b/tasks/browser.rake
@@ -74,7 +74,7 @@ namespace :browser do
     mkdir_p "test/browser/build"
     cp "dist/aws-sdk-all.js", "test/browser/build/aws-sdk-all.js"
     files = "test/helpers.js ";
-    files += Dir.glob("test/**/*.spec.js").join(" ")
+    files += Dir.glob("test/**/*.spec.js").delete_if{|name| name.start_with?("test/react-native/")}.join(" ")
     sh({"SERVICES" => "all"}, $BROWSERIFY +
        " -i domain #{files} > #{$BROWSERIFY_TEST}")
     rm_f "test/configuration.js"

--- a/test/react-native/add-content-type.spec.js
+++ b/test/react-native/add-content-type.spec.js
@@ -1,0 +1,43 @@
+var helpers = require('../helpers');
+var AWS = helpers.AWS;
+var addContentType = require('../../lib/react-native/add-content-type').addContentType;
+
+describe('React Native', function() {
+    var mockService = new AWS.Service({
+        paramValidation: true
+    });
+
+    describe('addContentType', function() {
+        it('should add an empty content type if one is not defined and there is a body', function() {
+            var req = mockService.makeRequest('fakeOp');
+            req.httpRequest.body = 'body';
+            delete req.httpRequest.headers['Content-Type'];
+            addContentType(req);
+            expect(typeof req.httpRequest.headers['Content-Type']).to.eql('string');
+        });
+        it('should not add a content type if body is empty', function() {
+            var req = mockService.makeRequest('fakeOp');
+            req.httpRequest.body = null;
+            delete req.httpRequest.headers['Content-Type'];
+            addContentType(req);
+            expect(typeof req.httpRequest.headers['Content-Type']).to.eql('undefined');
+        });
+        it('should not override content type if content type is already defined', function() {
+            var req = mockService.makeRequest('fakeOp');
+            req.httpRequest.body = 'body';
+            req.httpRequest.headers['Content-Type'] = 'type';
+            addContentType(req);
+            expect(req.httpRequest.headers['Content-Type']).to.eql('type');
+        });
+        it('should not override content type if generating presigned url', function() {
+            var req = mockService.makeRequest('fakeOp');
+            req.httpRequest.body = 'body';
+            delete req.httpRequest.headers['Content-Type'];
+            helpers.spyOn(req, 'isPresigned').andCallFake(function() {
+                return true;
+            });
+            addContentType(req);
+            expect(typeof req.httpRequest.headers['Content-Type']).to.eql('undefined');
+        });
+    });
+});

--- a/test/react-native/util.spec.js
+++ b/test/react-native/util.spec.js
@@ -1,0 +1,14 @@
+var helpers = require('../helpers');
+var AWS = helpers.AWS;
+var addContentType = require('../../lib/react-native/add-content-type').addContentType;
+
+describe('React Native', function() {
+    var mockService = new AWS.Service({
+        paramValidation: true
+    });
+    describe('util', function() {
+        it('environment should be js-react-native', function() {
+            expect(AWS.util.environment).to.eql('js-react-native');
+        });
+    });
+});

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1302,8 +1302,8 @@
       return expect(AWS.util.userAgent()).to.match(/^aws-sdk-nodejs/);
     });
     it('should include an identifier for the react-native SDK', function() {
-      AWS.util.environment = 'react-native';
-      return expect(AWS.util.userAgent()).to.match(/^aws-sdk-react-native/);
+      AWS.util.environment = 'js-react-native';
+      return expect(AWS.util.userAgent()).to.match(/^aws-sdk-js-react-native/);
     });
     it('should include the current SDK version number', function() {
       return expect(AWS.util.userAgent()).to.have.string(AWS.VERSION);


### PR DESCRIPTION
React Native's Android XMLHttpRequest implementation requires the Content-Type header to be set when the request contains a body. For some protocols, e.g. rest-json, the SDK doesn't set a Content-Type. Now, if a request contains a body and the Content-Type is not already set, nor is it a presigned url, it will be set to an empty string.

This change only affects the React Native build of the SDK.

Fixes #1490 

Tested on Android and iOS.

/cc @jeskew 