### PR TITLE
Fix global clock skew issue

### DIFF
--- a/.changes/next-release/bugfix-clock skew-24b80590.json
+++ b/.changes/next-release/bugfix-clock skew-24b80590.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "clock skew",
+  "description": "put the updating clock skew logic to each service client instead of using global config"
+}

--- a/lib/core.js
+++ b/lib/core.js
@@ -17,7 +17,7 @@ AWS.util.update(AWS, {
   /**
    * @constant
    */
-  VERSION: '2.113.0',
+  VERSION: '2.112.0',
 
   /**
    * @api private

--- a/lib/core.js
+++ b/lib/core.js
@@ -17,7 +17,7 @@ AWS.util.update(AWS, {
   /**
    * @constant
    */
-  VERSION: '2.112.0',
+  VERSION: '2.113.0',
 
   /**
    * @api private

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -196,7 +196,9 @@ AWS.EventListeners = {
         }
 
         try {
-          var date = AWS.util.date.getDate();
+          var date = typeof service.getServiceClock === 'function' ?
+                        service.getServiceClock() :
+                        AWS.util.date.getDate();
           var SignerClass = service.getSignerClass(req);
           var signer = new SignerClass(req.httpRequest,
             service.api.signingName || service.api.endpointPrefix,
@@ -308,8 +310,7 @@ AWS.EventListeners = {
           error(err);
         }
       }
-
-      var timeDiff = (AWS.util.date.getDate() - this.signedAt) / 1000;
+      var timeDiff = (resp.request.service.getServiceClock() - this.signedAt) / 1000;
       if (timeDiff >= 60 * 10) { // if we signed 10min ago, re-sign
         this.emit('sign', [this], function(err) {
           if (err) done(err);
@@ -329,11 +330,12 @@ AWS.EventListeners = {
       resp.httpResponse.buffers = [];
       resp.httpResponse.numBytes = 0;
       var dateHeader = headers.date || headers.Date;
+      var service = resp.request.service;
       if (dateHeader) {
         var serverTime = Date.parse(dateHeader);
-        if (resp.request.service.config.correctClockSkew
-            && AWS.util.isClockSkewed(serverTime)) {
-          AWS.util.applyClockOffset(serverTime);
+        if (service.config.correctClockSkew
+            && service.isClockSkewed(serverTime)) {
+          service.applyClockOffset(serverTime);
         }
       }
     });
@@ -472,7 +474,7 @@ AWS.EventListeners = {
       if (!logger) return;
 
       function buildMessage() {
-        var time = AWS.util.date.getDate().getTime();
+        var time = resp.request.service.getServiceClock().getTime();
         var delta = (time - req.startTime.getTime()) / 1000;
         var ansi = logger.isTTY ? true : false;
         var status = resp.httpResponse.statusCode;

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -196,8 +196,8 @@ AWS.EventListeners = {
         }
 
         try {
-          var date = typeof service.getServiceClock === 'function' ?
-                        service.getServiceClock() :
+          var date = typeof service.getSkewCorrectedDate === 'function' ?
+                        service.getSkewCorrectedDate() :
                         AWS.util.date.getDate();
           var SignerClass = service.getSignerClass(req);
           var signer = new SignerClass(req.httpRequest,
@@ -310,7 +310,7 @@ AWS.EventListeners = {
           error(err);
         }
       }
-      var timeDiff = (resp.request.service.getServiceClock() - this.signedAt) / 1000;
+      var timeDiff = (resp.request.service.getSkewCorrectedDate() - this.signedAt) / 1000;
       if (timeDiff >= 60 * 10) { // if we signed 10min ago, re-sign
         this.emit('sign', [this], function(err) {
           if (err) done(err);
@@ -474,7 +474,7 @@ AWS.EventListeners = {
       if (!logger) return;
 
       function buildMessage() {
-        var time = resp.request.service.getServiceClock().getTime();
+        var time = resp.request.service.getSkewCorrectedDate().getTime();
         var delta = (time - req.startTime.getTime()) / 1000;
         var ansi = logger.isTTY ? true : false;
         var status = resp.httpResponse.statusCode;

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -196,9 +196,7 @@ AWS.EventListeners = {
         }
 
         try {
-          var date = typeof service.getSkewCorrectedDate === 'function' ?
-                        service.getSkewCorrectedDate() :
-                        AWS.util.date.getDate();
+          var date = service.getSkewCorrectedDate();
           var SignerClass = service.getSignerClass(req);
           var signer = new SignerClass(req.httpRequest,
             service.api.signingName || service.api.endpointPrefix,

--- a/lib/request.js
+++ b/lib/request.js
@@ -322,7 +322,7 @@ AWS.Request = inherit({
     this.params = params || {};
     this.httpRequest = new AWS.HttpRequest(endpoint, region);
     this.httpRequest.appendToUserAgent(customUserAgent);
-    this.startTime = AWS.util.date.getDate();
+    this.startTime = service.getServiceClock();
 
     this.response = new AWS.Response(this);
     this._asm = new AcceptorStateMachine(fsm.states, 'validate');

--- a/lib/request.js
+++ b/lib/request.js
@@ -322,7 +322,7 @@ AWS.Request = inherit({
     this.params = params || {};
     this.httpRequest = new AWS.HttpRequest(endpoint, region);
     this.httpRequest.appendToUserAgent(customUserAgent);
-    this.startTime = service.getServiceClock();
+    this.startTime = service.getSkewCorrectedDate();
 
     this.response = new AWS.Response(this);
     this._asm = new AcceptorStateMachine(fsm.states, 'validate');

--- a/lib/service.js
+++ b/lib/service.js
@@ -403,7 +403,7 @@ AWS.Service = inherit({
   /**
    * @api private
    */
-  getServiceClock: function getServiceClock() {
+  getSkewCorrectedDate: function getSkewCorrectedDate() {
     return new Date(new Date().getTime() + this.config.systemClockOffset);
   },
 
@@ -421,7 +421,7 @@ AWS.Service = inherit({
    */
   isClockSkewed: function isClockSkewed(newServerTime) {
     if (newServerTime) {
-      return Math.abs(this.getServiceClock().getTime() - newServerTime) >= 30000;
+      return Math.abs(this.getSkewCorrectedDate().getTime() - newServerTime) >= 30000;
     }
   },
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -404,7 +404,7 @@ AWS.Service = inherit({
    * @api private
    */
   getSkewCorrectedDate: function getSkewCorrectedDate() {
-    return new Date(new Date().getTime() + this.config.systemClockOffset);
+    return new Date(Date.now() + this.config.systemClockOffset);
   },
 
   /**
@@ -412,7 +412,7 @@ AWS.Service = inherit({
    */
   applyClockOffset: function applyClockOffset(newServerTime) {
     if (newServerTime) {
-      this.config.systemClockOffset = newServerTime - new Date().getTime();
+      this.config.systemClockOffset = newServerTime - Date.now();
     }
   },
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -421,7 +421,7 @@ AWS.Service = inherit({
    */
   isClockSkewed: function isClockSkewed(newServerTime) {
     if (newServerTime) {
-      return Math.abs(this.getServiceClock - newServerTime) >= 30000;
+      return Math.abs(this.getServiceClock().getTime() - newServerTime) >= 30000;
     }
   },
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -403,6 +403,31 @@ AWS.Service = inherit({
   /**
    * @api private
    */
+  getServiceClock: function getServiceClock() {
+    return new Date(new Date().getTime() + this.config.systemClockOffset);
+  },
+
+  /**
+   * @api private
+   */
+  applyClockOffset: function applyClockOffset(newServerTime) {
+    if (newServerTime) {
+      this.config.systemClockOffset = newServerTime - new Date().getTime();
+    }
+  },
+
+  /**
+   * @api private
+   */
+  isClockSkewed: function isClockSkewed(newServerTime) {
+    if (newServerTime) {
+      return Math.abs(this.getServiceClock - newServerTime) >= 30000;
+    }
+  },
+
+  /**
+   * @api private
+   */
   throttledError: function throttledError(error) {
     // this logic varies between services
     switch (error.code) {

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -917,7 +917,7 @@ AWS.util.update(AWS.S3.prototype, {
     conditions,
     expiresInSeconds
   ) {
-    var now = this.getServiceClock();
+    var now = this.getSkewCorrectedDate();
     if (!credentials || !region || !bucket) {
       throw new Error('Unable to create a POST object policy without a bucket,'
         + ' region, and credentials');

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -917,7 +917,7 @@ AWS.util.update(AWS.S3.prototype, {
     conditions,
     expiresInSeconds
   ) {
-    var now = AWS.util.date.getDate();
+    var now = this.getServiceClock();
     if (!credentials || !region || !bucket) {
       throw new Error('Unable to create a POST object policy without a bucket,'
         + ' region, and credentials');

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -26,7 +26,7 @@ function signedUrlBuilder(request) {
     }
     request.httpRequest.headers[expiresHeader] = expires;
   } else if (signerClass === AWS.Signers.S3) {
-    var now = request.service ? request.service.getServiceClock() : AWS.util.date.getDate();
+    var now = request.service ? request.service.getSkewCorrectedDate() : AWS.util.date.getDate();
     request.httpRequest.headers[expiresHeader] = parseInt(
       AWS.util.date.unixTimestamp(now) + expires, 10).toString();
   } else {

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -26,8 +26,9 @@ function signedUrlBuilder(request) {
     }
     request.httpRequest.headers[expiresHeader] = expires;
   } else if (signerClass === AWS.Signers.S3) {
+    var now = request.service ? request.service.getServiceClock() : AWS.util.date.getDate();
     request.httpRequest.headers[expiresHeader] = parseInt(
-      AWS.util.date.unixTimestamp() + expires, 10).toString();
+      AWS.util.date.unixTimestamp(now) + expires, 10).toString();
   } else {
     throw AWS.util.error(new Error(), {
       message: 'Presigning only supports S3 or SigV4 signing.',

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -325,12 +325,12 @@
         helpers.mockHttpResponse(200, {
           date: serverDate.toString()
         }, '');
-        helpers.spyOn(AWS.util, 'isClockSkewed').andReturn(true);
+        helpers.spyOn(service, 'isClockSkewed').andReturn(true);
         request = makeRequest();
         response = request.send();
-        offset = Math.abs(AWS.config.systemClockOffset);
+        offset = Math.abs(service.config.systemClockOffset);
         expect(offset > 299000 && offset < 310000).to.equal(true);
-        AWS.config.systemClockOffset = 0;
+        service.config.systemClockOffset = 0;
         return done();
       });
     });

--- a/test/polly/presigner.spec.js
+++ b/test/polly/presigner.spec.js
@@ -2,19 +2,6 @@ var helpers = require('../helpers');
 var AWS = helpers.AWS;
 
 describe('AWS.Polly.Presigner', function() {
-  var getDate = null;
-  // Each test will treat the date as 'Date(0)'
-  beforeEach(function() {
-    getDate = AWS.util.date.getDate;
-    AWS.util.date.getDate = function() {
-      return new Date(0);
-    };
-  });
-
-  afterEach(function() {
-    AWS.util.date.getDate = getDate;
-  });
-
   describe('constructor', function() {
 
     it('can use global config if no options are provided', function() {
@@ -89,13 +76,17 @@ describe('AWS.Polly.Presigner', function() {
   });
 
   describe('getSynthesizeSpeechUrl', function() {
-      var presigner = new AWS.Polly.Presigner({
-          region: 'us-west-2',
-          credentials: {
-            accessKeyId: 'akid',
-            secretAccessKey: 'secret'
-          }
-        });
+    var presigner = new AWS.Polly.Presigner({
+      region: 'us-west-2',
+      credentials: {
+        accessKeyId: 'akid',
+        secretAccessKey: 'secret'
+      }
+    });
+    beforeEach(function() {
+      helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
+    });
+
     describe('generates a url with', function() {
       var presigner = null;
 
@@ -107,6 +98,7 @@ describe('AWS.Polly.Presigner', function() {
             secretAccessKey: 'secret'
           }
         });
+        helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
       });
 
       it('plain text', function() {
@@ -172,6 +164,7 @@ describe('AWS.Polly.Presigner', function() {
               VoiceId: 'fake'
             }
         });
+        helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
         var expectedUrl = 'https://polly.us-west-2.amazonaws.com/v1/speech?OutputFormat=mp3&Text=Hello%20world&TextType=text&VoiceId=fake&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=akid%2F19700101%2Fus-west-2%2Fpolly%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=ad22388e7298c19a491bc77b0c1fd8f169de31f031497a0266a15e1379520ff8&X-Amz-SignedHeaders=host';
         var url = presigner.getSynthesizeSpeechUrl({
           Text: 'Hello world'

--- a/test/polly/presigner.spec.js
+++ b/test/polly/presigner.spec.js
@@ -84,7 +84,7 @@ describe('AWS.Polly.Presigner', function() {
       }
     });
     beforeEach(function() {
-      helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
+      helpers.spyOn(presigner.service, 'getSkewCorrectedDate').andReturn(new Date(0));
     });
 
     describe('generates a url with', function() {
@@ -98,7 +98,7 @@ describe('AWS.Polly.Presigner', function() {
             secretAccessKey: 'secret'
           }
         });
-        helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
+        helpers.spyOn(presigner.service, 'getSkewCorrectedDate').andReturn(new Date(0));
       });
 
       it('plain text', function() {
@@ -164,7 +164,7 @@ describe('AWS.Polly.Presigner', function() {
               VoiceId: 'fake'
             }
         });
-        helpers.spyOn(presigner.service, 'getServiceClock').andReturn(new Date(0));
+        helpers.spyOn(presigner.service, 'getSkewCorrectedDate').andReturn(new Date(0));
         var expectedUrl = 'https://polly.us-west-2.amazonaws.com/v1/speech?OutputFormat=mp3&Text=Hello%20world&TextType=text&VoiceId=fake&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=akid%2F19700101%2Fus-west-2%2Fpolly%2Faws4_request&X-Amz-Date=19700101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=ad22388e7298c19a491bc77b0c1fd8f169de31f031497a0266a15e1379520ff8&X-Amz-SignedHeaders=host';
         var url = presigner.getSynthesizeSpeechUrl({
           Text: 'Hello world'

--- a/test/rds/signer.spec.js
+++ b/test/rds/signer.spec.js
@@ -2,18 +2,6 @@ var helpers = require('../helpers');
 var AWS = helpers.AWS;
  
 describe('AWS.RDS.Signer', function() {
-    var getDate = null;
-    beforeEach(function() {
-        getDate = AWS.util.date.getDate;
-        AWS.util.date.getDate = function() {
-            return new Date(0);
-        };
-    });
- 
-    afterEach(function() {
-        AWS.util.date.getDate = getDate;
-    })
- 
     describe('constructor', function() {
         it('can be instantiated without parameters', function() {
             var signer = new AWS.RDS.Signer();
@@ -39,6 +27,9 @@ describe('AWS.RDS.Signer', function() {
         };
         var requiredOptions = Object.keys(testOptions);
         var rdsSigner = new AWS.RDS.Signer();
+        beforeEach(function() {
+            helpers.spyOn(AWS.Service.prototype, 'getServiceClock').andReturn(new Date(0));
+        });
         requiredOptions.forEach(function(field) {
             it('will error if ' + field + 'is not accessible', function() {
                 var options = AWS.util.copy(testOptions);

--- a/test/rds/signer.spec.js
+++ b/test/rds/signer.spec.js
@@ -28,7 +28,7 @@ describe('AWS.RDS.Signer', function() {
         var requiredOptions = Object.keys(testOptions);
         var rdsSigner = new AWS.RDS.Signer();
         beforeEach(function() {
-            helpers.spyOn(AWS.Service.prototype, 'getServiceClock').andReturn(new Date(0));
+            helpers.spyOn(AWS.Service.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
         });
         requiredOptions.forEach(function(field) {
             it('will error if ' + field + 'is not accessible', function() {

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -777,9 +777,9 @@
       it('should find clock skew if service time is skewed within 30 seconds', function() {
         var mockService = new MockService();
         var now = new Date().getTime();
-        helpers.spyOn(mockService, 'getServiceClock').andReturn(new Date(now + 120000));
+        helpers.spyOn(mockService, 'getSkewCorrectedDate').andReturn(new Date(now + 120000));
         expect(mockService.isClockSkewed(now)).to.equal(true);
-        helpers.spyOn(mockService, 'getServiceClock').andReturn(new Date(now + 29900));
+        helpers.spyOn(mockService, 'getSkewCorrectedDate').andReturn(new Date(now + 29900));
         expect(mockService.isClockSkewed(now)).to.equal(false);
       }); 
       it('should apply the clock offset to service config', function() {
@@ -795,7 +795,7 @@
           systemClockOffset: 30000
         })
         var now = new Date().getTime();
-        var serviceTime = mockService.getServiceClock().getTime()
+        var serviceTime = mockService.getSkewCorrectedDate().getTime()
         expect(now + 29900 < serviceTime && serviceTime < now + 30100).to.equal(true);
       });
     });

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -728,7 +728,7 @@
         });
       });
     });
-    return describe('customizeRequests', function() {
+    describe('customizeRequests', function() {
       it('should accept nullable types', function() {
         var didError, err;
         didError = false;
@@ -769,33 +769,34 @@
     });
     describe('Service date sync functions', function() { 
       beforeEach(function(done) {
-        AWS.config = new AWS.Config();
-        return done();
-      });    
-      it('should find clock skew if service time is skewed within 30 seconds', function() {
         AWS.config.update({
-          systemClockOffset: 120000
+          systemClockOffset: 0
         });
-        var mockService = new MockService();
-        expect(mockService.isClockSkewed()).to.equal(true);
-        mockService.config.update({
-          systemClockOffset: 30000 - 1
-        })
-        expect(mockService.isClockSkewed()).to.equal(false);
-        expect(AWS.util.date.isClockSkewed()).to.equal(true); 
+        done();
       });
+      it('should find clock skew if service time is skewed within 30 seconds', function() {
+        var mockService = new MockService();
+        var now = new Date().getTime();
+        helpers.spyOn(mockService, 'getServiceClock').andReturn(new Date(now + 120000));
+        expect(mockService.isClockSkewed(now)).to.equal(true);
+        helpers.spyOn(mockService, 'getServiceClock').andReturn(new Date(now + 29900));
+        expect(mockService.isClockSkewed(now)).to.equal(false);
+      }); 
       it('should apply the clock offset to service config', function() {
         var mockService = new MockService();
         expect(mockService.config.systemClockOffset).to.equal(0);
-        mockService.applyClockOffset(new Date() + 30000);
-        expect(mockService.config.systemClockOffset).to.equal(30000);
+        mockService.applyClockOffset(new Date().getTime() + 30000);
+        var offset = mockService.config.systemClockOffset
+        expect(offset > 29900 && offset < 30100).to.equal(true);
       });
       it('should get date for each service', function() {
         var mockService = new MockService();
         mockService.config.update({
           systemClockOffset: 30000
         })
-        expect(mockService.getServiceClock()).to.equal(new Date().getTime() + 30000);
+        var now = new Date().getTime();
+        var serviceTime = mockService.getServiceClock().getTime()
+        expect(now + 29900 < serviceTime && serviceTime < now + 30100).to.equal(true);
       });
     });
   });

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -30,12 +30,14 @@
         return expect(CustomService.apiVersions).to.eql(['1999-05-05', '2001-01-01']);
       });
     });
+
     describe('constructor', function() {
       it('should use AWS.config copy if no config is provided', function() {
         service = new AWS.Service();
         expect(service.config).not.to.equal(AWS.config);
         return expect(service.config.sslEnabled).to.equal(true);
       });
+
       it('should merge custom options on top of global defaults if config provided', function() {
         service = new AWS.Service({
           maxRetries: 5
@@ -43,6 +45,7 @@
         expect(service.config.sslEnabled).to.equal(true);
         return expect(service.config.maxRetries).to.equal(5);
       });
+
       it('should inherit the config from global config if it is not set specificly', function() {
         var s3;
         AWS.config.update({
@@ -53,6 +56,7 @@
         expect(s3.config.systemClockOffset).to.equal(120000);
         return expect(s3.config.correctClockSkew).to.equal(true);
       })
+
       it('merges service-specific configuration from global config', function() {
         var s3;
         AWS.config.update({
@@ -64,6 +68,7 @@
         expect(s3.endpoint.host).to.equal('localhost');
         return delete AWS.config.s3;
       });
+
       it('service-specific global config overrides global config', function() {
         var region, s3;
         region = AWS.config.region;
@@ -78,6 +83,7 @@
         AWS.config.region = region;
         return delete AWS.config.s3;
       });
+
       it('service-specific local config overrides service-specific global config', function() {
         var s3;
         AWS.config.update({
@@ -91,6 +97,7 @@
         expect(s3.config.region).to.equal('eu-west-1');
         return delete AWS.config.s3;
       });
+
       it('merges credential data into config', function() {
         service = new AWS.Service({
           accessKeyId: 'foo',
@@ -99,6 +106,7 @@
         expect(service.config.credentials.accessKeyId).to.equal('foo');
         return expect(service.config.credentials.secretAccessKey).to.equal('bar');
       });
+
       it('should allow AWS.config to be object literal', function() {
         var cfg;
         cfg = AWS.config;
@@ -110,6 +118,7 @@
         expect(service.config.sslEnabled).to.equal(true);
         return AWS.config = cfg;
       });
+
       it('tries to construct service with latest API version', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['2001-01-01', '1999-05-05']);
@@ -118,6 +127,7 @@
           return new CustomService();
         }).to["throw"](errmsg);
       });
+
       it('tries to construct service with exact API version match', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['2001-01-01', '1999-05-05']);
@@ -128,6 +138,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('skips any API versions with a * and uses next (future) service', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['1998-01-01', '1999-05-05*', '2001-01-01']);
@@ -138,6 +149,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('skips multiple API versions with a * and uses next (future) service', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['1998-01-01', '1999-05-05*', '1999-07-07*', '2001-01-01']);
@@ -148,6 +160,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('tries to construct service with fuzzy API version match', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['2001-01-01', '1999-05-05']);
@@ -158,6 +171,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('uses global apiVersion value when constructing versioned services', function() {
         var CustomService, errmsg;
         AWS.config.apiVersion = '2002-03-04';
@@ -168,6 +182,7 @@
         }).to["throw"](errmsg);
         return AWS.config.apiVersion = null;
       });
+
       it('uses global apiVersions value when constructing versioned services', function() {
         var CustomService, errmsg;
         AWS.config.apiVersions = {
@@ -180,6 +195,7 @@
         }).to["throw"](errmsg);
         return AWS.config.apiVersions = {};
       });
+
       it('uses service specific apiVersions before apiVersion', function() {
         var CustomService, errmsg;
         AWS.config.apiVersions = {
@@ -194,6 +210,7 @@
         AWS.config.apiVersion = null;
         return AWS.config.apiVersions = {};
       });
+
       it('tries to construct service with fuzzy API version match', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['2001-01-01', '1999-05-05']);
@@ -204,6 +221,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('fails if apiVersion matches nothing', function() {
         var CustomService, errmsg;
         CustomService = AWS.Service.defineService('custom', ['2001-01-01', '1999-05-05']);
@@ -214,6 +232,7 @@
           });
         }).to["throw"](errmsg);
       });
+
       it('allows construction of services from one-off apiConfig properties', function() {
         service = new AWS.Service({
           apiConfig: {
@@ -228,6 +247,7 @@
         expect(typeof service.operationName).to.equal('function');
         return expect(service.operationName() instanceof AWS.Request).to.equal(true);
       });
+
       it('interpolates endpoint when reading from configuration', function() {
         service = new MockService({
           endpoint: '{scheme}://{service}.{region}.domain.tld'
@@ -239,7 +259,8 @@
         });
         return expect(service.config.endpoint).to.equal('http://mockservice.mock-region.domain.tld');
       });
-      return describe('will work with', function() {
+
+      describe('will work with', function() {
         var allServices, className, ctor, obsoleteVersions, results, serviceIdentifier, version;
         allServices = require('../clients/all');
         results = [];
@@ -269,6 +290,7 @@
         return results;
       });
     });
+    
     describe('setEndpoint', function() {
       var FooService;
       FooService = null;
@@ -728,6 +750,7 @@
         });
       });
     });
+
     describe('customizeRequests', function() {
       it('should accept nullable types', function() {
         var didError, err;

--- a/test/services/ec2.spec.js
+++ b/test/services/ec2.spec.js
@@ -25,7 +25,7 @@
     describe('copySnapshot', function() {
       return it('generates PresignedUrl and DestinationRegion parameters', function() {
         var params;
-        helpers.spyOn(ec2.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
+        helpers.spyOn(ec2.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
         helpers.mockHttpResponse(200, {}, '');
         params = {
           SourceRegion: 'src-region',

--- a/test/services/ec2.spec.js
+++ b/test/services/ec2.spec.js
@@ -25,7 +25,7 @@
     describe('copySnapshot', function() {
       return it('generates PresignedUrl and DestinationRegion parameters', function() {
         var params;
-        helpers.spyOn(ec2.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
+        helpers.spyOn(AWS.EC2.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
         helpers.mockHttpResponse(200, {}, '');
         params = {
           SourceRegion: 'src-region',

--- a/test/services/ec2.spec.js
+++ b/test/services/ec2.spec.js
@@ -25,7 +25,7 @@
     describe('copySnapshot', function() {
       return it('generates PresignedUrl and DestinationRegion parameters', function() {
         var params;
-        helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(0));
+        helpers.spyOn(ec2.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
         helpers.mockHttpResponse(200, {}, '');
         params = {
           SourceRegion: 'src-region',
@@ -34,7 +34,20 @@
         return ec2.copySnapshot(params, function() {
           var parts;
           parts = this.request.httpRequest.body.split('&').sort();
-          return ['Action=CopySnapshot', 'DestinationRegion=mock-region', 'PresignedUrl=https%3A%2F%2Fec2.src-region.amazonaws.com%2F%3F' + 'Action%3DCopySnapshot%26DestinationRegion%3Dmock-region%26SourceRegion%3Dsrc-region' + '%26SourceSnapshotId%3Dsnap-123456789%26Version%3D2016-11-15' + '%26X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3Dakid%252F19700101' + '%252Fsrc-region%252Fec2%252Faws4_request%26X-Amz-Date%3D19700101T000000Z' + '%26X-Amz-Expires%3D3600%26X-Amz-Security-Token%3Dsession' + '%26X-Amz-Signature%3De322173cd374af0ef234e8661f4d4a0420d12286cdc0745d75b8b405caefd6a9' + '%26X-Amz-SignedHeaders%3Dhost', 'SourceRegion=src-region', 'SourceSnapshotId=snap-123456789'].forEach(function(i) {
+          return [
+            'Action=CopySnapshot',
+            'DestinationRegion=mock-region',
+            'PresignedUrl=https%3A%2F%2Fec2.src-region.amazonaws.com%2F%3F' +
+            'Action%3DCopySnapshot%26DestinationRegion%3Dmock-region%26SourceRegion%3Dsrc-region' +
+            '%26SourceSnapshotId%3Dsnap-123456789%26Version%3D2016-11-15' +
+            '%26X-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3Dakid%252F19700101' +
+            '%252Fsrc-region%252Fec2%252Faws4_request%26X-Amz-Date%3D19700101T000000Z' +
+            '%26X-Amz-Expires%3D3600%26X-Amz-Security-Token%3Dsession' +
+            '%26X-Amz-Signature%3De322173cd374af0ef234e8661f4d4a0420d12286cdc0745d75b8b405caefd6a9' +
+            '%26X-Amz-SignedHeaders%3Dhost',
+            'SourceRegion=src-region',
+            'SourceSnapshotId=snap-123456789'
+          ].forEach(function(i) {
             return expect(parts).to.contain(i);
           });
         });

--- a/test/services/rds.spec.js
+++ b/test/services/rds.spec.js
@@ -51,8 +51,8 @@
           paramValidation: true
         });
         spy = helpers.spyOn(rds, 'buildCrossRegionPresignedUrl').andCallThrough();
-        helpers.spyOn(rds.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
-        return helpers.spyOn(rds, 'getServiceClock').andReturn(new Date(0));
+        helpers.spyOn(rds.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
+        return helpers.spyOn(rds, 'getSkewCorrectedDate').andReturn(new Date(0));
       });
       it('builds presigned url for copyDBSnapshot', function() {
         var req;

--- a/test/services/rds.spec.js
+++ b/test/services/rds.spec.js
@@ -51,7 +51,7 @@
           paramValidation: true
         });
         spy = helpers.spyOn(rds, 'buildCrossRegionPresignedUrl').andCallThrough();
-        helpers.spyOn(rds.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
+        helpers.spyOn(AWS.RDS.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
         return helpers.spyOn(rds, 'getSkewCorrectedDate').andReturn(new Date(0));
       });
       it('builds presigned url for copyDBSnapshot', function() {

--- a/test/services/rds.spec.js
+++ b/test/services/rds.spec.js
@@ -51,7 +51,8 @@
           paramValidation: true
         });
         spy = helpers.spyOn(rds, 'buildCrossRegionPresignedUrl').andCallThrough();
-        return helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(0));
+        helpers.spyOn(rds.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
+        return helpers.spyOn(rds, 'getServiceClock').andReturn(new Date(0));
       });
       it('builds presigned url for copyDBSnapshot', function() {
         var req;

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2299,8 +2299,7 @@ describe('AWS.S3', function() {
     var date = null;
 
     beforeEach(function(done) {
-      helpers.spyOn(s3, 'getSkewCorrectedDate').andReturn(new Date(0));
-      helpers.spyOn(s3.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
+      helpers.spyOn(AWS.S3.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
       return done();
     });
 

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2299,15 +2299,12 @@ describe('AWS.S3', function() {
     var date = null;
 
     beforeEach(function(done) {
-      date = AWS.util.date.getDate;
-      AWS.util.date.getDate = function() {
-        return new Date(0);
-      };
+      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(0));
+      helpers.spyOn(s3.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
       return done();
     });
 
     afterEach(function(done) {
-      AWS.util.date.getDate = date;
       done();
     });
 
@@ -2618,8 +2615,8 @@ describe('AWS.S3', function() {
     });
 
     it('should default to expiration in one hour', function(done) {
-      helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(946684800 * 1000));
       s3 = new AWS.S3();
+      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(946684800 * 1000));
       s3.createPresignedPost({
         Bucket: 'bucket'
       }, function(err, data) {
@@ -2630,9 +2627,9 @@ describe('AWS.S3', function() {
     });
 
     it('should allow users to provide a custom expiration', function(done) {
-      helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(946684800 * 1000));
       var customTtl = 900;
       s3 = new AWS.S3();
+      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(946684800 * 1000));
       return s3.createPresignedPost({
         Bucket: 'bucket',
         Expires: customTtl

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2299,8 +2299,8 @@ describe('AWS.S3', function() {
     var date = null;
 
     beforeEach(function(done) {
-      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(0));
-      helpers.spyOn(s3.constructor.prototype, 'getServiceClock').andReturn(new Date(0));
+      helpers.spyOn(s3, 'getSkewCorrectedDate').andReturn(new Date(0));
+      helpers.spyOn(s3.constructor.prototype, 'getSkewCorrectedDate').andReturn(new Date(0));
       return done();
     });
 
@@ -2616,7 +2616,7 @@ describe('AWS.S3', function() {
 
     it('should default to expiration in one hour', function(done) {
       s3 = new AWS.S3();
-      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(946684800 * 1000));
+      helpers.spyOn(s3, 'getSkewCorrectedDate').andReturn(new Date(946684800 * 1000));
       s3.createPresignedPost({
         Bucket: 'bucket'
       }, function(err, data) {
@@ -2629,7 +2629,7 @@ describe('AWS.S3', function() {
     it('should allow users to provide a custom expiration', function(done) {
       var customTtl = 900;
       s3 = new AWS.S3();
-      helpers.spyOn(s3, 'getServiceClock').andReturn(new Date(946684800 * 1000));
+      helpers.spyOn(s3, 'getSkewCorrectedDate').andReturn(new Date(946684800 * 1000));
       return s3.createPresignedPost({
         Bucket: 'bucket',
         Expires: customTtl

--- a/test/signers/presign.spec.js
+++ b/test/signers/presign.spec.js
@@ -14,6 +14,7 @@
     var resultUrl;
     resultUrl = "https://monitoring.mock-region.amazonaws.com/?" + ("Action=ListMetrics&Version=" + cw.api.apiVersion + "&") + "X-Amz-Algorithm=AWS4-HMAC-SHA256&" + "X-Amz-Credential=akid%2F19700101%2Fmock-region%2Fmonitoring%2Faws4_request&" + "X-Amz-Date=19700101T000000Z&X-Amz-Expires=3600&X-Amz-Security-Token=session&" + "X-Amz-Signature=953bd6d74e86c12adc305f656473d614269d2f20a0c18c5edbb3d7f57ca2b439&" + "X-Amz-SignedHeaders=host";
     beforeEach(function() {
+      helpers.spyOn(cw, 'getServiceClock').andReturn(new Date(0));
       return helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(0));
     });
     it('presigns requests', function() {

--- a/test/signers/presign.spec.js
+++ b/test/signers/presign.spec.js
@@ -14,7 +14,7 @@
     var resultUrl;
     resultUrl = "https://monitoring.mock-region.amazonaws.com/?" + ("Action=ListMetrics&Version=" + cw.api.apiVersion + "&") + "X-Amz-Algorithm=AWS4-HMAC-SHA256&" + "X-Amz-Credential=akid%2F19700101%2Fmock-region%2Fmonitoring%2Faws4_request&" + "X-Amz-Date=19700101T000000Z&X-Amz-Expires=3600&X-Amz-Security-Token=session&" + "X-Amz-Signature=953bd6d74e86c12adc305f656473d614269d2f20a0c18c5edbb3d7f57ca2b439&" + "X-Amz-SignedHeaders=host";
     beforeEach(function() {
-      helpers.spyOn(cw, 'getServiceClock').andReturn(new Date(0));
+      helpers.spyOn(cw, 'getSkewCorrectedDate').andReturn(new Date(0));
       return helpers.spyOn(AWS.util.date, 'getDate').andReturn(new Date(0));
     });
     it('presigns requests', function() {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -126,7 +126,7 @@
     describe('getDate', function() {
       it('should return current date by default', function() {
         var now, obj;
-        now = {};
+        now = new Date(0);
         obj = AWS.util.isNode() ? global : window;
         helpers.spyOn(obj, 'Date').andCallFake(function() {
           return now;

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -170,6 +170,30 @@
         });
       });
     });
+
+    describe('applyClockOffset', function() {
+      it('should apply new clock offset to AWS.config given new service time', function() {
+        var now = new Date().getTime();
+        AWS.config.systemClockOffset = 0;
+        AWS.util.applyClockOffset(now + 30000);
+        var updatedOffset = AWS.config.systemClockOffset;
+        expect(29900 < updatedOffset && 30100 > updatedOffset).to.equal(true);
+      });
+    });
+
+    describe('isClockSkewed', function() {
+      it('should apply new clock offset to AWS.config given new service time', function() {
+        var util = AWS.util;
+        var now = new Date();
+        obj = AWS.util.isNode() ? global : window;
+        helpers.spyOn(obj, 'Date').andCallFake(function() {
+          return now;
+        });
+        expect(util.isClockSkewed(now.getTime() + 300100)).to.equal(true);
+        expect(util.isClockSkewed(now.getTime() + 299900)).to.equal(false);
+      });
+    });
+
     describe('iso8601', function() {
       it('should return date formatted as YYYYMMDDTHHmmssZ', function() {
         var date;
@@ -187,6 +211,7 @@
         return expect(util.iso8601(date)).to.equal('1970-01-01T00:11:00Z');
       });
     });
+
     describe('rfc822', function() {
       it('should return date formatted as YYYYMMDDTHHmmssZ', function() {
         var date;


### PR DESCRIPTION
Previously, when a particular service clock is incorrect and we config the correctClockSkew: true, the SDK will add an offset to the local clock. However, since this offset is kept in global config, the SDK will apply this time offset even when communicating with healthy services. This may lead to request error. In this fix, every service client keeps its own time offset so that incorrect clock in one service may not affect others.
/cc @jeskew @chrisradek 