### PR TITLE
S3 bucket slashes

### DIFF
--- a/.changes/next-release/feature-S3-8ccad09a.json
+++ b/.changes/next-release/feature-S3-8ccad09a.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "S3",
+  "description": "Allows forward slashes in Bucket names when using SigV4 to create or retrieve objects. This is to maintain compatibility with behavior when using SigV2. In new code, Buckets should not contain forward slashes. Instead, directories should be part of an object's key."
+}

--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -215,3 +215,63 @@ Feature: Working with Objects in S3
   Scenario: Error handling
     Given I put "data" to the invalid key ""
     Then the status code should be 400
+
+  @bucket-slashes
+  Scenario: Sigv4 Bucket with trailing slash
+    Given I use signatureVersion "v4"
+    When I put "" to the key "" with bucket suffix "/"
+    Then the object "/" should exist
+  
+  @bucket-slashes
+  Scenario: Sigv4 Bucket with dobule trailing slashes
+    Given I use signatureVersion "v4"
+    When I put "" to the key "" with bucket suffix "//"
+    Then the object "//" should exist
+
+  @bucket-slashes
+  Scenario: Sigv4 Bucket with slashes without trailing slash
+    Given I use signatureVersion "v4"
+    When I put "" to the key "" with bucket suffix "/a/b"
+    Then the object "a/b/" should exist
+
+  @bucket-slashes
+  Scenario: Sigv4 Bucket with slashes with Key
+    Given I use signatureVersion "v4"
+    When I put "" to the key "foo" with bucket suffix "/a/b"
+    Then the object "a/b/foo" should exist
+
+  @bucket-slashes
+  Scenario: Sigv4 Bucket with trailing slashes with Key
+    Given I use signatureVersion "v4"
+    When I put "" to the key "foo" with bucket suffix "/a/b/"
+    Then the object "a/b//foo" should exist
+
+  @bucket-slashes
+  Scenario: Sigv2 Bucket with trailing slash
+    Given I use signatureVersion "v2"
+    When I put "" to the key "" with bucket suffix "/"
+    Then the object "/" should exist
+  
+  @bucket-slashes
+  Scenario: Sigv2 Bucket with double trailing slashes
+    Given I use signatureVersion "v2"
+    When I put "" to the key "" with bucket suffix "//"
+    Then the object "//" should exist
+
+  @bucket-slashes
+  Scenario: Sigv2 Bucket with slashes without trailing slash
+    Given I use signatureVersion "v2"
+    When I put "" to the key "" with bucket suffix "/a/b"
+    Then the object "a/b/" should exist
+
+  @bucket-slashes
+  Scenario: Sigv2 Bucket with slashes with Key
+    Given I use signatureVersion "v2"
+    When I put "" to the key "foo" with bucket suffix "/a/b"
+    Then the object "a/b/foo" should exist
+
+  @bucket-slashes
+  Scenario: Sigv2 Bucket with trailing slashes with Key
+    Given I use signatureVersion "v2"
+    When I put "" to the key "foo" with bucket suffix "/a/b/"
+    Then the object "a/b//foo" should exist

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -311,4 +311,22 @@ module.exports = function () {
       }
     });
   });
+
+  this.Given(/^I use signatureVersion "([^"]*)"$/, function(signatureVersion, next) {
+    this.s3Slashes = new this.AWS.S3({signatureVersion: signatureVersion});
+    next();
+  });
+
+  this.When(/^I put "([^"]*)" to the key "([^"]*)" with bucket suffix "([^"]*)"$/, function(data, key, suffix, next) {
+    var world = this;
+    var params = {
+      Bucket: this.sharedBucket + suffix,
+      Key: key,
+      Body: data
+    };
+    this.s3Slashes.putObject(params, function(err, data) {
+      world.assert.equal(!!err, false);
+      next();
+    });
+  });
 };

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -271,13 +271,14 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
   bindServiceObject: function bindServiceObject(params) {
     params = params || {};
     var self = this;
-
     // bind parameters to new service object
     if (!self.service) {
       self.service = new AWS.S3({params: params});
     } else {
-      var config = AWS.util.copy(self.service.config);
-      self.service = new self.service.constructor.__super__(config);
+      var service = self.service;
+      var config = AWS.util.copy(service.config);
+      config.signatureVersion = service.getSignatureVersion();
+      self.service = new service.constructor.__super__(config);
       self.service.config.params =
         AWS.util.merge(self.service.config.params || {}, params);
     }

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -162,10 +162,20 @@ AWS.util.update(AWS.S3.prototype, {
       return;
     }
     var bucket = req.params && req.params.Bucket;
-    if (bucket && bucket.indexOf('/') >= 0) {
-      var msg = 'Bucket names cannot contain forward slashes. Bucket: ' + bucket;
-      throw AWS.util.error(new Error(),
-        { code: 'InvalidBucket', message: msg });
+    var key = req.params && req.params.Key;
+    var slashIndex = bucket && bucket.indexOf('/');
+    if (bucket && slashIndex >= 0) {
+      if (typeof key === 'string') {
+        req.params = AWS.util.copy(req.params);
+        // Need to include trailing slash to match sigv2 behavior
+        var prefix = bucket.substr(slashIndex + 1) || '';
+        req.params.Key = prefix + '/' + key;
+        req.params.Bucket = bucket.substr(0, slashIndex);
+      } else {
+        var msg = 'Bucket names cannot contain forward slashes. Bucket: ' + bucket;
+        throw AWS.util.error(new Error(),
+          { code: 'InvalidBucket', message: msg });
+      }
     }
   },
 
@@ -195,7 +205,6 @@ AWS.util.update(AWS.S3.prototype, {
     var b = req.params.Bucket;
     var service = req.service;
     var endpoint = httpRequest.endpoint;
-
     if (b) {
       if (!service.pathStyleBucketName(b)) {
         if (service.config.useAccelerateEndpoint && service.isValidAccelerateOperation(req.operation)) {

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -1081,6 +1081,17 @@
       });
     });
     describe('upload', function() {
+      it('sets it\'s signatureVersion to match the calling service client', function() {
+        var s3 = new AWS.S3({
+          region: 'us-east-1'
+        });
+        var uploader = s3.upload({
+          Bucket: 'bucket',
+          Key: 'key',
+          Body: 'body'
+        });
+        expect(s3.getSignatureVersion()).to.equal(uploader.service.getSignatureVersion());
+      });
       it('accepts parameters in upload() call', function() {
         var done;
         helpers.mockResponses([

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -205,7 +205,7 @@
             done();
           });
         });
-        it('using sigv4 and the "Bucket" parameter contains forward slashes and "Key" exists', function(done) {
+        it('using sigv2 and the "Bucket" parameter contains forward slashes and "Key" exists', function(done) {
           helpers.mockResponses([
             {
               data: {


### PR DESCRIPTION
Updates `s3.upload` to use the same signature version as the client calling it.

Also allows forward slashes in S3 bucket names when an operation supports a Bucket and Key parameter. This is to maintain backwards compatibility with code written when signature version 2 was the default.

/cc @jeskew 