### PR TITLE
Fix markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,24 +79,31 @@ Our goal is to keep these TypeScript definition files updated with each release 
 
 ### Pre-requisites
 Before you can begin using these TypeScript definitions with your project, you need to make sure your project meets a few of these requirements:
+
  * Use TypeScript v2.x
  * Includes the TypeScript definitions for node. You can use npm to install this by typing the following into a terminal window:
-  ```sh
+
+    ```sh
     npm install --save-dev @types/node
-  ```
+    ```
+
  * Your `tsconfig.json` or `jsconfig.json` includes `'dom'` and `'es2015.promise'` under `compilerOptions.lib`.
  See [tsconfig.json](./ts/tsconfig.json) for an example.
 
 ### In the Browser
 To use the TypeScript definition files with the global `AWS` object in a front-end project, add the following line to the top of your JavaScript file:
+
 ```javascript
 /// <reference types="aws-sdk" />
 ```
+
 This will provide support for the global `AWS` object.
 
 ### In Node.js
 To use the TypeScript definition files within a Node.js project, simply import `aws-sdk` as you normally would.
+
 In a TypeScript file:
+
 ```javascript
 // import entire SDK
 import AWS = require('aws-sdk');
@@ -105,7 +112,9 @@ import AWS = require('aws-sdk/global');
 // import individual service
 import S3 = require('aws-sdk/clients/s3');
 ```
+
 In a JavaScript file:
+
 ```javascript
 // import entire SDK
 var AWS = require('aws-sdk');
@@ -117,11 +126,13 @@ var S3 = require('aws-sdk/clients/s3');
 
 ### Known Limitations
 There are a few known limitations with the bundled TypeScript definitions at this time:
+
  * Service client typings reflect the latest `apiVersion`, regardless of which `apiVersion` is specified when creating a client.
  * Service-bound parameters use the `any` type.
 
 ## Getting Help
 Please use these community resources for getting help. We use the GitHub issues for tracking bugs and feature requests and have limited bandwidth to address them.
+
  * Ask a question on [StackOverflow](https://stackoverflow.com/) and tag it with `aws-sdk-js`
  * Come join the AWS JavaScript community on [gitter](https://gitter.im/aws/aws-sdk-js?source=orgpage)
  * Open a support ticket with [AWS Support](https://console.aws.amazon.com/support/home#/)


### PR DESCRIPTION
The markdown in README.md had a few problems that caused it to be displayed incorrectly by some markdown parsers, even though GitHub displayed it correctly. For example, http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/index.html displayed the lists incorrectly.