### PR TITLE
Updates React Native build to allow same style imports as JS SDK

### DIFF
--- a/clients/acm.js
+++ b/clients/acm.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['acm'] = {};
 AWS.ACM = Service.defineService('acm', ['2015-12-08']);

--- a/clients/all.js
+++ b/clients/all.js
@@ -1,6 +1,4 @@
 require('../lib/node_loader');
-var AWS = require('../lib/core');
-
 module.exports = {
   ACM: require('./acm'),
   APIGateway: require('./apigateway'),

--- a/clients/apigateway.js
+++ b/clients/apigateway.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['apigateway'] = {};
 AWS.APIGateway = Service.defineService('apigateway', ['2015-07-09']);

--- a/clients/applicationautoscaling.js
+++ b/clients/applicationautoscaling.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['applicationautoscaling'] = {};
 AWS.ApplicationAutoScaling = Service.defineService('applicationautoscaling', ['2016-02-06']);

--- a/clients/appstream.js
+++ b/clients/appstream.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['appstream'] = {};
 AWS.AppStream = Service.defineService('appstream', ['2016-12-01']);

--- a/clients/athena.js
+++ b/clients/athena.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['athena'] = {};
 AWS.Athena = Service.defineService('athena', ['2017-05-18']);

--- a/clients/autoscaling.js
+++ b/clients/autoscaling.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['autoscaling'] = {};
 AWS.AutoScaling = Service.defineService('autoscaling', ['2011-01-01']);

--- a/clients/batch.js
+++ b/clients/batch.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['batch'] = {};
 AWS.Batch = Service.defineService('batch', ['2016-08-10']);

--- a/clients/browser_default.js
+++ b/clients/browser_default.js
@@ -1,6 +1,4 @@
 require('../lib/node_loader');
-var AWS = require('../lib/core');
-
 module.exports = {
   ACM: require('./acm'),
   APIGateway: require('./apigateway'),

--- a/clients/budgets.js
+++ b/clients/budgets.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['budgets'] = {};
 AWS.Budgets = Service.defineService('budgets', ['2016-10-20']);

--- a/clients/clouddirectory.js
+++ b/clients/clouddirectory.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['clouddirectory'] = {};
 AWS.CloudDirectory = Service.defineService('clouddirectory', ['2016-05-10']);

--- a/clients/cloudformation.js
+++ b/clients/cloudformation.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudformation'] = {};
 AWS.CloudFormation = Service.defineService('cloudformation', ['2010-05-15']);

--- a/clients/cloudfront.js
+++ b/clients/cloudfront.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudfront'] = {};
 AWS.CloudFront = Service.defineService('cloudfront', ['2013-05-12*', '2013-11-11*', '2014-05-31*', '2014-10-21*', '2014-11-06*', '2015-04-17*', '2015-07-27*', '2015-09-17*', '2016-01-13*', '2016-01-28*', '2016-08-01*', '2016-08-20*', '2016-09-07*', '2016-09-29*', '2016-11-25', '2016-11-25*', '2017-03-25']);

--- a/clients/cloudhsm.js
+++ b/clients/cloudhsm.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudhsm'] = {};
 AWS.CloudHSM = Service.defineService('cloudhsm', ['2014-05-30']);

--- a/clients/cloudsearch.js
+++ b/clients/cloudsearch.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudsearch'] = {};
 AWS.CloudSearch = Service.defineService('cloudsearch', ['2011-02-01', '2013-01-01']);

--- a/clients/cloudsearchdomain.js
+++ b/clients/cloudsearchdomain.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudsearchdomain'] = {};
 AWS.CloudSearchDomain = Service.defineService('cloudsearchdomain', ['2013-01-01']);

--- a/clients/cloudtrail.js
+++ b/clients/cloudtrail.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudtrail'] = {};
 AWS.CloudTrail = Service.defineService('cloudtrail', ['2013-11-01']);

--- a/clients/cloudwatch.js
+++ b/clients/cloudwatch.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudwatch'] = {};
 AWS.CloudWatch = Service.defineService('cloudwatch', ['2010-08-01']);

--- a/clients/cloudwatchevents.js
+++ b/clients/cloudwatchevents.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudwatchevents'] = {};
 AWS.CloudWatchEvents = Service.defineService('cloudwatchevents', ['2014-02-03*', '2015-10-07']);

--- a/clients/cloudwatchlogs.js
+++ b/clients/cloudwatchlogs.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cloudwatchlogs'] = {};
 AWS.CloudWatchLogs = Service.defineService('cloudwatchlogs', ['2014-03-28']);

--- a/clients/codebuild.js
+++ b/clients/codebuild.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['codebuild'] = {};
 AWS.CodeBuild = Service.defineService('codebuild', ['2016-10-06']);

--- a/clients/codecommit.js
+++ b/clients/codecommit.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['codecommit'] = {};
 AWS.CodeCommit = Service.defineService('codecommit', ['2015-04-13']);

--- a/clients/codedeploy.js
+++ b/clients/codedeploy.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['codedeploy'] = {};
 AWS.CodeDeploy = Service.defineService('codedeploy', ['2014-10-06']);

--- a/clients/codepipeline.js
+++ b/clients/codepipeline.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['codepipeline'] = {};
 AWS.CodePipeline = Service.defineService('codepipeline', ['2015-07-09']);

--- a/clients/codestar.js
+++ b/clients/codestar.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['codestar'] = {};
 AWS.CodeStar = Service.defineService('codestar', ['2017-04-19']);

--- a/clients/cognitoidentity.js
+++ b/clients/cognitoidentity.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cognitoidentity'] = {};
 AWS.CognitoIdentity = Service.defineService('cognitoidentity', ['2014-06-30']);

--- a/clients/cognitoidentityserviceprovider.js
+++ b/clients/cognitoidentityserviceprovider.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cognitoidentityserviceprovider'] = {};
 AWS.CognitoIdentityServiceProvider = Service.defineService('cognitoidentityserviceprovider', ['2016-04-18']);

--- a/clients/cognitosync.js
+++ b/clients/cognitosync.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cognitosync'] = {};
 AWS.CognitoSync = Service.defineService('cognitosync', ['2014-06-30']);

--- a/clients/configservice.js
+++ b/clients/configservice.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['configservice'] = {};
 AWS.ConfigService = Service.defineService('configservice', ['2014-11-12']);

--- a/clients/cur.js
+++ b/clients/cur.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['cur'] = {};
 AWS.CUR = Service.defineService('cur', ['2017-01-06']);

--- a/clients/datapipeline.js
+++ b/clients/datapipeline.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['datapipeline'] = {};
 AWS.DataPipeline = Service.defineService('datapipeline', ['2012-10-29']);

--- a/clients/dax.js
+++ b/clients/dax.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['dax'] = {};
 AWS.DAX = Service.defineService('dax', ['2017-04-19']);

--- a/clients/devicefarm.js
+++ b/clients/devicefarm.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['devicefarm'] = {};
 AWS.DeviceFarm = Service.defineService('devicefarm', ['2015-06-23']);

--- a/clients/directconnect.js
+++ b/clients/directconnect.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['directconnect'] = {};
 AWS.DirectConnect = Service.defineService('directconnect', ['2012-10-25']);

--- a/clients/directoryservice.js
+++ b/clients/directoryservice.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['directoryservice'] = {};
 AWS.DirectoryService = Service.defineService('directoryservice', ['2015-04-16']);

--- a/clients/discovery.js
+++ b/clients/discovery.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['discovery'] = {};
 AWS.Discovery = Service.defineService('discovery', ['2015-11-01']);

--- a/clients/dms.js
+++ b/clients/dms.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['dms'] = {};
 AWS.DMS = Service.defineService('dms', ['2016-01-01']);

--- a/clients/dynamodb.js
+++ b/clients/dynamodb.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['dynamodb'] = {};
 AWS.DynamoDB = Service.defineService('dynamodb', ['2011-12-05', '2012-08-10']);

--- a/clients/dynamodbstreams.js
+++ b/clients/dynamodbstreams.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['dynamodbstreams'] = {};
 AWS.DynamoDBStreams = Service.defineService('dynamodbstreams', ['2012-08-10']);

--- a/clients/ec2.js
+++ b/clients/ec2.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['ec2'] = {};
 AWS.EC2 = Service.defineService('ec2', ['2013-06-15*', '2013-10-15*', '2014-02-01*', '2014-05-01*', '2014-06-15*', '2014-09-01*', '2014-10-01*', '2015-03-01*', '2015-04-15*', '2015-10-01*', '2016-04-01*', '2016-09-15*', '2016-11-15']);

--- a/clients/ecr.js
+++ b/clients/ecr.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['ecr'] = {};
 AWS.ECR = Service.defineService('ecr', ['2015-09-21']);

--- a/clients/ecs.js
+++ b/clients/ecs.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['ecs'] = {};
 AWS.ECS = Service.defineService('ecs', ['2014-11-13']);

--- a/clients/efs.js
+++ b/clients/efs.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['efs'] = {};
 AWS.EFS = Service.defineService('efs', ['2015-02-01']);

--- a/clients/elasticache.js
+++ b/clients/elasticache.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['elasticache'] = {};
 AWS.ElastiCache = Service.defineService('elasticache', ['2012-11-15*', '2014-03-24*', '2014-07-15*', '2014-09-30*', '2015-02-02']);

--- a/clients/elasticbeanstalk.js
+++ b/clients/elasticbeanstalk.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['elasticbeanstalk'] = {};
 AWS.ElasticBeanstalk = Service.defineService('elasticbeanstalk', ['2010-12-01']);

--- a/clients/elastictranscoder.js
+++ b/clients/elastictranscoder.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['elastictranscoder'] = {};
 AWS.ElasticTranscoder = Service.defineService('elastictranscoder', ['2012-09-25']);

--- a/clients/elb.js
+++ b/clients/elb.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['elb'] = {};
 AWS.ELB = Service.defineService('elb', ['2012-06-01']);

--- a/clients/elbv2.js
+++ b/clients/elbv2.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['elbv2'] = {};
 AWS.ELBv2 = Service.defineService('elbv2', ['2015-12-01']);

--- a/clients/emr.js
+++ b/clients/emr.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['emr'] = {};
 AWS.EMR = Service.defineService('emr', ['2009-03-31']);

--- a/clients/es.js
+++ b/clients/es.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['es'] = {};
 AWS.ES = Service.defineService('es', ['2015-01-01']);

--- a/clients/firehose.js
+++ b/clients/firehose.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['firehose'] = {};
 AWS.Firehose = Service.defineService('firehose', ['2015-08-04']);

--- a/clients/gamelift.js
+++ b/clients/gamelift.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['gamelift'] = {};
 AWS.GameLift = Service.defineService('gamelift', ['2015-10-01']);

--- a/clients/glacier.js
+++ b/clients/glacier.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['glacier'] = {};
 AWS.Glacier = Service.defineService('glacier', ['2012-06-01']);

--- a/clients/greengrass.js
+++ b/clients/greengrass.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['greengrass'] = {};
 AWS.Greengrass = Service.defineService('greengrass', ['2017-06-07']);

--- a/clients/health.js
+++ b/clients/health.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['health'] = {};
 AWS.Health = Service.defineService('health', ['2016-08-04']);

--- a/clients/iam.js
+++ b/clients/iam.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['iam'] = {};
 AWS.IAM = Service.defineService('iam', ['2010-05-08']);

--- a/clients/importexport.js
+++ b/clients/importexport.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['importexport'] = {};
 AWS.ImportExport = Service.defineService('importexport', ['2010-06-01']);

--- a/clients/inspector.js
+++ b/clients/inspector.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['inspector'] = {};
 AWS.Inspector = Service.defineService('inspector', ['2015-08-18*', '2016-02-16']);

--- a/clients/iot.js
+++ b/clients/iot.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['iot'] = {};
 AWS.Iot = Service.defineService('iot', ['2015-05-28']);

--- a/clients/iotdata.js
+++ b/clients/iotdata.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['iotdata'] = {};
 AWS.IotData = Service.defineService('iotdata', ['2015-05-28']);

--- a/clients/kinesis.js
+++ b/clients/kinesis.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['kinesis'] = {};
 AWS.Kinesis = Service.defineService('kinesis', ['2013-12-02']);

--- a/clients/kinesisanalytics.js
+++ b/clients/kinesisanalytics.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['kinesisanalytics'] = {};
 AWS.KinesisAnalytics = Service.defineService('kinesisanalytics', ['2015-08-14']);

--- a/clients/kms.js
+++ b/clients/kms.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['kms'] = {};
 AWS.KMS = Service.defineService('kms', ['2014-11-01']);

--- a/clients/lambda.js
+++ b/clients/lambda.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lambda'] = {};
 AWS.Lambda = Service.defineService('lambda', ['2014-11-11', '2015-03-31']);

--- a/clients/lexmodelbuildingservice.js
+++ b/clients/lexmodelbuildingservice.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lexmodelbuildingservice'] = {};
 AWS.LexModelBuildingService = Service.defineService('lexmodelbuildingservice', ['2017-04-19']);

--- a/clients/lexruntime.js
+++ b/clients/lexruntime.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lexruntime'] = {};
 AWS.LexRuntime = Service.defineService('lexruntime', ['2016-11-28']);

--- a/clients/lightsail.js
+++ b/clients/lightsail.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lightsail'] = {};
 AWS.Lightsail = Service.defineService('lightsail', ['2016-11-28']);

--- a/clients/machinelearning.js
+++ b/clients/machinelearning.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['machinelearning'] = {};
 AWS.MachineLearning = Service.defineService('machinelearning', ['2014-12-12']);

--- a/clients/marketplacecommerceanalytics.js
+++ b/clients/marketplacecommerceanalytics.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['marketplacecommerceanalytics'] = {};
 AWS.MarketplaceCommerceAnalytics = Service.defineService('marketplacecommerceanalytics', ['2015-07-01']);

--- a/clients/marketplaceentitlementservice.js
+++ b/clients/marketplaceentitlementservice.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['marketplaceentitlementservice'] = {};
 AWS.MarketplaceEntitlementService = Service.defineService('marketplaceentitlementservice', ['2017-01-11']);

--- a/clients/marketplacemetering.js
+++ b/clients/marketplacemetering.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['marketplacemetering'] = {};
 AWS.MarketplaceMetering = Service.defineService('marketplacemetering', ['2016-01-14']);

--- a/clients/mobileanalytics.js
+++ b/clients/mobileanalytics.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['mobileanalytics'] = {};
 AWS.MobileAnalytics = Service.defineService('mobileanalytics', ['2014-06-05']);

--- a/clients/mturk.js
+++ b/clients/mturk.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['mturk'] = {};
 AWS.MTurk = Service.defineService('mturk', ['2017-01-17']);

--- a/clients/opsworks.js
+++ b/clients/opsworks.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['opsworks'] = {};
 AWS.OpsWorks = Service.defineService('opsworks', ['2013-02-18']);

--- a/clients/opsworkscm.js
+++ b/clients/opsworkscm.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['opsworkscm'] = {};
 AWS.OpsWorksCM = Service.defineService('opsworkscm', ['2016-11-01']);

--- a/clients/organizations.js
+++ b/clients/organizations.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['organizations'] = {};
 AWS.Organizations = Service.defineService('organizations', ['2016-11-28']);

--- a/clients/pinpoint.js
+++ b/clients/pinpoint.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['pinpoint'] = {};
 AWS.Pinpoint = Service.defineService('pinpoint', ['2016-12-01']);

--- a/clients/polly.js
+++ b/clients/polly.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['polly'] = {};
 AWS.Polly = Service.defineService('polly', ['2016-06-10']);

--- a/clients/rds.js
+++ b/clients/rds.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['rds'] = {};
 AWS.RDS = Service.defineService('rds', ['2013-01-10', '2013-02-12', '2013-09-09', '2014-09-01', '2014-09-01*', '2014-10-31']);

--- a/clients/redshift.js
+++ b/clients/redshift.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['redshift'] = {};
 AWS.Redshift = Service.defineService('redshift', ['2012-12-01']);

--- a/clients/rekognition.js
+++ b/clients/rekognition.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['rekognition'] = {};
 AWS.Rekognition = Service.defineService('rekognition', ['2016-06-27']);

--- a/clients/resourcegroupstaggingapi.js
+++ b/clients/resourcegroupstaggingapi.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['resourcegroupstaggingapi'] = {};
 AWS.ResourceGroupsTaggingAPI = Service.defineService('resourcegroupstaggingapi', ['2017-01-26']);

--- a/clients/route53.js
+++ b/clients/route53.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['route53'] = {};
 AWS.Route53 = Service.defineService('route53', ['2013-04-01']);

--- a/clients/route53domains.js
+++ b/clients/route53domains.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['route53domains'] = {};
 AWS.Route53Domains = Service.defineService('route53domains', ['2014-05-15']);

--- a/clients/s3.js
+++ b/clients/s3.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['s3'] = {};
 AWS.S3 = Service.defineService('s3', ['2006-03-01']);

--- a/clients/servicecatalog.js
+++ b/clients/servicecatalog.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['servicecatalog'] = {};
 AWS.ServiceCatalog = Service.defineService('servicecatalog', ['2015-12-10']);

--- a/clients/ses.js
+++ b/clients/ses.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['ses'] = {};
 AWS.SES = Service.defineService('ses', ['2010-12-01']);

--- a/clients/shield.js
+++ b/clients/shield.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['shield'] = {};
 AWS.Shield = Service.defineService('shield', ['2016-06-02']);

--- a/clients/simpledb.js
+++ b/clients/simpledb.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['simpledb'] = {};
 AWS.SimpleDB = Service.defineService('simpledb', ['2009-04-15']);

--- a/clients/sms.js
+++ b/clients/sms.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['sms'] = {};
 AWS.SMS = Service.defineService('sms', ['2016-10-24']);

--- a/clients/snowball.js
+++ b/clients/snowball.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['snowball'] = {};
 AWS.Snowball = Service.defineService('snowball', ['2016-06-30']);

--- a/clients/sns.js
+++ b/clients/sns.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['sns'] = {};
 AWS.SNS = Service.defineService('sns', ['2010-03-31']);

--- a/clients/sqs.js
+++ b/clients/sqs.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['sqs'] = {};
 AWS.SQS = Service.defineService('sqs', ['2012-11-05']);

--- a/clients/ssm.js
+++ b/clients/ssm.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['ssm'] = {};
 AWS.SSM = Service.defineService('ssm', ['2014-11-06']);

--- a/clients/stepfunctions.js
+++ b/clients/stepfunctions.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['stepfunctions'] = {};
 AWS.StepFunctions = Service.defineService('stepfunctions', ['2016-11-23']);

--- a/clients/storagegateway.js
+++ b/clients/storagegateway.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['storagegateway'] = {};
 AWS.StorageGateway = Service.defineService('storagegateway', ['2013-06-30']);

--- a/clients/sts.js
+++ b/clients/sts.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['sts'] = {};
 AWS.STS = Service.defineService('sts', ['2011-06-15']);

--- a/clients/support.js
+++ b/clients/support.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['support'] = {};
 AWS.Support = Service.defineService('support', ['2013-04-15']);

--- a/clients/swf.js
+++ b/clients/swf.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['swf'] = {};
 AWS.SWF = Service.defineService('swf', ['2012-01-25']);

--- a/clients/waf.js
+++ b/clients/waf.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['waf'] = {};
 AWS.WAF = Service.defineService('waf', ['2015-08-24']);

--- a/clients/wafregional.js
+++ b/clients/wafregional.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['wafregional'] = {};
 AWS.WAFRegional = Service.defineService('wafregional', ['2016-11-28']);

--- a/clients/workdocs.js
+++ b/clients/workdocs.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['workdocs'] = {};
 AWS.WorkDocs = Service.defineService('workdocs', ['2016-05-01']);

--- a/clients/workspaces.js
+++ b/clients/workspaces.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['workspaces'] = {};
 AWS.WorkSpaces = Service.defineService('workspaces', ['2015-04-08']);

--- a/clients/xray.js
+++ b/clients/xray.js
@@ -1,7 +1,7 @@
 require('../lib/node_loader');
 var AWS = require('../lib/core');
-var Service = require('../lib/service');
-var apiLoader = require('../lib/api_loader');
+var Service = AWS.Service;
+var apiLoader = AWS.apiLoader;
 
 apiLoader.services['xray'] = {};
 AWS.XRay = Service.defineService('xray', ['2016-04-12']);

--- a/dist-tools/client-creator.js
+++ b/dist-tools/client-creator.js
@@ -159,14 +159,12 @@ ClientCreator.prototype.generateAllServicesSource = function generateAllServices
   var self = this;
   var code = '';
   code += 'require(\'../lib/node_loader\');\n';
-  //code += 'var AWS = require(\'../lib/core\');\n\n';
   code += 'module.exports = {\n';
 
   services.forEach(function(service, idx) {
     var className = metadata[service].name;
     var tab = '  ';
     var isLast = idx === services.length - 1;
-    //code += self.generateDefinePropertySource('AWS', service, className);
     code += self.tabs(1) + className + ': require(\'./' + service + '\')' + (isLast ? '' : ',') + '\n';
   });
   code += '};';

--- a/dist-tools/client-creator.js
+++ b/dist-tools/client-creator.js
@@ -86,8 +86,8 @@ ClientCreator.prototype.generateClientFileSource = function generateClientFileSo
   var code = '';
   code += 'require(\'../lib/node_loader\');\n';
   code += 'var AWS = require(\'../lib/core\');\n';
-  code += 'var Service = require(\'../lib/service\');\n';
-  code += 'var apiLoader = require(\'../lib/api_loader\');\n\n';
+  code += 'var Service = AWS.Service;\n';
+  code += 'var apiLoader = AWS.apiLoader;\n\n';
   code += 'apiLoader.services[\'' + serviceName +'\'] = {};\n';
   code += 'AWS.' + className + ' = Service.defineService(\'' + serviceName + '\', [\'' + [].concat(obsoleteVersions, versionNumbers).sort().join('\', \'') + '\']);\n';
   // pull in service customizations
@@ -159,7 +159,7 @@ ClientCreator.prototype.generateAllServicesSource = function generateAllServices
   var self = this;
   var code = '';
   code += 'require(\'../lib/node_loader\');\n';
-  code += 'var AWS = require(\'../lib/core\');\n\n';
+  //code += 'var AWS = require(\'../lib/core\');\n\n';
   code += 'module.exports = {\n';
 
   services.forEach(function(service, idx) {

--- a/dist-tools/webpack.config.rn-base.js
+++ b/dist-tools/webpack.config.rn-base.js
@@ -1,0 +1,33 @@
+// import path for resolving file paths
+var path = require('path');
+module.exports = {
+    // Specify the entry point for our app.
+    entry: {
+        'aws-sdk-core-react-native': path.join(__dirname, '..', 'lib', 'core.js'),
+        'aws-sdk-util-react-native': path.join(__dirname, '..', 'lib', 'util.js'),
+    },
+    // Specify the output file containing our bundled code
+    output: {
+        path: path.join(__dirname, '..', 'dist'),
+        filename: '[name].js',
+        libraryTarget: 'umd',
+        //library: 'AWS'
+    },
+    resolve: {},
+    module: {
+        /**
+         * Tell webpack how to load 'json' files.
+         * By default, webpack only knows how to handle
+         * JavaScript files.
+         * When webpack comes across a 'require()' statement
+         * where a json file is being imported, it will use
+         * the json-loader.
+         */
+        loaders: [
+            {
+                test: /\.json$/,
+                loaders: ['json']
+            }
+        ]
+    }
+}

--- a/dist-tools/webpack.config.rn-core.js
+++ b/dist-tools/webpack.config.rn-core.js
@@ -1,0 +1,32 @@
+// import path for resolving file paths
+var path = require('path');
+module.exports = {
+    // Specify the entry point for our app.
+    entry: [
+        path.join(__dirname, '..', 'lib', 'core.js'),
+    ],
+    // Specify the output file containing our bundled code
+    output: {
+        path: path.join(__dirname, '..', 'dist'),
+        filename: 'aws-sdk-core-react-native.js',
+        libraryTarget: 'umd',
+        library: 'AWS'
+    },
+    resolve: {},
+    module: {
+        /**
+         * Tell webpack how to load 'json' files.
+         * By default, webpack only knows how to handle
+         * JavaScript files.
+         * When webpack comes across a 'require()' statement
+         * where a json file is being imported, it will use
+         * the json-loader.
+         */
+        loaders: [
+            {
+                test: /\.json$/,
+                loaders: ['json']
+            }
+        ]
+    }
+}

--- a/dist-tools/webpack.config.rn-dep.js
+++ b/dist-tools/webpack.config.rn-dep.js
@@ -2,16 +2,14 @@
 var path = require('path');
 module.exports = {
     // Specify the entry point for our app.
-    entry: {
-        'aws-sdk-core-react-native': path.join(__dirname, '..', 'lib', 'core.js'),
-        'aws-sdk-util-react-native': path.join(__dirname, '..', 'lib', 'util.js'),
-    },
+    entry: [
+        'xml2js'
+    ],
     // Specify the output file containing our bundled code
     output: {
         path: path.join(__dirname, '..', 'dist'),
-        filename: '[name].js',
-        libraryTarget: 'umd',
-        //library: 'AWS'
+        filename: 'xml2js.js',
+        libraryTarget: 'commonjs2',
     },
     resolve: {},
     module: {

--- a/lib/api_loader.js
+++ b/lib/api_loader.js
@@ -1,16 +1,13 @@
-var AWS = require('./core');
-
-AWS.apiLoader = function(svc, version) {
-  if (!AWS.apiLoader.services.hasOwnProperty(svc)) {
+function apiLoader(svc, version) {
+  if (!apiLoader.services.hasOwnProperty(svc)) {
     throw new Error('InvalidService: Failed to load api for ' + svc);
   }
-  return AWS.apiLoader.services[svc][version];
-};
+  return apiLoader.services[svc][version];
+}
 
 /**
  * This member of AWS.apiLoader is private, but changing it will necessitate a
  * change to ../scripts/services-table-generator.ts
  */
-AWS.apiLoader.services = {};
-
-module.exports = AWS.apiLoader;
+apiLoader.services = {};
+module.exports = apiLoader;

--- a/lib/browser_loader.js
+++ b/lib/browser_loader.js
@@ -8,9 +8,14 @@ util.querystring = require('querystring/');
 util.environment = 'js';
 
 var AWS = require('./core');
+module.exports = AWS;
 
-// Use default API loader function
-require('./api_loader');
+require('./credentials');
+require('./credentials/credential_provider_chain');
+require('./credentials/temporary_credentials');
+require('./credentials/web_identity_credentials');
+require('./credentials/cognito_identity_credentials');
+require('./credentials/saml_credentials');
 
 // Load the DOMParser XML parser
 AWS.XML.Parser = require('./xml/browser_parser');

--- a/lib/core.js
+++ b/lib/core.js
@@ -62,23 +62,14 @@ AWS.util.update(AWS, {
     ResourceWaiter: require('./model/resource_waiter')
   },
 
-  util: require('./util'),
-
   /**
    * @api private
    */
-  apiLoader: function() { throw new Error('No API loader set'); }
+  apiLoader: require('./api_loader')
 });
 
 require('./service');
 require('./config');
-
-require('./credentials');
-require('./credentials/credential_provider_chain');
-require('./credentials/temporary_credentials');
-require('./credentials/web_identity_credentials');
-require('./credentials/cognito_identity_credentials');
-require('./credentials/saml_credentials');
 
 require('./http');
 require('./sequential_executor');

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -8,11 +8,15 @@ util.stream = require('stream');
 util.url = require('url');
 util.querystring = require('querystring');
 util.environment = 'nodejs';
+var AWS;
+module.exports = AWS = require('./core');
 
-var AWS = require('./core');
-
-// Use default API loader function
-require('./api_loader');
+require('./credentials');
+require('./credentials/credential_provider_chain');
+require('./credentials/temporary_credentials');
+require('./credentials/web_identity_credentials');
+require('./credentials/cognito_identity_credentials');
+require('./credentials/saml_credentials');
 
 // Load the xml2js XML parser
 AWS.XML.Parser = require('./xml/node_parser');

--- a/lib/polly/presigner.js
+++ b/lib/polly/presigner.js
@@ -1,5 +1,5 @@
 var AWS = require('../core');
-var rest = require('../protocol/rest');
+var rest = AWS.Protocol.Rest;
 
 /**
  * A presigner object can be used to generate presigned urls for the Polly service.

--- a/lib/react-native-loader.js
+++ b/lib/react-native-loader.js
@@ -1,20 +1,12 @@
-var util = require('./util');
-// react-native specific modules
-util.crypto.lib = require('crypto-browserify');
-util.Buffer = require('buffer/').Buffer;
-util.url = require('url/');
-util.querystring = require('querystring/');
-util.environment = 'js-react-native';
-
 var AWS = require('./core');
-module.exports = AWS;
+// react-native specific modules
+AWS.util.crypto.lib = require('crypto-browserify');
+AWS.util.Buffer = require('buffer/').Buffer;
+AWS.util.url = require('url/');
+AWS.util.querystring = require('querystring/');
+AWS.util.environment = 'js-react-native';
 
-// // react-native specific modules
- AWS.util.crypto.lib = util.crypto.lib;
- AWS.util.Buffer = util.Buffer;
- AWS.util.url = util.url;
- AWS.util.querystring = util.querystring;
- AWS.util.environment = util.environment;
+module.exports = AWS;
 
 require('./credentials');
 require('./credentials/credential_provider_chain');

--- a/lib/react-native-loader.js
+++ b/lib/react-native-loader.js
@@ -1,5 +1,4 @@
 var util = require('./util');
-
 // react-native specific modules
 util.crypto.lib = require('crypto-browserify');
 util.Buffer = require('buffer/').Buffer;
@@ -8,9 +7,21 @@ util.querystring = require('querystring/');
 util.environment = 'js-react-native';
 
 var AWS = require('./core');
+module.exports = AWS;
 
-// Use default API loader function
-require('./api_loader');
+// // react-native specific modules
+ AWS.util.crypto.lib = util.crypto.lib;
+ AWS.util.Buffer = util.Buffer;
+ AWS.util.url = util.url;
+ AWS.util.querystring = util.querystring;
+ AWS.util.environment = util.environment;
+
+require('./credentials');
+require('./credentials/credential_provider_chain');
+require('./credentials/temporary_credentials');
+require('./credentials/web_identity_credentials');
+require('./credentials/cognito_identity_credentials');
+require('./credentials/saml_credentials');
 
 // Load the DOMParser XML parser
 AWS.XML.Parser = require('./xml/node_parser');

--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -1,5 +1,6 @@
-var util = require('../util');
-var Shape = require('../model/shape');
+var AWS = require('../core');
+var util = AWS.util;
+var Shape = AWS.Model.Shape;
 
 var xml2js = require('xml2js');
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "buffer": "4.9.1",
     "crypto-browserify": "1.0.9",
+    "events": "^1.1.1",
     "jmespath": "0.15.0",
     "querystring": "0.2.0",
     "sax": "1.2.1",
@@ -57,37 +58,12 @@
   "browserify": {
     "transform": "./dist-tools/transform.js"
   },
-  "react-native-apiloader": {
-    "lib/aws.js": "../react-native.js",
-    "lib/browser.js": "../react-native.js",
-    "fs": "./lib/empty.js",
-    "uuid/lib/rng": "uuid/lib/rng-browser.js",
-    "./lib/node_loader.js": "./lib/react-native-loader.js",
-    "./lib/browser_loader.js": "./lib/react-native-loader.js",
-    "index.js": "./react-native.js",
-    "./support/isBuffer.js": "./support/isBufferBrowser.js"
-  },
-  "react-native-base": {
-    "lib/aws.js": "../react-native.js",
-    "lib/browser.js": "../react-native.js",
-    "fs": "./lib/empty.js",
-    "uuid/lib/rng": "uuid/lib/rng-browser.js",
-    "./lib/node_loader.js": "./lib/react-native-loader.js",
-    "./lib/browser_loader.js": "./lib/react-native-loader.js",
-    "index.js": "./react-native.js",
-    "./support/isBuffer.js": "./support/isBufferBrowser.js"
-  },
-  "react-native-test": {
-    "fs": "./lib/empty.js",
-    "./lib/node_loader.js": "./dist/aws-sdk-base-react-native",
-    "./lib/browser_loader.js": "./dist/aws-sdk-base-react-native",
-    "./lib/react-native-loader.js": "./dist/aws-sdk-base-react-native"
-  },
   "react-native": {
     "fs": "./lib/empty.js",
     "./lib/node_loader.js": "./lib/react-native-loader.js",
     "./lib/browser_loader.js": "./lib/react-native-loader.js",
-    "./lib/core.js": "./dist/aws-sdk-core-react-native.js"
+    "./lib/core.js": "./dist/aws-sdk-core-react-native.js",
+    "xml2js": "./dist/xml2js.js"
   },
   "directories": {
     "lib": "lib"
@@ -155,7 +131,10 @@
     "testfiles": "istanbul `[ $COVERAGE ] && echo 'cover _mocha' || echo 'test mocha'`",
     "tstest": "tsc -p ./ts",
     "add-change": "node ./scripts/changelog/add-change.js",
-    "build-react-native": "webpack --config dist-tools/webpack.config.rn.js",
+    "build-react-native-deps": "webpack --config dist-tools/webpack.config.rn-dep.js",
+    "build-react-native-core": "webpack --config dist-tools/webpack.config.rn-core.js",
+    "build-react-native-dist": "webpack --config dist-tools/webpack.config.rn.js",
+    "build-react-native": "npm -s run-script build-react-native-deps && npm -s run-script build-react-native-core && npm -s run-script build-react-native-dist",
     "react-native-test": "npm -s run-script build-react-native && rake reactnative:test && karma start"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "devDependencies": {
     "@types/node": "^6.0.46",
-    "browserify": "14.4.0",
+    "browserify": "13.1.0",
     "chai": "^3.0",
     "codecov": "^1.0.1",
     "coffee-script": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "devDependencies": {
     "@types/node": "^6.0.46",
-    "browserify": "13.1.0",
+    "browserify": "14.4.0",
     "chai": "^3.0",
     "codecov": "^1.0.1",
     "coffee-script": "1.6.3",
@@ -57,7 +57,7 @@
   "browserify": {
     "transform": "./dist-tools/transform.js"
   },
-  "react-native": {
+  "react-native-apiloader": {
     "lib/aws.js": "../react-native.js",
     "lib/browser.js": "../react-native.js",
     "fs": "./lib/empty.js",
@@ -66,6 +66,28 @@
     "./lib/browser_loader.js": "./lib/react-native-loader.js",
     "index.js": "./react-native.js",
     "./support/isBuffer.js": "./support/isBufferBrowser.js"
+  },
+  "react-native-base": {
+    "lib/aws.js": "../react-native.js",
+    "lib/browser.js": "../react-native.js",
+    "fs": "./lib/empty.js",
+    "uuid/lib/rng": "uuid/lib/rng-browser.js",
+    "./lib/node_loader.js": "./lib/react-native-loader.js",
+    "./lib/browser_loader.js": "./lib/react-native-loader.js",
+    "index.js": "./react-native.js",
+    "./support/isBuffer.js": "./support/isBufferBrowser.js"
+  },
+  "react-native-test": {
+    "fs": "./lib/empty.js",
+    "./lib/node_loader.js": "./dist/aws-sdk-base-react-native",
+    "./lib/browser_loader.js": "./dist/aws-sdk-base-react-native",
+    "./lib/react-native-loader.js": "./dist/aws-sdk-base-react-native"
+  },
+  "react-native": {
+    "fs": "./lib/empty.js",
+    "./lib/node_loader.js": "./lib/react-native-loader.js",
+    "./lib/browser_loader.js": "./lib/react-native-loader.js",
+    "./lib/core.js": "./dist/aws-sdk-core-react-native.js"
   },
   "directories": {
     "lib": "lib"

--- a/react-native.js
+++ b/react-native.js
@@ -1,6 +1,4 @@
-require('./lib/react-native-loader');
-
-var AWS = require('./lib/core');
+var AWS = require('./lib/react-native-loader');
 
 require('./clients/all');
 module.exports = AWS;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@
   ignoreRequire = require;
 
   if (typeof window === 'undefined') {
-    AWS = ignoreRequire('../lib/aws');
+    //AWS = ignoreRequire('../lib/aws');
     topLevelScope = global;
   } else {
     AWS = window.AWS;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@
   ignoreRequire = require;
 
   if (typeof window === 'undefined') {
-    //AWS = ignoreRequire('../lib/aws');
+    AWS = ignoreRequire('../lib/aws');
     topLevelScope = global;
   } else {
     AWS = window.AWS;


### PR DESCRIPTION
This change makes it possible to use the SDK in react native environments by importing the same as in node.js or the browser, instead of the current way.

```javascript
/* New way */
import * as AWS from 'aws-sdk';
import S3 from 'aws-sdk/clients/s3';
```
```javascript
/* Current way */
import * as AWS from 'aws-sdk/dist/aws-sdk-react-native';
```

This comes with a few benefits:
1. Typings will now work without any workarounds
2. Libraries that currently depend on the SDK will not need to change how they import the SDK when running in a react native environment.
3. Individual services can be imported, which should reduce application sizes.

Because the SDK has circular dependencies throughout, and react native's bundler doesn't support that, I had to get a little fancy with the react-native build process. Nearly every file imports `lib/core.js`, which itself creates circular dependencies, so I used webpack to create a bundle of just that. Any file that could be an entry point (such as the `clients` directory) has been updated to reference classes from `lib/core.js` instead of the submodule directly, to prevent the metro-bundler from choking on circular deps.

/cc @jeskew 