### PR TITLE
Mention in documentation examples that strings provided for binary properties will be base64 encoded

### DIFF
--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -211,7 +211,6 @@ class SharedExampleVisitor
       when 'float', 'double', 'bigdecimal' then 'FloatShape'
       when 'integer', 'long', 'short', 'biginteger' then 'IntegerShape'
       when 'string', 'character' then 'StringShape'
-      when 'base64' then 'Base64Shape'
       when 'binary', 'blob' then 'BinaryShape'
       else type
     end
@@ -432,13 +431,13 @@ class ExampleShapeVisitor
     "true || false"
   end
 
-  def visit_base64(node, required = false)
-    "new Buffer('...') || 'STRING_VALUE'"
-  end
-
   def visit_binary(node, required = false)
     value = "new Buffer('...') || 'STRING_VALUE'"
-    value += " || streamObject" if node['streaming']
+    if node['streaming']
+      value += " || streamObject"
+    else
+      value += " /* Strings will be Base-64 encoded on your behalf */"
+    end
     value
   end
   alias visit_blob visit_binary
@@ -480,7 +479,6 @@ class ShapeDocumentor
     when 'double' then 'Float'
     when 'bigdecimal' then 'Float'
     when 'boolean' then 'Boolean'
-    when 'base64' then 'Buffer, Typed Array, Blob, String'
     when 'binary' then 'Buffer, Typed Array, Blob, String'
     when 'blob' then 'Buffer, Typed Array, Blob, String'
     when 'timestamp' then 'Date'


### PR DESCRIPTION
It can be confusing if you're providing base64 encoded data to an operation to find out that is being base64 encoded a second time. This change adds a comment to the usage samples in the documentation that points out that base64 strings will be encoded on the user's behalf.
<img width="1275" alt="base64-callout-screenshot" src="https://user-images.githubusercontent.com/705500/30658638-3bff733e-9df0-11e7-91bb-dbf8272e5e03.png">
