### PR TITLE
Enable logging via environment variable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -462,7 +462,7 @@ AWS.Config = AWS.util.inherit({
     credentials: null,
     credentialProvider: null,
     region: null,
-    logger: null,
+    logger: process.env.AWS_DEBUG ? console : undefined,
     apiVersions: {},
     apiVersion: null,
     endpoint: undefined,

--- a/lib/config.js
+++ b/lib/config.js
@@ -462,7 +462,7 @@ AWS.Config = AWS.util.inherit({
     credentials: null,
     credentialProvider: null,
     region: null,
-    logger: process.env.AWS_DEBUG ? console : undefined,
+    logger: process.env.AWSJS_DEBUG ? console : undefined,
     apiVersions: {},
     apiVersion: null,
     endpoint: undefined,


### PR DESCRIPTION
Hi,

I often find it desirable during debugging to turn on logging for `aws-sdk` so that I can see the requests and their parameters being made to AWS. To enable logging, I am required to alter my code with:

```
const AWS = require('aws-sdk');
AWS.config.update({ logger: console });
```

We use `aws-sdk` in approximately 50 repositories as part of our microservice architecture. This alteration becomes unwieldy when I need to turn on logging for multiple services. It would be highly convenient and efficient to be able to set an environment variable that would turn on logging in `aws-sdk`, for example `AWS_DEBUG=1`.

I have made a demonstration of how this might be done in this PR, albeit a bit raw. If you think it can be done in a better place, please alter the PR. I wanted to create a sample implementation to kick of discussion around what I see as a very necessary and useful feature.