### PR TITLE
Roll buffer dependency back to 4.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "webpack": "^1.15.0"
   },
   "dependencies": {
-    "buffer": "5.0.6",
+    "buffer": "4.9.1",
     "crypto-browserify": "1.0.9",
     "jmespath": "0.15.0",
     "querystring": "0.2.0",


### PR DESCRIPTION
This PR fixes #1565 by rolling back our buffer dependency from 5.0.6 to 4.9.1. Buffer 5.x explicitly only supports IE11, whereas this package supports IE10.

The original impetus for moving to 5.0.6, #1467, will need to be addressed in another way.