### PR TITLE
Allow chained profiles from config (fixes #1891)

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -47,6 +47,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    * @option options disableAssumeRole [Boolean] (false) True to disable
    *   support for profiles that assume an IAM role. If true, and an assume
    *   role profile is selected, an error is raised.
+   * @option options preferStaticCredentials [Boolean] (false) True to
+   *   prefer static credentials to role_arn if both are present.
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
@@ -56,6 +58,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
     this.disableAssumeRole = Boolean(options.disableAssumeRole);
+    this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
     this.get(function() {});
   },
 
@@ -100,7 +103,23 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         );
       }
 
-      if (profile['role_arn']) {
+      /*
+      In the CLI, the presence of both a role_arn and static credentials have
+      different meanings depending on how many profiles have been visited. For
+      the first profile processed, role_arn takes precedence over any static
+      credentials, but for all subsequent profiles, static credentials are
+      used if present, and only in their absence will the profile's
+      source_profile and role_arn keys be used to load another set of
+      credentials. This var is intended to yield compatible behaviour in this
+      sdk.
+      */
+      var preferStaticCredentialsToRoleArn = Boolean(
+        this.preferStaticCredentials
+        && profile['aws_access_key_id']
+        && profile['aws_secret_access_key']
+      )
+
+      if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
         this.loadRoleProfile(profiles, profile, callback);
         return;
       }
@@ -160,7 +179,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     var sourceCredentials = new AWS.SharedIniFileCredentials(
       Object.assign({}, this.options, {
-        profile: sourceProfileName
+        profile: sourceProfileName,
+        preferStaticCredentials: true
       })
     );
 

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -148,9 +148,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sourceProfile = creds[sourceProfileName];
+    var sourceProfileExistanceTest = creds[sourceProfileName];
 
-    if (typeof sourceProfile !== 'object') {
+    if (typeof sourceProfileExistanceTest !== 'object') {
       throw AWS.util.error(
         new Error('source_profile ' + sourceProfileName + ' using profile '
           + this.profile + ' does not exist'),
@@ -158,24 +158,15 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
+    var sourceCredentials = new AWS.SharedIniFileCredentials(
+      Object.assign({}, this.options, {
+        profile: sourceProfileName
+      })
+    );
+
     this.roleArn = roleArn;
-
-    var sourceCredentials = {
-      accessKeyId: sourceProfile['aws_access_key_id'],
-      secretAccessKey: sourceProfile['aws_secret_access_key'],
-      sessionToken: sourceProfile['aws_session_token']
-    };
-
-    if (!sourceCredentials.accessKeyId || !sourceCredentials.secretAccessKey) {
-      throw AWS.util.error(
-        new Error('Credentials not set in source_profile ' +
-                  sourceProfileName + ' using profile ' + this.profile),
-        { code: 'SharedIniFileCredentialsProviderFailure' }
-      );
-    }
-
     var sts = new STS({
-      credentials: new AWS.Credentials(sourceCredentials)
+      credentials: sourceCredentials
     });
 
     var roleParams = {

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -519,7 +519,7 @@
           return done();
         });
       });
-      return it('will assume a role from the config file whose source profile is defined in the credentials file', function(done) {
+      it('will assume a role from the config file whose source profile is defined in the credentials file', function(done) {
         var creds, credsCtorSpy;
         process.env.AWS_SDK_LOAD_CONFIG = '1';
         helpers.spyOn(AWS.util, 'readFileSync').andCallFake(function(path) {
@@ -542,6 +542,40 @@
           expect(creds.secretAccessKey).to.equal('SECRET');
           expect(creds.sessionToken).to.equal('TOKEN');
           expect(creds.expireTime).to.eql(new Date(0));
+          return done();
+        });
+      });
+      it('should prefer static credentials to role_arn in source profiles', function(done) {
+        var creds, mock;
+        mock = '[default]\nrole_arn = arn\nsource_profile = foo_first\n[foo_first]\naws_access_key_id=first_key\naws_secret_access_key=first_secret\nrole_arn = arn_foo_first\nsource_profile = foo_base\n[foo_base]\naws_access_key_id = baseKey\naws_secret_access_key = baseSecret\n';
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+        helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
+        var STSPrototype = (new STS()).constructor.prototype;
+        creds = new AWS.SharedIniFileCredentials();
+        assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallThrough();
+        expect(creds.roleArn).to.equal('arn');
+        return creds.refresh(function(err) {
+          expect(assumeRoleSpy.calls.length).to.equal(1);
+          firstAssumeRoleArg = assumeRoleSpy.calls[0]["arguments"][0];
+          expect(firstAssumeRoleArg.RoleArn).to.equal('arn')
+          return done();
+        });
+      });
+      it('should prefer role_arn to static credentials in the base profile', function(done) {
+        var creds, mock;
+        mock = '[default]\nrole_arn = arn\naws_access_key_id=base_key\naws_secret_access_key=base_secret\nsource_profile = foo_first\n[foo_first]\nrole_arn = arn_foo_first\nsource_profile = foo_base\n[foo_base]\naws_access_key_id = baseKey\naws_secret_access_key = baseSecret\n';
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+        helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
+        var STSPrototype = (new STS()).constructor.prototype;
+        creds = new AWS.SharedIniFileCredentials();
+        assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallThrough();
+        expect(creds.roleArn).to.equal('arn');
+        return creds.refresh(function(err) {
+          expect(assumeRoleSpy.calls.length).to.equal(2);
+          firstAssumeRoleArg = assumeRoleSpy.calls[0]["arguments"][0];
+          expect(firstAssumeRoleArg.RoleArn).to.equal('arn_foo_first')
+          secondAssumeRoleArg = assumeRoleSpy.calls[1]["arguments"][0];
+          expect(secondAssumeRoleArg.RoleArn).to.equal('arn')
           return done();
         });
       });

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -476,7 +476,7 @@
         mock = '[default]\nrole_arn = arn\nsource_profile = foo_first\n[foo_first]\nrole_arn = arn_foo_first\nsource_profile = foo_base\n[foo_base]\naws_access_key_id = baseKey\naws_secret_access_key = baseSecret\n';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
         helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
-        const STSPrototype = (new STS()).constructor.prototype;
+        var STSPrototype = (new STS()).constructor.prototype;
         creds = new AWS.SharedIniFileCredentials();
         assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallThrough();
         expect(creds.roleArn).to.equal('arn');

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -471,6 +471,28 @@
           return done();
         });
       });
+      it('will assume a role from chained source_profile profiles', function(done) {
+        var creds, mock;
+        mock = '[default]\nrole_arn = arn\nsource_profile = foo_first\n[foo_first]\nrole_arn = arn_foo_first\nsource_profile = foo_base\n[foo_base]\naws_access_key_id = baseKey\naws_secret_access_key = baseSecret\n';
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+        helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
+        const STSPrototype = (new STS()).constructor.prototype;
+        creds = new AWS.SharedIniFileCredentials();
+        assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallThrough();
+        expect(creds.roleArn).to.equal('arn');
+        return creds.refresh(function(err) {
+          expect(assumeRoleSpy.calls.length).to.equal(2);
+          firstAssumeRoleArg = assumeRoleSpy.calls[0]["arguments"][0];
+          expect(firstAssumeRoleArg.RoleArn).to.equal('arn_foo_first')
+          secondAssumeRoleArg = assumeRoleSpy.calls[1]["arguments"][0];
+          expect(secondAssumeRoleArg.RoleArn).to.equal('arn')
+          expect(creds.accessKeyId).to.equal('KEY');
+          expect(creds.secretAccessKey).to.equal('SECRET');
+          expect(creds.sessionToken).to.equal('TOKEN');
+          expect(creds.expireTime).to.eql(new Date(0));
+          return done();
+        });
+      });
       it('will assume a role from the credentials file whose source profile is defined in the config file', function(done) {
         var creds, credsCtorSpy;
         process.env.AWS_SDK_LOAD_CONFIG = '1';
@@ -483,14 +505,13 @@
         });
         helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
         creds = new AWS.SharedIniFileCredentials();
-        credsCtorSpy = helpers.spyOn(AWS, 'Credentials').andCallThrough();
+        credsCtorSpy = helpers.spyOn(AWS, 'SharedIniFileCredentials').andCallThrough();
         expect(creds.roleArn).to.equal('arn');
         return creds.refresh(function(err) {
           var sourceCreds;
           expect(credsCtorSpy.calls.length).to.equal(1);
-          sourceCreds = credsCtorSpy.calls[0]["arguments"][0];
-          expect(sourceCreds.accessKeyId).to.equal('akid');
-          expect(sourceCreds.secretAccessKey).to.equal('secret');
+          parentCredsArg = credsCtorSpy.calls[0]["arguments"][0];
+          expect(parentCredsArg.profile).to.equal('foo');
           expect(creds.accessKeyId).to.equal('KEY');
           expect(creds.secretAccessKey).to.equal('SECRET');
           expect(creds.sessionToken).to.equal('TOKEN');
@@ -510,14 +531,13 @@
         });
         helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
         creds = new AWS.SharedIniFileCredentials();
-        credsCtorSpy = helpers.spyOn(AWS, 'Credentials').andCallThrough();
+        credsCtorSpy = helpers.spyOn(AWS, 'SharedIniFileCredentials').andCallThrough();
         expect(creds.roleArn).to.equal('arn');
         return creds.refresh(function(err) {
           var sourceCreds;
           expect(credsCtorSpy.calls.length).to.equal(1);
-          sourceCreds = credsCtorSpy.calls[0]["arguments"][0];
-          expect(sourceCreds.accessKeyId).to.equal('akid');
-          expect(sourceCreds.secretAccessKey).to.equal('secret');
+          parentCredsArg = credsCtorSpy.calls[0]["arguments"][0];
+          expect(parentCredsArg.profile).to.equal('foo');
           expect(creds.accessKeyId).to.equal('KEY');
           expect(creds.secretAccessKey).to.equal('SECRET');
           expect(creds.sessionToken).to.equal('TOKEN');


### PR DESCRIPTION
The Python SDK allows chained profiles, e.g. 
```ini
; matching aws credentials in ~/.aws/credentials
[profile base]
region = ap-southeast-2
output = text

[profile first]
role_arn = arn:aws:iam::00000:role/first-role
source_profile = base

[profile second]
role_arn = arn:aws:iam::00000:role/second-role
source_profile = first
```
(See #1891)
This PR adds this functionality to the JS SDK as well. Implementation is nice and simple - instead of directly constructing a `Credentials` with the access and secret key of the `source_profile` of a given profile, `SharedIniFileCredentials` just creates a parent `SharedIniFileCredentials` referring to the source profile, and uses this for its `STS` call.
Net code (not including tests) actually decreases as a result of this change.

Couple of questions/notes just related to testing:
 - spying on the SharedIniFileCredentials constructor caused some weird issues (such as breaking the constructor), are these known about?
 - Because of the above, I spied on STS.assumeRole instead. However Is there a better way of getting to this method? `STS.prototype.assumeRole` does not seem to work, hence the roundabout `(new STS()).constructor.prototype.assumeRole` .

Cheers
Jarrad