### PR TITLE
Add CORS support for Translate service

### DIFF
--- a/.changes/next-release/feature-CORS-7111f29f.json
+++ b/.changes/next-release/feature-CORS-7111f29f.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CORS",
+  "description": "make Translate service available in browser version of SDK by default"
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -518,7 +518,8 @@
     "name": "SageMaker"
   },
   "translate": {
-    "name": "Translate"
+    "name": "Translate",
+    "cors": true
   },
   "resourcegroups": {
     "prefix": "resource-groups",


### PR DESCRIPTION
Related to #2151. Have confirmed that Translate supports CORS. 

