### PR TITLE
Force setImmediate on s3.getSignedUrl when a callback is provided

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -772,11 +772,11 @@ AWS.util.update(AWS.S3.prototype, {
     var expires = params.Expires || 900;
     delete params.Expires; // we can't validate this
     var request = this.makeRequest(operation, params);
-    var hasNextTick = typeof process === 'object' && typeof process.nextTick === 'function';
+    var hasSetImmediate = typeof setImmediate === 'function' && setImmediate;
     if (!callback) {
       return request.presign(expires, callback);
-    } else if (hasNextTick) {
-      process.nextTick(function() {
+    } else if (hasSetImmediate) {
+      setImmediate(function() {
         return request.presign(expires, callback);
       });
     } else {

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -772,7 +772,18 @@ AWS.util.update(AWS.S3.prototype, {
     var expires = params.Expires || 900;
     delete params.Expires; // we can't validate this
     var request = this.makeRequest(operation, params);
-    return request.presign(expires, callback);
+    var hasNextTick = typeof process === 'object' && typeof process.nextTick === 'function';
+    if (!callback) {
+      return request.presign(expires, callback);
+    } else if (hasNextTick) {
+      process.nextTick(function() {
+        return request.presign(expires, callback);
+      });
+    } else {
+      setTimeout(function() {
+        return request.presign(expires, callback);
+      }, 0);
+    }
   },
 
 


### PR DESCRIPTION
This is to address issue #1612.

If a callback is not provided to `s3.getSignedUrl`, then it returns the url as usual. If `process.nextTick` is a valid function, and an asynchronous callback is expected , it forces the callback to return on the next tick. As a fallback for other environments, it wraps the callback in a `setTimeout(function() {}, 0)`.

I've tested this update in my own Node environment with both a synchronous and an asynchronous call to `s3.getSignedUrl()`. Making many calls to this service in an `async.each()` loop now works as expected without exceeding the stack size. I also ran the `npm test` script.