### PR TITLE
Fixes missing Buffer in event stream in react native

### DIFF
--- a/lib/event-stream/alloc-buffer.js
+++ b/lib/event-stream/alloc-buffer.js
@@ -1,4 +1,4 @@
-var Buffer = require('../util').Buffer;
+var Buffer = require('../core').util.Buffer;
 /**
  * Allocates a buffer.
  * @param {number} size Number of bytes to allocate for the buffer.

--- a/lib/event-stream/build-message.js
+++ b/lib/event-stream/build-message.js
@@ -1,8 +1,9 @@
-var crypto = require('../../lib/util').crypto;
+var util = require('../core').util;
+var crypto = util.crypto;
 var Int64 = require('./int64').Int64;
 var toBuffer = require('./to-buffer').toBuffer;
 var allocBuffer = require('./alloc-buffer').allocBuffer;
-var Buffer = require('../util').Buffer;
+var Buffer = util.Buffer;
 
 /**
  * @api private

--- a/lib/event-stream/int64.js
+++ b/lib/event-stream/int64.js
@@ -1,4 +1,4 @@
-var util = require('../util');
+var util = require('../core').util;
 var toBuffer = require('./to-buffer').toBuffer;
 
 /**

--- a/lib/event-stream/split-message.js
+++ b/lib/event-stream/split-message.js
@@ -1,4 +1,4 @@
-var util = require('../util');
+var util = require('../core').util;
 var toBuffer = require('./to-buffer').toBuffer;
 
 // All prelude components are unsigned, 32-bit integers

--- a/lib/event-stream/to-buffer.js
+++ b/lib/event-stream/to-buffer.js
@@ -1,4 +1,4 @@
-var Buffer = require('../util').Buffer;
+var Buffer = require('../core').util.Buffer;
 /**
  * Converts data into Buffer.
  * @param {ArrayBuffer|string|number[]|Buffer} data Data to convert to a Buffer


### PR DESCRIPTION
In react-native, we need to grab `util` from `core` instead of directly from the util file. This is due to our work-around for react native packager's inability to handle circular dependencies.