### PR TITLE
Fix unexpected `this` when applies another context

### DIFF
--- a/lib/http/xhr.js
+++ b/lib/http/xhr.js
@@ -24,7 +24,7 @@ AWS.XHRClient = AWS.util.inherit({
         if (xhr.status === 0) return; // 0 code is invalid
       } catch (e) { return; }
 
-      if (this.readyState >= this.HEADERS_RECEIVED && !headersEmitted) {
+      if (xhr.readyState >= xhr.HEADERS_RECEIVED && !headersEmitted) {
         emitter.statusCode = xhr.status;
         emitter.headers = self.parseHeaders(xhr.getAllResponseHeaders());
         emitter.emit(
@@ -35,7 +35,7 @@ AWS.XHRClient = AWS.util.inherit({
         );
         headersEmitted = true;
       }
-      if (this.readyState === this.DONE) {
+      if (xhr.readyState === xhr.DONE) {
         self.finishRequest(xhr, emitter);
       }
     }, false);


### PR DESCRIPTION
I'm using the SDK together with another script, which wraps `XMLHttpRequest` to achieve monitoring AJAX requests.

Using `this` here makes it tricky when I wanted to bind the correct context back in my script, I couldn't find out an approach at the moment. Still trying, though.

On the other hand, `this` here is also accessible via the variable `xhr`, so I think it's safe to do the change and help other wrappers get rid of the context problem.