### PR TITLE
add cors config for KinesisVideoArchivedMedia and KinesisVideo

### DIFF
--- a/.changes/next-release/feature-CORS-df67f4f9.json
+++ b/.changes/next-release/feature-CORS-df67f4f9.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CORS",
+  "description": "KinesisVideo and KinesisVideoArchivedMedia support CORS. This change make the services available in browser version of SDK by default"
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -499,14 +499,16 @@
   },
   "kinesisvideoarchivedmedia": {
     "prefix": "kinesis-video-archived-media",
-    "name": "KinesisVideoArchivedMedia"
+    "name": "KinesisVideoArchivedMedia",
+    "cors": true
   },
   "kinesisvideomedia": {
     "prefix": "kinesis-video-media",
     "name": "KinesisVideoMedia"
   },
   "kinesisvideo": {
-    "name": "KinesisVideo"
+    "name": "KinesisVideo",
+    "cors": true
   },
   "sagemakerruntime": {
     "prefix": "runtime.sagemaker",


### PR DESCRIPTION
KinesisVideo and KinesisVideoArchivedMedia support CORS. This change make the services available in browser version of SDK by default.

/cc @chrisradek @MixMasterMitch