### PR TITLE
Fixes S3 ManagedUpload leavePartsOnError issue when resuming Buffer uploads

### DIFF
--- a/.changes/next-release/bugfix-S3-cc923e46.json
+++ b/.changes/next-release/bugfix-S3-cc923e46.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Calling send multiple times on an S3 ManagedUpload with leavePartsOnError set to true should no longer result in truncated files being uploaded to S3. Calling send multiple times is not supported with streams."
+}

--- a/features/extra/helpers.js
+++ b/features/extra/helpers.js
@@ -147,11 +147,16 @@ module.exports = {
     if (!fs.existsSync(fixturePath)) fs.mkdirSync(fixturePath);
     var filename = path.join(fixturePath, name);
     var body;
-    switch (size) {
-      case 'empty': body = new Buffer(0); break;
-      case 'small': body = new Buffer(1024 * 1024); break;
-      case 'large': body = new Buffer(1024 * 1024 * 20); break;
+    if (typeof size === 'string') {
+      switch (size) {
+        case 'empty': body = new Buffer(0); break;
+        case 'small': body = new Buffer(1024 * 1024); break;
+        case 'large': body = new Buffer(1024 * 1024 * 20); break;
+      }
+    } else if (typeof size === 'number') {
+      body = new Buffer(size);
     }
+
     fs.writeFileSync(filename, body);
     return filename;
   },

--- a/features/s3/managed_upload.feature
+++ b/features/s3/managed_upload.feature
@@ -53,3 +53,22 @@ Feature: S3 Managed Upload
     When I get the object "checksummed_data"
     Then the HTTP response should have a content length of 20971520
     And the MD5 checksum of the response data should equal the generated checksum
+
+  @leave_parts_on_error
+  Scenario: Resuming an upload
+    When I use S3 managed upload to upload some 20MB buffer to the key "broken_buffer"
+    And I abort the upload
+    Then I receive a "RequestAbortedError" error
+    When I resume the upload
+    Then the object "broken_buffer" should exist
+    And the ContentLength should equal 20971520
+
+  @leave_parts_on_error
+  Scenario: Resuming a partial upload
+    When I use S3 managed upload to partially upload some 20MB buffer to the key "partial_buffer"
+    Then I receive a "RequestAbortedError" error
+    When I resume the upload
+    Then the object "partial_buffer" should exist
+    And the ContentLength should equal 20971520
+    And uploadPart should have been called 5 times
+    

--- a/features/s3/step_definitions/managed_upload.js
+++ b/features/s3/step_definitions/managed_upload.js
@@ -60,4 +60,84 @@ module.exports = function () {
     this.assert.equal(this.data.ContentLength, val);
     callback();
   });
+
+  this.When(/^I use S3 managed upload to upload some (\d+MB) buffer to the key "([^"]*)"$/, function(size, key, callback) {
+    var self = this;
+    var params = {
+      Bucket: self.sharedBucket,
+      Key: key,
+      Body: self.createBuffer(size)
+    };
+    self.progressEvents = [];
+    var progress = function progress(info) {
+      self.progressEvents.push(info);
+    };
+
+    var managedUpload = self.managedUpload = new self.AWS.S3.ManagedUpload({
+      leavePartsOnError: true,
+      params: params,
+      service: self.s3
+    });
+
+    managedUpload.on('httpUploadProgress', progress).send(function(err, data) {
+      self.error = err;
+      self.data = data;
+    });
+    callback();
+  });
+
+  this.When(/^I use S3 managed upload to partially upload some (\d+MB) buffer to the key "([^"]*)"$/, function(size, key, callback) {
+    var self = this;
+    var params = {
+      Bucket: self.sharedBucket,
+      Key: key,
+      Body: self.createBuffer(size)
+    };
+    self.progressEvents = [];
+    var didAbort = false;
+    var progress = function progress(info) {
+      if (self.progressEvents.length && !didAbort) {
+        didAbort = true;
+        self.managedUpload.abort();
+      }
+      self.progressEvents.push(info);
+    };
+
+    var managedUpload = self.managedUpload = new self.AWS.S3.ManagedUpload({
+      leavePartsOnError: true,
+      queueSize: 1,
+      params: params,
+      service: self.s3
+    });
+
+    managedUpload.on('httpUploadProgress', progress).send(function(err, data) {
+      self.error = err;
+      self.data = data;
+      callback();
+    });
+  });
+
+  this.When(/^I abort the upload$/, function(callback) {
+    this.managedUpload.abort();
+    callback();
+  });
+
+  this.Then(/^I receive a "([^"]*)" error$/, function(errName, callback) {
+    this.assert.equal(this.error.name, errName);
+    callback();
+  });
+
+  this.When(/^I resume the upload$/, function(callback) {
+    var self = this;
+    self.managedUpload.send(function(err, data) {
+      self.error = err;
+      self.data = data;
+      callback();
+    });
+  });
+
+  this.Then(/^uploadPart should have been called (\d+) times$/, function(count, callback) {
+    this.assert.equal(this.progressEvents.length, count);
+    callback();
+  });
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -435,7 +435,7 @@ AWS.Request = inherit({
       });
     });
 
-    if (this.httpRequest.stream) { // abort HTTP stream
+    if (this.httpRequest.stream && !this.httpRequest.stream.didCallback) { // abort HTTP stream
       this.httpRequest.stream.abort();
       if (this.httpRequest._abortCallback) {
          this.httpRequest._abortCallback();

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -590,8 +590,18 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       self.body.resume();
     }
 
+    // cleanup multipartReq listeners
+    if (self.multipartReq) {
+      self.multipartReq.removeAllListeners('success');
+      self.multipartReq.removeAllListeners('error');
+      self.multipartReq.removeAllListeners('complete');
+      delete self.multipartReq;
+    }
+
     if (self.service.config.params.UploadId && !self.leavePartsOnError) {
       self.service.abortMultipartUpload().send();
+    } else if (self.leavePartsOnError) {
+      self.isDoneChunking = false;
     }
 
     AWS.util.each(self.parts, function(partNumber, part) {


### PR DESCRIPTION
Addresses #1538 & #778 

When the S3 ManagedUpload is configured with `leavePartsOnError` set to `true`, it does not clean up data that has been uploaded to S3.

Calling `send` multiple times when the Body is a Buffer should attempt to upload the data that was not already saved to S3.

There is an issue where calling `send` a 2nd time would instead upload the 1st part using a `putObject` request, resulting in a 5MB file being uploaded, instead of the full file. This happens when all parts have been queued for upload. On a subsequent `send`, the uploader considers the payload to be 'chunked', and assumes the first part it encounters to be the full file.

This change resets the `isDoneChunking` state when an upload fails/is aborted.

Note that resuming an upload still will not work for streams, since streams are exhausted on failure. Supporting resume on streams should be an enhancement we make at some point.

/cc @jeskew 