### PR TITLE
Test node 9 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
+  - "10"
 env:
   - TEST_SCRIPT=coverage
 


### PR DESCRIPTION
Travis should ensure this module passes on all commonly-used node versions. Since node 9 and 10 are publicly available and used, let's test it.