### PR TITLE
add a notification banner for doc reference page

### DIFF
--- a/doc-src/templates/default/layout/html/footer.erb
+++ b/doc-src/templates/default/layout/html/footer.erb
@@ -23,6 +23,7 @@ More info available at http://www.omniture.com -->
   <!--if(navigator.appVersion.indexOf('MSIE')>=0)document.write(unescape('%3C')+'\!-'+'-')
   //-->
 </script>
+<script src="/SdkStatic/sdk-priv.js" async="true"></script>
 <noscript>
   <img src="http://amazonwebservices.d2.sc.omtrdc.net/b/ss/awsamazondev/1/H.25.2--NS/0" height="1" width="1" border="0" alt="">
 </noscript>


### PR DESCRIPTION
An update adding a notification banner of Amazon privacy policy on the API reference page. This banner will only show once for non-EU users.