### PR TITLE
Reverts mocha to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "karma": "^1.4.1",
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.2",
-    "mocha": "4.0.0",
+    "mocha": "^3.0.0",
     "repl.history": "*",
     "semver": "*",
     "typescript": "2.0.8",


### PR DESCRIPTION
Mocha V4 dropped support for older versions of node.js. V4 dropped support for versions of node that are no longer maintained. This, coupled with our codecov configuration (wait only for 1 build to complete) caused codecov to report a loss in coverage.

