### PR TITLE
Export CognitoIdentityCredentials

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -375,3 +375,5 @@ AWS.CognitoIdentityCredentials = AWS.util.inherit(AWS.Credentials, {
     }
   })()
 });
+
+exports.CognitoIdentityCredentials = AWS.CognitoIdentityCredentials;


### PR DESCRIPTION
In order to reduce frontend bundle size, it is nice to be able to import things one-by-one instead of importing the whole SDK.
However using CognitoIdentityCredentials alone is not possible because it is not exported even though the types say so.

```typescript
import * as S3 from 'aws-sdk/clients/s3';
import { CognitoIdentityCredentials } from 'aws-sdk/lib/credentials/cognito_identity_credentials';

console.log(S3, CognitoIdentityCredentials);
```

This logs: `f () {...} undefined`