### PR TITLE
add CORS support for Pricing

### DIFF
--- a/.changes/next-release/feature-CORS-7010e6b1.json
+++ b/.changes/next-release/feature-CORS-7010e6b1.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CORS",
+  "description": "add cors support for pricing API. Make Pricing client available by default in browsers SDK."
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -460,7 +460,8 @@
     "name": "Mobile"
   },
   "pricing": {
-    "name": "Pricing"
+    "name": "Pricing",
+    "cors": true
   },
   "costexplorer": {
     "prefix": "ce",


### PR DESCRIPTION
Pricing API supports CORS recently. Update metadata to make it available in browser SDK.

solve: #1967 

/cc @chrisradek 