### PR TITLE
Update timestamp serializing

### DIFF
--- a/.changes/next-release/bugfix-Serialization-3778c3c9.json
+++ b/.changes/next-release/bugfix-Serialization-3778c3c9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Serialization",
+  "description": "fix timestamp serialization issue in querystring; Update the logic of formatting the timestamp;"
+}

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -39,6 +39,7 @@ function Shape(shape, options, memberName) {
   property(this, 'isEvent', Boolean(shape.event), false);
   property(this, 'isEventPayload', Boolean(shape.eventpayload), false);
   property(this, 'isEventHeader', Boolean(shape.eventheader), false);
+  property(this, 'isTimestampFormatSet', Boolean(shape.timestampFormat) || shape.prototype && shape.prototype.isTimestampFormatSet === true, false);
 
   if (options.documentation) {
     property(this, 'documentation', shape.documentation);
@@ -275,25 +276,25 @@ function TimestampShape(shape) {
   var self = this;
   Shape.apply(this, arguments);
 
-  if (this.location === 'header') {
-    property(this, 'timestampFormat', 'rfc822');
-  } else if (shape.timestampFormat) {
+  if (shape.timestampFormat) {
     property(this, 'timestampFormat', shape.timestampFormat);
-  } else if (!this.timestampFormat && this.api) {
-    if (this.api.timestampFormat) {
-      property(this, 'timestampFormat', this.api.timestampFormat);
-    } else {
-      switch (this.api.protocol) {
-        case 'json':
-        case 'rest-json':
-          property(this, 'timestampFormat', 'unixTimestamp');
-          break;
-        case 'rest-xml':
-        case 'query':
-        case 'ec2':
-          property(this, 'timestampFormat', 'iso8601');
-          break;
-      }
+  } else if (self.isTimestampFormatSet && this.timestampFormat) {
+    property(this, 'timestampFormat', this.timestampFormat);
+  } else if (this.location === 'header') {
+    property(this, 'timestampFormat', 'rfc822');
+  } else if (this.location === 'querystring') {
+    property(this, 'timestampFormat', 'iso8601');
+  } else if (this.api) {
+    switch (this.api.protocol) {
+      case 'json':
+      case 'rest-json':
+        property(this, 'timestampFormat', 'unixTimestamp');
+        break;
+      case 'rest-xml':
+      case 'query':
+      case 'ec2':
+        property(this, 'timestampFormat', 'iso8601');
+        break;
     }
   }
 
@@ -307,6 +308,10 @@ function TimestampShape(shape) {
   this.toWireFormat = function(value) {
     return util.date.format(value, self.timestampFormat);
   };
+}
+
+function defaultFormat() {
+
 }
 
 function StringShape() {

--- a/lib/protocol/rest.js
+++ b/lib/protocol/rest.js
@@ -23,7 +23,7 @@ function generateURI(endpointPath, operationPath, input, params) {
 
       if (member.type === 'list') {
         queryString[member.name] = paramValue.map(function(val) {
-          return util.uriEscape(String(val));
+          return util.uriEscape(member.member.toWireFormat(val).toString());
         });
       } else if (member.type === 'map') {
         util.each(paramValue, function(key, value) {
@@ -36,7 +36,7 @@ function generateURI(endpointPath, operationPath, input, params) {
           }
         });
       } else {
-        queryString[member.name] = util.uriEscape(String(paramValue));
+        queryString[member.name] = util.uriEscape(member.toWireFormat(paramValue).toString());
       }
     }
   });

--- a/test/fixtures/protocol/input/ec2.json
+++ b/test/fixtures/protocol/input/ec2.json
@@ -332,8 +332,19 @@
         "members": {
           "TimeArg": {
             "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
           }
         }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
       },
       "TimestampType": {
         "type": "timestamp"
@@ -348,11 +359,13 @@
           "name": "OperationName"
         },
         "params": {
-          "TimeArg": 1422172800
+          "TimeArg": 1422172800,
+          "TimeCustom": 1422172800,
+          "TimeFormat": 1422172800
         },
         "serialized": {
           "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
+          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z&TimeCustom=1422172800&TimeFormat=1422172800"
         }
       }
     ]
@@ -369,7 +382,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-              "idempotencyToken": true
+            "idempotencyToken": true
           }
         }
       },

--- a/test/fixtures/protocol/input/json.json
+++ b/test/fixtures/protocol/input/json.json
@@ -57,8 +57,19 @@
         "members": {
           "TimeArg": {
             "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
           }
         }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "rfc822",
+        "type": "timestamp"
       },
       "TimestampType": {
         "type": "timestamp"
@@ -73,10 +84,12 @@
           "name": "OperationName"
         },
         "params": {
-          "TimeArg": 1422172800
+          "TimeArg": 1422172800,
+          "TimeCustom": 1422172800,
+          "TimeFormat": 1422172800
         },
         "serialized": {
-          "body": "{\"TimeArg\": 1422172800}",
+          "body": "{\"TimeArg\": 1422172800, \"TimeCustom\": \"Sun, 25 Jan 2015 08:00:00 GMT\", \"TimeFormat\": \"Sun, 25 Jan 2015 08:00:00 GMT\"}",
           "headers": {
             "X-Amz-Target": "com.amazonaws.foo.OperationName",
             "Content-Type": "application/x-amz-json-1.1"
@@ -101,7 +114,7 @@
             "shape": "BlobType"
           },
           "BlobMap": {
-              "shape": "BlobMapType"
+            "shape": "BlobMapType"
           }
         }
       },
@@ -146,8 +159,8 @@
         },
         "params": {
           "BlobMap": {
-              "key1": "foo",
-              "key2": "bar"
+            "key1": "foo",
+            "key2": "bar"
           }
         },
         "serialized": {
@@ -180,7 +193,7 @@
       "ListOfStructures": {
         "type": "list",
         "member": {
-            "shape": "BlobType"
+          "shape": "BlobType"
         }
       },
       "BlobType": {
@@ -204,8 +217,10 @@
         "serialized": {
           "body": "{\"ListParam\": [\"Zm9v\", \"YmFy\"]}",
           "uri": "/",
-          "headers": {"X-Amz-Target": "com.amazonaws.foo.OperationName",
-                      "Content-Type": "application/x-amz-json-1.1"}
+          "headers": {
+            "X-Amz-Target": "com.amazonaws.foo.OperationName",
+            "Content-Type": "application/x-amz-json-1.1"
+          }
         }
       }
     ]
@@ -488,7 +503,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-              "idempotencyToken": true
+            "idempotencyToken": true
           }
         }
       },

--- a/test/fixtures/protocol/input/query.json
+++ b/test/fixtures/protocol/input/query.json
@@ -554,6 +554,50 @@
     ]
   },
   {
+    "description": "Base64 encoded Blobs nested",
+    "metadata": {
+      "protocol": "query",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+		  "BlobArgs": {
+			"shape": "BlobsType"
+		  }
+        }
+      },
+	  "BlobsType": {
+        "type": "list",
+        "member": {
+          "shape": "BlobType"
+        },
+        "flattened": true
+	  },
+      "BlobType": {
+        "type": "blob"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "BlobArgs": ["foo"]
+        },
+        "serialized": {
+          "uri": "/",
+          "body": "Action=OperationName&Version=2014-01-01&BlobArgs.1=Zm9v"
+        }
+      }
+    ]
+  },
+  {
     "description": "Timestamp values",
     "metadata": {
       "protocol": "query",
@@ -565,8 +609,19 @@
         "members": {
           "TimeArg": {
             "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
           }
         }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
       },
       "TimestampType": {
         "type": "timestamp"
@@ -581,11 +636,13 @@
           "name": "OperationName"
         },
         "params": {
-          "TimeArg": 1422172800
+          "TimeArg": 1422172800,
+          "TimeCustom": 1422172800,
+          "TimeFormat": 1422172800
         },
         "serialized": {
           "uri": "/",
-          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z"
+          "body": "Action=OperationName&Version=2014-01-01&TimeArg=2015-01-25T08%3A00%3A00Z&TimeCustom=1422172800&TimeFormat=1422172800"
         }
       }
     ]
@@ -789,7 +846,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-              "idempotencyToken": true
+            "idempotencyToken": true
           }
         }
       },

--- a/test/fixtures/protocol/input/rest-json.json
+++ b/test/fixtures/protocol/input/rest-json.json
@@ -677,7 +677,7 @@
       }
     ]
   },
-    {
+  {
     "description": "Blob payload",
     "metadata": {
       "protocol": "rest-json",
@@ -1103,8 +1103,50 @@
             "shape": "TimestampType",
             "location": "header",
             "locationName": "x-amz-timearg"
+          },
+          "TimeArgInQuery": {
+            "shape": "TimestampType",
+            "location": "querystring",
+            "locationName": "TimeQuery"
+          },
+          "TimeCustom": {
+            "timestampFormat": "iso8601",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom-header"
+          },
+          "TimeCustomInQuery": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "querystring",
+            "locationName": "TimeCustomQuery"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatRfcType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatUnixType",
+            "location": "header",
+            "locationName": "x-amz-timeformat-header"
+          },
+          "TimeFormatInQuery": {
+            "shape": "TimestampFormatUnixType",
+            "location": "querystring",
+            "locationName": "TimeFormatQuery"
           }
         }
+      },
+      "TimestampFormatRfcType": {
+        "timestampFormat": "rfc822",
+        "type": "timestamp"
+      },
+      "TimestampFormatUnixType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
       },
       "TimestampType": {
         "type": "timestamp"
@@ -1123,32 +1165,24 @@
           "name": "OperationName"
         },
         "params": {
-          "TimeArg": 1422172800
+          "TimeArg": 1422172800,
+          "TimeArgInQuery": 1422172800,
+          "TimeArgInHeader": 1422172800,
+          "TimeCustom": 1422172800,
+          "TimeCustomInQuery": 1422172800,
+          "TimeCustomInHeader": 1422172800,
+          "TimeFormat": 1422172800,
+          "TimeFormatInQuery": 1422172800,
+          "TimeFormatInHeader": 1422172800
         },
         "serialized": {
-          "uri": "/path",
-          "headers": {},
-          "body": "{\"TimeArg\": 1422172800}"
-        }
-      },
-      {
-        "given": {
-          "input": {
-            "shape": "InputShape"
+          "uri": "/path?TimeQuery=2015-01-25T08%3A00%3A00Z&TimeCustomQuery=1422172800&TimeFormatQuery=1422172800",
+          "headers": {
+            "x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT",
+            "x-amz-timecustom-header": "1422172800",
+            "x-amz-timeformat-header": "1422172800"
           },
-          "http": {
-            "method": "POST",
-            "requestUri": "/path"
-          },
-          "name": "OperationName"
-        },
-        "params": {
-          "TimeArgInHeader": 1422172800
-        },
-        "serialized": {
-          "uri": "/path",
-          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT"},
-          "body": ""
+          "body": "{\"TimeArg\": 1422172800, \"TimeCustom\": \"2015-01-25T08:00:00Z\", \"TimeFormat\": \"Sun, 25 Jan 2015 08:00:00 GMT\"}"
         }
       }
     ]
@@ -1251,7 +1285,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-              "idempotencyToken": true
+            "idempotencyToken": true
           }
         }
       },
@@ -1310,17 +1344,46 @@
     "shapes": {
       "InputShape": {
         "type": "structure",
+        "payload": "Body",
         "members": {
-          "Attr": {
+          "HeaderField": {
             "shape": "StringType",
-              "jsonvalue": true,
-              "location": "header",
-              "locationName": "X-Amz-Foo"
+            "jsonvalue": true,
+            "location": "header",
+            "locationName": "X-Amz-Foo"
+          },
+          "QueryField": {
+            "shape": "StringType",
+            "jsonvalue": true,
+            "location": "querystring",
+            "locationName": "Bar"
+          },
+          "Body": {
+            "shape": "BodyStructure"
           }
         }
       },
       "StringType": {
         "type": "string"
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "jsonvalue": true
+        }
+      },
+      "BodyStructure": {
+        "type": "structure",
+        "members": {
+          "BodyField": {
+            "shape": "StringType",
+            "jsonvalue": true
+          },
+          "BodyListField": {
+            "shape": "ListType"
+          }
+        }
       }
     },
     "cases": [
@@ -1335,12 +1398,37 @@
           "name": "OperationName"
         },
         "params": {
-          "Attr": {"Foo":"Bar"}
+          "HeaderField": {"Foo":"Bar"},
+          "QueryField": {"Foo":"Bar"},
+          "Body": {
+            "BodyField": {"Foo":"Bar"}
+          }
+        },
+        "serialized": {
+          "uri": "/?Bar=%7B%22Foo%22%3A%22Bar%22%7D",
+          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
+          "body": "{\"BodyField\":\"{\\\"Foo\\\":\\\"Bar\\\"}\"}"
+        }
+      },
+      {
+        "given": {
+          "input": {
+            "shape": "InputShape"
+          },
+          "http": {
+            "method": "POST"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "Body": {
+            "BodyListField": [{"Foo":"Bar"}]
+          }
         },
         "serialized": {
           "uri": "/",
-          "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
-          "body": ""
+          "headers": {},
+          "body": "{\"BodyListField\":[\"{\\\"Foo\\\":\\\"Bar\\\"}\"]}"
         }
       },
       {

--- a/test/fixtures/protocol/input/rest-xml.json
+++ b/test/fixtures/protocol/input/rest-xml.json
@@ -599,7 +599,7 @@
     ]
   },
   {
-    "description": "Blob and timestamp shapes",
+    "description": "Blob shapes",
     "metadata": {
       "protocol": "rest-xml",
       "apiVersion": "2014-01-01"
@@ -616,16 +616,10 @@
       "StructureShape": {
         "type": "structure",
         "members": {
-          "t": {
-            "shape": "TShape"
-          },
           "b": {
             "shape": "BShape"
           }
         }
-      },
-      "TShape": {
-        "type": "timestamp"
       },
       "BShape": {
         "type": "blob"
@@ -647,15 +641,118 @@
         },
         "params": {
           "StructureParam": {
-            "t": 1422172800,
             "b": "foo"
           }
         },
         "serialized": {
           "method": "POST",
-          "body": "<OperationRequest xmlns=\"https://foo/\"><StructureParam><t>2015-01-25T08:00:00Z</t><b>Zm9v</b></StructureParam></OperationRequest>",
+          "body": "<OperationRequest xmlns=\"https://foo/\"><StructureParam><b>Zm9v</b></StructureParam></OperationRequest>",
           "uri": "/2014-01-01/hostedzone",
           "headers": {}
+        }
+      }
+    ]
+  },
+  {
+    "description": "Timestamp shapes",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeArgInHeader": {
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timearg"
+          },
+          "TimeArgInQuery": {
+            "shape": "TimestampType",
+            "location": "querystring",
+            "locationName": "TimeQuery"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom-header"
+          },
+          "TimeCustomInQuery": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "querystring",
+            "locationName": "TimeCustomQuery"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatRfcType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatUnixType",
+            "location": "header",
+            "locationName": "x-amz-timeformat-header"
+          },
+          "TimeFormatInQuery": {
+            "shape": "TimestampFormatUnixType",
+            "location": "querystring",
+            "locationName": "TimeFormatQuery"
+          }
+        }
+      },
+      "TimestampFormatRfcType": {
+        "timestampFormat": "rfc822",
+        "type": "timestamp"
+      },
+      "TimestampFormatUnixType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/hostedzone"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "TimestampStructure",
+            "xmlNamespace": {"uri": "https://foo/"}
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "TimeArg": 1422172800,
+          "TimeArgInQuery": 1422172800,
+          "TimeArgInHeader": 1422172800,
+          "TimeCustom": 1422172800,
+          "TimeCustomInQuery": 1422172800,
+          "TimeCustomInHeader": 1422172800,
+          "TimeFormat": 1422172800,
+          "TimeFormatInQuery": 1422172800,
+          "TimeFormatInHeader": 1422172800
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "<TimestampStructure xmlns=\"https://foo/\"><TimeArg>2015-01-25T08:00:00Z</TimeArg><TimeCustom>Sun, 25 Jan 2015 08:00:00 GMT</TimeCustom><TimeFormat>Sun, 25 Jan 2015 08:00:00 GMT</TimeFormat></TimestampStructure>",
+          "uri": "/2014-01-01/hostedzone?TimeQuery=2015-01-25T08%3A00%3A00Z&TimeCustomQuery=1422172800&TimeFormatQuery=1422172800",
+          "headers": {
+            "x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT",
+            "x-amz-timecustom-header": "1422172800",
+            "x-amz-timeformat-header": "1422172800"
+          }
         }
       }
     ]
@@ -1205,21 +1302,21 @@
         }
       },
       "Grantee": {
-         "type": "structure",
-         "members": {
-           "Type": {
-             "shape": "Type",
-             "locationName": "xsi:type",
-             "xmlAttribute": true
-           },
-           "EmailAddress": {
-             "shape": "StringType"
-           }
-         },
-         "xmlNamespace": {
-           "prefix": "xsi",
-           "uri":"http://www.w3.org/2001/XMLSchema-instance"
-         }
+        "type": "structure",
+        "members": {
+          "Type": {
+            "shape": "Type",
+            "locationName": "xsi:type",
+            "xmlAttribute": true
+          },
+          "EmailAddress": {
+            "shape": "StringType"
+          }
+        },
+        "xmlNamespace": {
+          "prefix": "xsi",
+          "uri":"http://www.w3.org/2001/XMLSchema-instance"
+        }
       },
       "Type": {
         "type": "string"
@@ -1587,51 +1684,6 @@
     ]
   },
   {
-    "description": "Timestamp in header",
-    "metadata": {
-      "protocol": "rest-xml",
-      "apiVersion": "2014-01-01"
-    },
-    "shapes": {
-      "InputShape": {
-        "type": "structure",
-        "members": {
-          "TimeArgInHeader": {
-            "shape": "TimestampType",
-            "location": "header",
-            "locationName": "x-amz-timearg"
-          }
-        }
-      },
-      "TimestampType": {
-        "type": "timestamp"
-      }
-    },
-    "cases": [
-      {
-        "given": {
-          "input": {
-            "shape": "InputShape"
-          },
-          "http": {
-            "method": "POST",
-            "requestUri": "/path"
-          },
-          "name": "OperationName"
-        },
-        "params": {
-          "TimeArgInHeader": 1422172800
-        },
-        "serialized": {
-          "method": "POST",
-          "body": "",
-          "uri": "/path",
-          "headers": {"x-amz-timearg": "Sun, 25 Jan 2015 08:00:00 GMT"}
-        }
-      }
-    ]
-  },
-  {
     "description": "Idempotency token auto fill",
     "metadata": {
       "protocol": "rest-xml",
@@ -1643,7 +1695,7 @@
         "members": {
           "Token": {
             "shape": "StringType",
-              "idempotencyToken": true
+            "idempotencyToken": true
           }
         }
       },

--- a/test/fixtures/protocol/output/ec2.json
+++ b/test/fixtures/protocol/output/ec2.json
@@ -450,5 +450,73 @@
         }
       }
     ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "ec2"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38+00:00</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38+00:00</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/test/fixtures/protocol/output/json.json
+++ b/test/fixtures/protocol/output/json.json
@@ -142,24 +142,38 @@
       "OutputShape": {
         "type": "structure",
         "members": {
-          "TimeMember": {
-            "shape": "TimeType"
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
           },
           "StructMember": {
             "shape": "TimeContainer"
           }
         }
       },
-      "TimeType": {
-        "type": "timestamp"
-      },
       "TimeContainer": {
         "type": "structure",
         "members": {
           "foo": {
-            "shape": "TimeType"
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
           }
         }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "iso8601",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
       }
     },
     "cases": [
@@ -171,15 +185,18 @@
           "name": "OperationName"
         },
         "result": {
-          "TimeMember": 1398796238,
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
           "StructMember": {
-            "foo": 1398796238
+            "foo": 1398796238,
+            "bar": 1398796238
           }
         },
         "response": {
           "status_code": 200,
           "headers": {},
-          "body": "{\"TimeMember\": 1398796238, \"StructMember\": {\"foo\": 1398796238}}"
+          "body": "{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38+00:00\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38+00:00\"}}"
         }
       }
     ]

--- a/test/fixtures/protocol/output/query.json
+++ b/test/fixtures/protocol/output/query.json
@@ -772,5 +772,73 @@
         }
       }
     ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "query"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeFormat": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38+00:00</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38+00:00</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/test/fixtures/protocol/output/rest-json.json
+++ b/test/fixtures/protocol/output/rest-json.json
@@ -166,24 +166,54 @@
       "OutputShape": {
         "type": "structure",
         "members": {
-          "TimeMember": {
-            "shape": "TimeType"
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeArgInHeader": {
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timearg"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatType",
+            "location": "header",
+            "locationName": "x-amz-timeformat"
           },
           "StructMember": {
             "shape": "TimeContainer"
           }
         }
       },
-      "TimeType": {
-        "type": "timestamp"
-      },
       "TimeContainer": {
         "type": "structure",
         "members": {
           "foo": {
-            "shape": "TimeType"
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
           }
         }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "iso8601",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
       }
     },
     "cases": [
@@ -195,15 +225,25 @@
           "name": "OperationName"
         },
         "result": {
-          "TimeMember": 1398796238,
+          "TimeArg": 1398796238,
+          "TimeArgInHeader": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeCustomInHeader": 1398796238,
+          "TimeFormat": 1398796238,
+          "TimeFormatInHeader": 1398796238,
           "StructMember": {
-            "foo": 1398796238
+            "foo": 1398796238,
+            "bar": 1398796238
           }
         },
         "response": {
           "status_code": 200,
-          "headers": {},
-          "body": "{\"TimeMember\": 1398796238, \"StructMember\": {\"foo\": 1398796238}}"
+          "headers": {
+            "x-amz-timearg": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "x-amz-timecustom": "1398796238",
+            "x-amz-timeformat": "2014-04-29T18:30:38+00:00"
+          },
+          "body": "{\"TimeArg\": 1398796238, \"TimeCustom\": \"Tue, 29 Apr 2014 18:30:38 GMT\", \"TimeFormat\": \"2014-04-29T18:30:38+00:00\", \"StructMember\": {\"foo\": 1398796238, \"bar\": \"2014-04-29T18:30:38+00:00\"}}"
         }
       }
     ]
@@ -511,20 +551,20 @@
         "result": {
           "AllHeaders": {
             "Content-Length": "10",
-            "x-Foo": "bar",
-            "X-bam": "boo"
+            "X-Foo": "bar",
+            "X-Bam": "boo"
           },
           "PrefixedHeaders": {
             "Foo": "bar",
-            "bam": "boo"
+            "Bam": "boo"
           }
         },
         "response": {
           "status_code": 200,
           "headers": {
             "Content-Length": "10",
-            "x-Foo": "bar",
-            "X-bam": "boo"
+            "X-Foo": "bar",
+            "X-Bam": "boo"
           },
           "body": "{}"
         }
@@ -634,16 +674,30 @@
       "OutputShape": {
         "type": "structure",
         "members": {
-          "Attr": {
+          "HeaderField": {
             "shape": "StringType",
-              "jsonvalue": true,
-              "location": "header",
-              "locationName": "X-Amz-Foo"
+            "jsonvalue": true,
+            "location": "header",
+            "locationName": "X-Amz-Foo"
+          },
+          "BodyField":{
+            "shape": "StringType",
+            "jsonvalue": true
+          },
+          "BodyListField": {
+            "shape": "ListType"
           }
         }
       },
       "StringType": {
         "type": "string"
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType",
+          "jsonvalue": true
+        }
       }
     },
     "cases": [
@@ -655,12 +709,29 @@
           "name": "OperationName"
         },
         "result": {
-          "Attr": {"Foo":"Bar"}
+          "HeaderField": {"Foo":"Bar"},
+          "BodyField": {"Foo":"Bar"}
         },
         "response": {
           "status_code": 200,
           "headers": {"X-Amz-Foo": "eyJGb28iOiJCYXIifQ=="},
-          "body": ""
+          "body": "{\"BodyField\":\"{\\\"Foo\\\":\\\"Bar\\\"}\"}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "BodyListField": [{"Foo":"Bar"}]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"BodyListField\":[\"{\\\"Foo\\\":\\\"Bar\\\"}\"]}"
         }
       }
     ]

--- a/test/fixtures/protocol/output/rest-xml.json
+++ b/test/fixtures/protocol/output/rest-xml.json
@@ -716,5 +716,96 @@
         }
       }
     ]
+  },
+  {
+    "description": "Timestamp members",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "TimeArg": {
+            "shape": "TimestampType"
+          },
+          "TimeArgInHeader": {
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timearg"
+          },
+          "TimeCustom": {
+            "timestampFormat": "rfc822",
+            "shape": "TimestampType"
+          },
+          "TimeCustomInHeader": {
+            "timestampFormat": "unixTimestamp",
+            "shape": "TimestampType",
+            "location": "header",
+            "locationName": "x-amz-timecustom"
+          },
+          "TimeFormat": {
+            "shape": "TimestampFormatType"
+          },
+          "TimeFormatInHeader": {
+            "shape": "TimestampFormatType",
+            "location": "header",
+            "locationName": "x-amz-timeformat"
+          },
+          "StructMember": {
+            "shape": "TimeContainer"
+          }
+        }
+      },
+      "TimeContainer": {
+        "type": "structure",
+        "members": {
+          "foo": {
+            "shape": "TimestampType"
+          },
+          "bar": {
+            "shape": "TimestampFormatType"
+          }
+        }
+      },
+      "TimestampFormatType": {
+        "timestampFormat": "unixTimestamp",
+        "type": "timestamp"
+      },
+      "TimestampType": {
+        "type": "timestamp"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "TimeArg": 1398796238,
+          "TimeArgInHeader": 1398796238,
+          "TimeCustom": 1398796238,
+          "TimeCustomInHeader": 1398796238,
+          "TimeFormat": 1398796238,
+          "TimeFormatInHeader": 1398796238,
+          "StructMember": {
+            "foo": 1398796238,
+            "bar": 1398796238
+          }
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+            "x-amz-timearg": "Tue, 29 Apr 2014 18:30:38 GMT",
+            "x-amz-timecustom": "1398796238",
+            "x-amz-timeformat": "1398796238"
+          },
+          "body": "<OperationNameResponse><StructMember><foo>2014-04-29T18:30:38+00:00</foo><bar>1398796238</bar></StructMember><TimeArg>2014-04-29T18:30:38+00:00</TimeArg><TimeCustom>Tue, 29 Apr 2014 18:30:38 GMT</TimeCustom><TimeFormat>1398796238</TimeFormat><RequestId>requestid</RequestId></OperationNameResponse>"
+        }
+      }
+    ]
   }
 ]

--- a/test/json/builder.spec.js
+++ b/test/json/builder.spec.js
@@ -161,7 +161,7 @@
         str = '{"Items":{"MyKey":5,"MyOtherKey":10}}';
         return expect(build(rules, params)).to.equal(str);
       });
-      it('traslates nested timestamps', function() {
+      it('traslates nested timestamps and ignore the metadata timestampFormat', function() {
         var formatted, now, params, rules;
         rules = {
           type: 'structure',
@@ -183,8 +183,8 @@
             When: now
           }
         };
-        formatted = AWS.util.date.iso8601(now).replace(/\.\d+Z$/, '');
-        return expect(build(rules, params)).to.match(new RegExp('\\{"Build":\\{"When":"' + formatted + '"\\}\\}'));
+        formatted = AWS.util.date.unixTimestamp(now);
+        return expect(build(rules, params)).to.match(new RegExp('\\{"Build":\\{"When":' + formatted + '\\}\\}'));
       });
       it('translates integers formatted as strings', function() {
         var rules;

--- a/test/model/api.spec.js
+++ b/test/model/api.spec.js
@@ -21,7 +21,6 @@
             globalEndpoint: 'global',
             signatureVersion: 'v4',
             protocol: 'json',
-            timestampFormat: 'rfc822',
             xmlNamespace: 'URI',
             serviceAbbreviation: 'abbr',
             serviceFullName: 'name',
@@ -33,7 +32,6 @@
         expect(api.globalEndpoint).to.equal('global');
         expect(api.signatureVersion).to.equal('v4');
         expect(api.protocol).to.equal('json');
-        expect(api.timestampFormat).to.equal('rfc822');
         expect(api.xmlNamespaceUri).to.equal('URI');
         expect(api.abbreviation).to.equal('abbr');
         expect(api.fullName).to.equal('name');

--- a/test/model/shape.spec.js
+++ b/test/model/shape.spec.js
@@ -123,28 +123,6 @@
           });
           expect(shape.members.Date.timestampFormat).to.eql('iso8601');
         });
-        it('will use api metadata timestampFormat if not found elsewhere', function() {
-          var api = new AWS.Model.Api({
-            metadata: {
-              timestampFormat: 'unixTimestamp'
-            },
-            shapes: {
-              S1: {
-                type: 'timestamp'
-              }
-            }
-          });
-          var shape = AWS.Model.Shape.create({
-            members: {
-              Date: {
-                shape: 'S1',
-              }
-            }
-          }, {
-            api: api
-          });
-          expect(shape.members.Date.timestampFormat).to.eql('unixTimestamp');
-        });
         it('will default to unixTimestamp when if not specified and protocol is json', function() {
           var api = new AWS.Model.Api({
             metadata: {

--- a/test/protocol/rest.spec.js
+++ b/test/protocol/rest.spec.js
@@ -214,7 +214,7 @@
           };
           return expect(build().httpRequest.path).to.equal('/abc/xyz?bar=bar');
         });
-        return it('uri escapes params in both path and querystring', function() {
+        it('uri escapes params in both path and querystring', function() {
           request.params = {
             Path: 'a b',
             Query: 'a/b'
@@ -234,6 +234,33 @@
           };
           return expect(build().httpRequest.path).to.equal('/a%20b?query=a%2Fb');
         });
+        it('serialize params in right format in querystring', function() {
+          var date = new Date(60 * 60 * 1000);
+          request.params = {
+            Foo: date,
+            Bar: [date, date],
+          }
+          defop({
+            input: input,
+            http: {
+              requestUri: '/path'
+            }
+          });
+          input.members.Foo = {
+            type: 'timestamp',
+            timestampFormat: 'unixTimestamp',
+            location: 'querystring',
+            locationName: 'foo'
+          };
+          input.members.Bar = {
+            type: 'list',
+            location: 'querystring',
+            member: {
+              type: 'timestamp',
+            }
+          }
+          expect(build().httpRequest.path).to.equal('/path?Bar=1970-01-01T01%3A00%3A00Z&Bar=1970-01-01T01%3A00%3A00Z&foo=3600')
+        })
       });
       describe('headers', function() {
         beforeEach(function() {
@@ -326,7 +353,6 @@
       describe('timestamp header without format', function() {
         return it('populates the header using the api formatting', function() {
           var date;
-          service.api.timestampFormat = 'rfc822';
           date = new Date();
           date.setMilliseconds(0);
           request.params = {
@@ -346,7 +372,6 @@
       return describe('timestamp header with api formatting and parameter formatting', function() {
         return it('populates the header using the parameter formatting', function() {
           var date;
-          service.api.timestampFormat = 'invalid';
           date = new Date();
           date.setMilliseconds(0);
           request.params = {

--- a/test/xml/builder.spec.js
+++ b/test/xml/builder.spec.js
@@ -568,11 +568,11 @@
       time.setMilliseconds(0);
       it('iso8601', function() {
         var params, rules, xml;
-        api.timestampFormat = 'iso8601';
         rules = {
           members: {
             Expires: {
-              type: 'timestamp'
+              type: 'timestamp',
+              timestampFormat: 'iso8601'
             }
           }
         };
@@ -584,11 +584,11 @@
       });
       it('rfc822', function() {
         var params, rules, xml;
-        api.timestampFormat = 'rfc822';
         rules = {
           members: {
             Expires: {
-              type: 'timestamp'
+              type: 'timestamp',
+              timestampFormat: 'rfc822'
             }
           }
         };
@@ -600,11 +600,11 @@
       });
       it('unix timestamp', function() {
         var params, rules, xml;
-        api.timestampFormat = 'unixTimestamp';
         rules = {
           members: {
             Expires: {
-              type: 'timestamp'
+              type: 'timestamp',
+              timestampFormat: 'unixTimestamp'
             }
           }
         };
@@ -616,7 +616,6 @@
       });
       return it('follows the forat given on the shape', function() {
         var params, rules, xml;
-        api.timestampFormat = 'unixTimestamp';
         rules = {
           members: {
             Expires: {


### PR DESCRIPTION
The goal of this change is to make sure timestamp shapes are correctly serialized according to new spec:

* `timesstampFormat` in API models metadata will be ignored
* Use the `timestampFormat` trait of the member reference if present
* Use the `timestampFormat` trait of the shape if present.
* Use the format required by the protocol for the given location.

Several unit tests are also updated because of the removal of timestampFormat in metadata

The first commit updates the rest protocal serializer; the second commit contains new test cases to protocol test.

/cc @chrisradek 