### PR TITLE
Fixes a DocumentClient bug with the minified version of the browser SDK.

### DIFF
--- a/.changes/next-release/bugfix-DocumentClient-bd9eaf09.json
+++ b/.changes/next-release/bugfix-DocumentClient-bd9eaf09.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "DocumentClient",
+  "description": "Fixes a bug with the minified version of the browser SDK where sending Sets of data with the DynamoDB DocumentClient would cause an error to be returned from the service."
+}

--- a/lib/dynamodb/numberValue.js
+++ b/lib/dynamodb/numberValue.js
@@ -10,6 +10,7 @@ var util = require('../core').util;
  */
 var DynamoDBNumberValue = util.inherit({
   constructor: function NumberValue(value) {
+    this.wrapperName = 'NumberValue';
     this.value = value.toString();
   },
 

--- a/lib/dynamodb/set.js
+++ b/lib/dynamodb/set.js
@@ -18,6 +18,7 @@ var DynamoDBSet = util.inherit({
 
   constructor: function Set(list, options) {
     options = options || {};
+    this.wrapperName = 'Set';
     this.initialize(list, options.validate);
   },
 

--- a/lib/dynamodb/types.js
+++ b/lib/dynamodb/types.js
@@ -6,7 +6,7 @@ function typeOf(data) {
   } else if (data !== undefined && isBinary(data)) {
     return 'Binary';
   } else if (data !== undefined && data.constructor) {
-    return util.typeName(data.constructor);
+    return data.wrapperName || util.typeName(data.constructor);
   } else if (data !== undefined && typeof data === 'object') {
     // this object is the result of Object.create(null), hence the absence of a
     // defined constructor

--- a/tasks/browser.rake
+++ b/tasks/browser.rake
@@ -50,7 +50,7 @@ namespace :browser do
   end
 
   task :build_all => [:setup_dist_tools, :dist_path] do
-    sh({"MINIFY" => ""}, "#{$BUILDER} all > dist/aws-sdk-all.js")
+    sh({"MINIFY" => "1"}, "#{$BUILDER} all > dist/aws-sdk-all.js")
   end
 
   desc 'Caches assets to the dist-tools build server'

--- a/test/dynamodb/converter.spec.js
+++ b/test/dynamodb/converter.spec.js
@@ -429,7 +429,7 @@ describe('AWS.DynamoDB.Converter', function() {
         'should convert StringSetAttributeValues into sets with strings',
         function() {
           var converted = output({SS: ['a', 'b', 'c']});
-          expect(converted).to.have.keys('values', 'type');
+          expect(converted).to.have.keys('values', 'type', 'wrapperName');
           expect(converted.type).to.equal('String');
           expect(converted.values).to.deep.equal(['a', 'b', 'c']);
         }
@@ -441,7 +441,7 @@ describe('AWS.DynamoDB.Converter', function() {
         'should convert NumberSetAttributeValues into sets with numbers',
         function() {
           var converted = output({NS: ['1', '2', '3']});
-          expect(converted).to.have.keys('values', 'type');
+          expect(converted).to.have.keys('values', 'type', 'wrapperName');
           expect(converted.type).to.equal('Number');
           expect(converted.values).to.deep.equal([1, 2, 3]);
         }
@@ -456,7 +456,7 @@ describe('AWS.DynamoDB.Converter', function() {
               {wrapNumbers: true}
             );
 
-            expect(converted).to.have.keys('values', 'type');
+            expect(converted).to.have.keys('values', 'type', 'wrapperName');
             expect(converted.type).to.equal('Number');
             for (var i = 0; i < converted.values.length; i++) {
               expect(converted.values[i].toString()).to.equal(unsafeInteger);
@@ -471,7 +471,7 @@ describe('AWS.DynamoDB.Converter', function() {
         function() {
           var b64Strings = ['dead', 'beef', 'face'];
           var converted = output({BS: b64Strings.map(AWS.util.base64.decode)});
-          expect(converted).to.have.keys('values', 'type');
+          expect(converted).to.have.keys('values', 'type', 'wrapperName');
           expect(converted.type).to.equal('Binary');
           expect(converted.values.map(AWS.util.base64.encode))
             .to.deep.equal(b64Strings);


### PR DESCRIPTION
Where sending Sets of data with the DynamoDB DocumentClient would cause an error to be returned from the service.

Also updated the browser test task to use the minified version of the browser SDK so we should catch these problems in the future.

There was an issue occurring where trying to use `Set`s with the DynamoDB `DocumentClient` would fail in the minified SDK. This is because the typeName check looked at the `constructor.name` property of a Set. Since minifying the SDK gets rid of function names, the `constructor.name` property of Sets became `constructor` instead of `Set`.

I've kept the existing check in place for native types (like typed arrays) but also check for a new property on our custom types first.