### PR TITLE
Triggering send on an AWS.Request multiple times will cause an error to be thrown

### DIFF
--- a/.changes/next-release/feature-Request-207f10cd.json
+++ b/.changes/next-release/feature-Request-207f10cd.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Request",
+  "description": "The SDK will throw an error if the same AWS.Request object is used more than once. Previously, sending a request by supplying a callback and calling createReadStream would result in corrupted data in the stream due to multiple http requests being sent."
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -327,7 +327,7 @@ AWS.Request = inherit({
     this.response = new AWS.Response(this);
     this._asm = new AcceptorStateMachine(fsm.states, 'validate');
     this._haltHandlersOnError = false;
-
+    this._didSend = false;
     AWS.SequentialExecutor.call(this);
     this.emit = this.emitEvent;
   },
@@ -357,6 +357,7 @@ AWS.Request = inherit({
    *     request.send();
    */
   send: function send(callback) {
+    this.preventMultipleCalls();
     if (callback) {
       // append to user agent
       this.httpRequest.appendToUserAgent('callback');
@@ -364,9 +365,23 @@ AWS.Request = inherit({
         callback.call(resp, resp.error, resp.data);
       });
     }
+    this._didSend = true;
     this.runTo();
 
     return this.response;
+  },
+
+  /**
+   * @api private
+   */
+  preventMultipleCalls: function preventMultipleCalls() {
+    if (this._didSend) {
+      throw AWS.util.error(new Error(
+        'Request triggered multiple times. Make sure callbacks and createReadStream are not both used on the same request.'
+      ), {
+         code: 'RequestAlreadyTriggeredError', retryable: false
+      });
+    }
   },
 
   /**
@@ -563,13 +578,20 @@ AWS.Request = inherit({
    * @!macro nobrowser
    */
   createReadStream: function createReadStream() {
+    this.preventMultipleCalls();
     var streams = AWS.util.stream;
     var req = this;
     var stream = null;
 
     if (AWS.HttpClient.streamsApiVersion === 2) {
       stream = new streams.PassThrough();
-      process.nextTick(function() { req.send(); });
+      process.nextTick(function() {
+        try {
+          req.send();
+        } catch (err) {
+          req.emit('error', [err]);
+        }
+      });
     } else {
       stream = new streams.Stream();
       stream.readable = true;
@@ -578,7 +600,13 @@ AWS.Request = inherit({
       stream.on('newListener', function(event) {
         if (!stream.sent && event === 'data') {
           stream.sent = true;
-          process.nextTick(function() { req.send(); });
+          process.nextTick(function() {
+            try {
+              req.send();
+            } catch (err) {
+              req.emit('error', [err]);
+            }
+          });
         }
       });
     }


### PR DESCRIPTION
Currently, triggering a `send` on `AWS.Request` multiple times can result in multiple http requests to be sent. This can lead to data corruption in some cases, since each http request will contribute buffer chunks to the parent AWS.Request.

If `AWS.Request.send` and `AWS.Request.createReadStream` are called using the same request, the stream will emit an error that can be listened for. If AWS.Request.send is called multiple times, then each call beyond the first will throw an error that needs to be caught.

In the latter case, I could not pass the error to the callback the user provides without failing all calls. It might make sense to completely fail a request if it is called multiple times.

/cc @jeskew 


Addresses #1628 and #959