### PR TITLE
Adding connectTimeout option in EC2MetadataCredentials class.

### DIFF
--- a/lib/credentials/ec2_metadata_credentials.d.ts
+++ b/lib/credentials/ec2_metadata_credentials.d.ts
@@ -12,6 +12,10 @@ export class EC2MetadataCredentials extends Credentials {
              * Timeout in milliseconds.
              */
             timeout?: number
+            /**
+             * Connection timeout in milliseconds.
+             */
+            connectTimeout?: number
         }
         maxRetries?: number
     }

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -23,7 +23,7 @@ require('../metadata_service');
  *
  * If your requests are timing out in connecting to the metadata service, such
  * as when testing on a development machine, you can use the connectTimeout
- * option, specified in milliseconds, which also defaults to 5 seconds.
+ * option, specified in milliseconds, which also defaults to 1 second.
  * ```
  *
  * @see AWS.Config.retryDelayOptions

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -20,6 +20,10 @@ require('../metadata_service');
  *   maxRetries: 10, // retry 10 times
  *   retryDelayOptions: { base: 200 } // see AWS.Config for information
  * });
+ *
+ * If your requests are timing out in connecting to the metadata service, such
+ * as when testing on a development machine, you can use the connectTimeout
+ * option, specified in milliseconds, which also defaults to 5 seconds.
  * ```
  *
  * @see AWS.Config.retryDelayOptions
@@ -35,7 +39,9 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
       {maxRetries: this.defaultMaxRetries}, options);
     if (!options.httpOptions) options.httpOptions = {};
     options.httpOptions = AWS.util.merge(
-      {timeout: this.defaultTimeout}, options.httpOptions);
+      {timeout: this.defaultTimeout,
+       connectTimeout: this.defaultConnectTimeout},
+      options.httpOptions);
 
     this.metadataService = new AWS.MetadataService(options);
     this.metadata = {};
@@ -45,6 +51,11 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   defaultTimeout: 1000,
+
+  /**
+   * @api private
+   */
+  defaultConnectTimeout: 1000,
 
   /**
    * @api private

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -659,7 +659,11 @@
           creds = new AWS.EC2MetadataCredentials(opts);
           return expect(opts).to.eql({});
         });
-        return it('allows setting timeout', function() {
+        it('checking default timeout', function() {
+          creds = new AWS.EC2MetadataCredentials({});
+          return expect(creds.metadataService.httpOptions.timeout).to.equal(1000);
+        });
+        it('allows setting timeout', function() {
           var opts;
           opts = {
             httpOptions: {
@@ -668,6 +672,20 @@
           };
           creds = new AWS.EC2MetadataCredentials(opts);
           return expect(creds.metadataService.httpOptions.timeout).to.equal(5000);
+        });
+        it('checking default connectTimeout', function() {
+          creds = new AWS.EC2MetadataCredentials({});
+          return expect(creds.metadataService.httpOptions.connectTimeout).to.equal(1000);
+        });
+        it('allows setting connectTimeout', function() {
+          var opts;
+          opts = {
+            httpOptions: {
+              connectTimeout: 5000
+            }
+          };
+          creds = new AWS.EC2MetadataCredentials(opts);
+          return expect(creds.metadataService.httpOptions.connectTimeout).to.equal(5000);
         });
       });
       describe('needsRefresh', function() {


### PR DESCRIPTION
When I was testing EC2MetadataCredentials on my laptop, where it obviously would not work, the `timeout` field did nothing because it wasn't even connecting. But passing a `connectTimeout` field timed out as expected. So I've added types for this and documentation about the field.