### PR TITLE
Throw Error for Invalid Headers during v4 signing

### DIFF
--- a/.changes/next-release/bugfix-Core-fac0551b.json
+++ b/.changes/next-release/bugfix-Core-fac0551b.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Core",
+  "description": "The SDK will now throw an InvalidHeader error when a header's value is not stringifiable. See #1598."
+}

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -138,8 +138,14 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     AWS.util.arrayEach.call(this, headers, function (item) {
       var key = item[0].toLowerCase();
       if (this.isSignableHeader(key)) {
+        var value = item[1];
+        if (typeof value === 'undefined' || value === null || typeof value.toString !== 'function') {
+          throw AWS.util.error(new Error('Header ' + key + ' contains invalid value'), {
+            code: 'InvalidHeader'
+          });
+        }
         parts.push(key + ':' +
-          this.canonicalHeaderValues(item[1].toString()));
+          this.canonicalHeaderValues(value.toString()));
       }
     });
     return parts.join('\n');

--- a/test/signers/v4.spec.js
+++ b/test/signers/v4.spec.js
@@ -164,24 +164,28 @@
       it('should return headers', function() {
         return expect(signer.canonicalHeaders()).to.eql(['host:localhost', 'x-amz-content-sha256:3128b8d4f3108b3e1677a38eb468d1c6dec926a58eaea235d034b9c71c3864d4', 'x-amz-date:' + datetime, 'x-amz-security-token:session', 'x-amz-target:DynamoDB_20111205.ListTables', 'x-amz-user-agent:aws-sdk-js/0.1'].join('\n'));
       });
+
       it('should ignore Authorization header', function() {
         signer.request.headers = {
           'Authorization': 'foo'
         };
         return expect(signer.canonicalHeaders()).to.equal('');
       });
+
       it('should ignore X-Amzn-Trace-Id header', function() {
         signer.request.headers = {
           'X-Amzn-Trace-Id': 'foo'
         };
         return expect(signer.canonicalHeaders()).to.equal('');
       });
+
       it('should lowercase all header names (not values)', function() {
         signer.request.headers = {
           'FOO': 'BAR'
         };
         return expect(signer.canonicalHeaders()).to.equal('foo:BAR');
       });
+
       it('should sort headers by key', function() {
         signer.request.headers = {
           abc: 'a',
@@ -191,18 +195,66 @@
         };
         return expect(signer.canonicalHeaders()).to.equal('abc:a\nbar:d\nbca:b\nqux:c');
       });
+
       it('should compact multiple spaces in keys/values to a single space', function() {
         signer.request.headers = {
           'Header': 'Value     with  Multiple   \t spaces'
         };
         return expect(signer.canonicalHeaders()).to.equal('header:Value with Multiple spaces');
       });
-      return it('should strip starting and end of line spaces', function() {
+
+      it('should strip starting and end of line spaces', function() {
         signer.request.headers = {
           'Header': ' \t   Value  \t  '
         };
         return expect(signer.canonicalHeaders()).to.equal('header:Value');
       });
+
+      it('should throw an error when header value is null', function() {
+        signer.request.headers = {
+          foo: null,
+          bar: 'd'
+        };
+        var err;
+        try {
+          signer.canonicalHeaders();
+        } catch (e) {
+          err = e;
+        }
+        expect(typeof err).to.equal('object');
+        expect(err.code).to.equal('InvalidHeader');
+      });
+
+      it('should throw an error when header value is undefined', function() {
+        signer.request.headers = {
+          foo: undefined,
+          bar: 'd'
+        };
+        var err;
+        try {
+          signer.canonicalHeaders();
+        } catch (e) {
+          err = e;
+        }
+        expect(typeof err).to.equal('object');
+        expect(err.code).to.equal('InvalidHeader');
+      });
+
+      it('should throw an error when header value does not have toString', function() {
+        signer.request.headers = {
+          foo: Object.create(null),
+          bar: 'd'
+        };
+        var err;
+        try {
+          signer.canonicalHeaders();
+        } catch (e) {
+          err = e;
+        }
+        expect(typeof err).to.equal('object');
+        expect(err.code).to.equal('InvalidHeader');
+      });
+
     });
     return describe('presigned urls', function() {
       it('hoists content-type to the query string', function() {


### PR DESCRIPTION
Non-stringifiable headers will now throw an InvalidHeader error when encountered during V4 signing

Fixes #1598

/cc @jeskew 