### PR TITLE
Fixes issue with promises when using react native 0.56.0.

### DIFF
--- a/.changes/next-release/bugfix-react-native-0dd527b9.json
+++ b/.changes/next-release/bugfix-react-native-0dd527b9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "react-native",
+  "description": "Fixes issue where promise methods are undefined when using react-native 0.56.0. See [this issue](https://github.com/facebook/metro/issues/208) for more information."
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -767,13 +767,14 @@ var util = {
    * @api private
    */
   addPromises: function addPromises(constructors, PromiseDependency) {
+    var deletePromises = false;
     if (PromiseDependency === undefined && AWS && AWS.config) {
       PromiseDependency = AWS.config.getPromisesDependency();
     }
     if (PromiseDependency === undefined && typeof Promise !== 'undefined') {
       PromiseDependency = Promise;
     }
-    if (typeof PromiseDependency !== 'function') var deletePromises = true;
+    if (typeof PromiseDependency !== 'function') deletePromises = true;
     if (!Array.isArray(constructors)) constructors = [constructors];
 
     for (var ind = 0; ind < constructors.length; ind++) {


### PR DESCRIPTION
I created an [issue](https://github.com/facebook/metro/issues/208) on the `metro` package, but the behavior we are seeing is due to a bug in one of their dependencies (babel).

I combed our code-base and it looked like this is the only place we were affected. I tested these changes using react-native 0.56.0 to verify the fix.

/cc @AllanFly120 