### PR TITLE
Fixes browser XML parsing issue when encountering descendants with the same tag name

### DIFF
--- a/.changes/next-release/bugfix-browser-fc46aa77.json
+++ b/.changes/next-release/bugfix-browser-fc46aa77.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "browser",
+  "description": "Fixed an issue with the browser XML parser logic where the incorrect value may be returned if a complex shape (map, structure) had an immediate child and a nested descendant with the same tag name."
+}

--- a/lib/xml/browser_parser.js
+++ b/lib/xml/browser_parser.js
@@ -61,7 +61,7 @@ DomXmlParser.prototype.parse = function(xml, shape) {
 
   if (result && result.documentElement && !error) {
     var data = parseXml(result.documentElement, shape);
-    var metadata = result.getElementsByTagName('ResponseMetadata')[0];
+    var metadata = getElementByTagName(result.documentElement, 'ResponseMetadata');
     if (metadata) {
       data.ResponseMetadata = parseXml(metadata, {});
     }
@@ -72,6 +72,15 @@ DomXmlParser.prototype.parse = function(xml, shape) {
     return {};
   }
 };
+
+function getElementByTagName(xml, tag) {
+  var elements = xml.getElementsByTagName(tag);
+  for (var i = 0, iLen = elements.length; i < iLen; i++) {
+    if (elements[i].parentNode === xml) {
+      return elements[i];
+    }
+  }
+}
 
 function parseXml(xml, shape) {
   if (!shape) shape = {};
@@ -96,7 +105,7 @@ function parseStructure(xml, shape) {
       }
     } else {
       var xmlChild = memberShape.flattened ? xml :
-        xml.getElementsByTagName(memberShape.name)[0];
+        getElementByTagName(xml, memberShape.name)
       if (xmlChild) {
         data[memberName] = parseXml(xmlChild, memberShape);
       } else if (!memberShape.flattened && memberShape.type === 'list') {
@@ -117,8 +126,8 @@ function parseMap(xml, shape) {
   var child = xml.firstElementChild;
   while (child) {
     if (child.nodeName === tagName) {
-      var key = child.getElementsByTagName(xmlKey)[0].textContent;
-      var value = child.getElementsByTagName(xmlValue)[0];
+      var key = getElementByTagName(child, xmlKey).textContent;
+      var value = getElementByTagName(child, xmlValue);
       data[key] = parseXml(value, shape.value);
     }
     child = child.nextElementSibling;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,6 +8,9 @@
 
   ignoreRequire = require;
 
+  // import SDK for tests that do not access the AWS namespace
+  require('../index');
+
   if (typeof window === 'undefined') {
     AWS = ignoreRequire('../lib/aws');
     topLevelScope = global;


### PR DESCRIPTION
Tested in IE and major browsers.

This definitely affects CloudFront since the `Item` structure contains a child `Enabled`, and has another descendant with the name `Enabled`. 

I use `parentNode` to find which node is a child of the one being parsed since that's available at least as far back as IE10. I'd rather trust the browsers' implementations of `getElementsByTagName` to properly grab that tag of a node than attempt to iterate over each child and check the property myself. It wasn't clear if `node.nextSibling` was available in all the browsers we support.

/cc @AllanFly120 