### PR TITLE
fix: type was incorrect for Service.setupRequestListeners()

### DIFF
--- a/lib/service.d.ts
+++ b/lib/service.d.ts
@@ -46,7 +46,7 @@ export class Service {
     /**
      * Override this method to setup any custom request listeners for each new request to the service.
      */
-    setupRequestListeners(): void;
+    setupRequestListeners(request: Request<any, AWSError>): void;
     /**
      * Waits for a given state.
      */

--- a/lib/service.js
+++ b/lib/service.js
@@ -278,7 +278,7 @@ AWS.Service = inherit({
    *
    * @abstract
    */
-  setupRequestListeners: function setupRequestListeners() {
+  setupRequestListeners: function setupRequestListeners(request) {
   },
 
   /**


### PR DESCRIPTION
While using this library with TypeScript I found that overriding `<Service>.setupRequestListeners()` produced compilation errors since the argument was missing from the function signature.

This PR simply adds in the missing argument.