### PR TITLE
Allow empty string bodies

### DIFF
--- a/.changes/next-release/bugfix-S3-37b3e4ef.json
+++ b/.changes/next-release/bugfix-S3-37b3e4ef.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Update ManagedUploader body verification to allow empty strings"
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -257,9 +257,10 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   validateBody: function validateBody() {
     var self = this;
     self.body = self.service.config.params.Body;
-    if (!self.body) throw new Error('params.Body is required');
     if (typeof self.body === 'string') {
       self.body = new AWS.util.Buffer(self.body);
+    } else if (!self.body) {
+      throw new Error('params.Body is required');
     }
     self.sliceFn = AWS.util.arraySliceFn(self.body);
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@types/node": "^6.0.46",
     "browserify": "13.1.0",
-    "chai": "*",
+    "chai": "^3.0",
     "codecov": "^1.0.1",
     "coffee-script": "1.6.3",
     "coffeeify": "*",

--- a/test/s3/managed_upload.spec.js
+++ b/test/s3/managed_upload.spec.js
@@ -330,6 +330,27 @@
           return done();
         });
       });
+
+      it('supports empty string bodies', function(done) {
+          var reqs = helpers.mockResponses([
+              {
+                  data: {
+                      ETag: 'ETAG'
+                  }
+              }
+          ]);
+          upload = new AWS.S3.ManagedUpload({
+              params: {
+                  Body: ''
+              }
+          });
+          return upload.send(function() {
+              expect(helpers.operationsForRequests(reqs)).to.eql(['s3.putObject']);
+              expect(err).not.to.exist;
+              return done();
+          });
+      });
+
       it('errors if partSize is smaller than minPartSize', function() {
         return expect(function() {
           return new AWS.S3.ManagedUpload({


### PR DESCRIPTION
Fixes #1528 

The managed uploader already allows the uploading of empty buffers, and providing an empty string is another way of expressing the same intention to upload a marker file. The uploader will still throw when `params.Body` is `null` or `false`