### PR TITLE
clean integration test of redshift & directconnect

### DIFF
--- a/.changes/next-release/bugfix-integration test-9ad37d8e.json
+++ b/.changes/next-release/bugfix-integration test-9ad37d8e.json
@@ -1,5 +1,0 @@
-{
-  "type": "bugfix",
-  "category": "integration test",
-  "description": "remove some integration tests that could claim too much resources"
-}

--- a/.changes/next-release/bugfix-integration test-9ad37d8e.json
+++ b/.changes/next-release/bugfix-integration test-9ad37d8e.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "integration test",
+  "description": "remove some integration tests that could claim too much resources"
+}

--- a/features/directconnect/directconnect.feature
+++ b/features/directconnect/directconnect.feature
@@ -4,9 +4,9 @@ Feature: AWS Direct Connect
 
   I want to use AWS Direct Connect
 
-  Scenario: Managing connections
-    Given I describe the connection
-    Then I should get response of type Array
+  Scenario: describe connections
+    When I describe the connection
+    Then I should get response of type "Array"
 
   Scenario: Error handling
     Given I create a Direct Connect connection with an invalid location

--- a/features/directconnect/directconnect.feature
+++ b/features/directconnect/directconnect.feature
@@ -5,11 +5,8 @@ Feature: AWS Direct Connect
   I want to use AWS Direct Connect
 
   Scenario: Managing connections
-    Given I create a Direct Connect connection with name prefix "aws-sdk-js"
-    Then I should get a Direct Connect connection ID
-    And I describe the connection
-    Then the bandwidth should match the connection bandwidth
-    And I delete the Direct Connect connection
+    Given I describe the connection
+    Then I should get response of type Array
 
   Scenario: Error handling
     Given I create a Direct Connect connection with an invalid location

--- a/features/directconnect/directconnect.feature
+++ b/features/directconnect/directconnect.feature
@@ -5,8 +5,9 @@ Feature: AWS Direct Connect
   I want to use AWS Direct Connect
 
   Scenario: describe connections
-    When I describe the connection
-    Then I should get response of type "Array"
+    Given I run the "describeConnections" operation
+    Then the request should be successful
+    And the value at "connections" should be a list
 
   Scenario: Error handling
     Given I create a Direct Connect connection with an invalid location

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -4,31 +4,15 @@ module.exports = function() {
     callback();
   });
 
-  this.Given(/^I describe the connection$/, function(prefix, callback) {
-    var params = {};
+  this.When(/^I describe the connection$/, function(callback) {
+    var params = {connectionId: this.connectionId};
     this.request(null, 'describeConnections', params, callback);
   });
 
-  this.Then(/^I should get response of type ([^"]*)$/, function(callback) {
-      console.log('_____________', this.data.connections.prototype.constructor.name)
-    this.assert.equal(this.data.connections.prototype.constructor.name, type)
+  this.Then(/^I should get response of type "([^"]*)"$/, function(array, callback) {
+    this.assert.equal(this.data.connections.constructor.name, array)
     callback();
   });
-
-//   this.Then(/^I describe the connection$/, function(callback) {
-//     var params = {connectionId: this.connectionId};
-//     this.request(null, 'describeConnections', params, callback);
-//   });
-
-//   this.Then(/^the bandwidth should match the connection bandwidth$/, function(callback) {
-//     this.assert.equal(this.connectionData.bandwidth, this.data.connections[0].bandwidth);
-//     callback();
-//   });
-
-//   this.Then(/^I delete the Direct Connect connection$/, function(callback) {
-//     var params = {connectionId: this.connectionId};
-//     this.request(null, 'deleteConnection', params, callback);
-//   });
 
   this.Given(/^I create a Direct Connect connection with an invalid location$/, function(callback) {
     var params = {

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -4,34 +4,31 @@ module.exports = function() {
     callback();
   });
 
-  this.When(/^I create a Direct Connect connection with name prefix "([^"]*)"$/, function(prefix, callback) {
-    var params = {
-      bandwidth: '1Gbps', location: 'EqDC2',
-      connectionName: this.uniqueName(prefix)
-    };
-    this.request(null, 'createConnection', params, callback);
-  });
-
-  this.Then(/^I should get a Direct Connect connection ID$/, function(callback) {
-    this.connectionId = this.data.connectionId;
-    this.connectionData = this.data;
-    callback();
-  });
-
-  this.Then(/^I describe the connection$/, function(callback) {
-    var params = {connectionId: this.connectionId};
+  this.Given(/^I describe the connection$/, function(prefix, callback) {
+    var params = {};
     this.request(null, 'describeConnections', params, callback);
   });
 
-  this.Then(/^the bandwidth should match the connection bandwidth$/, function(callback) {
-    this.assert.equal(this.connectionData.bandwidth, this.data.connections[0].bandwidth);
+  this.Then(/^I should get response of type ([^"]*)$/, function(callback) {
+      console.log('_____________', this.data.connections.prototype.constructor.name)
+    this.assert.equal(this.data.connections.prototype.constructor.name, type)
     callback();
   });
 
-  this.Then(/^I delete the Direct Connect connection$/, function(callback) {
-    var params = {connectionId: this.connectionId};
-    this.request(null, 'deleteConnection', params, callback);
-  });
+//   this.Then(/^I describe the connection$/, function(callback) {
+//     var params = {connectionId: this.connectionId};
+//     this.request(null, 'describeConnections', params, callback);
+//   });
+
+//   this.Then(/^the bandwidth should match the connection bandwidth$/, function(callback) {
+//     this.assert.equal(this.connectionData.bandwidth, this.data.connections[0].bandwidth);
+//     callback();
+//   });
+
+//   this.Then(/^I delete the Direct Connect connection$/, function(callback) {
+//     var params = {connectionId: this.connectionId};
+//     this.request(null, 'deleteConnection', params, callback);
+//   });
 
   this.Given(/^I create a Direct Connect connection with an invalid location$/, function(callback) {
     var params = {

--- a/features/directconnect/step_definitions/directconnect.js
+++ b/features/directconnect/step_definitions/directconnect.js
@@ -4,16 +4,6 @@ module.exports = function() {
     callback();
   });
 
-  this.When(/^I describe the connection$/, function(callback) {
-    var params = {connectionId: this.connectionId};
-    this.request(null, 'describeConnections', params, callback);
-  });
-
-  this.Then(/^I should get response of type "([^"]*)"$/, function(array, callback) {
-    this.assert.equal(this.data.connections.constructor.name, array)
-    callback();
-  });
-
   this.Given(/^I create a Direct Connect connection with an invalid location$/, function(callback) {
     var params = {
       bandwidth: '1Gbps',

--- a/features/redshift/redshift.feature
+++ b/features/redshift/redshift.feature
@@ -5,8 +5,9 @@ Feature: Amazon Redshift
   I want to use Amazon Redshift
 
   Scenario: Describe cluster parameter groups
-    When I describe Redshift cluster parameter groups
-    Then the response should be type of "Array"
+    Given I run the "describeClusterParameterGroups" operation
+    Then the request should be successful
+    And the value at "ParameterGroups" should be a list
 
   Scenario: Error handling
     Given I create a Redshift cluster parameter group with prefix name ""

--- a/features/redshift/redshift.feature
+++ b/features/redshift/redshift.feature
@@ -4,12 +4,9 @@ Feature: Amazon Redshift
 
   I want to use Amazon Redshift
 
-  Scenario: Creating and deleting cluster parameter groups
-    Given I create a Redshift cluster parameter group with prefix name "aws-js-sdk"
-    And the Redshift cluster parameter group name is in the result
-    And I describe Redshift cluster parameter groups
-    Then the Redshift cluster parameter group should be in the list
-    And I delete the Redshift cluster parameter group
+  Scenario: Describe cluster parameter groups
+    When I describe Redshift cluster parameter groups
+    Then the response should be type of "Array"
 
   Scenario: Error handling
     Given I create a Redshift cluster parameter group with prefix name ""

--- a/features/redshift/step_definitions/redshift.js
+++ b/features/redshift/step_definitions/redshift.js
@@ -13,14 +13,4 @@ module.exports = function() {
     };
     this.request(null, 'createClusterParameterGroup', params, callback, false);
   });
-
-  this.When(/^I describe Redshift cluster parameter groups$/, function(callback) {
-    this.request(null, 'describeClusterParameterGroups', {}, callback);
-  });
-
-  this.Then(/^the response should be type of "([^"]*)"$/, function(array, callback) {
-    this.assert.equal(this.data.ParameterGroups.constructor.name, array);
-    callback();
-  });
-
 };

--- a/features/redshift/step_definitions/redshift.js
+++ b/features/redshift/step_definitions/redshift.js
@@ -14,25 +14,13 @@ module.exports = function() {
     this.request(null, 'createClusterParameterGroup', params, callback, false);
   });
 
-  this.Given(/^the Redshift cluster parameter group name is in the result$/, function(callback) {
-    this.assert.equal(this.data.ClusterParameterGroup.ParameterGroupName, this.parameterGroupName);
-    callback();
-  });
-
-  this.Given(/^I describe Redshift cluster parameter groups$/, function(callback) {
+  this.When(/^I describe Redshift cluster parameter groups$/, function(callback) {
     this.request(null, 'describeClusterParameterGroups', {}, callback);
   });
 
-  this.Then(/^the Redshift cluster parameter group should be in the list$/, function(callback) {
-    var name = this.parameterGroupName;
-    this.assert.contains(this.data.ParameterGroups, function(parameterGroup) {
-      return parameterGroup.ParameterGroupName === name;
-    });
+  this.Then(/^the response should be type of "([^"]*)"$/, function(array, callback) {
+    this.assert.equal(this.data.ParameterGroups.constructor.name, array);
     callback();
   });
 
-  this.Then(/^I delete the Redshift cluster parameter group$/, function(callback) {
-    var params = {ParameterGroupName: this.parameterGroupName};
-    this.request(null, 'deleteClusterParameterGroup', params, callback);
-  });
 };


### PR DESCRIPTION
remove those operations that create new connections or parameter groups. 