### PR TITLE
Fixes edge case where event messages had incorrect length calculated

### DIFF
--- a/.changes/next-release/bugfix-S3-5efacd15.json
+++ b/.changes/next-release/bugfix-S3-5efacd15.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Fixes edge case where event message lengths were sometimes incorrectly calculated."
+}

--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -140,6 +140,7 @@ class MethodDocumentor
         memberNum = memberNum + 1
       end
       lines << "    });"
+      lines << "    eventStream.on('error', function(err) { /** Handle error events **/});"
       lines << "    eventStream.on('end', function() { /** Finished reading all events **/});"
       lines << "  });"
       lines << ""

--- a/lib/event-stream/build-message.js
+++ b/lib/event-stream/build-message.js
@@ -147,6 +147,9 @@ function crc32(buffer) {
     return crc32Buffer;
 }
 
+/**
+ * @api private
+ */
 var HEADER_VALUE_TYPE = {
     boolTrue: 0,
     boolFalse: 1,

--- a/lib/event-stream/event-message-chunker-stream.js
+++ b/lib/event-stream/event-message-chunker-stream.js
@@ -86,6 +86,18 @@ EventMessageChunkerStream.prototype._transform = function(chunk, encoding, callb
     callback();
 };
 
+EventMessageChunkerStream.prototype._flush = function(callback) {
+    if (this.currentMessageTotalLength) {
+        if (this.currentMessageTotalLength === this.currentMessagePendingLength) {
+            callback(null, this.currentMessage);
+        } else {
+            callback(new Error('Truncated event message received.'));
+        }
+    } else {
+        callback();
+    }
+}
+
 /**
  * @param {number} size Size of the message to be allocated.
  * @api private

--- a/lib/event-stream/event-message-chunker-stream.js
+++ b/lib/event-stream/event-message-chunker-stream.js
@@ -31,36 +31,31 @@ EventMessageChunkerStream.prototype._transform = function(chunk, encoding, callb
         if (!this.currentMessage) {
             // working on a new message, determine total length
             var bytesRemaining = chunkLength - currentOffset;
-            if (bytesRemaining >= 4) {
-                this.allocateMessage(chunk.readUInt32BE(currentOffset));
-                currentOffset += 4;
-            } else {
-                // prevent edge case where total length spans 2 chunks
-                if (!this.messageLengthBuffer) {
-                    this.messageLengthBuffer = allocBuffer(4);
-                }
-                var numBytesForTotal = Math.min(
-                    4 - this.currentMessagePendingLength, // remaining bytes to fill the messageLengthBuffer
-                    bytesRemaining // bytes left in chunk
-                );
-
-                chunk.copy(
-                    this.messageLengthBuffer,
-                    this.currentMessagePendingLength,
-                    currentOffset,
-                    currentOffset + numBytesForTotal
-                );
-
-                this.currentMessagePendingLength += numBytesForTotal;
-                currentOffset += numBytesForTotal;
-
-                if (this.currentMessagePendingLength < 4) {
-                    // not enough information to create the current message
-                    break;
-                }
-                this.allocateMessage(this.messageLengthBuffer.readUInt32BE(0));
-                this.messageLengthBuffer = null;
+            // prevent edge case where total length spans 2 chunks
+            if (!this.messageLengthBuffer) {
+                this.messageLengthBuffer = allocBuffer(4);
             }
+            var numBytesForTotal = Math.min(
+                4 - this.currentMessagePendingLength, // remaining bytes to fill the messageLengthBuffer
+                bytesRemaining // bytes left in chunk
+            );
+
+            chunk.copy(
+                this.messageLengthBuffer,
+                this.currentMessagePendingLength,
+                currentOffset,
+                currentOffset + numBytesForTotal
+            );
+
+            this.currentMessagePendingLength += numBytesForTotal;
+            currentOffset += numBytesForTotal;
+
+            if (this.currentMessagePendingLength < 4) {
+                // not enough information to create the current message
+                break;
+            }
+            this.allocateMessage(this.messageLengthBuffer.readUInt32BE(0));
+            this.messageLengthBuffer = null;
         }
 
         // write data into current message

--- a/lib/event-stream/event-message-unmarshaller-stream.js
+++ b/lib/event-stream/event-message-unmarshaller-stream.js
@@ -22,9 +22,13 @@ EventUnmarshallerStream.prototype = Object.create(Transform.prototype);
  * @param {*} callback
  */
 EventUnmarshallerStream.prototype._transform = function(chunk, encoding, callback) {
-    var event = parseEvent(this.parser, chunk, this.eventStreamModel);
-    this.push(event);
-    callback();
+    try {
+        var event = parseEvent(this.parser, chunk, this.eventStreamModel);
+        this.push(event);
+        return callback();
+    } catch (err) {
+        callback(err);
+    }
 };
 
 /**

--- a/lib/event-stream/parse-event.js
+++ b/lib/event-stream/parse-event.js
@@ -14,7 +14,7 @@ function parseEvent(parser, message, shape) {
     var messageType = parsedMessage.headers[':message-type'];
     if (messageType) {
         if (messageType.value === 'error') {
-            return parseError(parsedMessage);
+            throw parseError(parsedMessage);
         } else if (messageType.value !== 'event') {
             // not sure how to parse non-events/non-errors, ignore for now
             return;

--- a/lib/event-stream/streaming-create-event-stream.js
+++ b/lib/event-stream/streaming-create-event-stream.js
@@ -20,6 +20,14 @@ function createEventStream(stream, parser, model) {
         eventMessageChunker
     ).pipe(eventStream);
 
+    stream.on('error', function(err) {
+        eventMessageChunker.emit('error', err);
+    });
+
+    eventMessageChunker.on('error', function(err) {
+        eventStream.emit('error', err);
+    });
+
     return eventStream;
 }
 

--- a/test/event-stream/event-message-chunker-stream.spec.js
+++ b/test/event-stream/event-message-chunker-stream.spec.js
@@ -95,5 +95,29 @@ if (Transform) {
                 done();
             });
         });
+
+        it('splits payloads when total event message length spans 2 chunks', function(done) {
+            /** @type {Buffer[]} */
+            var messages = [];
+            var mockMessages = [
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.endEventMessage
+            ];
+            var mockStream = new MockEventMessageSource(
+                mockMessages,
+                testEventMessages.recordEventMessage.length + 2
+            );
+
+            var eventChunker = new EventMessageChunkerStream();
+            mockStream.pipe(eventChunker);
+            eventChunker.on('data', function(message) {
+                messages.push(message);
+            });
+            eventChunker.on('end', function() {
+                expect(messages.length).to.equal(3);
+                done();
+            });
+        });
     });
 }

--- a/test/event-stream/mock-event-message-source-stream.fixture.js
+++ b/test/event-stream/mock-event-message-source-stream.fixture.js
@@ -5,20 +5,29 @@ var Readable = require('stream').Readable;
  * @param {number} emitSize
  * @param {*} options
  */
-function MockEventMessageSource(messages, emitSize, options) {
+function MockEventMessageSource(messages, emitSize, throwError, options) {
     Readable.call(this, options);
 
     this.data = Buffer.concat(messages);
     this.readCount = 0;
     this.emitSize = emitSize;
+    this.throwError = throwError;
 }
 
 MockEventMessageSource.prototype = Object.create(Readable.prototype);
 
 MockEventMessageSource.prototype._read = function() {
+    var self = this;
     if (this.readCount === this.data.length) {
-        this.push(null);
-        return;
+        if (this.throwError) {
+            process.nextTick(function() {
+                self.emit('error', new Error('Throwing an error!'));
+            });
+            return;
+        } else {
+            this.push(null);
+            return;
+        }
     }
 
     var bytesLeft = this.data.length - this.readCount;

--- a/test/event-stream/parse-event.spec.js
+++ b/test/event-stream/parse-event.spec.js
@@ -129,10 +129,8 @@ describe('parseEvent', function() {
             },
             body: toBuffer('')
         });
-
-        var error = parseEvent(mockParser, eventMessage, mockEventStreamShape);
-        expect(error.name).to.equal('FooError');
-        expect(error.code).to.equal('FooError');
-        expect(error.message).to.equal('Event Error');
+        expect(function() {
+            parseEvent(mockParser, eventMessage, mockEventStreamShape);
+        }).to.throw('Event Error').with.property('name', 'FooError');
     });
 });

--- a/test/event-stream/streaming-create-event-stream.spec.js
+++ b/test/event-stream/streaming-create-event-stream.spec.js
@@ -90,5 +90,46 @@ if (stream.Transform) {
                 done();
             });
         });
+
+        it('emits error on error events from source', function(done) {
+            var mockHttpResponse = new MockEventMessageSource(
+                [
+                    testEventMessages.recordEventMessage,
+                    testEventMessages.statsEventMessage,
+                    testEventMessages.endEventMessage
+                ],
+                10, true
+            );
+
+            var eventStream = createEventStream(mockHttpResponse, parser, mockEventStreamShape);
+
+            eventStream.on('data', function(event) {});
+            eventStream.on('error', function(err) {
+                expect(err.name).to.equal('Error');
+                expect(err.message).to.equal('Throwing an error!');
+                done();
+            });
+        });
+
+        it('emits error on error events from event chunker', function(done) {
+            var responseMessage = Buffer.concat([
+                testEventMessages.recordEventMessage,
+                testEventMessages.statsEventMessage,
+                testEventMessages.endEventMessage
+            ]);
+            var mockHttpResponse = new MockEventMessageSource(
+                [responseMessage.slice(0, responseMessage.length - 4)],
+                10
+            );
+
+            var eventStream = createEventStream(mockHttpResponse, parser, mockEventStreamShape);
+
+            eventStream.on('data', function(event) {});
+            eventStream.on('error', function(err) {
+                expect(err.name).to.equal('Error');
+                expect(err.message).to.equal('Truncated event message received.');
+                done();
+            });
+        });
     });
 }


### PR DESCRIPTION
Also updates event streams when using a stream (node.js) so that error events can now be handled on the stream's `error` event. If following the async/await or browser examples for event streams, existing code will catch the error. 

/cc @AllanFly120 