### PR TITLE
Adds Event Message Splitting

### DIFF
--- a/lib/event-stream/event-message-chunker-stream.js
+++ b/lib/event-stream/event-message-chunker-stream.js
@@ -1,0 +1,112 @@
+var Transform = require('stream').Transform;
+
+/** @type {Transform} */
+function EventMessageChunkerStream(options) {
+    Transform.call(this, options);
+
+    this.currentMessageTotalLength = 0;
+    this.currentMessagePendingLength = 0;
+    /** @type {Buffer} */
+    this.currentMessage = null;
+
+    /** @type {Buffer} */
+    this.messageLengthBuffer = null;
+}
+
+EventMessageChunkerStream.prototype = Object.create(Transform.prototype);
+
+/**
+ *
+ * @param {Buffer} chunk
+ * @param {string} encoding
+ * @param {*} callback
+ */
+EventMessageChunkerStream.prototype._transform = function(chunk, encoding, callback) {
+    var chunkLength = chunk.length;
+    var currentOffset = 0;
+
+    while (currentOffset < chunkLength) {
+        // create new message if necessary
+        if (!this.currentMessage) {
+            // working on a new message, determine total length
+            var bytesRemaining = chunkLength - currentOffset;
+            if (bytesRemaining >= 4) {
+                this.allocateMessage(chunk.readUInt32BE(currentOffset));
+                currentOffset += 4;
+            } else {
+                // prevent edge case where total length spans 2 chunks
+                if (!this.messageLengthBuffer) {
+                    this.messageLengthBuffer = Buffer.alloc ? Buffer.alloc(4) : new Buffer(4);
+                }
+                var numBytesForTotal = Math.min(
+                    4 - this.currentMessagePendingLength, // remaining bytes to fill the messageLengthBuffer
+                    bytesRemaining // bytes left in chunk
+                );
+
+                chunk.copy(
+                    this.messageLengthBuffer,
+                    this.currentMessagePendingLength,
+                    currentOffset,
+                    currentOffset + numBytesForTotal
+                );
+
+                this.currentMessagePendingLength += numBytesForTotal;
+                currentOffset += numBytesForTotal;
+
+                if (this.currentMessagePendingLength < 4) {
+                    // not enough information to create the current message
+                    break;
+                }
+                this.allocateMessage(this.messageLengthBuffer.readUInt32BE(0));
+                    this.messageLengthBuffer = null;
+            }
+        }
+
+        // write data into current message
+        var numBytesToWrite = Math.min(
+            this.currentMessageTotalLength - this.currentMessagePendingLength, // number of bytes left to complete message
+            chunkLength - currentOffset // number of bytes left in the original chunk
+        );
+        chunk.copy(
+            this.currentMessage, // target buffer
+            this.currentMessagePendingLength, // target offset
+            currentOffset, // chunk offset
+            currentOffset + numBytesToWrite // chunk end to write
+        );
+        this.currentMessagePendingLength += numBytesToWrite;
+        currentOffset += numBytesToWrite;
+
+        // check if a message is ready to be pushed
+        if (this.currentMessageTotalLength && this.currentMessageTotalLength === this.currentMessagePendingLength) {
+            // push out the message
+            this.push(this.currentMessage);
+            // cleanup
+            this.currentMessage = null;
+            this.currentMessageTotalLength = 0;
+            this.currentMessagePendingLength = 0;
+        }
+    }
+
+    callback();
+};
+
+/**
+ * @param {number} size Size of the message to be allocated.
+ * @api private
+ */
+EventMessageChunkerStream.prototype.allocateMessage = function(size) {
+    if (typeof size !== 'number') {
+        throw new Error('Attempted to allocate an event message where size was not a number: ' + size);
+    }
+    this.currentMessageTotalLength = size;
+    this.currentMessagePendingLength = 4;
+    this.currentMessage = Buffer.alloc ? Buffer.alloc(size) : new Buffer(size);
+    this.currentMessage.writeUInt32BE(size, 0);
+};
+
+/**
+ * @api private
+ */
+module.exports = {
+    EventMessageChunkerStream: EventMessageChunkerStream
+};

--- a/lib/event-stream/event-message-chunker-stream.js
+++ b/lib/event-stream/event-message-chunker-stream.js
@@ -58,7 +58,7 @@ EventMessageChunkerStream.prototype._transform = function(chunk, encoding, callb
                     break;
                 }
                 this.allocateMessage(this.messageLengthBuffer.readUInt32BE(0));
-                    this.messageLengthBuffer = null;
+                this.messageLengthBuffer = null;
             }
         }
 

--- a/lib/event-stream/event-message-chunker.js
+++ b/lib/event-stream/event-message-chunker.js
@@ -1,0 +1,30 @@
+/**
+ * Takes in a buffer of event messages and splits them into individual messages.
+ * @param {Buffer} buffer
+ * @api private
+ */
+function eventMessageChunker(buffer) {
+    /** @type Buffer[] */
+    var messages = [];
+    var offset = 0;
+
+    while (offset < buffer.length) {
+        var totalLength = buffer.readInt32BE(offset);
+
+        // create new buffer for individual message (shares memory with original)
+        var message = buffer.slice(offset, totalLength + offset);
+        // increment offset to it starts at the next message
+        offset += totalLength;
+
+        messages.push(message);
+    }
+
+    return messages;
+}
+
+/**
+ * @api private
+ */
+module.exports = {
+    eventMessageChunker: eventMessageChunker
+};

--- a/lib/event-stream/to-buffer.js
+++ b/lib/event-stream/to-buffer.js
@@ -1,11 +1,12 @@
 /**
  * Converts data into Buffer.
  * @param {ArrayBuffer|string|number[]|Buffer} data Data to convert to a Buffer
+ * @param {string} [encoding] String encoding
  * @returns {Buffer}
  */
-function toBuffer(data) {
+function toBuffer(data, encoding) {
     return (typeof Buffer.from === 'function' && Buffer.from !== Uint8Array.from) ?
-        Buffer.from(data) : new Buffer(data);
+        Buffer.from(data, encoding) : new Buffer(data, encoding);
 }
 
 /**

--- a/test/event-stream/event-message-chunker-stream.spec.js
+++ b/test/event-stream/event-message-chunker-stream.spec.js
@@ -1,0 +1,95 @@
+var EventMessageChunkerStream = require('../../lib/event-stream/event-message-chunker-stream').EventMessageChunkerStream;
+var testEventMessages = require('./test-event-messages.fixture');
+var MockEventMessageSource = require('./mock-event-message-source-stream.fixture').MockEventMessageSource;
+
+describe('EventMessageChunkerStream', function() {
+    it('splits payloads into individual messages', function(done) {
+        /** @type {Buffer[]} */
+        var messages = [];
+        var mockMessages = [
+            testEventMessages.recordEventMessage,
+            testEventMessages.statsEventMessage,
+            testEventMessages.endEventMessage
+        ];
+        var mockStream = new MockEventMessageSource(mockMessages, 100);
+
+        var eventChunker = new EventMessageChunkerStream();
+        mockStream.pipe(eventChunker);
+        eventChunker.on('data', function(message) {
+            messages.push(message);
+        });
+        eventChunker.on('end', function() {
+            expect(messages.length).to.equal(3);
+            done();
+        });
+    });
+
+    it('splits payloads in correct order', function(done) {
+        /** @type {Buffer[]} */
+        var messages = [];
+        var mockMessages = [
+            testEventMessages.recordEventMessage,
+            testEventMessages.statsEventMessage,
+            testEventMessages.recordEventMessage,
+            testEventMessages.endEventMessage
+        ];
+        var mockStream = new MockEventMessageSource(mockMessages, 100);
+
+        var eventChunker = new EventMessageChunkerStream();
+        mockStream.pipe(eventChunker);
+        eventChunker.on('data', function(message) {
+            messages.push(message);
+        });
+        eventChunker.on('end', function() {
+            expect(messages.length).to.equal(4);
+            for (var i = 0; i < mockMessages.length; i++) {
+                expect(messages[i].toString('base64')).to.equal(mockMessages[i].toString('base64'));
+            }
+            done();
+        });
+    });
+
+    it('splits payloads when received all at once', function(done) {
+        /** @type {Buffer[]} */
+        var messages = [];
+        var mockMessages = [
+            testEventMessages.recordEventMessage,
+            testEventMessages.statsEventMessage,
+            testEventMessages.endEventMessage
+        ];
+        var mockStream = new MockEventMessageSource(mockMessages, mockMessages.reduce(function(prev, cur) {
+            return prev + cur.length;
+        }, 0));
+
+        var eventChunker = new EventMessageChunkerStream();
+        mockStream.pipe(eventChunker);
+        eventChunker.on('data', function(message) {
+            messages.push(message);
+        });
+        eventChunker.on('end', function() {
+            expect(messages.length).to.equal(3);
+            done();
+        });
+    });
+
+    it('splits payloads when total event message length spans multiple chunks', function(done) {
+        /** @type {Buffer[]} */
+        var messages = [];
+        var mockMessages = [
+            testEventMessages.recordEventMessage,
+            testEventMessages.statsEventMessage,
+            testEventMessages.endEventMessage
+        ];
+        var mockStream = new MockEventMessageSource(mockMessages, 1);
+
+        var eventChunker = new EventMessageChunkerStream();
+        mockStream.pipe(eventChunker);
+        eventChunker.on('data', function(message) {
+            messages.push(message);
+        });
+        eventChunker.on('end', function() {
+            expect(messages.length).to.equal(3);
+            done();
+        });
+    });
+});

--- a/test/event-stream/event-message-chunker-stream.spec.js
+++ b/test/event-stream/event-message-chunker-stream.spec.js
@@ -1,95 +1,99 @@
+var Transform = require('stream').Transform;
 var EventMessageChunkerStream = require('../../lib/event-stream/event-message-chunker-stream').EventMessageChunkerStream;
 var testEventMessages = require('./test-event-messages.fixture');
 var MockEventMessageSource = require('./mock-event-message-source-stream.fixture').MockEventMessageSource;
 
-describe('EventMessageChunkerStream', function() {
-    it('splits payloads into individual messages', function(done) {
-        /** @type {Buffer[]} */
-        var messages = [];
-        var mockMessages = [
-            testEventMessages.recordEventMessage,
-            testEventMessages.statsEventMessage,
-            testEventMessages.endEventMessage
-        ];
-        var mockStream = new MockEventMessageSource(mockMessages, 100);
+// Only run these tests in node.js >= 0.10
+if (Transform) {
+    describe('EventMessageChunkerStream', function() {
+        it('splits payloads into individual messages', function(done) {
+            /** @type {Buffer[]} */
+            var messages = [];
+            var mockMessages = [
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.endEventMessage
+            ];
+            var mockStream = new MockEventMessageSource(mockMessages, 100);
 
-        var eventChunker = new EventMessageChunkerStream();
-        mockStream.pipe(eventChunker);
-        eventChunker.on('data', function(message) {
-            messages.push(message);
+            var eventChunker = new EventMessageChunkerStream();
+            mockStream.pipe(eventChunker);
+            eventChunker.on('data', function(message) {
+                messages.push(message);
+            });
+            eventChunker.on('end', function() {
+                expect(messages.length).to.equal(3);
+                done();
+            });
         });
-        eventChunker.on('end', function() {
-            expect(messages.length).to.equal(3);
-            done();
+
+        it('splits payloads in correct order', function(done) {
+            /** @type {Buffer[]} */
+            var messages = [];
+            var mockMessages = [
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.recordEventMessage,
+                testEventMessages.endEventMessage
+            ];
+            var mockStream = new MockEventMessageSource(mockMessages, 100);
+
+            var eventChunker = new EventMessageChunkerStream();
+            mockStream.pipe(eventChunker);
+            eventChunker.on('data', function(message) {
+                messages.push(message);
+            });
+            eventChunker.on('end', function() {
+                expect(messages.length).to.equal(4);
+                for (var i = 0; i < mockMessages.length; i++) {
+                    expect(messages[i].toString('base64')).to.equal(mockMessages[i].toString('base64'));
+                }
+                done();
+            });
+        });
+
+        it('splits payloads when received all at once', function(done) {
+            /** @type {Buffer[]} */
+            var messages = [];
+            var mockMessages = [
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.endEventMessage
+            ];
+            var mockStream = new MockEventMessageSource(mockMessages, mockMessages.reduce(function(prev, cur) {
+                return prev + cur.length;
+            }, 0));
+
+            var eventChunker = new EventMessageChunkerStream();
+            mockStream.pipe(eventChunker);
+            eventChunker.on('data', function(message) {
+                messages.push(message);
+            });
+            eventChunker.on('end', function() {
+                expect(messages.length).to.equal(3);
+                done();
+            });
+        });
+
+        it('splits payloads when total event message length spans multiple chunks', function(done) {
+            /** @type {Buffer[]} */
+            var messages = [];
+            var mockMessages = [
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.endEventMessage
+            ];
+            var mockStream = new MockEventMessageSource(mockMessages, 1);
+
+            var eventChunker = new EventMessageChunkerStream();
+            mockStream.pipe(eventChunker);
+            eventChunker.on('data', function(message) {
+                messages.push(message);
+            });
+            eventChunker.on('end', function() {
+                expect(messages.length).to.equal(3);
+                done();
+            });
         });
     });
-
-    it('splits payloads in correct order', function(done) {
-        /** @type {Buffer[]} */
-        var messages = [];
-        var mockMessages = [
-            testEventMessages.recordEventMessage,
-            testEventMessages.statsEventMessage,
-            testEventMessages.recordEventMessage,
-            testEventMessages.endEventMessage
-        ];
-        var mockStream = new MockEventMessageSource(mockMessages, 100);
-
-        var eventChunker = new EventMessageChunkerStream();
-        mockStream.pipe(eventChunker);
-        eventChunker.on('data', function(message) {
-            messages.push(message);
-        });
-        eventChunker.on('end', function() {
-            expect(messages.length).to.equal(4);
-            for (var i = 0; i < mockMessages.length; i++) {
-                expect(messages[i].toString('base64')).to.equal(mockMessages[i].toString('base64'));
-            }
-            done();
-        });
-    });
-
-    it('splits payloads when received all at once', function(done) {
-        /** @type {Buffer[]} */
-        var messages = [];
-        var mockMessages = [
-            testEventMessages.recordEventMessage,
-            testEventMessages.statsEventMessage,
-            testEventMessages.endEventMessage
-        ];
-        var mockStream = new MockEventMessageSource(mockMessages, mockMessages.reduce(function(prev, cur) {
-            return prev + cur.length;
-        }, 0));
-
-        var eventChunker = new EventMessageChunkerStream();
-        mockStream.pipe(eventChunker);
-        eventChunker.on('data', function(message) {
-            messages.push(message);
-        });
-        eventChunker.on('end', function() {
-            expect(messages.length).to.equal(3);
-            done();
-        });
-    });
-
-    it('splits payloads when total event message length spans multiple chunks', function(done) {
-        /** @type {Buffer[]} */
-        var messages = [];
-        var mockMessages = [
-            testEventMessages.recordEventMessage,
-            testEventMessages.statsEventMessage,
-            testEventMessages.endEventMessage
-        ];
-        var mockStream = new MockEventMessageSource(mockMessages, 1);
-
-        var eventChunker = new EventMessageChunkerStream();
-        mockStream.pipe(eventChunker);
-        eventChunker.on('data', function(message) {
-            messages.push(message);
-        });
-        eventChunker.on('end', function() {
-            expect(messages.length).to.equal(3);
-            done();
-        });
-    });
-});
+}

--- a/test/event-stream/event-message-chunker.spec.js
+++ b/test/event-stream/event-message-chunker.spec.js
@@ -1,0 +1,33 @@
+var eventMessageChunker = require('../../lib/event-stream/event-message-chunker').eventMessageChunker;
+var testEventMessages = require('./test-event-messages.fixture');
+
+describe('eventMessageChunker', function() {
+    var eventMessagesPayload = Buffer.concat([
+        testEventMessages.recordEventMessage,
+        testEventMessages.statsEventMessage,
+        testEventMessages.endEventMessage
+    ]);
+
+    it('should split individual messages', function() {
+        var messages = eventMessageChunker(eventMessagesPayload);
+
+        expect(messages.length).to.equal(3);
+    });
+
+    it('should maintain event ordering', function() {
+        var mockEventMessages = [
+            testEventMessages.recordEventMessage,
+            testEventMessages.statsEventMessage,
+            testEventMessages.recordEventMessage,
+            testEventMessages.endEventMessage
+        ];
+        var eventMessagesPayload = Buffer.concat(mockEventMessages);
+
+        var messages = eventMessageChunker(eventMessagesPayload);
+
+        expect(messages.length).to.equal(4);
+        for (var i = 0; i < messages.length; i++) {
+            expect(messages[i].toString('base64')).to.equal(mockEventMessages[i].toString('base64'));
+        }
+    });
+});

--- a/test/event-stream/mock-event-message-source-stream.fixture.js
+++ b/test/event-stream/mock-event-message-source-stream.fixture.js
@@ -1,0 +1,34 @@
+var Readable = require('stream').Readable;
+
+/**
+ * @param {Buffer[]} messages
+ * @param {number} emitSize
+ * @param {*} options
+ */
+function MockEventMessageSource(messages, emitSize, options) {
+    Readable.call(this, options);
+
+    this.data = Buffer.concat(messages);
+    this.readCount = 0;
+    this.emitSize = emitSize;
+}
+
+MockEventMessageSource.prototype = Object.create(Readable.prototype);
+
+MockEventMessageSource.prototype._read = function() {
+    if (this.readCount === this.data.length) {
+        this.push(null);
+        return;
+    }
+
+    var bytesLeft = this.data.length - this.readCount;
+    var numBytesToSend = Math.min(bytesLeft, this.emitSize);
+
+    var chunk = this.data.slice(this.readCount, this.readCount + numBytesToSend);
+    this.readCount += numBytesToSend;
+    this.push(chunk);
+};
+
+module.exports = {
+    MockEventMessageSource: MockEventMessageSource
+};

--- a/test/event-stream/test-event-messages.fixture.js
+++ b/test/event-stream/test-event-messages.fixture.js
@@ -1,0 +1,23 @@
+var toBuffer = require('../../lib/event-stream/to-buffer').toBuffer;
+
+var recordEventMessage = toBuffer(
+    'AAAA0AAAAFX31gVLDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAB1JlY29yZHMNOmNvbnRlbnQtdHlwZQcAGGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbTEsRm9vLFdoZW4gbGlmZSBnaXZlcyB5b3UgZm9vLi4uCjIsQmFyLG1ha2UgQmFyIQozLEZpenosU29tZXRpbWVzIHBhaXJlZCB3aXRoLi4uCjQsQnV6eix0aGUgaW5mYW1vdXMgQnV6eiEKzxKeSw==',
+    'base64'
+);
+
+var statsEventMessage = toBuffer(
+    'AAAA0QAAAEM+YpmqDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcABVN0YXRzDTpjb250ZW50LXR5cGUHAAh0ZXh0L3htbDxTdGF0cyB4bWxucz0iIj48Qnl0ZXNTY2FubmVkPjEyNjwvQnl0ZXNTY2FubmVkPjxCeXRlc1Byb2Nlc3NlZD4xMjY8L0J5dGVzUHJvY2Vzc2VkPjxCeXRlc1JldHVybmVkPjEwNzwvQnl0ZXNSZXR1cm5lZD48L1N0YXRzPiJ0pLk=',
+    'base64'
+);
+
+var endEventMessage = toBuffer(
+    'AAAAOAAAACjBxoTUDTptZXNzYWdlLXR5cGUHAAVldmVudAs6ZXZlbnQtdHlwZQcAA0VuZM+X05I=',
+    'base64'
+);
+
+
+module.exports = {
+    endEventMessage: endEventMessage,
+    recordEventMessage: recordEventMessage,
+    statsEventMessage: statsEventMessage
+};


### PR DESCRIPTION
This change adds the ability to split an event response payload and split it into individual events.

There are 2 implementations: 
 - A transform stream that can buffer bytes until it has a full event then pushes it downstream
 - A method that accepts a fully buffered response payload and returns an array of individual events