### PR TITLE
Prune unused types

### DIFF
--- a/.changes/next-release/bugfix-Typings-bc82a711.json
+++ b/.changes/next-release/bugfix-Typings-bc82a711.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Typings",
+  "description": "Updates typings-generator to remove unused model types."
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
     env: TEST_SCRIPT=region-check
   - node_js: "node"
     env: TEST_SCRIPT=translate-api-test
+  - node_js: "node"
+    env: TEST_SCRIPT=typings-generator-test
 
 script:
   - npm run $TEST_SCRIPT

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "build-react-native": "npm -s run-script build-react-native-deps && npm -s run-script build-react-native-core && npm -s run-script build-react-native-dist",
     "react-native-test": "npm -s run-script build-react-native && rake reactnative:test && karma start",
     "region-check": "node ./scripts/region-checker/index.js",
-    "translate-api-test": "mocha scripts/lib/translate-api.spec.js"
+    "translate-api-test": "mocha scripts/lib/translate-api.spec.js",
+    "typings-generator-test": "mocha scripts/lib/prune-shapes.spec.js"
   }
 }

--- a/scripts/lib/extra-2018-08-02.normal.json
+++ b/scripts/lib/extra-2018-08-02.normal.json
@@ -1,0 +1,179 @@
+{
+    "version": "2.0",
+    "metadata": {
+        "apiVersion": "2018-03-30",
+        "endpointPrefix": "foo",
+        "protocol": "rest-json",
+        "serviceId": "Foo",
+        "uid": "foo-2018-03-30"
+    },
+    "operations": {
+        "FancyOperation": {
+            "name" :"FancyOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "FancyStructure"
+            }
+        },
+        "BarOperation": {
+            "name": "BarOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "String"
+            },
+            "output": {
+                "shape": "String"
+            }
+        },
+        "EventStreamOnInputOperation": {
+            "name": "EventStreamOnInputOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "String"
+            }
+        },
+        "EventStreamOnInputPayloadOperation": {
+            "name": "EventStreamOnInputPayloadOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "String"
+            }
+        },
+        "EventStreamOnOutputOperation": {
+            "name": "EventStreamOnOutputOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "output": {
+                "shape": "String"
+            }
+        },
+        "EventStreamOnOutputPayloadOperation": {
+            "name": "EventStreamOnOutputPayloadOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "output": {
+                "shape": "String"
+            }
+        },
+        "BazOperation": {
+            "name": "BazOperation",
+            "http": {
+                "method": "GET",
+                "requestUri": "/"
+            },
+            "input": {
+                "shape": "String"
+            }
+        }
+    },
+    "shapes": {
+        "FancyStructure": {
+            "type": "structure",
+            "required": [],
+            "members": {
+                "Map": {
+                    "shape": "MapOfList"
+                }
+            }
+        },
+        "ListOfString": {
+            "type": "list",
+            "member": {
+                "shape": "String"
+            }
+        },
+        "ListOfList": {
+            "type": "list",
+            "member": {
+                "shape": "ListOfString"
+            }
+        },
+        "MapOfString": {
+            "type": "map",
+            "key": {
+                "shape": "String"
+            },
+            "value": {
+                "shape": "String"
+            }
+        },
+        "MapOfList": {
+            "type": "map",
+            "key": {
+                "shape": "String"
+            },
+            "value": {
+                "shape": "ListOfString"
+            }
+        },
+        "String": {
+            "type": "string"
+        },
+        "BarOperationInput": {
+            "type": "structure",
+            "members": {
+                "String": {
+                    "shape": "StringShape"
+                }
+            }
+        },
+        "BarOperationOutput": {
+            "type": "structure",
+            "members": {
+                "String": {
+                    "shape": "StringShape"
+                }
+            }
+        },
+        "BazOperationInput": {
+            "type": "structure",
+            "members": {
+                "BazString": {
+                    "shape": "BazStringShape",
+                    "timestampFormat": "iso8601"
+                }
+            }
+        },
+        "EventStreamPayload": {
+            "type": "structure",
+            "members": {
+                "Payload": {
+                    "shape": "EventStreamStructure"
+                },
+                "payload": "Payload"
+            }
+        },
+        "EventStreamStructure": {
+            "type": "structure",
+            "members": {
+                "String": {
+                    "shape": "StringShape"
+                }
+            },
+            "eventstream": true
+        },
+        "BazStringShape": {
+            "type": "timestamp",
+            "timestampFormat": "rfc822"
+        },
+        "StringShape": {
+            "type": "string"
+        }
+    }
+}

--- a/scripts/lib/get-operation-shape-names.js
+++ b/scripts/lib/get-operation-shape-names.js
@@ -1,0 +1,20 @@
+function getOperationShapeNames(model) {
+    var operationShapeNames = [];
+    var operations = model.operations;
+
+    for (var operationName of Object.keys(operations)) {
+        var operation = operations[operationName];
+        if (operation.input && operation.input.shape) {
+            operationShapeNames.push(operation.input.shape);
+        }
+        if (operation.output && operation.output.shape) {
+            operationShapeNames.push(operation.output.shape);
+        }
+    }
+
+    return operationShapeNames;
+};
+
+module.exports = {
+    getOperationShapeNames: getOperationShapeNames
+};

--- a/scripts/lib/prune-shapes.js
+++ b/scripts/lib/prune-shapes.js
@@ -10,7 +10,6 @@ function pruneShapes(model) {
     for (operationShape of operationShapeNames) {
         // traverse the tree and store visited shapes
         visitRelatedShapeNames(operationShape, shapeMap);
-        //shapeMap[operationShape].visited = true;
     }
 
     // iterate over the shapeMap and remove any shape that wasn't visited

--- a/scripts/lib/prune-shapes.js
+++ b/scripts/lib/prune-shapes.js
@@ -1,0 +1,28 @@
+var getOperationShapeNames = require('./get-operation-shape-names').getOperationShapeNames;
+var visitRelatedShapeNames = require('./visit-related-shape-names').visitRelatedShapeNames;
+
+function pruneShapes(model) {
+
+    // start by grabbing the input/output shapes on all operations
+    var operationShapeNames = getOperationShapeNames(model);
+    var shapeMap = model.shapes;
+
+    for (operationShape of operationShapeNames) {
+        // traverse the tree and store visited shapes
+        visitRelatedShapeNames(operationShape, shapeMap);
+        //shapeMap[operationShape].visited = true;
+    }
+
+    // iterate over the shapeMap and remove any shape that wasn't visited
+    var shapeNames = Object.keys(shapeMap);
+    for (var name of shapeNames) {
+        if (!shapeMap[name].visited) {
+            delete shapeMap[name];
+        }
+    }
+
+};
+
+module.exports = {
+    pruneShapes: pruneShapes
+};

--- a/scripts/lib/prune-shapes.spec.js
+++ b/scripts/lib/prune-shapes.spec.js
@@ -1,0 +1,64 @@
+var expect = require('chai').expect;
+var pruneShapes = require('./prune-shapes').pruneShapes;
+var extraModel = require('./extra-2018-08-02.normal.json');
+
+describe('pruneShapes', function() {
+    it('removes unused shapes from model', function() {
+        var model = deepCopyObject(extraModel);
+
+        var originalOperationNames = Object.keys(model.operations);
+        var originalShapeNames = Object.keys(model.shapes);
+
+        expect(originalShapeNames.sort()).to.eql([
+            'BarOperationInput',
+            'BarOperationOutput',
+            'BazOperationInput',
+            'BazStringShape',
+            'EventStreamPayload',
+            'EventStreamStructure',
+            'FancyStructure',
+            'ListOfList',
+            'ListOfString',
+            'MapOfList',
+            'MapOfString',
+            'String',
+            'StringShape'
+        ]);
+
+        pruneShapes(model);
+
+        // Unused shapes should now be removed
+        var visitedShapeNames = Object.keys(model.shapes);
+        expect(visitedShapeNames.sort()).to.eql([
+            'FancyStructure',
+            'ListOfString',
+            'MapOfList',
+            'String'
+        ]);
+
+        expect(originalOperationNames.sort()).to.eql(Object.keys(model.operations).sort());
+    });
+});
+
+function deepCopyObject(original) {
+    if (typeof original !== 'object' || original === null) {
+        return original;
+    }
+    var newObject = {};
+    var keys = Object.keys(original);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var value = original[key];
+        if (Array.isArray(value)) {
+            newObject[key] = [];
+            for (var j = 0; j < value.length; j++) {
+                newObject[key].push(deepCopyObject(value[j]));
+            }
+        } else if (typeof value === 'object' && value !== null) {
+            newObject[key] = deepCopyObject(value)
+        } else {
+            newObject[key] = value;
+        }
+    }
+    return newObject;
+}

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var pruneShapes = require('./prune-shapes').pruneShapes;
 
 var CUSTOM_CONFIG_ENUMS = {
     DUALSTACK: {
@@ -512,6 +513,8 @@ TSGenerator.prototype.containsEventStreams = function containsEventStreams(model
  */
 TSGenerator.prototype.processServiceModel = function processServiceModel(serviceIdentifier) {
     var model = this.loadServiceApi(serviceIdentifier);
+    pruneShapes(model);
+
     var self = this;
     var code = '';
     var className = this.metadata[serviceIdentifier].name;

--- a/scripts/lib/visit-related-shape-names.js
+++ b/scripts/lib/visit-related-shape-names.js
@@ -1,0 +1,40 @@
+
+/**
+ * 
+ * @param {string} startingShape 
+ * @param {{[key: string]: any}} shapeMap 
+ */
+function visitRelatedShapeNames(startingShape, shapeMap) {
+    var shape = shapeMap[startingShape];
+    if (shape.visited) {
+        // exit early if the shape has been visited
+        return;
+    }
+
+    shape.visited = true;
+
+    if (['structure', 'map', 'list'].indexOf(shape.type) < 0) {
+        // not a complex shape, so it's a terminal shape
+        return;
+    }
+
+    if (shape.type === 'structure') {
+        var members = shape.members;
+        for (var memberName of Object.keys(members)) {
+            var memberShapeName = members[memberName].shape;
+            visitRelatedShapeNames(memberShapeName, shapeMap);
+        }
+    } else if (shape.type === 'map') {
+        var keyShape = shape.key.shape;
+        var valueShape = shape.value.shape;
+        visitRelatedShapeNames(keyShape, shapeMap);
+        visitRelatedShapeNames(valueShape, shapeMap);
+    } else if (shape.type === 'list') {
+        var memberShape = shape.member.shape;
+        visitRelatedShapeNames(memberShape, shapeMap);
+    }
+}
+
+module.exports = {
+    visitRelatedShapeNames: visitRelatedShapeNames
+};


### PR DESCRIPTION
This update removes unused types from the generated typescript definition files.

This ends up affecting around 90-100 services, though Kinesis is the one most affected. The other services just have error shapes (like `errorMessage`) that are removed.

/cc @AllanFly120 