### PR TITLE
Use node XML parser from a Web Worker

### DIFF
--- a/lib/browser_loader.js
+++ b/lib/browser_loader.js
@@ -18,7 +18,11 @@ require('./credentials/cognito_identity_credentials');
 require('./credentials/saml_credentials');
 
 // Load the DOMParser XML parser
-AWS.XML.Parser = require('./xml/browser_parser');
+if (typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) {
+  AWS.XML.Parser = require('./xml/node_parser');
+} else {
+  AWS.XML.Parser = require('./xml/browser_parser');
+}
 
 // Load the XHR HttpClient
 require('./http/xhr');


### PR DESCRIPTION
The browser XML parser doesn't work for scripts running in a Web Worker because you don't have access to the DOM XMLParser.  In this case, using the Node.js XML parser works great.

There may be other webworker incompatibilities; this fixes the biggest blocker I've found so far with getting this library to work within a web worker. I'll update this PR with patches as I find problems.