### PR TITLE
Sets content-type for rest-json services when payloads are binary or streaming

### DIFF
--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -19,6 +19,9 @@ function populateBody(req) {
       applyContentTypeHeader(req);
     } else { // non-JSON payload
       req.httpRequest.body = params;
+      if (payloadShape.type === 'binary' || payloadShape.isStreaming) {
+        applyContentTypeHeader(req, true);
+      }
     }
   } else {
     req.httpRequest.body = builder.build(req.params, input);
@@ -26,9 +29,13 @@ function populateBody(req) {
   }
 }
 
-function applyContentTypeHeader(req) {
+function applyContentTypeHeader(req, isBinary) {
+  var operation = req.service.api.operations[req.operation];
+  var input = operation.input;
+
   if (!req.httpRequest.headers['Content-Type']) {
-    req.httpRequest.headers['Content-Type'] = 'application/json';
+    var type = isBinary ? 'binary/octet-stream' : 'application/json';
+    req.httpRequest.headers['Content-Type'] = type;
   }
 }
 

--- a/test/protocol/rest_json.spec.js
+++ b/test/protocol/rest_json.spec.js
@@ -237,6 +237,62 @@
           expect(request.httpRequest.headers['Content-Type'])
             .to.equal('application/json');
         });
+
+        it('should add a Content-Type with binary/octet-stream if paylaod is binary', function() {
+          request.params = {
+            Body: 'foobar'
+          };
+          defop({
+            input: {
+              payload: 'Body',
+              members: {
+                Body: {
+                  type: 'binary'
+                }
+              }
+            }
+          });
+          expect(build().httpRequest.headers['Content-Type']).to.equal('binary/octet-stream');
+        });
+
+        it('should add a Content-Type with binary/octet-stream if paylaod is streaming', function() {
+          request.params = {
+            Body: 'foobar'
+          };
+          defop({
+            input: {
+              payload: 'Body',
+              members: {
+                Body: {
+                  type: 'blob',
+                  streaming: true
+                }
+              }
+            }
+          });
+          expect(build().httpRequest.headers['Content-Type']).to.equal('binary/octet-stream');
+        });
+
+        it('should not add a Content-Type if paylaod is already defined', function() {
+          request.params = {
+            Body: 'foobar'
+          };
+
+          request.httpRequest.headers['Content-Type'] = 'foo';
+          defop({
+            input: {
+              payload: 'Body',
+              members: {
+                Body: {
+                  type: 'blob',
+                  streaming: true
+                }
+              }
+            }
+          });
+          expect(build().httpRequest.headers['Content-Type']).to.equal('foo');
+        });
+
       });
 
       describe('body', function() {

--- a/test/services/glacier.spec.js
+++ b/test/services/glacier.spec.js
@@ -56,6 +56,7 @@
             'X-Amz-Content-Sha256': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
             'x-amz-sha256-tree-hash': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
             'Content-Length': 3,
+            'Content-Type': 'binary/octet-stream',
             Host: 'glacier.mock-region.amazonaws.com'
           };
           headers[agentHeader] = AWS.util.userAgent();


### PR DESCRIPTION
I tested Glacier, Lambda, and Lex. Lex requires the content-type to be set so is not affected.

I believe that's all the rest-json services that accept a streaming or binary body.