### PR TITLE
FIX: error TS2503: Cannot find namespace 'AWS'

### DIFF
--- a/lib/credentials/credential_provider_chain.d.ts
+++ b/lib/credentials/credential_provider_chain.d.ts
@@ -12,7 +12,7 @@ export class CredentialProviderChain extends Credentials {
     /**
      * Return a Promise on resolve() function
      */
-    resolvePromise(): Promise<AWS.Credentials>;
+    resolvePromise(): Promise<Credentials>;
     /**
      * Returns a list of credentials objects or functions that return credentials objects. If the provider is a function, the function will be executed lazily when the provider needs to be checked for valid credentials. By default, this object will be set to the defaultProviders.
      */


### PR DESCRIPTION
the following file triggers an error when transpiling. it uses `Promise<AWS.Credentials>` as a type even though `AWS` is not declared. I believe only `Credentials` is wanted

https://github.com/aws/aws-sdk-js/pull/1672/files#diff-171e32a9b2d89468799d3311ac2c638b

my tsconfig

```
{
  "compilerOptions": {
    "sourceMap": true,
    "noImplicitAny": true,
    "module": "commonjs",
    "target": "es5",
    "jsx": "react",
    "allowJs": true,
    "lib": [
        "es5",
        "es2015.promise"
    ]
  }
}
```

rule in webpack

```
{
            test: /\.tsx?$/,
            use: 'ts-loader',
            exclude: [
                path.resolve(__dirname, 'node_modules'),
                path.resolve(__dirname, 'bower_components')
            ]
        }
```