### PR TITLE
Add AssumeRoleCredentials

### DIFF
--- a/.changes/next-release/feature-credentials-c8693268.json
+++ b/.changes/next-release/feature-credentials-c8693268.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "credentials",
+  "description": "Add AssumeRoleCredentials credential provider to create credentials from STS by assuming an IAM role"
+}

--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -1,5 +1,6 @@
 export {Config} from './config';
 export {Credentials} from './credentials';
+export {AssumeRoleCredentials} from './credentials/assume_role_credentials';
 export {CognitoIdentityCredentials} from './credentials/cognito_identity_credentials';
 export {CredentialProviderChain} from './credentials/credential_provider_chain';
 export {EC2MetadataCredentials} from './credentials/ec2_metadata_credentials';

--- a/lib/credentials/assume_role_credentials.d.ts
+++ b/lib/credentials/assume_role_credentials.d.ts
@@ -1,4 +1,4 @@
-import * as AWS from '../clients/all';
+import * as AWS from '../../clients/all';
 import {Credentials} from '../credentials';
 export class AssumeRoleCredentials extends Credentials {
 		/**

--- a/lib/credentials/assume_role_credentials.d.ts
+++ b/lib/credentials/assume_role_credentials.d.ts
@@ -1,0 +1,27 @@
+import * as AWS from '../clients/all';
+import {Credentials} from '../credentials';
+export class AssumeRoleCredentials extends Credentials {
+		/**
+		 * Creates credentials from STS by assuming an IAM role.
+		 *
+		 * @param {object} options - Configuration options
+		 */
+		constructor(options: AssumeRoleCredentialsOptions);
+	}
+    interface AssumeRoleCredentialsOptions {
+				/**
+				* The Amazon Resource Name (ARN) of the role to assume.
+				*/
+        roleArn: string,
+
+				/**
+				* An identifier for the assumed role session.
+				*/
+				roleSessionName: string,
+
+				/**
+				* Optional STS client. If not supplied, a default STS client will be
+				* constructed to assume the IAM role.
+				*/
+				STS?: AWS.STS
+    }

--- a/lib/credentials/assume_role_credentials.js
+++ b/lib/credentials/assume_role_credentials.js
@@ -1,0 +1,56 @@
+var AWS = require('../core');
+
+/**
+ * Represents credentials received from STS by assuming an IAM role.
+ *
+ *
+ * ```javascript
+ * AWS.config.credentials = new AWS.AssumeRoleCredentials({
+ *   roleArn: 'arn:aws:iam::123456789012:role/some-role',
+ *   roleSessionName: 'my-session'
+ * });
+ * ```
+ *
+ * @!macro nobrowser
+ */
+AWS.AssumeRoleCredentials = AWS.util.inherit(AWS.Credentials, {
+    constructor: function(options) {
+        AWS.Credentials.call(this);
+
+        options = options ? AWS.util.copy(options) : {};
+
+        this.roleArn = options.roleArn;
+        this.roleSessionName = options.roleSessionName;
+        this.STS = options.STS || new AWS.STS(options);
+    },
+
+    /**
+     * Loads the credentials from STS after assuming IAM role
+     *
+     * @callback callback function(err)
+     *   Called when the STS responds (or fails). When
+     *   this callback is called with no error, it means that the credentials
+     *   information has been loaded into the object (as the `accessKeyId`,
+     *   `secretAccessKey`, and `sessionToken` properties).
+     *   @param err [Error] if an error occurred, this value will be filled
+     * @see get
+     */
+    refresh: function refresh(callback) {
+        var self = this;
+        if (!callback) callback = function(err) { if (err) throw err; };
+
+        self.STS.assumeRole({
+            RoleArn: self.roleArn,
+            RoleSessionName: self.roleSessionName
+        }, function(err, data) {
+            if (!err) {
+                self.expired = false;
+                self.accessKeyId = data.Credentials.AccessKeyId;
+                self.secretAccessKey = data.Credentials.SecretAccessKey;
+                self.sessionToken = data.Credentials.SessionToken;
+                self.expireTime = new Date(data.Credentials.Expiration);
+            }
+            callback(err);
+        });
+    }
+});

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -25,6 +25,7 @@ AWS.XML.Parser = require('./xml/node_parser');
 require('./http/node');
 
 // Load custom credential providers
+require('./credentials/assume_role_credentials');
 require('./credentials/ec2_metadata_credentials');
 require('./credentials/ecs_credentials');
 require('./credentials/environment_credentials');

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -526,6 +526,86 @@
         });
       });
     });
+    describe('AWS.AssumeRoleCredentials', function() {
+      var creds, mockSTS;
+      creds = null;
+      beforeEach(function() {
+        return creds = new AWS.AssumeRoleCredentials({
+          roleArn: 'arn:aws:iam::123456789012:role/some-role',
+          roleSessionName: 'my-session'
+        });
+      });
+      mockSTS = function(expireTime) {
+        return helpers.spyOn(creds.STS, 'assumeRole').andCallFake(function(options, cb) {
+          return cb(null, {
+            ResponseMetadata: { RequestId: 'eb44d75a-6d91-4971-9a00-c0005d625e48' },
+            Credentials: {
+              AccessKeyId: 'KEY',
+              SecretAccessKey: 'SECRET',
+              SessionToken: 'TOKEN',
+              Expiration: expireTime.toISOString()
+            },
+            AssumedRoleUser: {
+              AssumedRoleId: 'ROLE_ID',
+              Arn: options.roleArn
+            }
+          })
+        });
+      };
+      describe('constructor', function() {
+        it('allows passing of AWS.STS options', function() {
+          var opts;
+          opts = {
+            maxRetries: 5
+          }
+          creds = new AWS.AssumeRoleCredentials(opts);
+          return expect(creds.STS.config.maxRetries).to.equal(opts.maxRetries);
+        });
+        it('does not modify options object', function() {
+          var opts;
+          opts = {};
+          creds = new AWS.AssumeRoleCredentials(opts);
+          return expect(opts).to.eql({});
+        });
+        return it('allows setting role arn and role session token', function() {
+          expect(creds.roleArn).to.equal('arn:aws:iam::123456789012:role/some-role');
+          return expect(creds.roleSessionName).to.equal('my-session');
+        });
+      });
+      describe('needsRefresh', function() {
+        return it('can be expired based on expire time from STS', function() {
+          mockSTS(new Date(0));
+          creds.refresh(function() {});
+          return expect(creds.needsRefresh()).to.equal(true);
+        });
+      });
+      return describe('refresh', function() {
+        it('loads credentials from STS', function() {
+          mockSTS(new Date(AWS.util.date.getDate().getTime() + 100000));
+          creds.refresh(function() {});
+          expect(creds.accessKeyId).to.equal('KEY');
+          expect(creds.secretAccessKey).to.equal('SECRET');
+          expect(creds.sessionToken).to.equal('TOKEN');
+          return expect(creds.needsRefresh()).to.equal(false);
+        });
+        return it('does try to load creds second time if STS failed', function() {
+          var spy;
+          spy = helpers.spyOn(creds.STS, 'assumeRole').andCallFake(function(options, cb) {
+            return cb(new Error('INVALID SERVICE'));
+          });
+          creds.refresh(function(err) {
+            return expect(err.message).to.equal('INVALID SERVICE');
+          });
+          return creds.refresh(function() {
+            return creds.refresh(function() {
+              return creds.refresh(function() {
+                return expect(spy.calls.length).to.equal(4);
+              });
+            });
+          });
+        });
+      });
+    });
     describe('AWS.EC2MetadataCredentials', function() {
       var creds, mockMetadataService;
       creds = null;

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -559,7 +559,16 @@
             maxRetries: 5
           }
           creds = new AWS.AssumeRoleCredentials(opts);
-          return expect(creds.STS.config.maxRetries).to.equal(opts.maxRetries);
+          return expect(creds.STS.config.maxRetries).to.equal(5);
+        });
+        it('allows passing of AWS.STS instance', function() {
+          var opts, STS;
+          STS = new AWS.STS({ maxRetries: 7 });
+          opts = {
+            STS: STS
+          }
+          creds = new AWS.AssumeRoleCredentials(opts);
+          return expect(creds.STS.config.maxRetries).to.equal(7);
         });
         it('does not modify options object', function() {
           var opts;


### PR DESCRIPTION
This addresses #1657 .
Changes:
- `AWS.AssumeRoleCredentials` credentials provider to provide and refresh credentials via STS by assuming an IAM role
- Added unit testing to test construction and credentials refresh
- register the credentials in the node loader