### PR TITLE
Add AWS.S3.getSignedUrlPromise

### DIFF
--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -960,14 +960,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	  promisifyMethod: function promisifyMethod(methodName, PromiseDependency) {
 	    return function promise() {
 	      var self = this;
+	      var args = Array.prototype.slice.call(arguments);
 	      return new PromiseDependency(function(resolve, reject) {
-	        self[methodName](function(err, data) {
-	          if (err) {
-	            reject(err);
-	          } else {
-	            resolve(data);
-	          }
+	        args.push(function(err, data) {
+	            if (err) {
+	                reject(err);
+	            } else {
+	                resolve(data);
+	            }
 	        });
+	        self[methodName].apply(self, args);
 	      });
 	    };
 	  },

--- a/dist/aws-sdk-react-native.js
+++ b/dist/aws-sdk-react-native.js
@@ -1261,14 +1261,16 @@ return /******/ (function(modules) { // webpackBootstrap
 		  promisifyMethod: function promisifyMethod(methodName, PromiseDependency) {
 		    return function promise() {
 		      var self = this;
+		      var args = Array.prototype.slice.call(arguments);
 		      return new PromiseDependency(function(resolve, reject) {
-		        self[methodName](function(err, data) {
-		          if (err) {
-		            reject(err);
-		          } else {
-		            resolve(data);
-		          }
+		        args.push(function(err, data) {
+		            if (err) {
+		                reject(err);
+		            } else {
+		                resolve(data);
+		            }
 		        });
+		        self[methodName].apply(self, args);
 		      });
 		    };
 		  },
@@ -44338,6 +44340,51 @@ return /******/ (function(modules) { // webpackBootstrap
 	    }
 	  },
 
+	  /**
+	   * @!method  getSignedUrlPromise()
+	   *   Returns a 'thenable' promise that will be resolved with a pre-signed URL for a given operation name.
+	   *
+	   *   Two callbacks can be provided to the `then` method on the returned promise.
+	   *   The first callback will be called if the promise is fulfilled, and the second
+	   *   callback will be called if the promise is rejected.
+	   *   @note Not all operation parameters are supported when using pre-signed
+	   *      URLs. Certain parameters, such as `SSECustomerKey`, `ACL`, `Expires`,
+	   *      `ContentLength`, or `Tagging` must be provided as headers when sending a
+	   *      request. If you are using pre-signed URLs to upload from a browser and
+	   *      need to use these fields, see {createPresignedPost}.
+	   *   @param operation [String] the name of the operation to call
+	   *   @param params [map] parameters to pass to the operation. See the given
+	   *      operation for the expected operation parameters. In addition, you can
+	   *      also pass the "Expires" parameter to inform S3 how long the URL should
+	   *      work for.
+	   *   @option params Expires [Integer] (900) the number of seconds to expire
+	   *      the pre-signed URL operation in. Defaults to 15 minutes.
+	   *   @callback fulfilledCallback function(url)
+	   *     Called if the promise is fulfilled.
+	   *     @param url [String] the signed url
+	   *   @callback rejectedCallback function(err)
+	   *     Called if the promise is rejected.
+	   *     @param err [Error] if an error occurred, this value will be filled
+	   *   @return [Promise] A promise that represents the state of the `refresh` call.
+	   *   @example Pre-signing a getObject operation
+	   *      var params = {Bucket: 'bucket', Key: 'key'};
+	   *      var promise = s3.getSignedUrlPromise('getObject', params);
+	   *      promise.then(function(url) {
+	   *        console.log('The URL is', url);
+	   *      }, function(err) { ... });
+	   *   @example Pre-signing a putObject operation with a specific payload
+	   *      var params = {Bucket: 'bucket', Key: 'key', Body: 'body'};
+	   *      var promise = s3.getSignedUrlPromise('putObject', params);
+	   *      promise.then(function(url) {
+	   *        console.log('The URL is', url);
+	   *      }, function(err) { ... });
+	   *   @example Passing in a 1-minute expiry time for a pre-signed URL
+	   *      var params = {Bucket: 'bucket', Key: 'key', Expires: 60};
+	   *      var promise = s3.getSignedUrlPromise('getObject', params);
+	   *      promise.then(function(url) {
+	   *        console.log('The URL is', url);
+	   *      }, function(err) { ... });
+	   */
 
 	  /**
 	   * Get a pre-signed POST policy to support uploading to S3 directly from an
@@ -44624,6 +44671,23 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return uploader;
 	  }
 	});
+
+
+	/**
+	 * @api private
+	 */
+	AWS.S3.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+	  this.prototype.getSignedUrlPromise = AWS.util.promisifyMethod('getSignedUrl', PromiseDependency);
+	};
+
+	/**
+	 * @api private
+	 */
+	AWS.S3.deletePromisesFromClass = function deletePromisesFromClass() {
+	  delete this.prototype.getSignedUrlPromise;
+	};
+
+	AWS.util.addPromises(AWS.S3);
 
 
 /***/ }),

--- a/lib/services/s3.d.ts
+++ b/lib/services/s3.d.ts
@@ -13,6 +13,11 @@ export class S3Customizations extends Service {
     getSignedUrl(operation: string, params: any): string;
 
     /**
+     * Returns a 'thenable' promise that will be resolved with a pre-signed URL for a given operation name.
+     */
+    getSignedUrlPromise(operation: string, params: any): Promise<void>;
+
+    /**
      * Get the form fields and target URL for direct POST uploading.
      */
     createPresignedPost(

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -802,13 +802,9 @@ AWS.util.update(AWS.S3.prototype, {
    *      work for.
    *   @option params Expires [Integer] (900) the number of seconds to expire
    *      the pre-signed URL operation in. Defaults to 15 minutes.
-   *   @param callback [Function] if a callback is provided, this function will
-   *      pass the URL as the second parameter (after the error parameter) to
-   *      the callback function.
-   *   @callback fulfilledCallback function()
-   *     Called if the promise is fulfilled. When this callback is called, it
-   *     means refreshed credentials information has been loaded into the object
-   *     (as the `accessKeyId`, `secretAccessKey`, and `sessionToken` properties).
+   *   @callback fulfilledCallback function(url)
+   *     Called if the promise is fulfilled.
+   *     @param url [String] the signed url
    *   @callback rejectedCallback function(err)
    *     Called if the promise is rejected.
    *     @param err [Error] if an error occurred, this value will be filled

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -784,8 +784,7 @@ AWS.util.update(AWS.S3.prototype, {
 
   /**
    * @!method  getSignedUrlPromise()
-   *   Returns a 'thenable' promise.
-   *   Get a pre-signed URL for a given operation name.
+   *   Returns a 'thenable' promise that will be resolved with a pre-signed URL for a given option name.
    *
    *   Two callbacks can be provided to the `then` method on the returned promise.
    *   The first callback will be called if the promise is fulfilled, and the second

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -782,6 +782,56 @@ AWS.util.update(AWS.S3.prototype, {
     }
   },
 
+  /**
+   * @!method  getSignedUrlPromise()
+   *   Returns a 'thenable' promise.
+   *   Get a pre-signed URL for a given operation name.
+   *
+   *   Two callbacks can be provided to the `then` method on the returned promise.
+   *   The first callback will be called if the promise is fulfilled, and the second
+   *   callback will be called if the promise is rejected.
+   *   @note Not all operation parameters are supported when using pre-signed
+   *      URLs. Certain parameters, such as `SSECustomerKey`, `ACL`, `Expires`,
+   *      `ContentLength`, or `Tagging` must be provided as headers when sending a
+   *      request. If you are using pre-signed URLs to upload from a browser and
+   *      need to use these fields, see {createPresignedPost}.
+   *   @param operation [String] the name of the operation to call
+   *   @param params [map] parameters to pass to the operation. See the given
+   *      operation for the expected operation parameters. In addition, you can
+   *      also pass the "Expires" parameter to inform S3 how long the URL should
+   *      work for.
+   *   @option params Expires [Integer] (900) the number of seconds to expire
+   *      the pre-signed URL operation in. Defaults to 15 minutes.
+   *   @param callback [Function] if a callback is provided, this function will
+   *      pass the URL as the second parameter (after the error parameter) to
+   *      the callback function.
+   *   @callback fulfilledCallback function()
+   *     Called if the promise is fulfilled. When this callback is called, it
+   *     means refreshed credentials information has been loaded into the object
+   *     (as the `accessKeyId`, `secretAccessKey`, and `sessionToken` properties).
+   *   @callback rejectedCallback function(err)
+   *     Called if the promise is rejected.
+   *     @param err [Error] if an error occurred, this value will be filled
+   *   @return [Promise] A promise that represents the state of the `refresh` call.
+   *   @example Pre-signing a getObject operation
+   *      var params = {Bucket: 'bucket', Key: 'key'};
+   *      var promise = s3.getSignedUrlPromise('getObject', params);
+   *      promise.then(function(url) {
+   *        console.log('The URL is', url);
+   *      }, function(err) { ... });
+   *   @example Pre-signing a putObject operation with a specific payload
+   *      var params = {Bucket: 'bucket', Key: 'key', Body: 'body'};
+   *      var promise = s3.getSignedUrlPromise('putObject', params);
+   *      promise.then(function(url) {
+   *        console.log('The URL is', url);
+   *      }, function(err) { ... });
+   *   @example Passing in a 1-minute expiry time for a pre-signed URL
+   *      var params = {Bucket: 'bucket', Key: 'key', Expires: 60};
+   *      var promise = s3.getSignedUrlPromise('getObject', params);
+   *      promise.then(function(url) {
+   *        console.log('The URL is', url);
+   *      }, function(err) { ... });
+   */
 
   /**
    * Get a pre-signed POST policy to support uploading to S3 directly from an
@@ -1068,3 +1118,20 @@ AWS.util.update(AWS.S3.prototype, {
     return uploader;
   }
 });
+
+
+/**
+ * @api private
+ */
+AWS.S3.addPromisesToClass = function addPromisesToClass(PromiseDependency) {
+  this.prototype.getSignedUrlPromise = AWS.util.promisifyMethod('getSignedUrl', PromiseDependency);
+};
+
+/**
+ * @api private
+ */
+AWS.S3.deletePromisesFromClass = function deletePromisesFromClass() {
+  delete this.prototype.getSignedUrlPromise;
+};
+
+AWS.util.addPromises(AWS.S3);

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -784,7 +784,7 @@ AWS.util.update(AWS.S3.prototype, {
 
   /**
    * @!method  getSignedUrlPromise()
-   *   Returns a 'thenable' promise that will be resolved with a pre-signed URL for a given option name.
+   *   Returns a 'thenable' promise that will be resolved with a pre-signed URL for a given operation name.
    *
    *   Two callbacks can be provided to the `then` method on the returned promise.
    *   The first callback will be called if the promise is fulfilled, and the second

--- a/lib/util.js
+++ b/lib/util.js
@@ -793,14 +793,16 @@ var util = {
   promisifyMethod: function promisifyMethod(methodName, PromiseDependency) {
     return function promise() {
       var self = this;
+      var args = Array.prototype.slice.call(arguments);
       return new PromiseDependency(function(resolve, reject) {
-        self[methodName](function(err, data) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(data);
-          }
+        args.push(function(err, data) {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(data);
+            }
         });
+        self[methodName].apply(self, args);
       });
     };
   },

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2541,6 +2541,36 @@ describe('AWS.S3', function() {
     });
   });
 
+  if (typeof Promise === 'function') {
+    return describe('getSignedUrlPromise', function() {
+      var catchFunction, err;
+      err = null;
+      catchFunction = function(e) {
+        err = e;
+      };
+      beforeEach(function() {
+        AWS.util.addPromises(AWS.S3, Promise);
+        err = null;
+      });
+      it('resolves when getSignedUrl is successful', function() {
+        return s3.getSignedUrlPromise('getObject', {
+          Bucket: 'bucket',
+          Key: 'key'
+        }).then(function(url) {
+          expect(url).to.equal('https://bucket.s3.amazonaws.com/key?AWSAccessKeyId=akid&Expires=900&Signature=4mlYnRmz%2BBFEPrgYz5tXcl9Wc4w%3D&x-amz-security-token=session');
+          expect(err).to.be["null"];
+        }, catchFunction);
+      });
+      it('rejects when getSignedUrl is unsuccessful', function() {
+        return s3.getSignedUrlPromise('getObjectsd', {
+          Bucket: 'bucket',
+          Key: 'key',
+        })["catch"](catchFunction).then(function() {
+          expect(err).to.not.be["null"];
+        });
+      });
+    });
+  }
   describe('createPresignedPost', function() {
     it('should include a url and a hash of form fields', function(done) {
       s3 = new AWS.S3();

--- a/ts/s3.ts
+++ b/ts/s3.ts
@@ -126,6 +126,12 @@ s3.putObject({
     Body: fs.createReadStream('/fake/path')
 });
 
+s3.getSignedUrlPromise('getObject', {
+  Bucket: 'bucket',
+  Key: 'key'
+}).then(function(url) {
+    console.log(url);
+});
 const upload = s3.upload(
     {
         Bucket: 'BUCKET',


### PR DESCRIPTION
This closes #1008. Few questions:
1. Do I need to add anything to `/ts/s3.ts`?
2. It seems odd that `S3.getSignedUrl` throws even when a callback is provided. I'd expect the error to be passed to the callback. There does not appear to be tests for this. The `errors if ContentLength is passed as parameter` test uses the no-callback version but there is no test for errors on `getSignedUrl`. Because of this, I only added basic error expectation testing. The error I would be expecting is `ContentLength is not supported in pre-signed URLs` but the error I get is `[TypeError: Cannot read property 'httpMethod' of undefined] to be a function`. This is because the getSignedUrlPromise throws errors directly, not through the promise.
3. I didn't test for the actual credentials refresh request happening using a spy or any of the other features in `getSignedUrl` since it seemed redundant as `getSignedUrlPromise` calls `getSignedUrl`.

Appreciate any feedback or comments on things I missed/did incorrectly. This is my first time contributing. Thanks! Tagging @jeskew.