### PR TITLE
Fix TypeScript definition for CredentialProviderChain constructor

### DIFF
--- a/lib/credentials/credential_provider_chain.d.ts
+++ b/lib/credentials/credential_provider_chain.d.ts
@@ -4,7 +4,7 @@ export class CredentialProviderChain extends Credentials {
     /**
      * Creates a new CredentialProviderChain with a default set of providers specified by defaultProviders.
      */
-    constructor(providers: provider[])
+    constructor(providers?: provider[])
     /**
      * Resolves the provider chain by searching for the first set of credentials in providers.
      */

--- a/ts/credentialproviderchain.ts
+++ b/ts/credentialproviderchain.ts
@@ -9,3 +9,5 @@ providerChain.resolvePromise().then(
 );
 
 providerChain.resolve(() => {});
+
+const providerChainNoArgs = new CredentialProviderChain();


### PR DESCRIPTION
The constructor's `providers` argument should be marked as optional.