### PR TITLE
update managed_upload validateBody method

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -259,6 +259,9 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     self.body = self.service.config.params.Body;
     if (typeof self.body === 'string') {
       self.body = new AWS.util.Buffer(self.body);
+    } else if (self.body instanceof AWS.util.stream.Stream &&
+               self.body.read !== 'function') {
+      throw new Error('params.body.read must be a function');
     } else if (!self.body) {
       throw new Error('params.Body is required');
     }

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -260,7 +260,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     if (typeof self.body === 'string') {
       self.body = new AWS.util.Buffer(self.body);
     } else if (self.body instanceof AWS.util.stream.Stream &&
-               self.body.read !== 'function') {
+               typeof self.body.read !== 'function') {
       throw new Error('params.body.read must be a function');
     } else if (!self.body) {
       throw new Error('params.Body is required');


### PR DESCRIPTION
- API users can pass a Stream object that does not have `.read(...)`.