### PR TITLE
Fixes payload validation for react-native if payload is Blob.

### DIFF
--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -10901,6 +10901,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var Stream = AWS.util.stream.Stream;
 	      if (AWS.util.Buffer.isBuffer(value) || value instanceof Stream) return;
 	    }
+	    if (Blob && value instanceof Blob) return;
 
 	    var types = ['Buffer', 'Stream', 'File', 'Blob', 'ArrayBuffer', 'DataView'];
 	    if (value) {

--- a/dist/aws-sdk-react-native.js
+++ b/dist/aws-sdk-react-native.js
@@ -11207,6 +11207,7 @@ return /******/ (function(modules) { // webpackBootstrap
 		      var Stream = AWS.util.stream.Stream;
 		      if (AWS.util.Buffer.isBuffer(value) || value instanceof Stream) return;
 		    }
+		    if (Blob && value instanceof Blob) return;
 
 		    var types = ['Buffer', 'Stream', 'File', 'Blob', 'ArrayBuffer', 'DataView'];
 		    if (value) {

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -243,6 +243,7 @@ AWS.ParamValidator = AWS.util.inherit({
       var Stream = AWS.util.stream.Stream;
       if (AWS.util.Buffer.isBuffer(value) || value instanceof Stream) return;
     }
+    if (Blob && value instanceof Blob) return;
 
     var types = ['Buffer', 'Stream', 'File', 'Blob', 'ArrayBuffer', 'DataView'];
     if (value) {


### PR DESCRIPTION
This PR will fix a issue reported to `aws-amplify` [#632](https://github.com/aws-amplify/amplify-js/issues/632)

Cause is that the React Native Metro builder will minify JS in production mode yielding to different class names. This will let the method `validatePayload` in [param_validator.js](https://github.com/aws/aws-sdk-js/blob/master/lib/param_validator.js#L238) fail.
A fail of this method will cause that `Blob` as payload for e.g. `S3.upload`, `Storage.put` (aws-amplify) is invalid althoug this methods will support `Blob`.

This PR will add a check if the payload value is a pure Blob object.