### PR TITLE
Sorts browser and react-native tests

### DIFF
--- a/tasks/browser.rake
+++ b/tasks/browser.rake
@@ -74,7 +74,7 @@ namespace :browser do
     mkdir_p "test/browser/build"
     cp "dist/aws-sdk-all.js", "test/browser/build/aws-sdk-all.js"
     files = "test/helpers.js ";
-    files += Dir.glob("test/**/*.spec.js").delete_if{|name| name.start_with?("test/react-native/")}.join(" ")
+    files += Dir.glob("test/**/*.spec.js").delete_if{|name| name.start_with?("test/react-native/")}.sort().join(" ")
     sh({"SERVICES" => "all"}, $BROWSERIFY +
        " -i domain #{files} > #{$BROWSERIFY_TEST}")
     rm_f "test/configuration.js"

--- a/tasks/react-native.rake
+++ b/tasks/react-native.rake
@@ -13,7 +13,7 @@ namespace :reactnative do
     mkdir_p "test/browser/build"
     cp "dist/aws-sdk-react-native.js", "test/browser/build/aws-sdk-all.js"
     files = "test/helpers.js ";
-    files += Dir.glob("test/**/*.spec.js").join(" ")
+    files += Dir.glob("test/**/*.spec.js").sort().join(" ")
     sh({"SERVICES" => "all"}, $BROWSERIFY +
        " -i domain #{files} > #{$BROWSERIFY_TEST}")
     rm_f "test/configuration.js"


### PR DESCRIPTION
Turns out Dir.glob() was returning tests in different orders on different systems. This caused issues for browserify in some instances. This will at least give us a consistently reproducible test environment.