### PR TITLE
Unpipe lengthAccumulator to prevent 'write after end' error

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -635,6 +635,7 @@ AWS.Request = inherit({
             lengthAccumulator.on('end', checkContentLengthAndEmit);
             stream.on('error', function(err) {
               shouldCheckContentLength = false;
+              httpStream.unpipe(lengthAccumulator);
               lengthAccumulator.emit('end');
               lengthAccumulator.end();
             });

--- a/test/request.spec.js
+++ b/test/request.spec.js
@@ -1147,6 +1147,25 @@ describe('AWS.Request', function() {
 
         // s.resume();
       });
+
+      it('successfully handles connection timeout', function (done) {
+        var request, s;
+        app = function (req, resp) {
+          resp.writeHead(200, {
+            'content-length': 512 * 1024
+          });
+          resp.write(new Buffer(512 * 1024));
+          resp.end();
+        };
+        service.config.httpOptions.timeout = 5;
+        request = service.makeRequest('mockMethod');
+        s = request.createReadStream();
+        s.on('error', function (e) {
+          setImmediate(function () {
+            done();
+          });
+        });
+      });
     });
   }
 


### PR DESCRIPTION
lengthAccumulator must be unpiped from httpStream otherwise 'write after end' error is thrown, which is impossible to handle. It seems that httpStream tries to write to lengthAccumulator even after lengthAccumulator.end() is called.

Here is all you need to reproduce the error:
```
let AWS = require('aws-sdk');

let s3 = new AWS.S3({
	httpOptions: {
		timeout: 1000
	}
});

let stream = s3.getObject({Bucket: 'bucket', Key: 'key'}).createReadStream();
stream.on('error', function() {
});

setTimeout(function() {}, 99999999);
```
Results to:
```
events.js:163
      throw er; // Unhandled 'error' event
      ^

Error: write after end
    at writeAfterEnd (_stream_writable.js:191:12)
    at PassThrough.Writable.write (_stream_writable.js:238:5)
    at IncomingMessage.ondata (_stream_readable.js:557:20)
    at emitOne (events.js:96:13)
    at IncomingMessage.emit (events.js:191:7)
    at IncomingMessage.Readable.read (_stream_readable.js:383:10)
    at flow (_stream_readable.js:763:34)
    at resume_ (_stream_readable.js:745:3)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
```

Node.js version v7.10.0