### PR TITLE
Support shared ini file mfa_serial with fn to fetch token code

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -10,5 +10,5 @@ interface SharedIniFileCredentialsOptions {
     profile?: string
     filename?: string
     disableAssumeRole?: boolean
-    tokenCodeFn?: (mfaSerial: string, callback: (err?: string, token?: string) => void) => void
+    tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
 }

--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -10,5 +10,5 @@ interface SharedIniFileCredentialsOptions {
     profile?: string
     filename?: string
     disableAssumeRole?: boolean
-    tokenCodeFn?: (mfaSerial: string, callback: (err: string|null|undefined, token: string) => void) => void
+    tokenCodeFn?: (mfaSerial: string, callback: (err?: string, token?: string) => void) => void
 }

--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -10,4 +10,5 @@ interface SharedIniFileCredentialsOptions {
     profile?: string
     filename?: string
     disableAssumeRole?: boolean
+    tokenCodeFn?: (mfaSerial: string, callback: (err: string|null|undefined, token: string) => void) => void
 }

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -225,9 +225,15 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       roleParams.SerialNumber = mfaSerial;
       self.tokenCodeFn(mfaSerial, function(err, token) {
         if (err) {
+          var message;
+          if (err instanceof Error) {
+            message = err.message;
+          } else {
+            message = err;
+          }
           self.callRefreshCallbacks(
             AWS.util.error(
-              new Error('Error fetching MFA token: ' + err),
+              new Error('Error fetching MFA token: ' + message),
               { code: 'SharedIniFileCredentialsProviderFailure' }
             ));
           return;

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -49,7 +49,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   role profile is selected, an error is raised.
    * @option options preferStaticCredentials [Boolean] (false) True to
    *   prefer static credentials to role_arn if both are present.
-   * @option options tokenCodeFn [Function] (noop function) Function to provide
+   * @option options tokenCodeFn [Function] (null) Function to provide
    *   STS Assume Role TokenCode, if mfa_serial is provided for profile in ini
    *   file. Function is called with value of mfa_serial and callback, and
    *   should provide the TokenCode or an error to the callback in the format
@@ -65,9 +65,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
     this.disableAssumeRole = Boolean(options.disableAssumeRole);
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
-    this.tokenCodeFn = options.tokenCodeFn || function(mfaSerial, callback) {
-      callback();
-    };
+    this.tokenCodeFn = options.tokenCodeFn || null;
     this.get(function() {});
   },
 
@@ -221,7 +219,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       roleParams.ExternalId = externalId;
     }
 
-    if (mfaSerial) {
+    if (mfaSerial && self.tokenCodeFn) {
       roleParams.SerialNumber = mfaSerial;
       self.tokenCodeFn(mfaSerial, function(err, token) {
         if (err) {

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -49,17 +49,36 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   role profile is selected, an error is raised.
    * @option options preferStaticCredentials [Boolean] (false) True to
    *   prefer static credentials to role_arn if both are present.
+   * @option options tokenCodeFn [Function] (noop function) Function to provide
+   *   STS Assume Role TokenCode, if mfa_serial is provided for profile in ini
+   *   file. Function is called with value of mfa_serial and callback, and
+   *   should provide the TokenCode or an error to the callback in the format
+   *   callback(err, token)
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
 
     options = options || {};
 
+    this.refreshCallbacks = [];
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
     this.disableAssumeRole = Boolean(options.disableAssumeRole);
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
+    this.tokenCodeFn = options.tokenCodeFn || function(mfaSerial, callback) {
+      callback();
+    };
     this.get(function() {});
+  },
+
+  /**
+   * @api private
+   */
+  callRefreshCallbacks: function (err) {
+    var cb;
+    while ((cb = this.refreshCallbacks.shift()) !== undefined) {
+      cb(err);
+    }
   },
 
   /**
@@ -75,6 +94,9 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   refresh: function refresh(callback) {
     if (!callback) callback = function(err) { if (err) throw err; };
+    this.refreshCallbacks.push(callback);
+    if (this.refreshCallbacks.length > 1) { return; }
+
     try {
       var profiles = {};
       var i, availableProfiles;
@@ -117,10 +139,10 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         this.preferStaticCredentials
         && profile['aws_access_key_id']
         && profile['aws_secret_access_key']
-      )
+      );
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
-        this.loadRoleProfile(profiles, profile, callback);
+        this.loadRoleProfile(profiles, profile);
         return;
       }
 
@@ -135,16 +157,16 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         );
       }
       this.expired = false;
-      callback();
+      this.callRefreshCallbacks();
     } catch (err) {
-      callback(err);
+      this.callRefreshCallbacks(err);
     }
   },
 
   /**
    * @api private
    */
-  loadRoleProfile: function loadRoleProfile(creds, roleProfile, callback) {
+  loadRoleProfile: function loadRoleProfile(creds, roleProfile) {
     if (this.disableAssumeRole) {
       throw AWS.util.error(
         new Error('Role assumption profiles are disabled. ' +
@@ -158,6 +180,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     var roleArn = roleProfile['role_arn'];
     var roleSessionName = roleProfile['role_session_name'];
     var externalId = roleProfile['external_id'];
+    var mfaSerial = roleProfile['mfa_serial'];
     var sourceProfileName = roleProfile['source_profile'];
 
     if (!sourceProfileName) {
@@ -176,7 +199,6 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
-
 
     var sourceCredentials = new AWS.SharedIniFileCredentials(
       AWS.util.merge(this.options || {}, {
@@ -199,9 +221,35 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       roleParams.ExternalId = externalId;
     }
 
+    if (mfaSerial) {
+      roleParams.SerialNumber = mfaSerial;
+      self.tokenCodeFn(mfaSerial, function(err, token) {
+        if (err) {
+          self.callRefreshCallbacks(
+            AWS.util.error(
+              new Error('Error fetching MFA token: ' + err),
+              { code: 'SharedIniFileCredentialsProviderFailure' }
+            ));
+          return;
+        }
+
+        roleParams.TokenCode = token;
+        self.assumeRole(sts, roleParams);
+      });
+      return;
+    }
+
+    self.assumeRole(sts, roleParams);
+  },
+
+  /**
+   * @api private
+   */
+  assumeRole: function(sts, roleParams) {
+    var self = this;
     sts.assumeRole(roleParams, function (err, data) {
       if (err) {
-        callback(err);
+        self.callRefreshCallbacks(err);
         return;
       }
 
@@ -209,7 +257,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       self.secretAccessKey = data.Credentials.SecretAccessKey;
       self.sessionToken = data.Credentials.SessionToken;
       self.expireTime = data.Credentials.Expiration;
-      callback();
+      self.callRefreshCallbacks();
     });
   }
+
 });

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -453,7 +453,7 @@
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
         creds = new AWS.SharedIniFileCredentials();
         return creds.refresh(function(err) {
-          expect(err.message).to.match(/Credentials not set in source_profile foo using profile default/);
+          expect(err.message).to.match(/Missing credentials in config/);
           done();
         });
       });

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -581,7 +581,7 @@
         });
       });
       it('default tokenCodeFn works if mfa_serial is provided', function(done) {
-        var creds, tokenCodeFn, tokenCodeFnSpy, mock;
+        var creds, tokenCodeFnSpy, mock;
         mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session\n'
           + '[profile withmfa]\nrole_arn = arn\nmfa_serial = serial\nsource_profile = default';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
@@ -594,8 +594,7 @@
         expect(tokenCodeFnSpy.calls.length).to.equal(1);
       });
       it('calls tokenCodeFn if mfa_serial is provided', function(done) {
-        var creds, tokenCodeFn, mock, assumeRoleSpy, tokenCodeFnSpy;
-        var STSPrototype = (new STS()).constructor.prototype;
+        var creds, tokenCodeFn, mock, tokenCodeFnSpy;
         mock = '[default]\nrole_arn = arn\nmfa_serial = serial\naws_access_key_id = key\naws_secret_access_key = secret\n'
           + '[profile withmfa]\nrole_arn = arn\nmfa_serial = serial\nsource_profile = default';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -581,23 +581,20 @@
         });
       });
       it('calls tokenCodeFn if mfa_serial is provided', function(done) {
-        var creds, tokenCodeFn, mock, tokenCodeFnSpy;
+        var tokenCodeFn, mock;
         mock = '[default]\nrole_arn = arn\nmfa_serial = serial\naws_access_key_id = key\naws_secret_access_key = secret\n'
           + '[profile withmfa]\nrole_arn = arn\nmfa_serial = serial\nsource_profile = default';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
         helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
-        tokenCodeFnSpy = helpers.createSpy('tokenCodeFn');
         tokenCodeFn = function(serial, callback) {
-          tokenCodeFnSpy(serial);
+          expect(serial).to.equal('serial');
           callback(null, '123456');
           done();
         };
-        creds = new AWS.SharedIniFileCredentials({
+        new AWS.SharedIniFileCredentials({
           profile: 'withmfa',
           tokenCodeFn: tokenCodeFn
         });
-        expect(tokenCodeFnSpy.calls.length).to.equal(1);
-        return expect(tokenCodeFnSpy.calls[0]["arguments"][0]).to.equal('serial');
       });
       it('callback receives tokenCodeFns error', function(done) {
         var creds, tokenCodeFn, mock;

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -619,7 +619,7 @@
           + '[profile withmfa]\nrole_arn = arn\nmfa_serial = serial\nsource_profile = default';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
         tokenCodeFn = function(serial, callback) {
-          callback('tokenCodeFn error');
+          callback(new Error('tokenCodeFn error'));
         };
         creds = new AWS.SharedIniFileCredentials({
           profile: 'withmfa',

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -580,19 +580,6 @@
           return done();
         });
       });
-      it('default tokenCodeFn works if mfa_serial is provided', function(done) {
-        var creds, tokenCodeFnSpy, mock;
-        mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session\n'
-          + '[profile withmfa]\nrole_arn = arn\nmfa_serial = serial\nsource_profile = default';
-        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
-        helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
-        creds = new AWS.SharedIniFileCredentials({ profile: 'withmfa' });
-        tokenCodeFnSpy = helpers.createSpy('tokenCodeFn');
-        creds.refresh(function(e) {
-          done();
-        });
-        expect(tokenCodeFnSpy.calls.length).to.equal(1);
-      });
       it('calls tokenCodeFn if mfa_serial is provided', function(done) {
         var creds, tokenCodeFn, mock, tokenCodeFnSpy;
         mock = '[default]\nrole_arn = arn\nmfa_serial = serial\naws_access_key_id = key\naws_secret_access_key = secret\n'


### PR DESCRIPTION
This change supports use of `mfa_serial` in the `SharedIniFileCredentials` provider. 

`tokenCodeFn` will be called if `mfa_serial` is found in the active profile of the shared ini file. This function will be called with the value of `mfa_serial` and should invoke the callback with the MFA token or an error. This token will be provided to the STS assume role call.

This change also prevents the `SharedIniFileCredentials` from refreshing multiple times concurrently (and thus having `tokenCodeFn` be called more than one time concurrently), similar to how the [MetadataService does it](https://github.com/aws/aws-sdk-js/blob/master/lib/metadata_service.js#L99-L100).

Example usage of this change, to prompt the user for a MFA token in a CLI application:

```
const inquirer = require('inquirer');
const aws = require('./index.js');

const f = (serial, cb) => {
  const resp = inquirer.prompt(
    {
      name: 'token',
      type: 'input',
      default: '',
      message: `MFA token for ${serial}:`
    }).then((r) => {
      cb(null, r.token);
    }).catch((e) => {
      console.log('error:', e);
      cb(e);
    });
};

const creds = new aws.SharedIniFileCredentials({
  tokenCodeFn: f,
  profile: 'profile-requiring-mfa'
});

(async () => {
  await creds.getPromise().then(function(e) {
    console.log(creds);
  }).catch(function(e) {
    console.log(creds, 'error:', e);
  });
})();
```

Using this with the credentials provider chain could be done by configuring `SharedIniFileCredentials` in the example [here](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property).

Fixes #1543