### PR TITLE
Fixes react native Blob issue in release builds

### DIFF
--- a/.changes/next-release/bugfix-ReactNative-bc65dc1a.json
+++ b/.changes/next-release/bugfix-ReactNative-bc65dc1a.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ReactNative",
+  "description": "Fixes issue where attempting to use a Blob object as input to an operation would cause a parameter validaiton error in release mode."
+}

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -242,6 +242,8 @@ AWS.ParamValidator = AWS.util.inherit({
     if (AWS.util.isNode()) { // special check for buffer/stream in Node.js
       var Stream = AWS.util.stream.Stream;
       if (AWS.util.Buffer.isBuffer(value) || value instanceof Stream) return;
+    } else {
+      if (typeof Blob !== void 0 && value instanceof Blob) return;
     }
 
     var types = ['Buffer', 'Stream', 'File', 'Blob', 'ArrayBuffer', 'DataView'];


### PR DESCRIPTION
Fixes issue where attempting to use a Blob object as input to an operation would cause a parameter validaiton error in release mode in react native.

Also needs [this PR](https://github.com/aws-amplify/amplify-js/pull/1610) from Amplify to get merged to fix issue with `Storage` package.

Replaces #2201 