### PR TITLE
Allow use of AWS CLI's file cache in SharedIniFileCredentials

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -14,4 +14,5 @@ interface SharedIniFileCredentialsOptions {
     tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
     httpOptions?: HTTPOptions
     callback?: (err?: Error) => void
+    useCache?: boolean
 }

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,8 +1,8 @@
 var AWS = require('../core');
 var STS = require('../../clients/sts');
-var iniLoader = require('../shared-ini').iniLoader;
 var path = require('path');
 var STSCredentialsCache = require('./sts_credentials_cache');
+var iniLoader = AWS.util.iniLoader;
 
 /**
  * Represents credentials loaded from shared credentials file
@@ -88,7 +88,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
 
-    this.options = options || {};
+    options = options || {};
 
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
@@ -96,8 +96,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
     this.tokenCodeFn = options.tokenCodeFn || null;
     this.httpOptions = options.httpOptions || null;
-    this.useCache = Boolean(this.options.useCache);
-    this.cacheExpiryWindowSeconds = this.options.cacheExpiryWindowSeconds || 60 * 15;
+    this.useCache = Boolean(options.useCache);
+    this.cacheExpiryWindowSeconds = options.cacheExpiryWindowSeconds || 60 * 15;
     this.get(options.callback || AWS.util.fn.noop);
   },
 
@@ -134,17 +134,11 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
-        this.loadRoleProfile(profiles, profile, function(err, data) {
-          if (err) {
-            callback(err);
-          } else {
+        this.loadRoleProfile(profiles, profile, function(err) {
+          if (!err) {
             self.expired = false;
-            self.accessKeyId = data.Credentials.AccessKeyId;
-            self.secretAccessKey = data.Credentials.SecretAccessKey;
-            self.sessionToken = data.Credentials.SessionToken;
-            self.expireTime = data.Credentials.Expiration;
-            callback(null);
           }
+          callback(err);
         });
         return;
       }
@@ -247,11 +241,10 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     var options = {
       useCache: this.useCache,
       tokenCodeFn: this.tokenCodeFn,
-      expiryWindowSeconds: this.cacheExpiryWindowSeconds
+      expiryWindowSeconds: this.cacheExpiryWindowSeconds,
+      httpOptions: this.httpOptions
     };
     var cache = new STSCredentialsCache(roleParams, sourceCredentials, options);
-    cache.assignCredentials(self, function(err) {
-      callback(err);
-    });
+    cache.assignCredentials(self, callback);
   }
 });

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,6 +1,8 @@
 var AWS = require('../core');
 var STS = require('../../clients/sts');
-var iniLoader = AWS.util.iniLoader;
+var iniLoader = require('../shared-ini').iniLoader;
+var path = require('path');
+var STSCredentialsCache = require('./sts_credentials_cache');
 
 /**
  * Represents credentials loaded from shared credentials file
@@ -72,11 +74,21 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
    *     milliseconds of inactivity on the socket. Defaults to two minutes
    *     (120000).
+   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
+   *     HTTP requests. Used in the browser environment only. Set to false to
+   *     send requests synchronously. Defaults to true (async on).
+   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
+   *     property of an XMLHttpRequest object. Used in the browser environment
+   *     only. Defaults to false.
+   * @option options useCache [Boolean] (false) True to use filesystem cache
+   *   for assumed role credentials
+   * @option options cacheExpiryWindowSeconds [Number] (60 * 15) Remaining lifetime
+   *   in seconds to reuse cached credentials
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
 
-    options = options || {};
+    this.options = options || {};
 
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
@@ -84,6 +96,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
     this.tokenCodeFn = options.tokenCodeFn || null;
     this.httpOptions = options.httpOptions || null;
+    this.useCache = Boolean(this.options.useCache);
+    this.cacheExpiryWindowSeconds = this.options.cacheExpiryWindowSeconds || 60 * 15;
     this.get(options.callback || AWS.util.fn.noop);
   },
 
@@ -216,10 +230,6 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     );
 
     this.roleArn = roleArn;
-    var sts = new STS({
-      credentials: sourceCredentials,
-      httpOptions: this.httpOptions
-    });
 
     var roleParams = {
       RoleArn: roleArn,
@@ -230,29 +240,18 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       roleParams.ExternalId = externalId;
     }
 
-    if (mfaSerial && self.tokenCodeFn) {
+    if (mfaSerial) {
       roleParams.SerialNumber = mfaSerial;
-      self.tokenCodeFn(mfaSerial, function(err, token) {
-        if (err) {
-          var message;
-          if (err instanceof Error) {
-            message = err.message;
-          } else {
-            message = err;
-          }
-          callback(
-            AWS.util.error(
-              new Error('Error fetching MFA token: ' + message),
-              { code: 'SharedIniFileCredentialsProviderFailure' }
-            ));
-          return;
-        }
-
-        roleParams.TokenCode = token;
-        sts.assumeRole(roleParams, callback);
-      });
-      return;
     }
-    sts.assumeRole(roleParams, callback);
+
+    var options = {
+      useCache: this.useCache,
+      tokenCodeFn: this.tokenCodeFn,
+      expiryWindowSeconds: this.cacheExpiryWindowSeconds
+    };
+    var cache = new STSCredentialsCache(roleParams, sourceCredentials, options);
+    cache.assignCredentials(self, function(err) {
+      callback(err);
+    });
   }
 });

--- a/lib/credentials/sts_credentials_cache.js
+++ b/lib/credentials/sts_credentials_cache.js
@@ -14,7 +14,10 @@ STSCredentialsCache = AWS.util.inherit({
     this.expiryWindowSeconds = options.expiryWindowSeconds || 60 * 15;
     this.tokenCodeFn = options.tokenCodeFn || null;
     this.useCache = Boolean(options.useCache);
-    this.service = new STS({credentials: sourceCredentials});
+    this.service = new STS({
+      credentials: sourceCredentials,
+      httpOptions: options.httpOptions
+    });
   },
 
   /**

--- a/lib/credentials/sts_credentials_cache.js
+++ b/lib/credentials/sts_credentials_cache.js
@@ -1,0 +1,172 @@
+var AWS = require('../core');
+var STS = require('../../clients/sts');
+
+STSCredentialsCache = AWS.util.inherit({
+
+  /**
+   * Optionally cache STS assumed role credentials.
+   *
+   * @api private
+   */
+  constructor: function STSCredentialsCache(params, sourceCredentials, options) {
+    options = options || {};
+    this.params = params;
+    this.expiryWindowSeconds = options.expiryWindowSeconds || 60 * 15;
+    this.tokenCodeFn = options.tokenCodeFn || null;
+    this.useCache = Boolean(options.useCache);
+    this.service = new STS({credentials: sourceCredentials});
+  },
+
+  /**
+   * @api private
+   */
+  assignCredentials: function assignCredentials(destinationCredentials, callback) {
+    if (!callback) callback = function(err) { if (err) throw err; };
+
+    if (this.useCache) {
+      var cacheKey = this.generateCacheKey();
+      this.credentialsFromCache(cacheKey, destinationCredentials, callback);
+    } else {
+      this.createCredentials(null, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  credentialsFromCache: function credentialsFromCache(cacheKey, destinationCredentials, callback) {
+    var cachedCreds = this.cacheRead(cacheKey);
+    if (this.credsValid(cachedCreds)) {
+      this.service.credentialsFrom(cachedCreds, destinationCredentials);
+      callback();
+    } else {
+      this.createCredentials(cacheKey, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  createCredentials: function createCredentials(cacheKey, destinationCredentials, callback) {
+    var self = this;
+
+    if (self.params.SerialNumber && self.tokenCodeFn) {
+      self.tokenCodeFn(self.params.SerialNumber, function(err, token) {
+        if (err) {
+          var message;
+          if (err instanceof Error) {
+            message = err.message;
+          } else {
+            message = err;
+          }
+          callback(
+            AWS.util.error(
+              new Error('Error fetching MFA token: ' + message),
+              { code: 'SharedIniFileCredentialsProviderFailure' }
+            ));
+          return;
+        }
+
+        self.params.TokenCode = token;
+        self.assumeRole(cacheKey, destinationCredentials, callback);
+      });
+    } else {
+      self.assumeRole(cacheKey, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  assumeRole: function assumeRole(cacheKey, destinationCredentials, callback) {
+    var self = this;
+    this.service.assumeRole(self.params, function (err, data) {
+      if (!err) {
+        self.service.credentialsFrom(data, destinationCredentials);
+        if (self.useCache && cacheKey) {
+          self.cacheWrite(cacheKey, data);
+        }
+      }
+      callback(err);
+    });
+  },
+
+  /**
+   * @api private
+   */
+  generateCacheKey: function generateCacheKey() {
+    var keys = Object.keys(this.params).filter(function(key) {
+      return key !== 'RoleSessionName';
+    });
+    var input = JSON.stringify(this.params, keys.sort());
+    return require('crypto').createHash('sha1').update(input).digest('hex');
+  },
+
+  /**
+   * @api private
+   */
+  cacheFilepath: function cacheFilepath(cacheKey) {
+    var path = require('path');
+    var home = require('os').homedir();
+    var defaultDir = path.join(home, '.aws', 'cli', 'cache');
+    var dir = process.env.AWS_CREDENTIAL_CACHE_DIRECTORY || defaultDir;
+    return path.join(dir, cacheKey) + '.json';
+  },
+
+  /**
+   * @api private
+   */
+  cacheRead: function cacheRead(cacheKey) {
+    var fs = require('fs');
+    try {
+      var contents = fs.readFileSync(this.cacheFilepath(cacheKey));
+      if (contents) {
+        var a = JSON.parse(contents);
+        return a;
+      }
+    } catch (e) {
+      // console.log(e);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  cacheWrite: function cacheWrite(cacheKey, data) {
+    var fs = require('fs');
+    var path = require('path');
+    var cacheFilepath = this.cacheFilepath(cacheKey);
+    var dir = path.dirname(path.resolve(cacheFilepath));
+
+    // mkdir -p
+    dir.split(path.sep).reduce(function(parentDir, childDir) {
+      var curDir = path.resolve('/', parentDir, childDir);
+      try {
+        fs.mkdirSync(curDir);
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          throw err;
+        }
+      }
+      return curDir;
+    });
+
+    fs.writeFileSync(cacheFilepath, JSON.stringify(data), 'utf-8');
+  },
+
+  /**
+   * @api private
+   */
+  credsValid: function credsValid(creds) {
+    if (creds && creds['Credentials'] && creds['Credentials']['Expiration']) {
+      var now = AWS.util.date.getDate();
+      var expiration = new Date(creds['Credentials']['Expiration']);
+      var remaining = (expiration.getTime() - now.getTime()) / 1000;
+      return remaining > this.expiryWindowSeconds;
+    }
+    return false;
+  },
+
+});
+
+module.exports = STSCredentialsCache;

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -703,7 +703,7 @@
         var fs = require('fs');
         // rm -r
         if (fs.existsSync(cachedir)) {
-          fs.readdirSync(cachedir).forEach(function(file){
+          fs.readdirSync(cachedir).forEach(function(file) {
             fs.unlinkSync(path.join(cachedir, file));
           });
           fs.rmdirSync(cachedir);

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -689,7 +689,28 @@
         iniLoader.clearCachedFiles();
         process.env = env;
       });
-      it('will fail if assume role is disabled', function(done) {
+      var cachedir;
+      beforeEach(function() {
+        var os = require('os');
+        var fs = require('fs');
+        var path = require('path');
+        helpers.spyOn(os, 'homedir').andReturn('/home/user');
+        cachedir = path.join(os.tmpdir(), 'aws-sdk-js-cache-' + process.pid);
+        process.env.AWS_CREDENTIAL_CACHE_DIRECTORY = cachedir;
+      });
+      afterEach(function() {
+        var path = require('path');
+        var fs = require('fs');
+        // rm -r
+        if (fs.existsSync(cachedir)) {
+          fs.readdirSync(cachedir).forEach(function(file){
+            fs.unlinkSync(path.join(cachedir, file));
+          });
+          fs.rmdirSync(cachedir);
+        }
+        delete process.env.AWS_CREDENTIAL_CACHE_DIRECTORY;
+      });
+      it('will fail if assume role is disabled', function() {
         var creds, mock;
         mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\nrole_arn = arn';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
@@ -745,6 +766,62 @@
           expect(creds.expireTime).to.eql(new Date(0));
           done();
         });
+      });
+      it('will only assume role once when using cache', function() {
+        var mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\nrole_arn = arn\nexternal\nasda\nsource_profile = foo\n[foo]\naws_access_key_id = akid2\naws_secret_access_key = secret2';
+        var readFileSpy = helpers.spyOn(AWS.util, 'readFileSync').andCallFake(function(filename) {
+          if (/credentials$/.test(filename)) {
+            return mock;
+          } else {
+            return readFileSpy.origMethod.apply(arguments);
+          }
+        });
+        var STSPrototype = (new STS()).constructor.prototype;
+        var assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallFake(function(params, callback) {
+          callback(null, {
+            Credentials: {
+              AccessKeyId: 'KEY',
+              SecretAccessKey: 'SECRET',
+              SessionToken: 'TOKEN',
+              Expiration: new Date(new Date().getTime() + 1000000).toISOString()
+            }
+          });
+        });
+        new AWS.SharedIniFileCredentials({ useCache: true });
+        expect(assumeRoleSpy.calls.length).to.equal(1);
+        new AWS.SharedIniFileCredentials({ useCache: true });
+        expect(assumeRoleSpy.calls.length).to.equal(1);
+      });
+      it('will correctly read credentials from cache', function() {
+        var mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\nrole_arn = arn\nexternal\nasda\nsource_profile = foo\n[foo]\naws_access_key_id = akid2\naws_secret_access_key = secret2';
+        var readFileSpy = helpers.spyOn(AWS.util, 'readFileSync').andCallFake(function(filename) {
+          if (/credentials$/.test(filename)) {
+            return mock;
+          } else {
+            return readFileSpy.origMethod.apply(arguments);
+          }
+        });
+        var STSPrototype = (new STS()).constructor.prototype;
+        var assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallFake(function(params, callback) {
+          callback(null, {
+            Credentials: {
+              AccessKeyId: 'KEY',
+              SecretAccessKey: 'SECRET',
+              SessionToken: 'TOKEN',
+              Expiration: new Date(new Date().getTime() + 1000000).toISOString()
+            }
+          });
+        });
+        var first = new AWS.SharedIniFileCredentials({ useCache: true });
+        expect(first.accessKeyId).to.equal('KEY');
+        expect(first.secretAccessKey).to.equal('SECRET');
+        expect(first.sessionToken).to.equal('TOKEN');
+        var second = new AWS.SharedIniFileCredentials({ useCache: true });
+        expect(second.accessKeyId).to.equal('KEY');
+        expect(second.secretAccessKey).to.equal('SECRET');
+        expect(second.sessionToken).to.equal('TOKEN');
+
+        expect(first.expireTime).to.equal(second.expireTime);
       });
       it('will assume a role from chained source_profile profiles', function(done) {
         var creds, mock;

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -710,7 +710,7 @@
         }
         delete process.env.AWS_CREDENTIAL_CACHE_DIRECTORY;
       });
-      it('will fail if assume role is disabled', function() {
+      it('will fail if assume role is disabled', function(done) {
         var creds, mock;
         mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\nrole_arn = arn';
         helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);


### PR DESCRIPTION
This is based mostly off of how [boto does credentials caching for the AWS CLI](https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/botocore/credentials.py#L536) and is compatible/could use caches from boto.

The main use-case of this functionality for me is to remove the need provide a token code on each invocation of a CLI tool when assuming roles that require MFA.