### PR TITLE
Add `x-amz-api-version` Header to All Requests

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -174,6 +174,17 @@ AWS.EventListeners = {
       req.httpRequest.headers['Host'] = req.httpRequest.endpoint.host;
     });
 
+    add('SET_API_VERSION', 'afterBuild', function SET_API_VERSION(req) {
+      var apiVersion = req.service.api.apiVersion;
+      if (
+        apiVersion &&
+        !req.httpRequest.headers['presigned-expires'] && //do not add this header when presigning
+        !req.httpRequest.headers['x-amz-api-version']
+      ) {
+        req.httpRequest.headers['x-amz-api-version'] = apiVersion;
+      }
+    });
+
     add('RESTART', 'restart', function RESTART() {
       var err = this.response.error;
       if (!err || !err.retryable) return;

--- a/test/services/glacier.spec.js
+++ b/test/services/glacier.spec.js
@@ -52,6 +52,7 @@
         return it('adds linear and tree hash headers to payload requests', function() {
           var headers, req;
           headers = {
+            'x-amz-api-version': '2012-06-01',
             'x-amz-glacier-version': '2012-06-01',
             'X-Amz-Content-Sha256': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',
             'x-amz-sha256-tree-hash': 'fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9',

--- a/test/signers/v4.spec.js
+++ b/test/signers/v4.spec.js
@@ -30,8 +30,8 @@
     date = new Date(1935346573456);
     datetime = AWS.util.date.iso8601(date).replace(/[:\-]|\.\d{3}/g, '');
     creds = null;
-    signature = '31fac5ed29db737fbcafac527470ca6d9283283197c5e6e94ea40ddcec14a9c1';
-    authorization = 'AWS4-HMAC-SHA256 Credential=akid/20310430/region/dynamodb/aws4_request, ' + 'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, ' + 'Signature=' + signature;
+    signature = '8ba025718f82f8e1f7ef32b4892ced21a7273d952f0a4077fbc26b49a7f46e91';
+    authorization = 'AWS4-HMAC-SHA256 Credential=akid/20310430/region/dynamodb/aws4_request, ' + 'SignedHeaders=host;x-amz-api-version;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, ' + 'Signature=' + signature;
     signer = null;
     beforeEach(function() {
       helpers.spyOn(AWS.util, 'userAgent').andReturn('aws-sdk-js/0.1');
@@ -162,7 +162,7 @@
     });
     describe('canonicalHeaders', function() {
       it('should return headers', function() {
-        return expect(signer.canonicalHeaders()).to.eql(['host:localhost', 'x-amz-content-sha256:3128b8d4f3108b3e1677a38eb468d1c6dec926a58eaea235d034b9c71c3864d4', 'x-amz-date:' + datetime, 'x-amz-security-token:session', 'x-amz-target:DynamoDB_20111205.ListTables', 'x-amz-user-agent:aws-sdk-js/0.1'].join('\n'));
+        return expect(signer.canonicalHeaders()).to.eql(['host:localhost', 'x-amz-api-version:2011-12-05', 'x-amz-content-sha256:3128b8d4f3108b3e1677a38eb468d1c6dec926a58eaea235d034b9c71c3864d4', 'x-amz-date:' + datetime, 'x-amz-security-token:session', 'x-amz-target:DynamoDB_20111205.ListTables', 'x-amz-user-agent:aws-sdk-js/0.1'].join('\n'));
       });
 
       it('should ignore Authorization header', function() {


### PR DESCRIPTION
This is part of #2253 but I want to bring it out alone because this change will affect all the services. Not sure this will break any customization. SDK will send this header so that service teams can decide whether to use endpoint discovery feature.

I have run the integration test and confirmed that the additional header doesn't break the test.

/cc @chrisradek 