### PR TITLE
Prevents automatically filling in Content-Length header for unsigned operations

### DIFF
--- a/.changes/next-release/bugfix-LexRuntime-bdb2ea86.json
+++ b/.changes/next-release/bugfix-LexRuntime-bdb2ea86.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "LexRuntime",
+  "description": "Adds support for non-file streams as an input to postContent."
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -61,6 +61,17 @@ AWS.EventListeners = {
   Core: {} /* doc hack */
 };
 
+/**
+ * @private
+ */
+function getOperationAuthtype(req) {
+  if (!req.service.api.operations) {
+    return '';
+  }
+  var operation = req.service.api.operations[req.operation];
+  return operation ? operation.authtype : '';
+}
+
 AWS.EventListeners = {
   Core: new SequentialExecutor().addNamedListeners(function(add, addAsync) {
     addAsync('VALIDATE_CREDENTIALS', 'validate',
@@ -143,7 +154,9 @@ AWS.EventListeners = {
     });
 
     add('SET_CONTENT_LENGTH', 'afterBuild', function SET_CONTENT_LENGTH(req) {
-      if (req.httpRequest.headers['Content-Length'] === undefined) {
+      var authtype = getOperationAuthtype(req);
+      if (req.httpRequest.headers['Content-Length'] === undefined
+          && authtype.indexOf('unsigned-body') === -1) {
         var length = AWS.util.string.byteLength(req.httpRequest.body);
         req.httpRequest.headers['Content-Length'] = length;
       }

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -62,7 +62,7 @@ AWS.EventListeners = {
 };
 
 /**
- * @private
+ * @api private
  */
 function getOperationAuthtype(req) {
   if (!req.service.api.operations) {

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -170,6 +170,19 @@
         contentLength = function(body) {
           return sendRequest(body).httpRequest.headers['Content-Length'];
         };
+        it('ignores Content-Length for operations with an unsigned authtype', function(done) {
+          var service = new AWS.Lambda();
+          service.api.operations.updateFunctionCode.authtype = 'v4-unsigned-body';
+          req = service.makeRequest('updateFunctionCode', {
+            FunctionName: 'fake',
+            ZipFile: new Buffer('fake')
+          });
+          req.runTo('sign', function(err) {
+            expect(typeof req.httpRequest.headers['Content-Length']).to.equal('undefined');
+            delete service.api.operations.updateFunctionCode.authtype;
+            done();
+          });
+        });
         it('builds Content-Length in the request headers for string content', function() {
           return expect(contentLength('FOOBAR')).to.equal(6);
         });

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -170,6 +170,7 @@
         contentLength = function(body) {
           return sendRequest(body).httpRequest.headers['Content-Length'];
         };
+
         it('ignores Content-Length for operations with an unsigned authtype', function(done) {
           var service = new AWS.Lambda();
           service.api.operations.updateFunctionCode.authtype = 'v4-unsigned-body';
@@ -183,18 +184,23 @@
             done();
           });
         });
+
         it('builds Content-Length in the request headers for string content', function() {
           return expect(contentLength('FOOBAR')).to.equal(6);
         });
+
         it('builds Content-Length for string "0"', function() {
           return expect(contentLength('0')).to.equal(1);
         });
+
         it('builds Content-Length for utf-8 string body', function() {
           return expect(contentLength('tï№')).to.equal(6);
         });
+
         it('builds Content-Length for buffer body', function() {
           return expect(contentLength(new AWS.util.Buffer('tï№'))).to.equal(6);
         });
+
         if (AWS.util.isNode()) {
           return it('builds Content-Length for file body', function(done) {
             var file;


### PR DESCRIPTION
The SDK currently will populate the Content-Length header for all requests if it isn't provided. For operations that accept a stream, such as S3 or Glacier, this has limited us to only allowing streams sourced from a file to be used.

The LexRuntime service does not require knowing the Content-Length of a request ahead of time, and can accept a stream as an input to postContent. This change uses the authtype field of an operation to determine if the body is unsigned, and then skips automatically populating the Content-Length. Currently Lex is the only service that uses this authtype field to indicate it uses an unsigned body. Aside from services like S3/Glacier, we can infer that if a service expects a payload to be unsigned, they likely don't expect to know the size of the payload upfront.


/cc @jeskew 