### PR TITLE
Fix #1740 - Missing `connectTimeout` in docs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -117,8 +117,13 @@ var PromisesDependency;
  *       SSL connections, a special Agent object is used in order to enable
  *       peer certificate verification. This feature is only supported in the
  *       Node.js environment.
- *     * **timeout** [Integer] &mdash; The number of milliseconds to wait before
- *       giving up on a connection attempt. Defaults to two minutes (120000).
+ *     * **connectTimeout** [Integer] &mdash; Sets the socket to timeout after
+ *       failing to establish a connection with the server after
+ *       `connectTimeout` milliseconds. This timeout has no effect once a socket
+ *       connection has been established.
+ *     * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
+ *       milliseconds of inactivity on the socket. Defaults to two minutes
+ *       (120000)
  *     * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
  *       HTTP requests. Used in the browser environment only. Set to false to
  *       send requests synchronously. Defaults to true (async on).


### PR DESCRIPTION
Add  `connectTimeout` in `httpOptions` documentation.

Update **timeout** documentation

Fix #1740