### PR TITLE
Correct environment variable name in AWS.RemoteCredentials docblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/browser/build
 test/browser/sample/appinfo.js
 dist/aws-sdk-all.js
 yarn.lock
+package-lock.json

--- a/lib/credentials/remote_credentials.js
+++ b/lib/credentials/remote_credentials.js
@@ -11,8 +11,8 @@ var AWS = require('../core'),
  * Represents credentials received from specified URI.
  *
  * This class will request refreshable credentials from the relative URI
- * specified by the AWS_REMOTE_CREDENTIALS_RELATIVE_URI or the
- * AWS_REMOTE_CREDENTIALS_FULL_URI environment variable. If valid credentials
+ * specified by the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI or the
+ * AWS_CONTAINER_CREDENTIALS_FULL_URI environment variable. If valid credentials
  * are returned in the response, these will be used with zero configuration.
  *
  * This credentials class will by default timeout after 1 second of inactivity


### PR DESCRIPTION
This PR updates [the API docs for `AWS.RemoteCredentials`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RemoteCredentials.html) to advise using the correct environment variable.