### PR TITLE
Updates SDK to always attempt to set the content-length of a request, but not fail if an operation has the unsigned-body trait

### DIFF
--- a/.changes/next-release/bugfix-Core-e1bebaca.json
+++ b/.changes/next-release/bugfix-Core-e1bebaca.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Core",
+  "description": "Updates SDK to attempt to determine the Content-Length of a payload when an operation uses the unsigned-body trait. Content-Length will still not be calculated for non-file streams. This will allow file streams to be passed to MediaStoreData.putObject."
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -155,10 +155,18 @@ AWS.EventListeners = {
 
     add('SET_CONTENT_LENGTH', 'afterBuild', function SET_CONTENT_LENGTH(req) {
       var authtype = getOperationAuthtype(req);
-      if (req.httpRequest.headers['Content-Length'] === undefined
-          && authtype.indexOf('unsigned-body') === -1) {
-        var length = AWS.util.string.byteLength(req.httpRequest.body);
-        req.httpRequest.headers['Content-Length'] = length;
+      if (req.httpRequest.headers['Content-Length'] === undefined) {
+        try {
+          var length = AWS.util.string.byteLength(req.httpRequest.body);
+          req.httpRequest.headers['Content-Length'] = length;
+        } catch (err) {
+          if (authtype.indexOf('unsigned-body') === -1) {
+            throw err;
+          } else {
+            // Body isn't signed and may not need content length (lex)
+            return;
+          }
+        }
       }
     });
 

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -8,6 +8,7 @@
 
   MockService = helpers.MockService;
   MockServiceFromApi = helpers.MockServiceFromApi;
+  var FooService = require('./foo-service.fixture').FooService;
 
   describe('AWS.EventListeners', function() {
     var completeHandler, config, delays, errorHandler, makeRequest, oldMathRandom, oldSetTimeout, randomValues, retryHandler, service, successHandler, totalWaited;
@@ -169,24 +170,64 @@
           return request;
         }
       };
-      return describe('adds Content-Length header', function() {
+
+      describe('adds Content-Length header', function() {
         var contentLength;
         contentLength = function(body) {
           return sendRequest(body).httpRequest.headers['Content-Length'];
         };
 
-        it('ignores Content-Length for operations with an unsigned authtype', function(done) {
-          var service = new AWS.Lambda();
-          service.api.operations.updateFunctionCode.authtype = 'v4-unsigned-body';
-          req = service.makeRequest('updateFunctionCode', {
-            FunctionName: 'fake',
-            ZipFile: new Buffer('fake')
+        describe('when using unsigned authtype', function() {
+          it('when paylaod is a buffer', function() {
+            var service = new FooService();
+            var req = service.putStream({
+              Body: new AWS.util.Buffer('test')
+            });
+
+            req.runTo('sign', function(err) {
+              expect(req.httpRequest.headers['Content-Length']).to.equal(4);
+              console.log(err);
+              expect(!err).to.equal(true);
+            });
           });
-          req.runTo('sign', function(err) {
-            expect(typeof req.httpRequest.headers['Content-Length']).to.equal('undefined');
-            delete service.api.operations.updateFunctionCode.authtype;
-            done();
+
+          it('when paylaod is a string', function() {
+            var service = new FooService();
+            var req = service.putStream({
+              Body: 'test'
+            });
+
+            req.runTo('sign', function(err) {
+              expect(req.httpRequest.headers['Content-Length']).to.equal(4);
+              expect(!err).to.equal(true);
+            });
           });
+
+          if (AWS.util.isNode()) {
+            it('when paylaod is a file stream', function() {
+              var service = new FooService();
+              var req = service.putStream({
+                Body: require('fs').createReadStream(__filename)
+              });
+  
+              req.runTo('sign', function(err) {
+                expect(req.httpRequest.headers['Content-Length'] > 0).to.equal(true);
+                expect(!err).to.equal(true);
+              });
+            });
+
+            it('unless payload is a non-file stream', function() {
+              var service = new FooService();
+              var req = service.putStream({
+                Body: new AWS.util.stream.Readable()
+              });
+  
+              req.runTo('sign', function(err) {
+                expect(typeof req.httpRequest.headers['Content-Length']).to.equal('undefined');
+                expect(!err).to.equal(true);
+              });
+            });
+          }
         });
 
         it('builds Content-Length in the request headers for string content', function() {
@@ -206,12 +247,20 @@
         });
 
         if (AWS.util.isNode()) {
-          return it('builds Content-Length for file body', function(done) {
+          it('builds Content-Length for file body', function(done) {
             var file;
             fs = require('fs');
             file = fs.createReadStream(__filename);
             return sendRequest(file, function(err) {
               return done();
+            });
+          });
+
+          it('throws an error for non-file body', function(done) {
+            sendRequest(new AWS.util.stream.Readable(), function(err) {
+              expect(typeof err).not.to.equal('undefined');
+              expect(err.message).to.equal('Non-file stream objects are not supported with SigV4');
+              done();
             });
           });
         }

--- a/test/foo-service.fixture.js
+++ b/test/foo-service.fixture.js
@@ -1,0 +1,50 @@
+var AWS = require('./helpers').AWS;
+var Api = require('../lib/model/api');
+
+var model = {
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2018-06-13",
+    "endpointPrefix": "foo",
+    "protocol": "rest-json",
+    "serviceAbbreviation": "Foo Service",
+    "serviceFullName": "Awesome Foo Service",
+    "serviceId": "Foo",
+    "signatureVersion": "v4",
+    "signingName": "foo",
+    "uid": "foo-2018-06-13"
+  },
+  "operations": {
+    "PutStream": {
+      "http": {
+        "method": "PUT",
+        "requestUri": "/"
+      },
+      "input": {
+        "type": "structure",
+        "required": [
+          "Body"
+        ],
+        "members": {
+          "Body": {
+            "shape": "StreamingBody"
+          }
+        },
+        "payload": "Body"
+      },
+      "authtype": "v4-unsigned-body"
+    }
+  },
+  "shapes": {
+    "StreamingBody": {
+      "type": "blob",
+      "streaming": true
+    }
+  }
+}
+
+var FooService = AWS.Service.defineService(new Api(model));
+
+module.exports = {
+  FooService: FooService
+};


### PR DESCRIPTION
This will specifically unblock the issue where `MediaStoreData.putObject` won't work if a file stream is passed as the body.