### PR TITLE
Clean up a comment of max duration for DurationSeconds

### DIFF
--- a/lib/credentials/saml_credentials.d.ts
+++ b/lib/credentials/saml_credentials.d.ts
@@ -28,7 +28,7 @@ export class SAMLCredentials extends Credentials {
         /**
          * The duration, in seconds, of the role session.
          * The minimum duration is 15 minutes.
-         * The maximum duration is 1 hour.
+         * The maximum duration is 12 hours.
          */
         DurationSeconds?: number
     }


### PR DESCRIPTION
It seems this was a forgotten comment when the DurationSeconds parameter was extended to a maximum of 12 hours.