### PR TITLE
Stop testing on unsupported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: node_js
 node_js:
-#  - "0.8"
   - "0.10"
   - "0.12"
-  - "4.2"
-  - "4.4"
-  - "5"
+  - "4"
   - "6"
-  - "7"
   - "8"
 env:
   - TEST_SCRIPT=coverage


### PR DESCRIPTION
node v5 and v7 (and any other odd numbered versions) are basically for node.js contributors, not for the users in general and they are expired now. So I dropped v5 and v7 from travis settings. Node v4 is a supported version, but the older minor versions are not supported, so dropped v4.2 and v4.4 and added v4 instead. (The current LTS version in 4.x line is v4.8.7).

See https://github.com/nodejs/Release for details.