### PR TITLE
Check options parameter

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -495,7 +495,7 @@ AWS.Config = AWS.util.inherit({
    * @api private
    */
   extractCredentials: function extractCredentials(options) {
-    if (options.accessKeyId && options.secretAccessKey) {
+    if (options && options.accessKeyId && options.secretAccessKey) {
       options = AWS.util.copy(options);
       options.credentials = new AWS.Credentials(options);
     }


### PR DESCRIPTION
Will fail if config is undefined.
```
.../node_modules/aws-sdk/lib/config.js:474
    if (options.accessKeyId && options.secretAccessKey) {
               ^
```

```
TypeError: Cannot read property 'accessKeyId' of undefined
    at Config.extractCredentials (.../node_modules/aws-sdk/lib/config.js:474:16)
```