### PR TITLE
Fix parameter validation

### DIFF
--- a/.changes/next-release/bugfix-ParameterValidation-09255151.json
+++ b/.changes/next-release/bugfix-ParameterValidation-09255151.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ParameterValidation",
+  "description": "Updates service models to include min, max, enum, and pattern data for use with SDK parameter validation."
+}

--- a/apis/AWSMigrationHub-2017-05-31.min.json
+++ b/apis/AWSMigrationHub-2017-05-31.min.json
@@ -21,8 +21,12 @@
           "CreatedArtifact"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "CreatedArtifact": {
             "shape": "S4"
           },
@@ -45,8 +49,12 @@
           "DiscoveredResource"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "DiscoveredResource": {
             "shape": "Sa"
           },
@@ -67,7 +75,9 @@
           "ProgressUpdateStreamName"
         ],
         "members": {
-          "ProgressUpdateStreamName": {},
+          "ProgressUpdateStreamName": {
+            "shape": "S2"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -85,7 +95,9 @@
           "ProgressUpdateStreamName"
         ],
         "members": {
-          "ProgressUpdateStreamName": {},
+          "ProgressUpdateStreamName": {
+            "shape": "S2"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -103,13 +115,17 @@
           "ApplicationId"
         ],
         "members": {
-          "ApplicationId": {}
+          "ApplicationId": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ApplicationStatus": {},
+          "ApplicationStatus": {
+            "shape": "Sl"
+          },
           "LastUpdatedTime": {
             "type": "timestamp"
           }
@@ -124,8 +140,12 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {}
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -134,8 +154,12 @@
           "MigrationTask": {
             "type": "structure",
             "members": {
-              "ProgressUpdateStream": {},
-              "MigrationTaskName": {},
+              "ProgressUpdateStream": {
+                "shape": "S2"
+              },
+              "MigrationTaskName": {
+                "shape": "S3"
+              },
               "Task": {
                 "shape": "Sq"
               },
@@ -146,7 +170,9 @@
                 "type": "list",
                 "member": {
                   "shape": "Sv"
-                }
+                },
+                "max": 100,
+                "min": 0
               }
             }
           }
@@ -162,9 +188,15 @@
           "CreatedArtifactName"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
-          "CreatedArtifactName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
+          "CreatedArtifactName": {
+            "shape": "S5"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -184,9 +216,15 @@
           "ConfigurationId"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
-          "ConfigurationId": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
+          "ConfigurationId": {
+            "shape": "Sb"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -205,8 +243,12 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -225,11 +267,17 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -254,11 +302,17 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -281,9 +335,13 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1e"
           },
-          "ResourceName": {}
+          "ResourceName": {
+            "type": "string",
+            "max": 1600,
+            "min": 1
+          }
         }
       },
       "output": {
@@ -295,13 +353,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProgressUpdateStream": {},
-                "MigrationTaskName": {},
-                "Status": {},
-                "ProgressPercent": {
-                  "type": "integer"
+                "ProgressUpdateStream": {
+                  "shape": "S2"
                 },
-                "StatusDetail": {},
+                "MigrationTaskName": {
+                  "shape": "S3"
+                },
+                "Status": {
+                  "shape": "Sr"
+                },
+                "ProgressPercent": {
+                  "shape": "St"
+                },
+                "StatusDetail": {
+                  "shape": "Ss"
+                },
                 "UpdateDateTime": {
                   "type": "timestamp"
                 }
@@ -317,7 +383,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1e"
           }
         }
       },
@@ -329,7 +395,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProgressUpdateStreamName": {}
+                "ProgressUpdateStreamName": {
+                  "shape": "S2"
+                }
               }
             }
           },
@@ -345,8 +413,12 @@
           "Status"
         ],
         "members": {
-          "ApplicationId": {},
-          "Status": {},
+          "ApplicationId": {
+            "shape": "Sj"
+          },
+          "Status": {
+            "shape": "Sl"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -368,8 +440,12 @@
           "NextUpdateSeconds"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "Task": {
             "shape": "Sq"
           },
@@ -377,7 +453,8 @@
             "type": "timestamp"
           },
           "NextUpdateSeconds": {
-            "type": "integer"
+            "type": "integer",
+            "min": 0
           },
           "DryRun": {
             "type": "boolean"
@@ -398,13 +475,19 @@
           "ResourceAttributeList"
         ],
         "members": {
-          "ProgressUpdateStream": {},
-          "MigrationTaskName": {},
+          "ProgressUpdateStream": {
+            "shape": "S2"
+          },
+          "MigrationTaskName": {
+            "shape": "S3"
+          },
           "ResourceAttributeList": {
             "type": "list",
             "member": {
               "shape": "Sv"
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "DryRun": {
             "type": "boolean"
@@ -418,15 +501,39 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 50,
+      "min": 1,
+      "pattern": "[^/:|\\000-\\037]+"
+    },
+    "S3": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[^:|]+"
+    },
     "S4": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Description": {}
+        "Name": {
+          "shape": "S5"
+        },
+        "Description": {
+          "type": "string",
+          "max": 500,
+          "min": 0
+        }
       }
+    },
+    "S5": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "arn:[a-z-]+:[a-z0-9-]+:(?:[a-z0-9-]+|):(?:[0-9]{12}|):.*"
     },
     "Sa": {
       "type": "structure",
@@ -434,9 +541,32 @@
         "ConfigurationId"
       ],
       "members": {
-        "ConfigurationId": {},
-        "Description": {}
+        "ConfigurationId": {
+          "shape": "Sb"
+        },
+        "Description": {
+          "type": "string",
+          "max": 500,
+          "min": 0
+        }
       }
+    },
+    "Sb": {
+      "type": "string",
+      "min": 1
+    },
+    "Sj": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "NOT_STARTED",
+        "IN_PROGRESS",
+        "COMPLETED"
+      ]
     },
     "Sq": {
       "type": "structure",
@@ -444,12 +574,35 @@
         "Status"
       ],
       "members": {
-        "Status": {},
-        "StatusDetail": {},
+        "Status": {
+          "shape": "Sr"
+        },
+        "StatusDetail": {
+          "shape": "Ss"
+        },
         "ProgressPercent": {
-          "type": "integer"
+          "shape": "St"
         }
       }
+    },
+    "Sr": {
+      "type": "string",
+      "enum": [
+        "NOT_STARTED",
+        "IN_PROGRESS",
+        "FAILED",
+        "COMPLETED"
+      ]
+    },
+    "Ss": {
+      "type": "string",
+      "max": 500,
+      "min": 0
+    },
+    "St": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
     },
     "Sv": {
       "type": "structure",
@@ -458,9 +611,32 @@
         "Value"
       ],
       "members": {
-        "Type": {},
-        "Value": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "IPV4_ADDRESS",
+            "IPV6_ADDRESS",
+            "MAC_ADDRESS",
+            "FQDN",
+            "VM_MANAGER_ID",
+            "VM_MANAGED_OBJECT_REFERENCE",
+            "VM_NAME",
+            "VM_PATH",
+            "BIOS_ID",
+            "MOTHERBOARD_SERIAL_NUMBER"
+          ]
+        },
+        "Value": {
+          "type": "string",
+          "max": 256,
+          "min": 1
+        }
       }
+    },
+    "S1e": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     }
   }
 }

--- a/apis/acm-2015-12-08.min.json
+++ b/apis/acm-2015-12-08.min.json
@@ -21,7 +21,9 @@
           "Tags"
         ],
         "members": {
-          "CertificateArn": {},
+          "CertificateArn": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "S3"
           }
@@ -35,7 +37,9 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -46,7 +50,9 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -55,8 +61,12 @@
           "Certificate": {
             "type": "structure",
             "members": {
-              "CertificateArn": {},
-              "DomainName": {},
+              "CertificateArn": {
+                "shape": "S2"
+              },
+              "DomainName": {
+                "shape": "Sb"
+              },
               "SubjectAlternativeNames": {
                 "shape": "Sc"
               },
@@ -75,25 +85,66 @@
               "ImportedAt": {
                 "type": "timestamp"
               },
-              "Status": {},
+              "Status": {
+                "shape": "Sm"
+              },
               "RevokedAt": {
                 "type": "timestamp"
               },
-              "RevocationReason": {},
+              "RevocationReason": {
+                "type": "string",
+                "enum": [
+                  "UNSPECIFIED",
+                  "KEY_COMPROMISE",
+                  "CA_COMPROMISE",
+                  "AFFILIATION_CHANGED",
+                  "SUPERCEDED",
+                  "CESSATION_OF_OPERATION",
+                  "CERTIFICATE_HOLD",
+                  "REMOVE_FROM_CRL",
+                  "PRIVILEGE_WITHDRAWN",
+                  "A_A_COMPROMISE"
+                ]
+              },
               "NotBefore": {
                 "type": "timestamp"
               },
               "NotAfter": {
                 "type": "timestamp"
               },
-              "KeyAlgorithm": {},
+              "KeyAlgorithm": {
+                "shape": "So"
+              },
               "SignatureAlgorithm": {},
               "InUseBy": {
                 "type": "list",
                 "member": {}
               },
-              "FailureReason": {},
-              "Type": {},
+              "FailureReason": {
+                "type": "string",
+                "enum": [
+                  "NO_AVAILABLE_CONTACTS",
+                  "ADDITIONAL_VERIFICATION_REQUIRED",
+                  "DOMAIN_NOT_ALLOWED",
+                  "INVALID_PUBLIC_DOMAIN",
+                  "CAA_ERROR",
+                  "PCA_LIMIT_EXCEEDED",
+                  "PCA_INVALID_ARN",
+                  "PCA_INVALID_STATE",
+                  "PCA_REQUEST_FAILED",
+                  "PCA_RESOURCE_NOT_FOUND",
+                  "PCA_INVALID_ARGS",
+                  "OTHER"
+                ]
+              },
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "IMPORTED",
+                  "AMAZON_ISSUED",
+                  "PRIVATE"
+                ]
+              },
               "RenewalSummary": {
                 "type": "structure",
                 "required": [
@@ -101,7 +152,15 @@
                   "DomainValidationOptions"
                 ],
                 "members": {
-                  "RenewalStatus": {},
+                  "RenewalStatus": {
+                    "type": "string",
+                    "enum": [
+                      "PENDING_AUTO_RENEWAL",
+                      "PENDING_VALIDATION",
+                      "SUCCESS",
+                      "FAILED"
+                    ]
+                  },
                   "DomainValidationOptions": {
                     "shape": "Sd"
                   }
@@ -112,7 +171,9 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Name": {}
+                    "Name": {
+                      "shape": "Sw"
+                    }
                   }
                 }
               },
@@ -121,13 +182,23 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Name": {},
+                    "Name": {
+                      "shape": "Sz"
+                    },
                     "OID": {}
                   }
                 }
               },
-              "CertificateAuthorityArn": {},
-              "RenewalEligibility": {},
+              "CertificateAuthorityArn": {
+                "shape": "S2"
+              },
+              "RenewalEligibility": {
+                "type": "string",
+                "enum": [
+                  "ELIGIBLE",
+                  "INELIGIBLE"
+                ]
+              },
               "Options": {
                 "shape": "S11"
               }
@@ -144,9 +215,13 @@
           "Passphrase"
         ],
         "members": {
-          "CertificateArn": {},
+          "CertificateArn": {
+            "shape": "S2"
+          },
           "Passphrase": {
             "type": "blob",
+            "max": 128,
+            "min": 4,
             "sensitive": true
           }
         }
@@ -154,10 +229,17 @@
       "output": {
         "type": "structure",
         "members": {
-          "Certificate": {},
-          "CertificateChain": {},
+          "Certificate": {
+            "shape": "S16"
+          },
+          "CertificateChain": {
+            "shape": "S17"
+          },
           "PrivateKey": {
             "type": "string",
+            "max": 524288,
+            "min": 1,
+            "pattern": "-{5}BEGIN PRIVATE KEY-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END PRIVATE KEY-{5}(\\u000D?\\u000A)?",
             "sensitive": true
           }
         }
@@ -170,14 +252,20 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Certificate": {},
-          "CertificateChain": {}
+          "Certificate": {
+            "shape": "S16"
+          },
+          "CertificateChain": {
+            "shape": "S17"
+          }
         }
       }
     },
@@ -189,23 +277,33 @@
           "PrivateKey"
         ],
         "members": {
-          "CertificateArn": {},
+          "CertificateArn": {
+            "shape": "S2"
+          },
           "Certificate": {
-            "type": "blob"
+            "type": "blob",
+            "max": 32768,
+            "min": 1
           },
           "PrivateKey": {
             "type": "blob",
+            "max": 524288,
+            "min": 1,
             "sensitive": true
           },
           "CertificateChain": {
-            "type": "blob"
+            "type": "blob",
+            "max": 2097152,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -215,42 +313,60 @@
         "members": {
           "CertificateStatuses": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sm"
+            }
           },
           "Includes": {
             "type": "structure",
             "members": {
               "extendedKeyUsage": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "Sz"
+                }
               },
               "keyUsage": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "Sw"
+                }
               },
               "keyTypes": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "So"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S1m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "type": "integer",
+            "max": 1000,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S1m"
+          },
           "CertificateSummaryList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "CertificateArn": {},
-                "DomainName": {}
+                "CertificateArn": {
+                  "shape": "S2"
+                },
+                "DomainName": {
+                  "shape": "Sb"
+                }
               }
             }
           }
@@ -264,7 +380,9 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -284,7 +402,9 @@
           "Tags"
         ],
         "members": {
-          "CertificateArn": {},
+          "CertificateArn": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "S3"
           }
@@ -298,12 +418,21 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
-          "ValidationMethod": {},
+          "DomainName": {
+            "shape": "Sb"
+          },
+          "ValidationMethod": {
+            "shape": "Sk"
+          },
           "SubjectAlternativeNames": {
             "shape": "Sc"
           },
-          "IdempotencyToken": {},
+          "IdempotencyToken": {
+            "type": "string",
+            "max": 32,
+            "min": 1,
+            "pattern": "\\w+"
+          },
           "DomainValidationOptions": {
             "type": "list",
             "member": {
@@ -313,21 +442,31 @@
                 "ValidationDomain"
               ],
               "members": {
-                "DomainName": {},
-                "ValidationDomain": {}
+                "DomainName": {
+                  "shape": "Sb"
+                },
+                "ValidationDomain": {
+                  "shape": "Sb"
+                }
               }
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "Options": {
             "shape": "S11"
           },
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -340,9 +479,15 @@
           "ValidationDomain"
         ],
         "members": {
-          "CertificateArn": {},
-          "Domain": {},
-          "ValidationDomain": {}
+          "CertificateArn": {
+            "shape": "S2"
+          },
+          "Domain": {
+            "shape": "Sb"
+          },
+          "ValidationDomain": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -354,7 +499,9 @@
           "Options"
         ],
         "members": {
-          "CertificateArn": {},
+          "CertificateArn": {
+            "shape": "S2"
+          },
           "Options": {
             "shape": "S11"
           }
@@ -363,6 +510,12 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 20,
+      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:[\\w+=/,.@-]*:[0-9]+:[\\w+=,.@-]+(/[\\w+=,.@-]+)*"
+    },
     "S3": {
       "type": "list",
       "member": {
@@ -371,14 +524,36 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
+    },
+    "Sb": {
+      "type": "string",
+      "max": 253,
+      "min": 1,
+      "pattern": "^(\\*\\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$"
     },
     "Sc": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      },
+      "max": 100,
+      "min": 1
     },
     "Sd": {
       "type": "list",
@@ -388,13 +563,24 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "Sb"
+          },
           "ValidationEmails": {
             "type": "list",
             "member": {}
           },
-          "ValidationDomain": {},
-          "ValidationStatus": {},
+          "ValidationDomain": {
+            "shape": "Sb"
+          },
+          "ValidationStatus": {
+            "type": "string",
+            "enum": [
+              "PENDING_VALIDATION",
+              "SUCCESS",
+              "FAILED"
+            ]
+          },
           "ResourceRecord": {
             "type": "structure",
             "required": [
@@ -404,19 +590,115 @@
             ],
             "members": {
               "Name": {},
-              "Type": {},
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "CNAME"
+                ]
+              },
               "Value": {}
             }
           },
-          "ValidationMethod": {}
+          "ValidationMethod": {
+            "shape": "Sk"
+          }
         }
-      }
+      },
+      "max": 1000,
+      "min": 1
+    },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "EMAIL",
+        "DNS"
+      ]
+    },
+    "Sm": {
+      "type": "string",
+      "enum": [
+        "PENDING_VALIDATION",
+        "ISSUED",
+        "INACTIVE",
+        "EXPIRED",
+        "VALIDATION_TIMED_OUT",
+        "REVOKED",
+        "FAILED"
+      ]
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "RSA_2048",
+        "RSA_1024",
+        "RSA_4096",
+        "EC_prime256v1",
+        "EC_secp384r1",
+        "EC_secp521r1"
+      ]
+    },
+    "Sw": {
+      "type": "string",
+      "enum": [
+        "DIGITAL_SIGNATURE",
+        "NON_REPUDIATION",
+        "KEY_ENCIPHERMENT",
+        "DATA_ENCIPHERMENT",
+        "KEY_AGREEMENT",
+        "CERTIFICATE_SIGNING",
+        "CRL_SIGNING",
+        "ENCIPHER_ONLY",
+        "DECIPHER_ONLY",
+        "ANY",
+        "CUSTOM"
+      ]
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "TLS_WEB_SERVER_AUTHENTICATION",
+        "TLS_WEB_CLIENT_AUTHENTICATION",
+        "CODE_SIGNING",
+        "EMAIL_PROTECTION",
+        "TIME_STAMPING",
+        "OCSP_SIGNING",
+        "IPSEC_END_SYSTEM",
+        "IPSEC_TUNNEL",
+        "IPSEC_USER",
+        "ANY",
+        "NONE",
+        "CUSTOM"
+      ]
     },
     "S11": {
       "type": "structure",
       "members": {
-        "CertificateTransparencyLoggingPreference": {}
+        "CertificateTransparencyLoggingPreference": {
+          "type": "string",
+          "enum": [
+            "ENABLED",
+            "DISABLED"
+          ]
+        }
       }
+    },
+    "S16": {
+      "type": "string",
+      "max": 32768,
+      "min": 1,
+      "pattern": "-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}(\\u000D?\\u000A)?"
+    },
+    "S17": {
+      "type": "string",
+      "max": 2097152,
+      "min": 1,
+      "pattern": "(-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}\\u000D?\\u000A)*-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}(\\u000D?\\u000A)?"
+    },
+    "S1m": {
+      "type": "string",
+      "max": 320,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]*"
     }
   }
 }

--- a/apis/acm-pca-2017-08-22.min.json
+++ b/apis/acm-pca-2017-08-22.min.json
@@ -27,14 +27,20 @@
           "RevocationConfiguration": {
             "shape": "Se"
           },
-          "CertificateAuthorityType": {},
-          "IdempotencyToken": {}
+          "CertificateAuthorityType": {
+            "shape": "Sk"
+          },
+          "IdempotencyToken": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          }
         }
       },
       "idempotent": true
@@ -48,15 +54,25 @@
           "AuditReportResponseFormat"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "S3BucketName": {},
-          "AuditReportResponseFormat": {}
+          "AuditReportResponseFormat": {
+            "type": "string",
+            "enum": [
+              "JSON",
+              "CSV"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AuditReportId": {},
+          "AuditReportId": {
+            "shape": "Ss"
+          },
           "S3Key": {}
         }
       },
@@ -69,9 +85,13 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "PermanentDeletionTimeInDays": {
-            "type": "integer"
+            "type": "integer",
+            "max": 30,
+            "min": 7
           }
         }
       }
@@ -83,7 +103,9 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          }
         }
       },
       "output": {
@@ -103,14 +125,25 @@
           "AuditReportId"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
-          "AuditReportId": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
+          "AuditReportId": {
+            "shape": "Ss"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AuditReportStatus": {},
+          "AuditReportStatus": {
+            "type": "string",
+            "enum": [
+              "CREATING",
+              "SUCCESS",
+              "FAILED"
+            ]
+          },
           "S3BucketName": {},
           "S3Key": {},
           "CreatedAt": {
@@ -127,8 +160,12 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
-          "CertificateArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
+          "CertificateArn": {
+            "shape": "Sn"
+          }
         }
       },
       "output": {
@@ -146,7 +183,9 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          }
         }
       },
       "output": {
@@ -164,7 +203,9 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          }
         }
       },
       "output": {
@@ -183,12 +224,18 @@
           "CertificateChain"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "Certificate": {
-            "type": "blob"
+            "type": "blob",
+            "max": 32768,
+            "min": 1
           },
           "CertificateChain": {
-            "type": "blob"
+            "type": "blob",
+            "max": 2097152,
+            "min": 0
           }
         }
       }
@@ -203,11 +250,17 @@
           "Validity"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
-          "Csr": {
-            "type": "blob"
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
           },
-          "SigningAlgorithm": {},
+          "Csr": {
+            "type": "blob",
+            "max": 32768,
+            "min": 1
+          },
+          "SigningAlgorithm": {
+            "shape": "S4"
+          },
           "Validity": {
             "type": "structure",
             "required": [
@@ -216,18 +269,32 @@
             ],
             "members": {
               "Value": {
-                "type": "long"
+                "type": "long",
+                "min": 1
               },
-              "Type": {}
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "END_DATE",
+                  "ABSOLUTE",
+                  "DAYS",
+                  "MONTHS",
+                  "YEARS"
+                ]
+              }
             }
           },
-          "IdempotencyToken": {}
+          "IdempotencyToken": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {}
+          "CertificateArn": {
+            "shape": "Sn"
+          }
         }
       },
       "idempotent": true
@@ -236,9 +303,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S1n"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1o"
           }
         }
       },
@@ -251,7 +320,9 @@
               "shape": "Sx"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -262,10 +333,14 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
-          "NextToken": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
+          "NextToken": {
+            "shape": "S1n"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1o"
           }
         }
       },
@@ -275,7 +350,9 @@
           "Tags": {
             "shape": "S1t"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -286,7 +363,9 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -299,9 +378,25 @@
           "RevocationReason"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
-          "CertificateSerial": {},
-          "RevocationReason": {}
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
+          "CertificateSerial": {
+            "shape": "S9"
+          },
+          "RevocationReason": {
+            "type": "string",
+            "enum": [
+              "UNSPECIFIED",
+              "KEY_COMPROMISE",
+              "CERTIFICATE_AUTHORITY_COMPROMISE",
+              "AFFILIATION_CHANGED",
+              "SUPERSEDED",
+              "CESSATION_OF_OPERATION",
+              "PRIVILEGE_WITHDRAWN",
+              "A_A_COMPROMISE"
+            ]
+          }
         }
       }
     },
@@ -313,7 +408,9 @@
           "Tags"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "Tags": {
             "shape": "S1t"
           }
@@ -328,7 +425,9 @@
           "Tags"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "Tags": {
             "shape": "S1t"
           }
@@ -342,11 +441,15 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {},
+          "CertificateAuthorityArn": {
+            "shape": "Sn"
+          },
           "RevocationConfiguration": {
             "shape": "Se"
           },
-          "Status": {}
+          "Status": {
+            "shape": "Sz"
+          }
         }
       }
     }
@@ -360,28 +463,99 @@
         "Subject"
       ],
       "members": {
-        "KeyAlgorithm": {},
-        "SigningAlgorithm": {},
+        "KeyAlgorithm": {
+          "type": "string",
+          "enum": [
+            "RSA_2048",
+            "RSA_4096",
+            "EC_prime256v1",
+            "EC_secp384r1"
+          ]
+        },
+        "SigningAlgorithm": {
+          "shape": "S4"
+        },
         "Subject": {
           "type": "structure",
           "members": {
-            "Country": {},
-            "Organization": {},
-            "OrganizationalUnit": {},
-            "DistinguishedNameQualifier": {},
-            "State": {},
-            "CommonName": {},
-            "SerialNumber": {},
-            "Locality": {},
-            "Title": {},
-            "Surname": {},
-            "GivenName": {},
-            "Initials": {},
-            "Pseudonym": {},
-            "GenerationQualifier": {}
+            "Country": {
+              "type": "string",
+              "pattern": "[A-Za-z]{2}"
+            },
+            "Organization": {
+              "shape": "S7"
+            },
+            "OrganizationalUnit": {
+              "shape": "S7"
+            },
+            "DistinguishedNameQualifier": {
+              "type": "string",
+              "max": 64,
+              "min": 0,
+              "pattern": "[a-zA-Z0-9'()+-.?:/= ]*"
+            },
+            "State": {
+              "shape": "S9"
+            },
+            "CommonName": {
+              "shape": "S7"
+            },
+            "SerialNumber": {
+              "shape": "S7"
+            },
+            "Locality": {
+              "shape": "S9"
+            },
+            "Title": {
+              "shape": "S7"
+            },
+            "Surname": {
+              "type": "string",
+              "max": 40,
+              "min": 0
+            },
+            "GivenName": {
+              "type": "string",
+              "max": 16,
+              "min": 0
+            },
+            "Initials": {
+              "type": "string",
+              "max": 5,
+              "min": 0
+            },
+            "Pseudonym": {
+              "shape": "S9"
+            },
+            "GenerationQualifier": {
+              "type": "string",
+              "max": 3,
+              "min": 0
+            }
           }
         }
       }
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "SHA256WITHECDSA",
+        "SHA384WITHECDSA",
+        "SHA512WITHECDSA",
+        "SHA256WITHRSA",
+        "SHA384WITHRSA",
+        "SHA512WITHRSA"
+      ]
+    },
+    "S7": {
+      "type": "string",
+      "max": 64,
+      "min": 0
+    },
+    "S9": {
+      "type": "string",
+      "max": 128,
+      "min": 0
     },
     "Se": {
       "type": "structure",
@@ -396,34 +570,81 @@
               "type": "boolean"
             },
             "ExpirationInDays": {
-              "type": "integer"
+              "type": "integer",
+              "max": 5000,
+              "min": 1
             },
-            "CustomCname": {},
-            "S3BucketName": {}
+            "CustomCname": {
+              "type": "string",
+              "max": 253,
+              "min": 0
+            },
+            "S3BucketName": {
+              "type": "string",
+              "max": 255,
+              "min": 3
+            }
           }
         }
       }
     },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "SUBORDINATE"
+      ]
+    },
+    "Sl": {
+      "type": "string",
+      "max": 36,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]*"
+    },
+    "Sn": {
+      "type": "string",
+      "max": 200,
+      "min": 5,
+      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:[\\w+=/,.@-]*:[0-9]+:[\\w+=,.@-]+(/[\\w+=/,.@-]+)*"
+    },
+    "Ss": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
+    },
     "Sx": {
       "type": "structure",
       "members": {
-        "Arn": {},
+        "Arn": {
+          "shape": "Sn"
+        },
         "CreatedAt": {
           "type": "timestamp"
         },
         "LastStateChangeAt": {
           "type": "timestamp"
         },
-        "Type": {},
+        "Type": {
+          "shape": "Sk"
+        },
         "Serial": {},
-        "Status": {},
+        "Status": {
+          "shape": "Sz"
+        },
         "NotBefore": {
           "type": "timestamp"
         },
         "NotAfter": {
           "type": "timestamp"
         },
-        "FailureReason": {},
+        "FailureReason": {
+          "type": "string",
+          "enum": [
+            "REQUEST_TIMED_OUT",
+            "UNSUPPORTED_ALGORITHM",
+            "OTHER"
+          ]
+        },
         "CertificateAuthorityConfiguration": {
           "shape": "S2"
         },
@@ -435,6 +656,28 @@
         }
       }
     },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "PENDING_CERTIFICATE",
+        "ACTIVE",
+        "DELETED",
+        "DISABLED",
+        "EXPIRED",
+        "FAILED"
+      ]
+    },
+    "S1n": {
+      "type": "string",
+      "max": 500,
+      "min": 1
+    },
+    "S1o": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
     "S1t": {
       "type": "list",
       "member": {
@@ -443,10 +686,22 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
     }
   }
 }

--- a/apis/alexaforbusiness-2017-11-09.min.json
+++ b/apis/alexaforbusiness-2017-11-09.min.json
@@ -20,8 +20,12 @@
           "AddressBookArn"
         ],
         "members": {
-          "ContactArn": {},
-          "AddressBookArn": {}
+          "ContactArn": {
+            "shape": "S2"
+          },
+          "AddressBookArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -33,8 +37,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {},
-          "RoomArn": {}
+          "DeviceArn": {
+            "shape": "S2"
+          },
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -46,8 +54,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {},
-          "RoomArn": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          },
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -62,9 +74,14 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S9"
+          },
+          "Description": {
+            "shape": "Sa"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -72,7 +89,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "AddressBookArn": {}
+          "AddressBookArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -84,11 +103,20 @@
           "PhoneNumber"
         ],
         "members": {
-          "DisplayName": {},
-          "FirstName": {},
-          "LastName": {},
-          "PhoneNumber": {},
+          "DisplayName": {
+            "shape": "Se"
+          },
+          "FirstName": {
+            "shape": "Se"
+          },
+          "LastName": {
+            "shape": "Se"
+          },
+          "PhoneNumber": {
+            "shape": "Sf"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -96,7 +124,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContactArn": {}
+          "ContactArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -112,13 +142,26 @@
           "WakeWord"
         ],
         "members": {
-          "ProfileName": {},
-          "Timezone": {},
-          "Address": {},
-          "DistanceUnit": {},
-          "TemperatureUnit": {},
-          "WakeWord": {},
+          "ProfileName": {
+            "shape": "Si"
+          },
+          "Timezone": {
+            "shape": "Sj"
+          },
+          "Address": {
+            "shape": "Sk"
+          },
+          "DistanceUnit": {
+            "shape": "Sl"
+          },
+          "TemperatureUnit": {
+            "shape": "Sm"
+          },
+          "WakeWord": {
+            "shape": "Sn"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           },
           "SetupModeDisabled": {
@@ -135,7 +178,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ProfileArn": {}
+          "ProfileArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -146,11 +191,20 @@
           "RoomName"
         ],
         "members": {
-          "RoomName": {},
-          "Description": {},
-          "ProfileArn": {},
-          "ProviderCalendarId": {},
+          "RoomName": {
+            "shape": "Ss"
+          },
+          "Description": {
+            "shape": "St"
+          },
+          "ProfileArn": {
+            "shape": "S2"
+          },
+          "ProviderCalendarId": {
+            "shape": "Su"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           },
           "Tags": {
@@ -161,7 +215,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "RoomArn": {}
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -172,9 +228,14 @@
           "SkillGroupName"
         ],
         "members": {
-          "SkillGroupName": {},
-          "Description": {},
+          "SkillGroupName": {
+            "shape": "S11"
+          },
+          "Description": {
+            "shape": "S12"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -182,7 +243,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -193,11 +256,23 @@
           "UserId"
         ],
         "members": {
-          "UserId": {},
-          "FirstName": {},
-          "LastName": {},
-          "Email": {},
+          "UserId": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[a-zA-Z0-9@_+.-]*"
+          },
+          "FirstName": {
+            "shape": "S16"
+          },
+          "LastName": {
+            "shape": "S17"
+          },
+          "Email": {
+            "shape": "S18"
+          },
           "ClientRequestToken": {
+            "shape": "Sb",
             "idempotencyToken": true
           },
           "Tags": {
@@ -208,7 +283,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "UserArn": {}
+          "UserArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -219,7 +296,9 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {}
+          "AddressBookArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -234,7 +313,9 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {}
+          "ContactArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -246,7 +327,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {}
+          "ProfileArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -258,7 +341,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {}
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -274,9 +359,15 @@
           "ParameterKey"
         ],
         "members": {
-          "RoomArn": {},
-          "SkillId": {},
-          "ParameterKey": {}
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "SkillId": {
+            "shape": "S1j"
+          },
+          "ParameterKey": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -288,7 +379,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -303,8 +396,12 @@
           "EnrollmentId"
         ],
         "members": {
-          "UserArn": {},
-          "EnrollmentId": {}
+          "UserArn": {
+            "shape": "S2"
+          },
+          "EnrollmentId": {
+            "shape": "S1p"
+          }
         }
       },
       "output": {
@@ -320,8 +417,12 @@
           "AddressBookArn"
         ],
         "members": {
-          "ContactArn": {},
-          "AddressBookArn": {}
+          "ContactArn": {
+            "shape": "S2"
+          },
+          "AddressBookArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -333,7 +434,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {}
+          "DeviceArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -345,8 +448,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {},
-          "RoomArn": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          },
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -361,7 +468,9 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {}
+          "AddressBookArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -370,9 +479,15 @@
           "AddressBook": {
             "type": "structure",
             "members": {
-              "AddressBookArn": {},
-              "Name": {},
-              "Description": {}
+              "AddressBookArn": {
+                "shape": "S2"
+              },
+              "Name": {
+                "shape": "S9"
+              },
+              "Description": {
+                "shape": "Sa"
+              }
             }
           }
         }
@@ -385,7 +500,9 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {}
+          "ContactArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -394,11 +511,21 @@
           "Contact": {
             "type": "structure",
             "members": {
-              "ContactArn": {},
-              "DisplayName": {},
-              "FirstName": {},
-              "LastName": {},
-              "PhoneNumber": {}
+              "ContactArn": {
+                "shape": "S2"
+              },
+              "DisplayName": {
+                "shape": "Se"
+              },
+              "FirstName": {
+                "shape": "Se"
+              },
+              "LastName": {
+                "shape": "Se"
+              },
+              "PhoneNumber": {
+                "shape": "Sf"
+              }
             }
           }
         }
@@ -408,7 +535,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {}
+          "DeviceArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -417,14 +546,26 @@
           "Device": {
             "type": "structure",
             "members": {
-              "DeviceArn": {},
-              "DeviceSerialNumber": {},
-              "DeviceType": {},
-              "DeviceName": {},
+              "DeviceArn": {
+                "shape": "S2"
+              },
+              "DeviceSerialNumber": {
+                "shape": "S26"
+              },
+              "DeviceType": {
+                "shape": "S27"
+              },
+              "DeviceName": {
+                "shape": "S28"
+              },
               "SoftwareVersion": {},
               "MacAddress": {},
-              "RoomArn": {},
-              "DeviceStatus": {},
+              "RoomArn": {
+                "shape": "S2"
+              },
+              "DeviceStatus": {
+                "shape": "S2b"
+              },
               "DeviceStatusInfo": {
                 "shape": "S2c"
               }
@@ -437,7 +578,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {}
+          "ProfileArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -446,13 +589,27 @@
           "Profile": {
             "type": "structure",
             "members": {
-              "ProfileArn": {},
-              "ProfileName": {},
-              "Address": {},
-              "Timezone": {},
-              "DistanceUnit": {},
-              "TemperatureUnit": {},
-              "WakeWord": {},
+              "ProfileArn": {
+                "shape": "S2"
+              },
+              "ProfileName": {
+                "shape": "Si"
+              },
+              "Address": {
+                "shape": "Sk"
+              },
+              "Timezone": {
+                "shape": "Sj"
+              },
+              "DistanceUnit": {
+                "shape": "Sl"
+              },
+              "TemperatureUnit": {
+                "shape": "Sm"
+              },
+              "WakeWord": {
+                "shape": "Sn"
+              },
               "SetupModeDisabled": {
                 "type": "boolean"
               },
@@ -471,7 +628,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {}
+          "RoomArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -480,11 +639,21 @@
           "Room": {
             "type": "structure",
             "members": {
-              "RoomArn": {},
-              "RoomName": {},
-              "Description": {},
-              "ProviderCalendarId": {},
-              "ProfileArn": {}
+              "RoomArn": {
+                "shape": "S2"
+              },
+              "RoomName": {
+                "shape": "Ss"
+              },
+              "Description": {
+                "shape": "St"
+              },
+              "ProviderCalendarId": {
+                "shape": "Su"
+              },
+              "ProfileArn": {
+                "shape": "S2"
+              }
             }
           }
         }
@@ -498,9 +667,15 @@
           "ParameterKey"
         ],
         "members": {
-          "RoomArn": {},
-          "SkillId": {},
-          "ParameterKey": {}
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "SkillId": {
+            "shape": "S1j"
+          },
+          "ParameterKey": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -516,7 +691,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -525,9 +702,15 @@
           "SkillGroup": {
             "type": "structure",
             "members": {
-              "SkillGroupArn": {},
-              "SkillGroupName": {},
-              "Description": {}
+              "SkillGroupArn": {
+                "shape": "S2"
+              },
+              "SkillGroupName": {
+                "shape": "S11"
+              },
+              "Description": {
+                "shape": "S12"
+              }
             }
           }
         }
@@ -540,11 +723,17 @@
           "DeviceArn"
         ],
         "members": {
-          "DeviceArn": {},
-          "EventType": {},
-          "NextToken": {},
+          "DeviceArn": {
+            "shape": "S2"
+          },
+          "EventType": {
+            "shape": "S2v"
+          },
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           }
         }
       },
@@ -556,7 +745,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {},
+                "Type": {
+                  "shape": "S2v"
+                },
                 "Value": {},
                 "Timestamp": {
                   "type": "timestamp"
@@ -564,7 +755,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2w"
+          }
         }
       }
     },
@@ -572,10 +765,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {},
-          "NextToken": {},
+          "SkillGroupArn": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -587,15 +786,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "SkillId": {},
-                "SkillName": {},
+                "SkillId": {
+                  "shape": "S1j"
+                },
+                "SkillName": {
+                  "type": "string",
+                  "max": 100,
+                  "min": 1,
+                  "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+                },
                 "SupportsLinking": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2w"
+          }
         }
       }
     },
@@ -606,10 +814,14 @@
           "Arn"
         ],
         "members": {
-          "Arn": {},
-          "NextToken": {},
+          "Arn": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           }
         }
       },
@@ -619,7 +831,9 @@
           "Tags": {
             "shape": "Sv"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2w"
+          }
         }
       }
     },
@@ -631,8 +845,12 @@
           "RoomSkillParameter"
         ],
         "members": {
-          "RoomArn": {},
-          "SkillId": {},
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "SkillId": {
+            "shape": "S1j"
+          },
           "RoomSkillParameter": {
             "shape": "S2p"
           }
@@ -651,15 +869,24 @@
           "SkillId"
         ],
         "members": {
-          "UserId": {},
-          "SkillId": {}
+          "UserId": {
+            "type": "string",
+            "pattern": "amzn1\\.[A-Za-z0-9+-\\/=.]{1,300}"
+          },
+          "SkillId": {
+            "shape": "S1j"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "RoomArn": {},
-          "RoomName": {},
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "RoomName": {
+            "shape": "Ss"
+          },
           "RoomSkillParameters": {
             "type": "list",
             "member": {
@@ -673,8 +900,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserArn": {},
-          "EnrollmentId": {}
+          "UserArn": {
+            "shape": "S2"
+          },
+          "EnrollmentId": {
+            "shape": "S1p"
+          }
         }
       },
       "output": {
@@ -692,9 +923,11 @@
           "SortCriteria": {
             "shape": "S3q"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           }
         }
       },
@@ -706,13 +939,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "AddressBookArn": {},
-                "Name": {},
-                "Description": {}
+                "AddressBookArn": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S9"
+                },
+                "Description": {
+                  "shape": "Sa"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -729,9 +970,11 @@
           "SortCriteria": {
             "shape": "S3q"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           }
         }
       },
@@ -743,15 +986,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "ContactArn": {},
-                "DisplayName": {},
-                "FirstName": {},
-                "LastName": {},
-                "PhoneNumber": {}
+                "ContactArn": {
+                  "shape": "S2"
+                },
+                "DisplayName": {
+                  "shape": "Se"
+                },
+                "FirstName": {
+                  "shape": "Se"
+                },
+                "LastName": {
+                  "shape": "Se"
+                },
+                "PhoneNumber": {
+                  "shape": "Sf"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -762,9 +1017,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           },
           "Filters": {
             "shape": "S3l"
@@ -782,22 +1039,38 @@
             "member": {
               "type": "structure",
               "members": {
-                "DeviceArn": {},
-                "DeviceSerialNumber": {},
-                "DeviceType": {},
-                "DeviceName": {},
+                "DeviceArn": {
+                  "shape": "S2"
+                },
+                "DeviceSerialNumber": {
+                  "shape": "S26"
+                },
+                "DeviceType": {
+                  "shape": "S27"
+                },
+                "DeviceName": {
+                  "shape": "S28"
+                },
                 "SoftwareVersion": {},
                 "MacAddress": {},
-                "DeviceStatus": {},
-                "RoomArn": {},
-                "RoomName": {},
+                "DeviceStatus": {
+                  "shape": "S2b"
+                },
+                "RoomArn": {
+                  "shape": "S2"
+                },
+                "RoomName": {
+                  "shape": "Ss"
+                },
                 "DeviceStatusInfo": {
                   "shape": "S2c"
                 }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -808,9 +1081,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           },
           "Filters": {
             "shape": "S3l"
@@ -828,17 +1103,33 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProfileArn": {},
-                "ProfileName": {},
-                "Address": {},
-                "Timezone": {},
-                "DistanceUnit": {},
-                "TemperatureUnit": {},
-                "WakeWord": {}
+                "ProfileArn": {
+                  "shape": "S2"
+                },
+                "ProfileName": {
+                  "shape": "Si"
+                },
+                "Address": {
+                  "shape": "Sk"
+                },
+                "Timezone": {
+                  "shape": "Sj"
+                },
+                "DistanceUnit": {
+                  "shape": "Sl"
+                },
+                "TemperatureUnit": {
+                  "shape": "Sm"
+                },
+                "WakeWord": {
+                  "shape": "Sn"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -849,9 +1140,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           },
           "Filters": {
             "shape": "S3l"
@@ -869,16 +1162,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "RoomArn": {},
-                "RoomName": {},
-                "Description": {},
-                "ProviderCalendarId": {},
-                "ProfileArn": {},
-                "ProfileName": {}
+                "RoomArn": {
+                  "shape": "S2"
+                },
+                "RoomName": {
+                  "shape": "Ss"
+                },
+                "Description": {
+                  "shape": "St"
+                },
+                "ProviderCalendarId": {
+                  "shape": "Su"
+                },
+                "ProfileArn": {
+                  "shape": "S2"
+                },
+                "ProfileName": {
+                  "shape": "Si"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -889,9 +1196,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           },
           "Filters": {
             "shape": "S3l"
@@ -909,13 +1218,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "SkillGroupArn": {},
-                "SkillGroupName": {},
-                "Description": {}
+                "SkillGroupArn": {
+                  "shape": "S2"
+                },
+                "SkillGroupName": {
+                  "shape": "S11"
+                },
+                "Description": {
+                  "shape": "S12"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -926,9 +1243,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2x"
           },
           "Filters": {
             "shape": "S3l"
@@ -946,16 +1265,37 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserArn": {},
-                "FirstName": {},
-                "LastName": {},
-                "Email": {},
-                "EnrollmentStatus": {},
-                "EnrollmentId": {}
+                "UserArn": {
+                  "shape": "S2"
+                },
+                "FirstName": {
+                  "shape": "S16"
+                },
+                "LastName": {
+                  "shape": "S17"
+                },
+                "Email": {
+                  "shape": "S18"
+                },
+                "EnrollmentStatus": {
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZED",
+                    "PENDING",
+                    "REGISTERED",
+                    "DISASSOCIATING",
+                    "DEREGISTERING"
+                  ]
+                },
+                "EnrollmentId": {
+                  "shape": "S1p"
+                }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2w"
+          },
           "TotalCount": {
             "type": "integer"
           }
@@ -966,7 +1306,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserArn": {}
+          "UserArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -981,11 +1323,25 @@
           "Features"
         ],
         "members": {
-          "RoomArn": {},
-          "DeviceArn": {},
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "DeviceArn": {
+            "shape": "S2"
+          },
           "Features": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "BLUETOOTH",
+                "VOLUME",
+                "NOTIFICATIONS",
+                "LISTS",
+                "SKILLS",
+                "ALL"
+              ]
+            }
           }
         }
       },
@@ -1002,7 +1358,9 @@
           "Tags"
         ],
         "members": {
-          "Arn": {},
+          "Arn": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "Sv"
           }
@@ -1021,10 +1379,14 @@
           "TagKeys"
         ],
         "members": {
-          "Arn": {},
+          "Arn": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sx"
+            }
           }
         }
       },
@@ -1040,9 +1402,15 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {},
-          "Name": {},
-          "Description": {}
+          "AddressBookArn": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S9"
+          },
+          "Description": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -1057,11 +1425,21 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {},
-          "DisplayName": {},
-          "FirstName": {},
-          "LastName": {},
-          "PhoneNumber": {}
+          "ContactArn": {
+            "shape": "S2"
+          },
+          "DisplayName": {
+            "shape": "Se"
+          },
+          "FirstName": {
+            "shape": "Se"
+          },
+          "LastName": {
+            "shape": "Se"
+          },
+          "PhoneNumber": {
+            "shape": "Sf"
+          }
         }
       },
       "output": {
@@ -1073,8 +1451,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {},
-          "DeviceName": {}
+          "DeviceArn": {
+            "shape": "S2"
+          },
+          "DeviceName": {
+            "shape": "S28"
+          }
         }
       },
       "output": {
@@ -1086,13 +1468,27 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {},
-          "ProfileName": {},
-          "Timezone": {},
-          "Address": {},
-          "DistanceUnit": {},
-          "TemperatureUnit": {},
-          "WakeWord": {},
+          "ProfileArn": {
+            "shape": "S2"
+          },
+          "ProfileName": {
+            "shape": "Si"
+          },
+          "Timezone": {
+            "shape": "Sj"
+          },
+          "Address": {
+            "shape": "Sk"
+          },
+          "DistanceUnit": {
+            "shape": "Sl"
+          },
+          "TemperatureUnit": {
+            "shape": "Sm"
+          },
+          "WakeWord": {
+            "shape": "Sn"
+          },
           "SetupModeDisabled": {
             "type": "boolean"
           },
@@ -1113,11 +1509,21 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {},
-          "RoomName": {},
-          "Description": {},
-          "ProviderCalendarId": {},
-          "ProfileArn": {}
+          "RoomArn": {
+            "shape": "S2"
+          },
+          "RoomName": {
+            "shape": "Ss"
+          },
+          "Description": {
+            "shape": "St"
+          },
+          "ProviderCalendarId": {
+            "shape": "Su"
+          },
+          "ProfileArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1129,9 +1535,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {},
-          "SkillGroupName": {},
-          "Description": {}
+          "SkillGroupArn": {
+            "shape": "S2"
+          },
+          "SkillGroupName": {
+            "shape": "S11"
+          },
+          "Description": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -1141,15 +1553,183 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
+    },
+    "S9": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "Sb": {
+      "type": "string",
+      "max": 150,
+      "min": 10,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
+    },
+    "Se": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "Sf": {
+      "type": "string",
+      "pattern": "^\\+\\d{8,}$"
+    },
+    "Si": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "Sj": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "Sk": {
+      "type": "string",
+      "max": 500,
+      "min": 1
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "METRIC",
+        "IMPERIAL"
+      ]
+    },
+    "Sm": {
+      "type": "string",
+      "enum": [
+        "FAHRENHEIT",
+        "CELSIUS"
+      ]
+    },
+    "Sn": {
+      "type": "string",
+      "enum": [
+        "ALEXA",
+        "AMAZON",
+        "ECHO",
+        "COMPUTER"
+      ]
+    },
+    "Ss": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "St": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "Su": {
+      "type": "string",
+      "max": 100,
+      "min": 0
+    },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Sx"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
       }
+    },
+    "Sx": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "S11": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "S12": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "S16": {
+      "type": "string",
+      "max": 30,
+      "min": 0,
+      "pattern": "([A-Za-z\\-' 0-9._]|\\p{IsLetter})*"
+    },
+    "S17": {
+      "type": "string",
+      "max": 30,
+      "min": 0,
+      "pattern": "([A-Za-z\\-' 0-9._]|\\p{IsLetter})*"
+    },
+    "S18": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "([0-9a-zA-Z]([+-.\\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\\w]*[0-9a-zA-Z]\\.)+[a-zA-Z]{2,9})"
+    },
+    "S1j": {
+      "type": "string",
+      "pattern": "(^amzn1\\.ask\\.skill\\.[0-9a-f\\-]{1,200})|(^amzn1\\.echo-sdk-ams\\.app\\.[0-9a-f\\-]{1,200})"
+    },
+    "S1k": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S1p": {
+      "type": "string",
+      "max": 128,
+      "min": 0
+    },
+    "S26": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9]{1,200}"
+    },
+    "S27": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9]{1,200}"
+    },
+    "S28": {
+      "type": "string",
+      "max": 100,
+      "min": 2,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
+    },
+    "S2b": {
+      "type": "string",
+      "enum": [
+        "READY",
+        "PENDING",
+        "WAS_OFFLINE",
+        "DEREGISTERED"
+      ]
     },
     "S2c": {
       "type": "structure",
@@ -1159,11 +1739,23 @@
           "member": {
             "type": "structure",
             "members": {
-              "Code": {}
+              "Code": {
+                "type": "string",
+                "enum": [
+                  "DEVICE_SOFTWARE_UPDATE_NEEDED",
+                  "DEVICE_WAS_OFFLINE"
+                ]
+              }
             }
           }
         },
-        "ConnectionStatus": {}
+        "ConnectionStatus": {
+          "type": "string",
+          "enum": [
+            "ONLINE",
+            "OFFLINE"
+          ]
+        }
       }
     },
     "S2p": {
@@ -1173,9 +1765,32 @@
         "ParameterValue"
       ],
       "members": {
-        "ParameterKey": {},
-        "ParameterValue": {}
+        "ParameterKey": {
+          "shape": "S1k"
+        },
+        "ParameterValue": {
+          "type": "string",
+          "max": 512,
+          "min": 1
+        }
       }
+    },
+    "S2v": {
+      "type": "string",
+      "enum": [
+        "CONNECTION_STATUS",
+        "DEVICE_STATUS"
+      ]
+    },
+    "S2w": {
+      "type": "string",
+      "max": 1000,
+      "min": 1
+    },
+    "S2x": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
     },
     "S3l": {
       "type": "list",
@@ -1186,13 +1801,23 @@
           "Values"
         ],
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 500,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 500,
+              "min": 1
+            },
+            "max": 5
           }
         }
-      }
+      },
+      "max": 25
     },
     "S3q": {
       "type": "list",
@@ -1203,10 +1828,21 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 500,
+            "min": 1
+          },
+          "Value": {
+            "type": "string",
+            "enum": [
+              "ASC",
+              "DESC"
+            ]
+          }
         }
-      }
+      },
+      "max": 25
     }
   }
 }

--- a/apis/apigateway-2015-07-09.min.json
+++ b/apis/apigateway-2015-07-09.min.json
@@ -62,7 +62,9 @@
             "locationName": "restapi_id"
           },
           "name": {},
-          "type": {},
+          "type": {
+            "shape": "Sa"
+          },
           "providerARNs": {
             "shape": "Sb"
           },
@@ -126,7 +128,9 @@
           "cacheClusterEnabled": {
             "type": "boolean"
           },
-          "cacheClusterSize": {},
+          "cacheClusterSize": {
+            "shape": "Sj"
+          },
           "variables": {
             "shape": "Sk"
           },
@@ -337,7 +341,9 @@
           "minimumCompressionSize": {
             "type": "integer"
           },
-          "apiKeySource": {},
+          "apiKeySource": {
+            "shape": "S1n"
+          },
           "endpointConfiguration": {
             "shape": "Sz"
           },
@@ -371,7 +377,9 @@
           "cacheClusterEnabled": {
             "type": "boolean"
           },
-          "cacheClusterSize": {},
+          "cacheClusterSize": {
+            "shape": "Sj"
+          },
           "variables": {
             "shape": "Sk"
           },
@@ -662,6 +670,7 @@
             "locationName": "restapi_id"
           },
           "responseType": {
+            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           }
@@ -725,6 +734,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -788,6 +798,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -1421,6 +1432,7 @@
             "locationName": "restapi_id"
           },
           "type": {
+            "shape": "St",
             "location": "querystring",
             "locationName": "type"
           },
@@ -1443,7 +1455,12 @@
           },
           "locationStatus": {
             "location": "querystring",
-            "locationName": "locationStatus"
+            "locationName": "locationStatus",
+            "type": "string",
+            "enum": [
+              "DOCUMENTED",
+              "UNDOCUMENTED"
+            ]
           }
         }
       },
@@ -1652,6 +1669,7 @@
             "locationName": "restapi_id"
           },
           "responseType": {
+            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           }
@@ -1759,6 +1777,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -1826,6 +1845,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -2573,7 +2593,11 @@
           },
           "format": {
             "location": "querystring",
-            "locationName": "format"
+            "locationName": "format",
+            "type": "string",
+            "enum": [
+              "csv"
+            ]
           },
           "failOnWarnings": {
             "location": "querystring",
@@ -2612,6 +2636,7 @@
             "locationName": "restapi_id"
           },
           "mode": {
+            "shape": "S5u",
             "location": "querystring",
             "locationName": "mode"
           },
@@ -2686,10 +2711,13 @@
             "locationName": "restapi_id"
           },
           "responseType": {
+            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           },
-          "statusCode": {},
+          "statusCode": {
+            "shape": "S1e"
+          },
           "responseParameters": {
             "shape": "Sk"
           },
@@ -2729,12 +2757,16 @@
             "location": "uri",
             "locationName": "http_method"
           },
-          "type": {},
+          "type": {
+            "shape": "S1g"
+          },
           "integrationHttpMethod": {
             "locationName": "httpMethod"
           },
           "uri": {},
-          "connectionType": {},
+          "connectionType": {
+            "shape": "S1h"
+          },
           "connectionId": {},
           "credentials": {},
           "requestParameters": {
@@ -2748,7 +2780,9 @@
           "cacheKeyParameters": {
             "shape": "S8"
           },
-          "contentHandling": {},
+          "contentHandling": {
+            "shape": "S1i"
+          },
           "timeoutInMillis": {
             "type": "integer"
           }
@@ -2786,6 +2820,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -2796,7 +2831,9 @@
           "responseTemplates": {
             "shape": "Sk"
           },
-          "contentHandling": {}
+          "contentHandling": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -2880,6 +2917,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -2912,6 +2950,7 @@
             "locationName": "restapi_id"
           },
           "mode": {
+            "shape": "S5u",
             "location": "querystring",
             "locationName": "mode"
           },
@@ -3342,6 +3381,7 @@
             "locationName": "restapi_id"
           },
           "responseType": {
+            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           },
@@ -3415,6 +3455,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -3489,6 +3530,7 @@
             "locationName": "http_method"
           },
           "statusCode": {
+            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -3746,6 +3788,14 @@
       "type": "list",
       "member": {}
     },
+    "Sa": {
+      "type": "string",
+      "enum": [
+        "TOKEN",
+        "REQUEST",
+        "COGNITO_USER_POOLS"
+      ]
+    },
     "Sb": {
       "type": "list",
       "member": {}
@@ -3755,7 +3805,9 @@
       "members": {
         "id": {},
         "name": {},
-        "type": {},
+        "type": {
+          "shape": "Sa"
+        },
         "providerARNs": {
           "shape": "Sb"
         },
@@ -3776,6 +3828,19 @@
         "restApiId": {},
         "stage": {}
       }
+    },
+    "Sj": {
+      "type": "string",
+      "enum": [
+        "0.5",
+        "1.6",
+        "6.1",
+        "13.5",
+        "28.4",
+        "58.2",
+        "118",
+        "237"
+      ]
     },
     "Sk": {
       "type": "map",
@@ -3815,12 +3880,34 @@
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "shape": "St"
+        },
         "path": {},
         "method": {},
-        "statusCode": {},
+        "statusCode": {
+          "type": "string",
+          "pattern": "^([1-5]\\d\\d|\\*|\\s*)$"
+        },
         "name": {}
       }
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "API",
+        "AUTHORIZER",
+        "MODEL",
+        "RESOURCE",
+        "METHOD",
+        "PATH_PARAMETER",
+        "QUERY_PARAMETER",
+        "REQUEST_HEADER",
+        "REQUEST_BODY",
+        "RESPONSE",
+        "RESPONSE_HEADER",
+        "RESPONSE_BODY"
+      ]
     },
     "Sv": {
       "type": "structure",
@@ -3847,7 +3934,14 @@
       "members": {
         "types": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "REGIONAL",
+              "EDGE",
+              "PRIVATE"
+            ]
+          }
         }
       }
     },
@@ -3952,7 +4046,9 @@
     "S1d": {
       "type": "structure",
       "members": {
-        "statusCode": {},
+        "statusCode": {
+          "shape": "S1e"
+        },
         "responseParameters": {
           "shape": "S1b"
         },
@@ -3961,13 +4057,21 @@
         }
       }
     },
+    "S1e": {
+      "type": "string",
+      "pattern": "[1-5]\\d\\d"
+    },
     "S1f": {
       "type": "structure",
       "members": {
-        "type": {},
+        "type": {
+          "shape": "S1g"
+        },
         "httpMethod": {},
         "uri": {},
-        "connectionType": {},
+        "connectionType": {
+          "shape": "S1h"
+        },
         "connectionId": {},
         "credentials": {},
         "requestParameters": {
@@ -3977,7 +4081,9 @@
           "shape": "Sk"
         },
         "passthroughBehavior": {},
-        "contentHandling": {},
+        "contentHandling": {
+          "shape": "S1i"
+        },
         "timeoutInMillis": {
           "type": "integer"
         },
@@ -3994,10 +4100,36 @@
         }
       }
     },
+    "S1g": {
+      "type": "string",
+      "enum": [
+        "HTTP",
+        "AWS",
+        "MOCK",
+        "HTTP_PROXY",
+        "AWS_PROXY"
+      ]
+    },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "INTERNET",
+        "VPC_LINK"
+      ]
+    },
+    "S1i": {
+      "type": "string",
+      "enum": [
+        "CONVERT_TO_BINARY",
+        "CONVERT_TO_TEXT"
+      ]
+    },
     "S1l": {
       "type": "structure",
       "members": {
-        "statusCode": {},
+        "statusCode": {
+          "shape": "S1e"
+        },
         "selectionPattern": {},
         "responseParameters": {
           "shape": "Sk"
@@ -4005,8 +4137,17 @@
         "responseTemplates": {
           "shape": "Sk"
         },
-        "contentHandling": {}
+        "contentHandling": {
+          "shape": "S1i"
+        }
       }
+    },
+    "S1n": {
+      "type": "string",
+      "enum": [
+        "HEADER",
+        "AUTHORIZER"
+      ]
     },
     "S1o": {
       "type": "structure",
@@ -4027,7 +4168,9 @@
         "minimumCompressionSize": {
           "type": "integer"
         },
-        "apiKeySource": {},
+        "apiKeySource": {
+          "shape": "S1n"
+        },
         "endpointConfiguration": {
           "shape": "Sz"
         },
@@ -4059,8 +4202,19 @@
         "cacheClusterEnabled": {
           "type": "boolean"
         },
-        "cacheClusterSize": {},
-        "cacheClusterStatus": {},
+        "cacheClusterSize": {
+          "shape": "Sj"
+        },
+        "cacheClusterStatus": {
+          "type": "string",
+          "enum": [
+            "CREATE_IN_PROGRESS",
+            "AVAILABLE",
+            "DELETE_IN_PROGRESS",
+            "NOT_AVAILABLE",
+            "FLUSH_IN_PROGRESS"
+          ]
+        },
         "methodSettings": {
           "type": "map",
           "key": {},
@@ -4092,7 +4246,14 @@
               "requireAuthorizationForCacheControl": {
                 "type": "boolean"
               },
-              "unauthorizedCacheControlHeaderStrategy": {}
+              "unauthorizedCacheControlHeaderStrategy": {
+                "type": "string",
+                "enum": [
+                  "FAIL_WITH_403",
+                  "SUCCEED_WITH_RESPONSE_HEADER",
+                  "SUCCEED_WITHOUT_RESPONSE_HEADER"
+                ]
+              }
             }
           }
         },
@@ -4161,7 +4322,14 @@
         "offset": {
           "type": "integer"
         },
-        "period": {}
+        "period": {
+          "type": "string",
+          "enum": [
+            "DAY",
+            "WEEK",
+            "MONTH"
+          ]
+        }
       }
     },
     "S24": {
@@ -4200,9 +4368,42 @@
         "targetArns": {
           "shape": "S8"
         },
-        "status": {},
+        "status": {
+          "type": "string",
+          "enum": [
+            "AVAILABLE",
+            "PENDING",
+            "DELETING",
+            "FAILED"
+          ]
+        },
         "statusMessage": {}
       }
+    },
+    "S2j": {
+      "type": "string",
+      "enum": [
+        "DEFAULT_4XX",
+        "DEFAULT_5XX",
+        "RESOURCE_NOT_FOUND",
+        "UNAUTHORIZED",
+        "INVALID_API_KEY",
+        "ACCESS_DENIED",
+        "AUTHORIZER_FAILURE",
+        "AUTHORIZER_CONFIGURATION_ERROR",
+        "INVALID_SIGNATURE",
+        "EXPIRED_TOKEN",
+        "MISSING_AUTHENTICATION_TOKEN",
+        "INTEGRATION_FAILURE",
+        "INTEGRATION_TIMEOUT",
+        "API_CONFIGURATION_ERROR",
+        "UNSUPPORTED_MEDIA_TYPE",
+        "BAD_REQUEST_PARAMETERS",
+        "BAD_REQUEST_BODY",
+        "REQUEST_TOO_LARGE",
+        "THROTTLED",
+        "QUOTA_EXCEEDED"
+      ]
     },
     "S2z": {
       "type": "structure",
@@ -4234,8 +4435,12 @@
     "S43": {
       "type": "structure",
       "members": {
-        "responseType": {},
-        "statusCode": {},
+        "responseType": {
+          "shape": "S2j"
+        },
+        "statusCode": {
+          "shape": "S1e"
+        },
         "responseParameters": {
           "shape": "Sk"
         },
@@ -4293,6 +4498,13 @@
         }
       }
     },
+    "S5u": {
+      "type": "string",
+      "enum": [
+        "merge",
+        "overwrite"
+      ]
+    },
     "S65": {
       "type": "map",
       "key": {},
@@ -4303,7 +4515,17 @@
       "member": {
         "type": "structure",
         "members": {
-          "op": {},
+          "op": {
+            "type": "string",
+            "enum": [
+              "add",
+              "remove",
+              "replace",
+              "move",
+              "copy",
+              "test"
+            ]
+          },
           "path": {},
           "value": {},
           "from": {}

--- a/apis/application-autoscaling-2016-02-06.min.json
+++ b/apis/application-autoscaling-2016-02-06.min.json
@@ -23,10 +23,18 @@
           "ScalableDimension"
         ],
         "members": {
-          "PolicyName": {},
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {}
+          "PolicyName": {
+            "shape": "S2"
+          },
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -43,10 +51,18 @@
           "ResourceId"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "ScheduledActionName": {},
-          "ResourceId": {},
-          "ScalableDimension": {}
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ScheduledActionName": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -63,9 +79,15 @@
           "ScalableDimension"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {}
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -80,15 +102,21 @@
           "ServiceNamespace"
         ],
         "members": {
-          "ServiceNamespace": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
           "ResourceIds": {
             "shape": "Sb"
           },
-          "ScalableDimension": {},
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -108,23 +136,33 @@
                 "CreationTime"
               ],
               "members": {
-                "ServiceNamespace": {},
-                "ResourceId": {},
-                "ScalableDimension": {},
+                "ServiceNamespace": {
+                  "shape": "S3"
+                },
+                "ResourceId": {
+                  "shape": "S2"
+                },
+                "ScalableDimension": {
+                  "shape": "S4"
+                },
                 "MinCapacity": {
                   "type": "integer"
                 },
                 "MaxCapacity": {
                   "type": "integer"
                 },
-                "RoleARN": {},
+                "RoleARN": {
+                  "shape": "S2"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -135,13 +173,21 @@
           "ServiceNamespace"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -162,25 +208,53 @@
                 "StatusCode"
               ],
               "members": {
-                "ActivityId": {},
-                "ServiceNamespace": {},
-                "ResourceId": {},
-                "ScalableDimension": {},
-                "Description": {},
-                "Cause": {},
+                "ActivityId": {
+                  "shape": "Sn"
+                },
+                "ServiceNamespace": {
+                  "shape": "S3"
+                },
+                "ResourceId": {
+                  "shape": "S2"
+                },
+                "ScalableDimension": {
+                  "shape": "S4"
+                },
+                "Description": {
+                  "shape": "Sd"
+                },
+                "Cause": {
+                  "shape": "Sd"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "StatusCode": {},
-                "StatusMessage": {},
-                "Details": {}
+                "StatusCode": {
+                  "type": "string",
+                  "enum": [
+                    "Pending",
+                    "InProgress",
+                    "Successful",
+                    "Overridden",
+                    "Unfulfilled",
+                    "Failed"
+                  ]
+                },
+                "StatusMessage": {
+                  "shape": "Sd"
+                },
+                "Details": {
+                  "shape": "Sd"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -194,13 +268,21 @@
           "PolicyNames": {
             "shape": "Sb"
           },
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -220,12 +302,24 @@
                 "CreationTime"
               ],
               "members": {
-                "PolicyARN": {},
-                "PolicyName": {},
-                "ServiceNamespace": {},
-                "ResourceId": {},
-                "ScalableDimension": {},
-                "PolicyType": {},
+                "PolicyARN": {
+                  "shape": "S2"
+                },
+                "PolicyName": {
+                  "shape": "St"
+                },
+                "ServiceNamespace": {
+                  "shape": "S3"
+                },
+                "ResourceId": {
+                  "shape": "S2"
+                },
+                "ScalableDimension": {
+                  "shape": "S4"
+                },
+                "PolicyType": {
+                  "shape": "Su"
+                },
                 "StepScalingPolicyConfiguration": {
                   "shape": "Sv"
                 },
@@ -241,7 +335,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -255,13 +351,21 @@
           "ScheduledActionNames": {
             "shape": "Sb"
           },
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -280,12 +384,24 @@
                 "CreationTime"
               ],
               "members": {
-                "ScheduledActionName": {},
-                "ScheduledActionARN": {},
-                "ServiceNamespace": {},
-                "Schedule": {},
-                "ResourceId": {},
-                "ScalableDimension": {},
+                "ScheduledActionName": {
+                  "shape": "S1o"
+                },
+                "ScheduledActionARN": {
+                  "shape": "S2"
+                },
+                "ServiceNamespace": {
+                  "shape": "S3"
+                },
+                "Schedule": {
+                  "shape": "S2"
+                },
+                "ResourceId": {
+                  "shape": "S2"
+                },
+                "ScalableDimension": {
+                  "shape": "S4"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -301,7 +417,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -315,11 +433,21 @@
           "ScalableDimension"
         ],
         "members": {
-          "PolicyName": {},
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
-          "PolicyType": {},
+          "PolicyName": {
+            "shape": "St"
+          },
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
+          "PolicyType": {
+            "shape": "Su"
+          },
           "StepScalingPolicyConfiguration": {
             "shape": "Sv"
           },
@@ -334,7 +462,9 @@
           "PolicyARN"
         ],
         "members": {
-          "PolicyARN": {},
+          "PolicyARN": {
+            "shape": "S2"
+          },
           "Alarms": {
             "shape": "S1i"
           }
@@ -350,11 +480,21 @@
           "ResourceId"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "Schedule": {},
-          "ScheduledActionName": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "Schedule": {
+            "shape": "S2"
+          },
+          "ScheduledActionName": {
+            "shape": "S1o"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -380,16 +520,24 @@
           "ScalableDimension"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "S3"
+          },
+          "ResourceId": {
+            "shape": "S2"
+          },
+          "ScalableDimension": {
+            "shape": "S4"
+          },
           "MinCapacity": {
             "type": "integer"
           },
           "MaxCapacity": {
             "type": "integer"
           },
-          "RoleARN": {}
+          "RoleARN": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -399,14 +547,79 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S3": {
+      "type": "string",
+      "enum": [
+        "ecs",
+        "elasticmapreduce",
+        "ec2",
+        "appstream",
+        "dynamodb",
+        "rds",
+        "sagemaker",
+        "custom-resource"
+      ]
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "elasticmapreduce:instancegroup:InstanceCount",
+        "appstream:fleet:DesiredCapacity",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits",
+        "rds:cluster:ReadReplicaCount",
+        "sagemaker:variant:DesiredInstanceCount",
+        "custom-resource:ResourceType:Property"
+      ]
+    },
     "Sb": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
+    },
+    "Sd": {
+      "type": "string",
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "Sn": {
+      "type": "string",
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "St": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "\\p{Print}+"
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "StepScaling",
+        "TargetTrackingScaling"
+      ]
     },
     "Sv": {
       "type": "structure",
       "members": {
-        "AdjustmentType": {},
+        "AdjustmentType": {
+          "type": "string",
+          "enum": [
+            "ChangeInCapacity",
+            "PercentChangeInCapacity",
+            "ExactCapacity"
+          ]
+        },
         "StepAdjustments": {
           "type": "list",
           "member": {
@@ -433,7 +646,14 @@
         "Cooldown": {
           "type": "integer"
         },
-        "MetricAggregationType": {}
+        "MetricAggregationType": {
+          "type": "string",
+          "enum": [
+            "Average",
+            "Minimum",
+            "Maximum"
+          ]
+        }
       }
     },
     "S14": {
@@ -451,8 +671,27 @@
             "PredefinedMetricType"
           ],
           "members": {
-            "PredefinedMetricType": {},
-            "ResourceLabel": {}
+            "PredefinedMetricType": {
+              "type": "string",
+              "enum": [
+                "DynamoDBReadCapacityUtilization",
+                "DynamoDBWriteCapacityUtilization",
+                "ALBRequestCountPerTarget",
+                "RDSReaderAverageCPUUtilization",
+                "RDSReaderAverageDatabaseConnections",
+                "EC2SpotFleetRequestAverageCPUUtilization",
+                "EC2SpotFleetRequestAverageNetworkIn",
+                "EC2SpotFleetRequestAverageNetworkOut",
+                "SageMakerVariantInvocationsPerInstance",
+                "ECSServiceAverageCPUUtilization",
+                "ECSServiceAverageMemoryUtilization"
+              ]
+            },
+            "ResourceLabel": {
+              "type": "string",
+              "max": 1023,
+              "min": 1
+            }
           }
         },
         "CustomizedMetricSpecification": {
@@ -479,7 +718,16 @@
                 }
               }
             },
-            "Statistic": {},
+            "Statistic": {
+              "type": "string",
+              "enum": [
+                "Average",
+                "Minimum",
+                "Maximum",
+                "SampleCount",
+                "Sum"
+              ]
+            },
             "Unit": {}
           }
         },
@@ -503,10 +751,20 @@
           "AlarmARN"
         ],
         "members": {
-          "AlarmName": {},
-          "AlarmARN": {}
+          "AlarmName": {
+            "shape": "Sn"
+          },
+          "AlarmARN": {
+            "shape": "Sn"
+          }
         }
       }
+    },
+    "S1o": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "(?!((^[ ]+.*)|(.*([\\u0000-\\u001f]|[\\u007f-\\u009f]|[:/|])+.*)|(.*[ ]+$))).+"
     },
     "S1p": {
       "type": "structure",

--- a/apis/appstream-2016-12-01.min.json
+++ b/apis/appstream-2016-12-01.min.json
@@ -21,8 +21,12 @@
           "StackName"
         ],
         "members": {
-          "FleetName": {},
-          "StackName": {}
+          "FleetName": {
+            "shape": "S2"
+          },
+          "StackName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -39,16 +43,28 @@
           "DestinationRegion"
         ],
         "members": {
-          "SourceImageName": {},
-          "DestinationImageName": {},
-          "DestinationRegion": {},
-          "DestinationImageDescription": {}
+          "SourceImageName": {
+            "shape": "S5"
+          },
+          "DestinationImageName": {
+            "shape": "S5"
+          },
+          "DestinationRegion": {
+            "type": "string",
+            "max": 32,
+            "min": 1
+          },
+          "DestinationImageDescription": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DestinationImageName": {}
+          "DestinationImageName": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -88,11 +104,21 @@
           "ComputeCapacity"
         ],
         "members": {
-          "Name": {},
-          "ImageName": {},
-          "ImageArn": {},
-          "InstanceType": {},
-          "FleetType": {},
+          "Name": {
+            "shape": "S5"
+          },
+          "ImageName": {
+            "shape": "S2"
+          },
+          "ImageArn": {
+            "shape": "Sk"
+          },
+          "InstanceType": {
+            "shape": "S2"
+          },
+          "FleetType": {
+            "shape": "Sl"
+          },
           "ComputeCapacity": {
             "shape": "Sm"
           },
@@ -105,8 +131,12 @@
           "DisconnectTimeoutInSeconds": {
             "type": "integer"
           },
-          "Description": {},
-          "DisplayName": {},
+          "Description": {
+            "shape": "S7"
+          },
+          "DisplayName": {
+            "shape": "Sr"
+          },
           "EnableDefaultInternetAccess": {
             "type": "boolean"
           },
@@ -132,12 +162,24 @@
           "InstanceType"
         ],
         "members": {
-          "Name": {},
-          "ImageName": {},
-          "ImageArn": {},
-          "InstanceType": {},
-          "Description": {},
-          "DisplayName": {},
+          "Name": {
+            "shape": "S5"
+          },
+          "ImageName": {
+            "shape": "S2"
+          },
+          "ImageArn": {
+            "shape": "Sk"
+          },
+          "InstanceType": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S7"
+          },
+          "DisplayName": {
+            "shape": "Sr"
+          },
           "VpcConfig": {
             "shape": "So"
           },
@@ -147,7 +189,9 @@
           "DomainJoinInfo": {
             "shape": "St"
           },
-          "AppstreamAgentVersion": {}
+          "AppstreamAgentVersion": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -166,7 +210,9 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "Validity": {
             "type": "long"
           }
@@ -175,7 +221,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "StreamingURL": {},
+          "StreamingURL": {
+            "shape": "S2"
+          },
           "Expires": {
             "type": "timestamp"
           }
@@ -189,14 +237,24 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
-          "DisplayName": {},
+          "Name": {
+            "shape": "S5"
+          },
+          "Description": {
+            "shape": "S7"
+          },
+          "DisplayName": {
+            "shape": "Sr"
+          },
           "StorageConnectors": {
             "shape": "S1f"
           },
-          "RedirectURL": {},
-          "FeedbackURL": {},
+          "RedirectURL": {
+            "shape": "S1l"
+          },
+          "FeedbackURL": {
+            "shape": "S1m"
+          },
           "UserSettings": {
             "shape": "S1n"
           },
@@ -223,20 +281,35 @@
           "UserId"
         ],
         "members": {
-          "StackName": {},
-          "FleetName": {},
-          "UserId": {},
-          "ApplicationId": {},
+          "StackName": {
+            "shape": "S2"
+          },
+          "FleetName": {
+            "shape": "S2"
+          },
+          "UserId": {
+            "type": "string",
+            "max": 32,
+            "min": 2,
+            "pattern": "[\\w+=,.@-]*"
+          },
+          "ApplicationId": {
+            "shape": "S2"
+          },
           "Validity": {
             "type": "long"
           },
-          "SessionContext": {}
+          "SessionContext": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamingURL": {},
+          "StreamingURL": {
+            "shape": "S2"
+          },
           "Expires": {
             "type": "timestamp"
           }
@@ -265,7 +338,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -280,7 +355,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -299,7 +376,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -319,8 +398,12 @@
           "SharedAccountId"
         ],
         "members": {
-          "Name": {},
-          "SharedAccountId": {}
+          "Name": {
+            "shape": "S5"
+          },
+          "SharedAccountId": {
+            "shape": "S2l"
+          }
         }
       },
       "output": {
@@ -335,7 +418,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -354,7 +439,9 @@
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -366,7 +453,9 @@
               "shape": "Sh"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -377,7 +466,9 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -389,7 +480,9 @@
               "shape": "Sv"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -403,7 +496,9 @@
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -415,7 +510,9 @@
               "shape": "S14"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -426,21 +523,33 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S5"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 500,
+            "min": 0
           },
           "SharedAwsAccountIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2l"
+            },
+            "max": 5,
+            "min": 1
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S5"
+          },
           "SharedImagePermissionsList": {
             "type": "list",
             "member": {
@@ -450,14 +559,18 @@
                 "imagePermissions"
               ],
               "members": {
-                "sharedAccountId": {},
+                "sharedAccountId": {
+                  "shape": "S2l"
+                },
                 "imagePermissions": {
                   "shape": "S2h"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -470,12 +583,20 @@
           },
           "Arns": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sk"
+            }
           },
-          "Type": {},
-          "NextToken": {},
+          "Type": {
+            "shape": "S2b"
+          },
+          "NextToken": {
+            "shape": "S2"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 25,
+            "min": 0
           }
         }
       },
@@ -488,7 +609,9 @@
               "shape": "S29"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -500,14 +623,24 @@
           "FleetName"
         ],
         "members": {
-          "StackName": {},
-          "FleetName": {},
-          "UserId": {},
-          "NextToken": {},
+          "StackName": {
+            "shape": "S2"
+          },
+          "FleetName": {
+            "shape": "S2"
+          },
+          "UserId": {
+            "shape": "S3c"
+          },
+          "NextToken": {
+            "shape": "S2"
+          },
           "Limit": {
             "type": "integer"
           },
-          "AuthenticationType": {}
+          "AuthenticationType": {
+            "shape": "S3d"
+          }
         }
       },
       "output": {
@@ -525,23 +658,46 @@
                 "State"
               ],
               "members": {
-                "Id": {},
-                "UserId": {},
-                "StackName": {},
-                "FleetName": {},
-                "State": {},
-                "AuthenticationType": {},
+                "Id": {
+                  "shape": "S2"
+                },
+                "UserId": {
+                  "shape": "S3c"
+                },
+                "StackName": {
+                  "shape": "S2"
+                },
+                "FleetName": {
+                  "shape": "S2"
+                },
+                "State": {
+                  "type": "string",
+                  "enum": [
+                    "ACTIVE",
+                    "PENDING",
+                    "EXPIRED"
+                  ]
+                },
+                "AuthenticationType": {
+                  "shape": "S3d"
+                },
                 "NetworkAccessConfiguration": {
                   "type": "structure",
                   "members": {
-                    "EniPrivateIpAddress": {},
-                    "EniId": {}
+                    "EniPrivateIpAddress": {
+                      "shape": "S2"
+                    },
+                    "EniId": {
+                      "shape": "S2"
+                    }
                   }
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -552,7 +708,9 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -564,7 +722,9 @@
               "shape": "S1v"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -576,8 +736,12 @@
           "StackName"
         ],
         "members": {
-          "FleetName": {},
-          "StackName": {}
+          "FleetName": {
+            "shape": "S2"
+          },
+          "StackName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -592,7 +756,9 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {}
+          "SessionId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -607,8 +773,12 @@
           "StackName"
         ],
         "members": {
-          "StackName": {},
-          "NextToken": {}
+          "StackName": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -617,7 +787,9 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -628,8 +800,12 @@
           "FleetName"
         ],
         "members": {
-          "FleetName": {},
-          "NextToken": {}
+          "FleetName": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -638,7 +814,9 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -649,7 +827,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -668,7 +848,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -683,8 +865,12 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "AppstreamAgentVersion": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "AppstreamAgentVersion": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -703,7 +889,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -718,7 +906,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -738,7 +928,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "Sk"
+          },
           "Tags": {
             "shape": "S3w"
           }
@@ -757,10 +949,16 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "Sk"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3x"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -798,10 +996,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "ImageName": {},
-          "ImageArn": {},
-          "Name": {},
-          "InstanceType": {},
+          "ImageName": {
+            "shape": "S2"
+          },
+          "ImageArn": {
+            "shape": "Sk"
+          },
+          "Name": {
+            "shape": "S2"
+          },
+          "InstanceType": {
+            "shape": "S2"
+          },
           "ComputeCapacity": {
             "shape": "Sm"
           },
@@ -818,8 +1024,12 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "Description": {},
-          "DisplayName": {},
+          "Description": {
+            "shape": "S7"
+          },
+          "DisplayName": {
+            "shape": "Sr"
+          },
           "EnableDefaultInternetAccess": {
             "type": "boolean"
           },
@@ -828,7 +1038,14 @@
           },
           "AttributesToDelete": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "VPC_CONFIGURATION",
+                "VPC_CONFIGURATION_SECURITY_GROUP_IDS",
+                "DOMAIN_JOIN_INFO"
+              ]
+            }
           }
         }
       },
@@ -850,8 +1067,12 @@
           "ImagePermissions"
         ],
         "members": {
-          "Name": {},
-          "SharedAccountId": {},
+          "Name": {
+            "shape": "S5"
+          },
+          "SharedAccountId": {
+            "shape": "S2l"
+          },
           "ImagePermissions": {
             "shape": "S2h"
           }
@@ -869,9 +1090,15 @@
           "Name"
         ],
         "members": {
-          "DisplayName": {},
-          "Description": {},
-          "Name": {},
+          "DisplayName": {
+            "shape": "Sr"
+          },
+          "Description": {
+            "shape": "S7"
+          },
+          "Name": {
+            "shape": "S2"
+          },
           "StorageConnectors": {
             "shape": "S1f"
           },
@@ -879,11 +1106,27 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "RedirectURL": {},
-          "FeedbackURL": {},
+          "RedirectURL": {
+            "shape": "S1l"
+          },
+          "FeedbackURL": {
+            "shape": "S1m"
+          },
           "AttributesToDelete": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "STORAGE_CONNECTORS",
+                "STORAGE_CONNECTOR_HOMEFOLDERS",
+                "STORAGE_CONNECTOR_GOOGLE_DRIVE",
+                "STORAGE_CONNECTOR_ONE_DRIVE",
+                "REDIRECT_URL",
+                "FEEDBACK_URL",
+                "THEME_NAME",
+                "USER_SETTINGS"
+              ]
+            }
           },
           "UserSettings": {
             "shape": "S1n"
@@ -904,9 +1147,27 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,100}$"
+    },
+    "S7": {
+      "type": "string",
+      "max": 256
+    },
     "Sb": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sc"
+      }
+    },
+    "Sc": {
+      "type": "string",
+      "max": 2000
     },
     "Sd": {
       "type": "structure",
@@ -917,10 +1178,13 @@
       "members": {
         "AccountName": {
           "type": "string",
+          "min": 1,
           "sensitive": true
         },
         "AccountPassword": {
           "type": "string",
+          "max": 127,
+          "min": 1,
           "sensitive": true
         }
       }
@@ -943,6 +1207,17 @@
         }
       }
     },
+    "Sk": {
+      "type": "string",
+      "pattern": "^arn:aws:[A-Za-z0-9][A-Za-z0-9_/.-]{0,62}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-Za-z0-9:_/+=,@.-]{0,1023}$"
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "ALWAYS_ON",
+        "ON_DEMAND"
+      ]
+    },
     "Sm": {
       "type": "structure",
       "required": [
@@ -959,19 +1234,30 @@
       "members": {
         "SubnetIds": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S2"
+          }
         },
         "SecurityGroupIds": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S2"
+          },
+          "max": 5
         }
       }
+    },
+    "Sr": {
+      "type": "string",
+      "max": 100
     },
     "St": {
       "type": "structure",
       "members": {
         "DirectoryName": {},
-        "OrganizationalUnitDistinguishedName": {}
+        "OrganizationalUnitDistinguishedName": {
+          "shape": "Sc"
+        }
       }
     },
     "Sv": {
@@ -984,14 +1270,30 @@
         "State"
       ],
       "members": {
-        "Arn": {},
-        "Name": {},
-        "DisplayName": {},
-        "Description": {},
-        "ImageName": {},
-        "ImageArn": {},
-        "InstanceType": {},
-        "FleetType": {},
+        "Arn": {
+          "shape": "Sk"
+        },
+        "Name": {
+          "shape": "S2"
+        },
+        "DisplayName": {
+          "shape": "S2"
+        },
+        "Description": {
+          "shape": "S2"
+        },
+        "ImageName": {
+          "shape": "S2"
+        },
+        "ImageArn": {
+          "shape": "Sk"
+        },
+        "InstanceType": {
+          "shape": "S2"
+        },
+        "FleetType": {
+          "shape": "Sl"
+        },
         "ComputeCapacityStatus": {
           "type": "structure",
           "required": [
@@ -1018,7 +1320,15 @@
         "DisconnectTimeoutInSeconds": {
           "type": "integer"
         },
-        "State": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "STARTING",
+            "RUNNING",
+            "STOPPING",
+            "STOPPED"
+          ]
+        },
         "VpcConfig": {
           "shape": "So"
         },
@@ -1030,8 +1340,12 @@
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {},
-              "ErrorMessage": {}
+              "ErrorCode": {
+                "shape": "S10"
+              },
+              "ErrorMessage": {
+                "shape": "S2"
+              }
             }
           }
         },
@@ -1043,28 +1357,99 @@
         }
       }
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION",
+        "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION",
+        "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION",
+        "NETWORK_INTERFACE_LIMIT_EXCEEDED",
+        "INTERNAL_SERVICE_ERROR",
+        "IAM_SERVICE_ROLE_IS_MISSING",
+        "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES",
+        "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION",
+        "SUBNET_NOT_FOUND",
+        "IMAGE_NOT_FOUND",
+        "INVALID_SUBNET_CONFIGURATION",
+        "SECURITY_GROUPS_NOT_FOUND",
+        "IGW_NOT_ATTACHED",
+        "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION",
+        "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND",
+        "DOMAIN_JOIN_ERROR_ACCESS_DENIED",
+        "DOMAIN_JOIN_ERROR_LOGON_FAILURE",
+        "DOMAIN_JOIN_ERROR_INVALID_PARAMETER",
+        "DOMAIN_JOIN_ERROR_MORE_DATA",
+        "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN",
+        "DOMAIN_JOIN_ERROR_NOT_SUPPORTED",
+        "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME",
+        "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED",
+        "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED",
+        "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED",
+        "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
+      ]
+    },
+    "S12": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
     "S14": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Arn": {},
-        "ImageArn": {},
-        "Description": {},
-        "DisplayName": {},
+        "Name": {
+          "shape": "S2"
+        },
+        "Arn": {
+          "shape": "Sk"
+        },
+        "ImageArn": {
+          "shape": "Sk"
+        },
+        "Description": {
+          "shape": "S2"
+        },
+        "DisplayName": {
+          "shape": "S2"
+        },
         "VpcConfig": {
           "shape": "So"
         },
-        "InstanceType": {},
-        "Platform": {},
-        "State": {},
+        "InstanceType": {
+          "shape": "S2"
+        },
+        "Platform": {
+          "shape": "S15"
+        },
+        "State": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "UPDATING_AGENT",
+            "RUNNING",
+            "STOPPING",
+            "STOPPED",
+            "REBOOTING",
+            "SNAPSHOTTING",
+            "DELETING",
+            "FAILED"
+          ]
+        },
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {},
-            "Message": {}
+            "Code": {
+              "type": "string",
+              "enum": [
+                "INTERNAL_ERROR",
+                "IMAGE_UNAVAILABLE"
+              ]
+            },
+            "Message": {
+              "shape": "S2"
+            }
           }
         },
         "CreatedTime": {
@@ -1081,16 +1466,28 @@
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {},
-              "ErrorMessage": {},
+              "ErrorCode": {
+                "shape": "S10"
+              },
+              "ErrorMessage": {
+                "shape": "S2"
+              },
               "ErrorTimestamp": {
                 "type": "timestamp"
               }
             }
           }
         },
-        "AppstreamAgentVersion": {}
+        "AppstreamAgentVersion": {
+          "shape": "S12"
+        }
       }
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "WINDOWS"
+      ]
     },
     "S1f": {
       "type": "list",
@@ -1100,14 +1497,36 @@
           "ConnectorType"
         ],
         "members": {
-          "ConnectorType": {},
-          "ResourceIdentifier": {},
+          "ConnectorType": {
+            "type": "string",
+            "enum": [
+              "HOMEFOLDERS",
+              "GOOGLE_DRIVE",
+              "ONE_DRIVE"
+            ]
+          },
+          "ResourceIdentifier": {
+            "type": "string",
+            "min": 1
+          },
           "Domains": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 64
+            },
+            "max": 10
           }
         }
       }
+    },
+    "S1l": {
+      "type": "string",
+      "max": 1000
+    },
+    "S1m": {
+      "type": "string",
+      "max": 1000
     },
     "S1n": {
       "type": "list",
@@ -1118,10 +1537,26 @@
           "Permission"
         ],
         "members": {
-          "Action": {},
-          "Permission": {}
+          "Action": {
+            "type": "string",
+            "enum": [
+              "CLIPBOARD_COPY_FROM_LOCAL_DEVICE",
+              "CLIPBOARD_COPY_TO_LOCAL_DEVICE",
+              "FILE_UPLOAD",
+              "FILE_DOWNLOAD",
+              "PRINTING_TO_LOCAL_DEVICE"
+            ]
+          },
+          "Permission": {
+            "type": "string",
+            "enum": [
+              "ENABLED",
+              "DISABLED"
+            ]
+          }
         }
-      }
+      },
+      "min": 1
     },
     "S1r": {
       "type": "structure",
@@ -1132,8 +1567,14 @@
         "Enabled": {
           "type": "boolean"
         },
-        "SettingsGroup": {}
+        "SettingsGroup": {
+          "shape": "S1t"
+        }
       }
+    },
+    "S1t": {
+      "type": "string",
+      "max": 100
     },
     "S1v": {
       "type": "structure",
@@ -1141,25 +1582,45 @@
         "Name"
       ],
       "members": {
-        "Arn": {},
-        "Name": {},
-        "Description": {},
-        "DisplayName": {},
+        "Arn": {
+          "shape": "Sk"
+        },
+        "Name": {
+          "shape": "S2"
+        },
+        "Description": {
+          "shape": "S2"
+        },
+        "DisplayName": {
+          "shape": "S2"
+        },
         "CreatedTime": {
           "type": "timestamp"
         },
         "StorageConnectors": {
           "shape": "S1f"
         },
-        "RedirectURL": {},
-        "FeedbackURL": {},
+        "RedirectURL": {
+          "shape": "S1l"
+        },
+        "FeedbackURL": {
+          "shape": "S1m"
+        },
         "StackErrors": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {},
-              "ErrorMessage": {}
+              "ErrorCode": {
+                "type": "string",
+                "enum": [
+                  "STORAGE_CONNECTOR_ERROR",
+                  "INTERNAL_SERVICE_ERROR"
+                ]
+              },
+              "ErrorMessage": {
+                "shape": "S2"
+              }
             }
           }
         },
@@ -1172,8 +1633,12 @@
             "Enabled": {
               "type": "boolean"
             },
-            "SettingsGroup": {},
-            "S3BucketName": {}
+            "SettingsGroup": {
+              "shape": "S1t"
+            },
+            "S3BucketName": {
+              "shape": "S2"
+            }
           }
         }
       }
@@ -1184,22 +1649,54 @@
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Arn": {},
-        "BaseImageArn": {},
-        "DisplayName": {},
-        "State": {},
-        "Visibility": {},
+        "Name": {
+          "shape": "S2"
+        },
+        "Arn": {
+          "shape": "Sk"
+        },
+        "BaseImageArn": {
+          "shape": "Sk"
+        },
+        "DisplayName": {
+          "shape": "S2"
+        },
+        "State": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "AVAILABLE",
+            "FAILED",
+            "COPYING",
+            "DELETING"
+          ]
+        },
+        "Visibility": {
+          "shape": "S2b"
+        },
         "ImageBuilderSupported": {
           "type": "boolean"
         },
-        "Platform": {},
-        "Description": {},
+        "Platform": {
+          "shape": "S15"
+        },
+        "Description": {
+          "shape": "S2"
+        },
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {},
-            "Message": {}
+            "Code": {
+              "type": "string",
+              "enum": [
+                "INTERNAL_ERROR",
+                "IMAGE_BUILDER_NOT_AVAILABLE",
+                "IMAGE_COPY_FAILURE"
+              ]
+            },
+            "Message": {
+              "shape": "S2"
+            }
           }
         },
         "Applications": {
@@ -1207,18 +1704,32 @@
           "member": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "DisplayName": {},
-              "IconURL": {},
-              "LaunchPath": {},
-              "LaunchParameters": {},
+              "Name": {
+                "shape": "S2"
+              },
+              "DisplayName": {
+                "shape": "S2"
+              },
+              "IconURL": {
+                "shape": "S2"
+              },
+              "LaunchPath": {
+                "shape": "S2"
+              },
+              "LaunchParameters": {
+                "shape": "S2"
+              },
               "Enabled": {
                 "type": "boolean"
               },
               "Metadata": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "shape": "S2"
+                },
+                "value": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1229,11 +1740,21 @@
         "PublicBaseImageReleasedDate": {
           "type": "timestamp"
         },
-        "AppstreamAgentVersion": {},
+        "AppstreamAgentVersion": {
+          "shape": "S12"
+        },
         "ImagePermissions": {
           "shape": "S2h"
         }
       }
+    },
+    "S2b": {
+      "type": "string",
+      "enum": [
+        "PUBLIC",
+        "PRIVATE",
+        "SHARED"
+      ]
     },
     "S2h": {
       "type": "structure",
@@ -1246,14 +1767,48 @@
         }
       }
     },
+    "S2l": {
+      "type": "string",
+      "pattern": "^\\d+$"
+    },
     "S2u": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
+    },
+    "S3c": {
+      "type": "string",
+      "max": 32,
+      "min": 2
+    },
+    "S3d": {
+      "type": "string",
+      "enum": [
+        "API",
+        "SAML",
+        "USERPOOL"
+      ]
     },
     "S3w": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S3x"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "min": 0,
+        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      },
+      "max": 50,
+      "min": 1
+    },
+    "S3x": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^(^(?!aws:).[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     }
   }
 }

--- a/apis/appsync-2017-07-25.min.json
+++ b/apis/appsync-2017-07-25.min.json
@@ -58,9 +58,13 @@
             "location": "uri",
             "locationName": "apiId"
           },
-          "name": {},
+          "name": {
+            "shape": "S7"
+          },
           "description": {},
-          "type": {},
+          "type": {
+            "shape": "S8"
+          },
           "serviceRoleArn": {},
           "dynamodbConfig": {
             "shape": "S9"
@@ -100,7 +104,9 @@
           "logConfig": {
             "shape": "Sh"
           },
-          "authenticationType": {},
+          "authenticationType": {
+            "shape": "Sj"
+          },
           "userPoolConfig": {
             "shape": "Sk"
           },
@@ -137,13 +143,22 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
-          "fieldName": {},
-          "dataSourceName": {},
-          "requestMappingTemplate": {},
-          "responseMappingTemplate": {}
+          "fieldName": {
+            "shape": "S7"
+          },
+          "dataSourceName": {
+            "shape": "S7"
+          },
+          "requestMappingTemplate": {
+            "shape": "Sr"
+          },
+          "responseMappingTemplate": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
@@ -172,7 +187,9 @@
             "locationName": "apiId"
           },
           "definition": {},
-          "format": {}
+          "format": {
+            "shape": "Sv"
+          }
         }
       },
       "output": {
@@ -228,6 +245,7 @@
             "locationName": "apiId"
           },
           "name": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           }
@@ -278,10 +296,12 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           }
@@ -309,6 +329,7 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           }
@@ -336,6 +357,7 @@
             "locationName": "apiId"
           },
           "name": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           }
@@ -394,7 +416,12 @@
           },
           "format": {
             "location": "querystring",
-            "locationName": "format"
+            "locationName": "format",
+            "type": "string",
+            "enum": [
+              "SDL",
+              "JSON"
+            ]
           }
         }
       },
@@ -426,10 +453,12 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           }
@@ -464,7 +493,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {},
+          "status": {
+            "shape": "S1k"
+          },
           "details": {}
         }
       }
@@ -487,10 +518,12 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "format": {
+            "shape": "Sv",
             "location": "querystring",
             "locationName": "format"
           }
@@ -521,13 +554,14 @@
             "locationName": "apiId"
           },
           "nextToken": {
+            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -540,7 +574,9 @@
               "shape": "S5"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -560,13 +596,14 @@
             "locationName": "apiId"
           },
           "nextToken": {
+            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -579,7 +616,9 @@
               "shape": "Sf"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -592,13 +631,14 @@
         "type": "structure",
         "members": {
           "nextToken": {
+            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -611,7 +651,9 @@
               "shape": "So"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -636,13 +678,14 @@
             "locationName": "typeName"
           },
           "nextToken": {
+            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -655,7 +698,9 @@
               "shape": "St"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -676,17 +721,19 @@
             "locationName": "apiId"
           },
           "format": {
+            "shape": "Sv",
             "location": "querystring",
             "locationName": "format"
           },
           "nextToken": {
+            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -699,7 +746,9 @@
               "shape": "Sx"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -726,7 +775,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {}
+          "status": {
+            "shape": "S1k"
+          }
         }
       }
     },
@@ -781,11 +832,14 @@
             "locationName": "apiId"
           },
           "name": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           },
           "description": {},
-          "type": {},
+          "type": {
+            "shape": "S8"
+          },
           "serviceRoleArn": {},
           "dynamodbConfig": {
             "shape": "S9"
@@ -829,7 +883,9 @@
           "logConfig": {
             "shape": "Sh"
           },
-          "authenticationType": {},
+          "authenticationType": {
+            "shape": "Sj"
+          },
           "userPoolConfig": {
             "shape": "Sk"
           },
@@ -866,16 +922,24 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           },
-          "dataSourceName": {},
-          "requestMappingTemplate": {},
-          "responseMappingTemplate": {}
+          "dataSourceName": {
+            "shape": "S7"
+          },
+          "requestMappingTemplate": {
+            "shape": "Sr"
+          },
+          "responseMappingTemplate": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
@@ -904,11 +968,14 @@
             "locationName": "apiId"
           },
           "typeName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "definition": {},
-          "format": {}
+          "format": {
+            "shape": "Sv"
+          }
         }
       },
       "output": {
@@ -931,6 +998,20 @@
           "type": "long"
         }
       }
+    },
+    "S7": {
+      "type": "string",
+      "pattern": "[_A-Za-z][_0-9A-Za-z]*"
+    },
+    "S8": {
+      "type": "string",
+      "enum": [
+        "AWS_LAMBDA",
+        "AMAZON_DYNAMODB",
+        "AMAZON_ELASTICSEARCH",
+        "NONE",
+        "HTTP"
+      ]
     },
     "S9": {
       "type": "structure",
@@ -976,9 +1057,13 @@
       "type": "structure",
       "members": {
         "dataSourceArn": {},
-        "name": {},
+        "name": {
+          "shape": "S7"
+        },
         "description": {},
-        "type": {},
+        "type": {
+          "shape": "S8"
+        },
         "serviceRoleArn": {},
         "dynamodbConfig": {
           "shape": "S9"
@@ -1001,9 +1086,25 @@
         "cloudWatchLogsRoleArn"
       ],
       "members": {
-        "fieldLogLevel": {},
+        "fieldLogLevel": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ERROR",
+            "ALL"
+          ]
+        },
         "cloudWatchLogsRoleArn": {}
       }
+    },
+    "Sj": {
+      "type": "string",
+      "enum": [
+        "API_KEY",
+        "AWS_IAM",
+        "AMAZON_COGNITO_USER_POOLS",
+        "OPENID_CONNECT"
+      ]
     },
     "Sk": {
       "type": "structure",
@@ -1015,7 +1116,13 @@
       "members": {
         "userPoolId": {},
         "awsRegion": {},
-        "defaultAction": {},
+        "defaultAction": {
+          "type": "string",
+          "enum": [
+            "ALLOW",
+            "DENY"
+          ]
+        },
         "appIdClientRegex": {}
       }
     },
@@ -1038,9 +1145,13 @@
     "So": {
       "type": "structure",
       "members": {
-        "name": {},
+        "name": {
+          "shape": "S7"
+        },
         "apiId": {},
-        "authenticationType": {},
+        "authenticationType": {
+          "shape": "Sj"
+        },
         "logConfig": {
           "shape": "Sh"
         },
@@ -1058,26 +1169,69 @@
         }
       }
     },
+    "Sr": {
+      "type": "string",
+      "max": 65536,
+      "min": 1
+    },
     "St": {
       "type": "structure",
       "members": {
-        "typeName": {},
-        "fieldName": {},
-        "dataSourceName": {},
+        "typeName": {
+          "shape": "S7"
+        },
+        "fieldName": {
+          "shape": "S7"
+        },
+        "dataSourceName": {
+          "shape": "S7"
+        },
         "resolverArn": {},
-        "requestMappingTemplate": {},
-        "responseMappingTemplate": {}
+        "requestMappingTemplate": {
+          "shape": "Sr"
+        },
+        "responseMappingTemplate": {
+          "shape": "Sr"
+        }
       }
+    },
+    "Sv": {
+      "type": "string",
+      "enum": [
+        "SDL",
+        "JSON"
+      ]
     },
     "Sx": {
       "type": "structure",
       "members": {
-        "name": {},
+        "name": {
+          "shape": "S7"
+        },
         "description": {},
         "arn": {},
         "definition": {},
-        "format": {}
+        "format": {
+          "shape": "Sv"
+        }
       }
+    },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "PROCESSING",
+        "ACTIVE",
+        "DELETING"
+      ]
+    },
+    "S1o": {
+      "type": "string",
+      "pattern": "[\\\\S]+"
+    },
+    "S1p": {
+      "type": "integer",
+      "max": 25,
+      "min": 0
     }
   }
 }

--- a/apis/athena-2017-05-18.min.json
+++ b/apis/athena-2017-05-18.min.json
@@ -39,7 +39,9 @@
               "type": "structure",
               "members": {
                 "NamedQueryId": {},
-                "ErrorCode": {},
+                "ErrorCode": {
+                  "shape": "Sd"
+                },
                 "ErrorMessage": {}
               }
             }
@@ -74,7 +76,9 @@
               "type": "structure",
               "members": {
                 "QueryExecutionId": {},
-                "ErrorCode": {},
+                "ErrorCode": {
+                  "shape": "Sd"
+                },
                 "ErrorMessage": {}
               }
             }
@@ -91,11 +95,20 @@
           "QueryString"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
-          "Database": {},
-          "QueryString": {},
+          "Name": {
+            "shape": "S7"
+          },
+          "Description": {
+            "shape": "S8"
+          },
+          "Database": {
+            "shape": "S9"
+          },
+          "QueryString": {
+            "shape": "Sa"
+          },
           "ClientRequestToken": {
+            "shape": "Sy",
             "idempotencyToken": true
           }
         }
@@ -174,7 +187,9 @@
           "QueryExecutionId": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 1000,
+            "min": 0
           }
         }
       },
@@ -225,7 +240,14 @@
                         "Scale": {
                           "type": "integer"
                         },
-                        "Nullable": {},
+                        "Nullable": {
+                          "type": "string",
+                          "enum": [
+                            "NOT_NULL",
+                            "NULLABLE",
+                            "UNKNOWN"
+                          ]
+                        },
                         "CaseSensitive": {
                           "type": "boolean"
                         }
@@ -246,7 +268,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 0
           }
         }
       },
@@ -266,7 +290,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 0
           }
         }
       },
@@ -288,8 +314,11 @@
           "ResultConfiguration"
         ],
         "members": {
-          "QueryString": {},
+          "QueryString": {
+            "shape": "Sa"
+          },
           "ClientRequestToken": {
+            "shape": "Sy",
             "idempotencyToken": true
           },
           "QueryExecutionContext": {
@@ -330,7 +359,9 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 50,
+      "min": 1
     },
     "S6": {
       "type": "structure",
@@ -340,22 +371,59 @@
         "QueryString"
       ],
       "members": {
-        "Name": {},
-        "Description": {},
-        "Database": {},
-        "QueryString": {},
+        "Name": {
+          "shape": "S7"
+        },
+        "Description": {
+          "shape": "S8"
+        },
+        "Database": {
+          "shape": "S9"
+        },
+        "QueryString": {
+          "shape": "Sa"
+        },
         "NamedQueryId": {}
       }
     },
+    "S7": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S8": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S9": {
+      "type": "string",
+      "max": 32,
+      "min": 1
+    },
+    "Sa": {
+      "type": "string",
+      "max": 262144,
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
     "Sg": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 50,
+      "min": 1
     },
     "Sk": {
       "type": "structure",
       "members": {
         "QueryExecutionId": {},
-        "Query": {},
+        "Query": {
+          "shape": "Sa"
+        },
         "ResultConfiguration": {
           "shape": "Sl"
         },
@@ -365,7 +433,16 @@
         "Status": {
           "type": "structure",
           "members": {
-            "State": {},
+            "State": {
+              "type": "string",
+              "enum": [
+                "QUEUED",
+                "RUNNING",
+                "SUCCEEDED",
+                "FAILED",
+                "CANCELLED"
+              ]
+            },
             "StateChangeReason": {},
             "SubmissionDateTime": {
               "type": "timestamp"
@@ -401,7 +478,14 @@
             "EncryptionOption"
           ],
           "members": {
-            "EncryptionOption": {},
+            "EncryptionOption": {
+              "type": "string",
+              "enum": [
+                "SSE_S3",
+                "SSE_KMS",
+                "CSE_KMS"
+              ]
+            },
             "KmsKey": {}
           }
         }
@@ -410,8 +494,15 @@
     "Sp": {
       "type": "structure",
       "members": {
-        "Database": {}
+        "Database": {
+          "shape": "S9"
+        }
       }
+    },
+    "Sy": {
+      "type": "string",
+      "max": 128,
+      "min": 32
     }
   }
 }

--- a/apis/autoscaling-2011-01-01.min.json
+++ b/apis/autoscaling-2011-01-01.min.json
@@ -21,7 +21,9 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {}
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -33,7 +35,9 @@
           "TargetGroupARNs"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "TargetGroupARNs": {
             "shape": "S6"
           }
@@ -53,7 +57,9 @@
           "LoadBalancerNames"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "LoadBalancerNames": {
             "shape": "Sa"
           }
@@ -73,7 +79,9 @@
           "ScheduledActionNames"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ScheduledActionNames": {
             "shape": "Se"
           }
@@ -97,7 +105,9 @@
           "ScheduledUpdateGroupActions"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ScheduledUpdateGroupActions": {
             "type": "list",
             "member": {
@@ -106,14 +116,18 @@
                 "ScheduledActionName"
               ],
               "members": {
-                "ScheduledActionName": {},
+                "ScheduledActionName": {
+                  "shape": "Sb"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "Recurrence": {},
+                "Recurrence": {
+                  "shape": "Sb"
+                },
                 "MinSize": {
                   "type": "integer"
                 },
@@ -147,11 +161,19 @@
           "LifecycleActionResult"
         ],
         "members": {
-          "LifecycleHookName": {},
-          "AutoScalingGroupName": {},
-          "LifecycleActionToken": {},
+          "LifecycleHookName": {
+            "shape": "St"
+          },
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "LifecycleActionToken": {
+            "shape": "Su"
+          },
           "LifecycleActionResult": {},
-          "InstanceId": {}
+          "InstanceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -169,12 +191,18 @@
           "MaxSize"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "LaunchConfigurationName": {},
+          "AutoScalingGroupName": {
+            "shape": "Sb"
+          },
+          "LaunchConfigurationName": {
+            "shape": "S4"
+          },
           "LaunchTemplate": {
             "shape": "Sy"
           },
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "S3"
+          },
           "MinSize": {
             "type": "integer"
           },
@@ -196,12 +224,18 @@
           "TargetGroupARNs": {
             "shape": "S6"
           },
-          "HealthCheckType": {},
+          "HealthCheckType": {
+            "shape": "S12"
+          },
           "HealthCheckGracePeriod": {
             "type": "integer"
           },
-          "PlacementGroup": {},
-          "VPCZoneIdentifier": {},
+          "PlacementGroup": {
+            "shape": "Sb"
+          },
+          "VPCZoneIdentifier": {
+            "shape": "S14"
+          },
           "TerminationPolicies": {
             "shape": "S15"
           },
@@ -217,22 +251,32 @@
                 "LifecycleTransition"
               ],
               "members": {
-                "LifecycleHookName": {},
+                "LifecycleHookName": {
+                  "shape": "St"
+                },
                 "LifecycleTransition": {},
-                "NotificationMetadata": {},
+                "NotificationMetadata": {
+                  "shape": "S1b"
+                },
                 "HeartbeatTimeout": {
                   "type": "integer"
                 },
                 "DefaultResult": {},
-                "NotificationTargetARN": {},
-                "RoleARN": {}
+                "NotificationTargetARN": {
+                  "shape": "S1d"
+                },
+                "RoleARN": {
+                  "shape": "S4"
+                }
               }
             }
           },
           "Tags": {
             "shape": "S1e"
           },
-          "ServiceLinkedRoleARN": {}
+          "ServiceLinkedRoleARN": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -243,36 +287,60 @@
           "LaunchConfigurationName"
         ],
         "members": {
-          "LaunchConfigurationName": {},
-          "ImageId": {},
-          "KeyName": {},
+          "LaunchConfigurationName": {
+            "shape": "Sb"
+          },
+          "ImageId": {
+            "shape": "Sb"
+          },
+          "KeyName": {
+            "shape": "Sb"
+          },
           "SecurityGroups": {
             "shape": "S1k"
           },
-          "ClassicLinkVPCId": {},
+          "ClassicLinkVPCId": {
+            "shape": "Sb"
+          },
           "ClassicLinkVPCSecurityGroups": {
             "shape": "S1l"
           },
-          "UserData": {},
-          "InstanceId": {},
-          "InstanceType": {},
-          "KernelId": {},
-          "RamdiskId": {},
+          "UserData": {
+            "shape": "S1m"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          },
+          "InstanceType": {
+            "shape": "Sb"
+          },
+          "KernelId": {
+            "shape": "Sb"
+          },
+          "RamdiskId": {
+            "shape": "Sb"
+          },
           "BlockDeviceMappings": {
             "shape": "S1n"
           },
           "InstanceMonitoring": {
             "shape": "S1w"
           },
-          "SpotPrice": {},
-          "IamInstanceProfile": {},
+          "SpotPrice": {
+            "shape": "S1y"
+          },
+          "IamInstanceProfile": {
+            "shape": "S16"
+          },
           "EbsOptimized": {
             "type": "boolean"
           },
           "AssociatePublicIpAddress": {
             "type": "boolean"
           },
-          "PlacementTenancy": {}
+          "PlacementTenancy": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -296,7 +364,9 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ForceDelete": {
             "type": "boolean"
           }
@@ -310,7 +380,9 @@
           "LaunchConfigurationName"
         ],
         "members": {
-          "LaunchConfigurationName": {}
+          "LaunchConfigurationName": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -322,8 +394,12 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {},
-          "AutoScalingGroupName": {}
+          "LifecycleHookName": {
+            "shape": "St"
+          },
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -340,8 +416,12 @@
           "TopicARN"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "TopicARN": {}
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "TopicARN": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -352,8 +432,12 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "PolicyName": {}
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "PolicyName": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -365,8 +449,12 @@
           "ScheduledActionName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "ScheduledActionName": {}
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "ScheduledActionName": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -413,7 +501,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "AdjustmentType": {}
+                "AdjustmentType": {
+                  "shape": "Sb"
+                }
               }
             }
           }
@@ -427,7 +517,9 @@
           "AutoScalingGroupNames": {
             "shape": "S2k"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -455,9 +547,15 @@
                 "CreatedTime"
               ],
               "members": {
-                "AutoScalingGroupName": {},
-                "AutoScalingGroupARN": {},
-                "LaunchConfigurationName": {},
+                "AutoScalingGroupName": {
+                  "shape": "Sb"
+                },
+                "AutoScalingGroupARN": {
+                  "shape": "S4"
+                },
+                "LaunchConfigurationName": {
+                  "shape": "Sb"
+                },
                 "LaunchTemplate": {
                   "shape": "Sy"
                 },
@@ -482,7 +580,9 @@
                 "TargetGroupARNs": {
                   "shape": "S6"
                 },
-                "HealthCheckType": {},
+                "HealthCheckType": {
+                  "shape": "S12"
+                },
                 "HealthCheckGracePeriod": {
                   "type": "integer"
                 },
@@ -498,11 +598,36 @@
                       "ProtectedFromScaleIn"
                     ],
                     "members": {
-                      "InstanceId": {},
-                      "AvailabilityZone": {},
-                      "LifecycleState": {},
-                      "HealthStatus": {},
-                      "LaunchConfigurationName": {},
+                      "InstanceId": {
+                        "shape": "S3"
+                      },
+                      "AvailabilityZone": {
+                        "shape": "Sb"
+                      },
+                      "LifecycleState": {
+                        "type": "string",
+                        "enum": [
+                          "Pending",
+                          "Pending:Wait",
+                          "Pending:Proceed",
+                          "Quarantined",
+                          "InService",
+                          "Terminating",
+                          "Terminating:Wait",
+                          "Terminating:Proceed",
+                          "Terminated",
+                          "Detaching",
+                          "Detached",
+                          "EnteringStandby",
+                          "Standby"
+                        ]
+                      },
+                      "HealthStatus": {
+                        "shape": "S12"
+                      },
+                      "LaunchConfigurationName": {
+                        "shape": "Sb"
+                      },
                       "LaunchTemplate": {
                         "shape": "Sy"
                       },
@@ -520,24 +645,38 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ProcessName": {},
-                      "SuspensionReason": {}
+                      "ProcessName": {
+                        "shape": "Sb"
+                      },
+                      "SuspensionReason": {
+                        "shape": "Sb"
+                      }
                     }
                   }
                 },
-                "PlacementGroup": {},
-                "VPCZoneIdentifier": {},
+                "PlacementGroup": {
+                  "shape": "Sb"
+                },
+                "VPCZoneIdentifier": {
+                  "shape": "S14"
+                },
                 "EnabledMetrics": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Metric": {},
-                      "Granularity": {}
+                      "Metric": {
+                        "shape": "Sb"
+                      },
+                      "Granularity": {
+                        "shape": "Sb"
+                      }
                     }
                   }
                 },
-                "Status": {},
+                "Status": {
+                  "shape": "Sb"
+                },
                 "Tags": {
                   "shape": "S2w"
                 },
@@ -547,11 +686,15 @@
                 "NewInstancesProtectedFromScaleIn": {
                   "type": "boolean"
                 },
-                "ServiceLinkedRoleARN": {}
+                "ServiceLinkedRoleARN": {
+                  "shape": "S4"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -565,7 +708,9 @@
           "MaxRecords": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -585,12 +730,24 @@
                 "ProtectedFromScaleIn"
               ],
               "members": {
-                "InstanceId": {},
-                "AutoScalingGroupName": {},
-                "AvailabilityZone": {},
-                "LifecycleState": {},
-                "HealthStatus": {},
-                "LaunchConfigurationName": {},
+                "InstanceId": {
+                  "shape": "S3"
+                },
+                "AutoScalingGroupName": {
+                  "shape": "Sb"
+                },
+                "AvailabilityZone": {
+                  "shape": "Sb"
+                },
+                "LifecycleState": {
+                  "shape": "S12"
+                },
+                "HealthStatus": {
+                  "shape": "S12"
+                },
+                "LaunchConfigurationName": {
+                  "shape": "Sb"
+                },
                 "LaunchTemplate": {
                   "shape": "Sy"
                 },
@@ -600,7 +757,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -621,9 +780,13 @@
         "members": {
           "LaunchConfigurationNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -647,29 +810,51 @@
                 "CreatedTime"
               ],
               "members": {
-                "LaunchConfigurationName": {},
-                "LaunchConfigurationARN": {},
-                "ImageId": {},
-                "KeyName": {},
+                "LaunchConfigurationName": {
+                  "shape": "Sb"
+                },
+                "LaunchConfigurationARN": {
+                  "shape": "S4"
+                },
+                "ImageId": {
+                  "shape": "Sb"
+                },
+                "KeyName": {
+                  "shape": "Sb"
+                },
                 "SecurityGroups": {
                   "shape": "S1k"
                 },
-                "ClassicLinkVPCId": {},
+                "ClassicLinkVPCId": {
+                  "shape": "Sb"
+                },
                 "ClassicLinkVPCSecurityGroups": {
                   "shape": "S1l"
                 },
-                "UserData": {},
-                "InstanceType": {},
-                "KernelId": {},
-                "RamdiskId": {},
+                "UserData": {
+                  "shape": "S1m"
+                },
+                "InstanceType": {
+                  "shape": "Sb"
+                },
+                "KernelId": {
+                  "shape": "Sb"
+                },
+                "RamdiskId": {
+                  "shape": "Sb"
+                },
                 "BlockDeviceMappings": {
                   "shape": "S1n"
                 },
                 "InstanceMonitoring": {
                   "shape": "S1w"
                 },
-                "SpotPrice": {},
-                "IamInstanceProfile": {},
+                "SpotPrice": {
+                  "shape": "S1y"
+                },
+                "IamInstanceProfile": {
+                  "shape": "S16"
+                },
                 "CreatedTime": {
                   "type": "timestamp"
                 },
@@ -679,11 +864,15 @@
                 "AssociatePublicIpAddress": {
                   "type": "boolean"
                 },
-                "PlacementTenancy": {}
+                "PlacementTenancy": {
+                  "shape": "Si"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -705,10 +894,15 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "LifecycleHookNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "St"
+            },
+            "max": 50
           }
         }
       },
@@ -721,12 +915,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "LifecycleHookName": {},
-                "AutoScalingGroupName": {},
+                "LifecycleHookName": {
+                  "shape": "St"
+                },
+                "AutoScalingGroupName": {
+                  "shape": "S4"
+                },
                 "LifecycleTransition": {},
-                "NotificationTargetARN": {},
-                "RoleARN": {},
-                "NotificationMetadata": {},
+                "NotificationTargetARN": {
+                  "shape": "S4"
+                },
+                "RoleARN": {
+                  "shape": "S4"
+                },
+                "NotificationMetadata": {
+                  "shape": "S1b"
+                },
                 "HeartbeatTimeout": {
                   "type": "integer"
                 },
@@ -747,8 +951,12 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "NextToken": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -763,12 +971,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "LoadBalancerTargetGroupARN": {},
-                "State": {}
+                "LoadBalancerTargetGroupARN": {
+                  "shape": "S7"
+                },
+                "State": {
+                  "shape": "Sb"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -779,8 +993,12 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "NextToken": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -795,12 +1013,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "LoadBalancerName": {},
-                "State": {}
+                "LoadBalancerName": {
+                  "shape": "Sb"
+                },
+                "State": {
+                  "shape": "Sb"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -814,7 +1038,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Metric": {}
+                "Metric": {
+                  "shape": "Sb"
+                }
               }
             }
           },
@@ -823,7 +1049,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Granularity": {}
+                "Granularity": {
+                  "shape": "Sb"
+                }
               }
             }
           }
@@ -837,7 +1065,9 @@
           "AutoScalingGroupNames": {
             "shape": "S2k"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -855,13 +1085,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {},
-                "TopicARN": {},
-                "NotificationType": {}
+                "AutoScalingGroupName": {
+                  "shape": "S4"
+                },
+                "TopicARN": {
+                  "shape": "S4"
+                },
+                "NotificationType": {
+                  "shape": "Sb"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -869,16 +1107,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "PolicyNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            }
           },
           "PolicyTypes": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Si"
+            }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -893,11 +1139,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {},
-                "PolicyName": {},
-                "PolicyARN": {},
-                "PolicyType": {},
-                "AdjustmentType": {},
+                "AutoScalingGroupName": {
+                  "shape": "Sb"
+                },
+                "PolicyName": {
+                  "shape": "Sb"
+                },
+                "PolicyARN": {
+                  "shape": "S4"
+                },
+                "PolicyType": {
+                  "shape": "Si"
+                },
+                "AdjustmentType": {
+                  "shape": "Sb"
+                },
                 "MinAdjustmentStep": {
                   "shape": "S43"
                 },
@@ -913,7 +1169,9 @@
                 "StepAdjustments": {
                   "shape": "S46"
                 },
-                "MetricAggregationType": {},
+                "MetricAggregationType": {
+                  "shape": "S12"
+                },
                 "EstimatedInstanceWarmup": {
                   "type": "integer"
                 },
@@ -926,7 +1184,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -936,13 +1196,19 @@
         "members": {
           "ActivityIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sj"
+            }
           },
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "MaxRecords": {
             "type": "integer"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -955,7 +1221,9 @@
           "Activities": {
             "shape": "S4s"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -972,7 +1240,9 @@
                 "ProcessName"
               ],
               "members": {
-                "ProcessName": {}
+                "ProcessName": {
+                  "shape": "Sb"
+                }
               }
             }
           }
@@ -983,7 +1253,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ScheduledActionNames": {
             "shape": "Se"
           },
@@ -993,7 +1265,9 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -1008,9 +1282,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {},
-                "ScheduledActionName": {},
-                "ScheduledActionARN": {},
+                "AutoScalingGroupName": {
+                  "shape": "Sb"
+                },
+                "ScheduledActionName": {
+                  "shape": "Sb"
+                },
+                "ScheduledActionARN": {
+                  "shape": "S4"
+                },
                 "Time": {
                   "type": "timestamp"
                 },
@@ -1020,7 +1300,9 @@
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "Recurrence": {},
+                "Recurrence": {
+                  "shape": "Sb"
+                },
                 "MinSize": {
                   "type": "integer"
                 },
@@ -1033,7 +1315,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -1046,15 +1330,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
+                "Name": {
+                  "shape": "Sj"
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "Sj"
+                  }
                 }
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sj"
+          },
           "MaxRecords": {
             "type": "integer"
           }
@@ -1067,7 +1357,9 @@
           "Tags": {
             "shape": "S2w"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -1093,7 +1385,9 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1117,7 +1411,9 @@
           "TargetGroupARNs"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "TargetGroupARNs": {
             "shape": "S6"
           }
@@ -1137,7 +1433,9 @@
           "LoadBalancerNames"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "LoadBalancerNames": {
             "shape": "Sa"
           }
@@ -1156,7 +1454,9 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "Metrics": {
             "shape": "S5h"
           }
@@ -1171,11 +1471,15 @@
           "Granularity"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "Metrics": {
             "shape": "S5h"
           },
-          "Granularity": {}
+          "Granularity": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -1190,7 +1494,9 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1213,8 +1519,12 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "PolicyName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "PolicyName": {
+            "shape": "S4"
+          },
           "HonorCooldown": {
             "type": "boolean"
           },
@@ -1237,7 +1547,9 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {}
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1258,12 +1570,22 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {},
-          "AutoScalingGroupName": {},
+          "LifecycleHookName": {
+            "shape": "St"
+          },
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "LifecycleTransition": {},
-          "RoleARN": {},
-          "NotificationTargetARN": {},
-          "NotificationMetadata": {},
+          "RoleARN": {
+            "shape": "S4"
+          },
+          "NotificationTargetARN": {
+            "shape": "S1d"
+          },
+          "NotificationMetadata": {
+            "shape": "S1b"
+          },
           "HeartbeatTimeout": {
             "type": "integer"
           },
@@ -1285,8 +1607,12 @@
           "NotificationTypes"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "TopicARN": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "TopicARN": {
+            "shape": "S4"
+          },
           "NotificationTypes": {
             "shape": "S33"
           }
@@ -1301,10 +1627,18 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "PolicyName": {},
-          "PolicyType": {},
-          "AdjustmentType": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "PolicyName": {
+            "shape": "Sb"
+          },
+          "PolicyType": {
+            "shape": "Si"
+          },
+          "AdjustmentType": {
+            "shape": "Sb"
+          },
           "MinAdjustmentStep": {
             "shape": "S43"
           },
@@ -1317,7 +1651,9 @@
           "Cooldown": {
             "type": "integer"
           },
-          "MetricAggregationType": {},
+          "MetricAggregationType": {
+            "shape": "S12"
+          },
           "StepAdjustments": {
             "shape": "S46"
           },
@@ -1333,7 +1669,9 @@
         "resultWrapper": "PutScalingPolicyResult",
         "type": "structure",
         "members": {
-          "PolicyARN": {},
+          "PolicyARN": {
+            "shape": "S4"
+          },
           "Alarms": {
             "shape": "S4a"
           }
@@ -1348,8 +1686,12 @@
           "ScheduledActionName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "ScheduledActionName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "ScheduledActionName": {
+            "shape": "Sb"
+          },
           "Time": {
             "type": "timestamp"
           },
@@ -1359,7 +1701,9 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "Recurrence": {},
+          "Recurrence": {
+            "shape": "Sb"
+          },
           "MinSize": {
             "type": "integer"
           },
@@ -1380,10 +1724,18 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {},
-          "AutoScalingGroupName": {},
-          "LifecycleActionToken": {},
-          "InstanceId": {}
+          "LifecycleHookName": {
+            "shape": "St"
+          },
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "LifecycleActionToken": {
+            "shape": "Su"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1405,7 +1757,9 @@
           "DesiredCapacity"
         ],
         "members": {
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "DesiredCapacity": {
             "type": "integer"
           },
@@ -1423,8 +1777,12 @@
           "HealthStatus"
         ],
         "members": {
-          "InstanceId": {},
-          "HealthStatus": {},
+          "InstanceId": {
+            "shape": "S3"
+          },
+          "HealthStatus": {
+            "shape": "S12"
+          },
           "ShouldRespectGracePeriod": {
             "type": "boolean"
           }
@@ -1443,7 +1801,9 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
           "ProtectedFromScaleIn": {
             "type": "boolean"
           }
@@ -1468,7 +1828,9 @@
           "ShouldDecrementDesiredCapacity"
         ],
         "members": {
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "S3"
+          },
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1491,8 +1853,12 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {},
-          "LaunchConfigurationName": {},
+          "AutoScalingGroupName": {
+            "shape": "S4"
+          },
+          "LaunchConfigurationName": {
+            "shape": "S4"
+          },
           "LaunchTemplate": {
             "shape": "Sy"
           },
@@ -1511,19 +1877,27 @@
           "AvailabilityZones": {
             "shape": "S11"
           },
-          "HealthCheckType": {},
+          "HealthCheckType": {
+            "shape": "S12"
+          },
           "HealthCheckGracePeriod": {
             "type": "integer"
           },
-          "PlacementGroup": {},
-          "VPCZoneIdentifier": {},
+          "PlacementGroup": {
+            "shape": "Sb"
+          },
+          "VPCZoneIdentifier": {
+            "shape": "S14"
+          },
           "TerminationPolicies": {
             "shape": "S15"
           },
           "NewInstancesProtectedFromScaleIn": {
             "type": "boolean"
           },
-          "ServiceLinkedRoleARN": {}
+          "ServiceLinkedRoleARN": {
+            "shape": "S4"
+          }
         }
       }
     }
@@ -1531,19 +1905,51 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
+    },
+    "S3": {
+      "type": "string",
+      "max": 19,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S4": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S6": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S7"
+      }
+    },
+    "S7": {
+      "type": "string",
+      "max": 511,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sa": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      }
+    },
+    "Sb": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Se": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4"
+      }
     },
     "Sg": {
       "type": "list",
@@ -1553,27 +1959,98 @@
           "ScheduledActionName"
         ],
         "members": {
-          "ScheduledActionName": {},
-          "ErrorCode": {},
-          "ErrorMessage": {}
+          "ScheduledActionName": {
+            "shape": "Sb"
+          },
+          "ErrorCode": {
+            "shape": "Si"
+          },
+          "ErrorMessage": {
+            "shape": "Sj"
+          }
         }
       }
+    },
+    "Si": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "St": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z0-9\\-_\\/]+"
+    },
+    "Su": {
+      "type": "string",
+      "max": 36,
+      "min": 36
     },
     "Sy": {
       "type": "structure",
       "members": {
-        "LaunchTemplateId": {},
-        "LaunchTemplateName": {},
-        "Version": {}
+        "LaunchTemplateId": {
+          "shape": "Sb"
+        },
+        "LaunchTemplateName": {
+          "type": "string",
+          "max": 128,
+          "min": 3,
+          "pattern": "[a-zA-Z0-9\\(\\)\\.-/_]+"
+        },
+        "Version": {
+          "shape": "Sb"
+        }
       }
     },
     "S11": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      },
+      "min": 1
+    },
+    "S12": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S14": {
+      "type": "string",
+      "max": 2047,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S15": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S16"
+      }
+    },
+    "S16": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S1b": {
+      "type": "string",
+      "max": 1023,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S1d": {
+      "type": "string",
+      "max": 1600,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S1e": {
       "type": "list",
@@ -1583,23 +2060,52 @@
           "Key"
         ],
         "members": {
-          "ResourceId": {},
-          "ResourceType": {},
-          "Key": {},
-          "Value": {},
+          "ResourceId": {
+            "shape": "Sj"
+          },
+          "ResourceType": {
+            "shape": "Sj"
+          },
+          "Key": {
+            "shape": "S1g"
+          },
+          "Value": {
+            "shape": "S1h"
+          },
           "PropagateAtLaunch": {
             "type": "boolean"
           }
         }
       }
     },
+    "S1g": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S1h": {
+      "type": "string",
+      "max": 256,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S1k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sj"
+      }
     },
     "S1l": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      }
+    },
+    "S1m": {
+      "type": "string",
+      "max": 21847,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S1n": {
       "type": "list",
@@ -1609,21 +2115,35 @@
           "DeviceName"
         ],
         "members": {
-          "VirtualName": {},
-          "DeviceName": {},
+          "VirtualName": {
+            "shape": "Sb"
+          },
+          "DeviceName": {
+            "shape": "Sb"
+          },
           "Ebs": {
             "type": "structure",
             "members": {
-              "SnapshotId": {},
-              "VolumeSize": {
-                "type": "integer"
+              "SnapshotId": {
+                "shape": "Sb"
               },
-              "VolumeType": {},
+              "VolumeSize": {
+                "type": "integer",
+                "max": 16384,
+                "min": 1
+              },
+              "VolumeType": {
+                "type": "string",
+                "max": 255,
+                "min": 1
+              },
               "DeleteOnTermination": {
                 "type": "boolean"
               },
               "Iops": {
-                "type": "integer"
+                "type": "integer",
+                "max": 20000,
+                "min": 100
               },
               "Encrypted": {
                 "type": "boolean"
@@ -1644,19 +2164,34 @@
         }
       }
     },
+    "S1y": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
     "S2k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4"
+      }
     },
     "S2w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceId": {},
-          "ResourceType": {},
-          "Key": {},
-          "Value": {},
+          "ResourceId": {
+            "shape": "Sj"
+          },
+          "ResourceType": {
+            "shape": "Sj"
+          },
+          "Key": {
+            "shape": "S1g"
+          },
+          "Value": {
+            "shape": "S1h"
+          },
           "PropagateAtLaunch": {
             "type": "boolean"
           }
@@ -1665,7 +2200,9 @@
     },
     "S33": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      }
     },
     "S43": {
       "type": "integer",
@@ -1696,8 +2233,12 @@
       "member": {
         "type": "structure",
         "members": {
-          "AlarmName": {},
-          "AlarmARN": {}
+          "AlarmName": {
+            "shape": "Sb"
+          },
+          "AlarmARN": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1713,8 +2254,18 @@
             "PredefinedMetricType"
           ],
           "members": {
-            "PredefinedMetricType": {},
-            "ResourceLabel": {}
+            "PredefinedMetricType": {
+              "type": "string",
+              "enum": [
+                "ASGAverageCPUUtilization",
+                "ASGAverageNetworkIn",
+                "ASGAverageNetworkOut",
+                "ALBRequestCountPerTarget"
+              ]
+            },
+            "ResourceLabel": {
+              "shape": "S1b"
+            }
           }
         },
         "CustomizedMetricSpecification": {
@@ -1741,7 +2292,16 @@
                 }
               }
             },
-            "Statistic": {},
+            "Statistic": {
+              "type": "string",
+              "enum": [
+                "Average",
+                "Minimum",
+                "Maximum",
+                "SampleCount",
+                "Sum"
+              ]
+            },
             "Unit": {}
           }
         },
@@ -1769,27 +2329,57 @@
         "StatusCode"
       ],
       "members": {
-        "ActivityId": {},
-        "AutoScalingGroupName": {},
-        "Description": {},
-        "Cause": {},
+        "ActivityId": {
+          "shape": "Sj"
+        },
+        "AutoScalingGroupName": {
+          "shape": "Sb"
+        },
+        "Description": {
+          "shape": "Sj"
+        },
+        "Cause": {
+          "shape": "S1b"
+        },
         "StartTime": {
           "type": "timestamp"
         },
         "EndTime": {
           "type": "timestamp"
         },
-        "StatusCode": {},
-        "StatusMessage": {},
+        "StatusCode": {
+          "type": "string",
+          "enum": [
+            "PendingSpotBidPlacement",
+            "WaitingForSpotInstanceRequestId",
+            "WaitingForSpotInstanceId",
+            "WaitingForInstanceId",
+            "PreInService",
+            "InProgress",
+            "WaitingForELBConnectionDraining",
+            "MidLifecycleAction",
+            "WaitingForInstanceWarmup",
+            "Successful",
+            "Failed",
+            "Cancelled"
+          ]
+        },
+        "StatusMessage": {
+          "shape": "Sb"
+        },
         "Progress": {
           "type": "integer"
         },
-        "Details": {}
+        "Details": {
+          "shape": "Sj"
+        }
       }
     },
     "S5h": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      }
     },
     "S5x": {
       "type": "structure",
@@ -1797,10 +2387,14 @@
         "AutoScalingGroupName"
       ],
       "members": {
-        "AutoScalingGroupName": {},
+        "AutoScalingGroupName": {
+          "shape": "S4"
+        },
         "ScalingProcesses": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "Sb"
+          }
         }
       }
     }

--- a/apis/autoscaling-plans-2018-01-06.min.json
+++ b/apis/autoscaling-plans-2018-01-06.min.json
@@ -22,7 +22,9 @@
           "ScalingInstructions"
         ],
         "members": {
-          "ScalingPlanName": {},
+          "ScalingPlanName": {
+            "shape": "S2"
+          },
           "ApplicationSource": {
             "shape": "S3"
           },
@@ -51,7 +53,9 @@
           "ScalingPlanVersion"
         ],
         "members": {
-          "ScalingPlanName": {},
+          "ScalingPlanName": {
+            "shape": "S2"
+          },
           "ScalingPlanVersion": {
             "type": "long"
           }
@@ -70,7 +74,9 @@
           "ScalingPlanVersion"
         ],
         "members": {
-          "ScalingPlanName": {},
+          "ScalingPlanName": {
+            "shape": "S2"
+          },
           "ScalingPlanVersion": {
             "type": "long"
           },
@@ -96,13 +102,21 @@
                 "ScalingStatusCode"
               ],
               "members": {
-                "ScalingPlanName": {},
+                "ScalingPlanName": {
+                  "shape": "S2"
+                },
                 "ScalingPlanVersion": {
                   "type": "long"
                 },
-                "ServiceNamespace": {},
-                "ResourceId": {},
-                "ScalableDimension": {},
+                "ServiceNamespace": {
+                  "shape": "Sc"
+                },
+                "ResourceId": {
+                  "shape": "Sd"
+                },
+                "ScalableDimension": {
+                  "shape": "Se"
+                },
                 "ScalingPolicies": {
                   "type": "list",
                   "member": {
@@ -112,16 +126,35 @@
                       "PolicyType"
                     ],
                     "members": {
-                      "PolicyName": {},
-                      "PolicyType": {},
+                      "PolicyName": {
+                        "type": "string",
+                        "max": 256,
+                        "min": 1,
+                        "pattern": "\\p{Print}+"
+                      },
+                      "PolicyType": {
+                        "type": "string",
+                        "enum": [
+                          "TargetTrackingScaling"
+                        ]
+                      },
                       "TargetTrackingConfiguration": {
                         "shape": "Sh"
                       }
                     }
                   }
                 },
-                "ScalingStatusCode": {},
-                "ScalingStatusMessage": {}
+                "ScalingStatusCode": {
+                  "type": "string",
+                  "enum": [
+                    "Inactive",
+                    "PartiallyActive",
+                    "Active"
+                  ]
+                },
+                "ScalingStatusMessage": {
+                  "shape": "S4"
+                }
               }
             }
           },
@@ -135,7 +168,9 @@
         "members": {
           "ScalingPlanNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           },
           "ScalingPlanVersion": {
             "type": "long"
@@ -167,7 +202,9 @@
                 "StatusCode"
               ],
               "members": {
-                "ScalingPlanName": {},
+                "ScalingPlanName": {
+                  "shape": "S2"
+                },
                 "ScalingPlanVersion": {
                   "type": "long"
                 },
@@ -177,8 +214,22 @@
                 "ScalingInstructions": {
                   "shape": "Sa"
                 },
-                "StatusCode": {},
-                "StatusMessage": {},
+                "StatusCode": {
+                  "type": "string",
+                  "enum": [
+                    "Active",
+                    "ActiveWithProblems",
+                    "CreationInProgress",
+                    "CreationFailed",
+                    "DeletionInProgress",
+                    "DeletionFailed",
+                    "UpdateInProgress",
+                    "UpdateFailed"
+                  ]
+                },
+                "StatusMessage": {
+                  "shape": "S4"
+                },
                 "StatusStartTime": {
                   "type": "timestamp"
                 },
@@ -203,7 +254,9 @@
           "ApplicationSource": {
             "shape": "S3"
           },
-          "ScalingPlanName": {},
+          "ScalingPlanName": {
+            "shape": "S2"
+          },
           "ScalingInstructions": {
             "shape": "Sa"
           },
@@ -219,24 +272,46 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\p{Print}&&[^|:/]]+"
+    },
     "S3": {
       "type": "structure",
       "members": {
-        "CloudFormationStackARN": {},
+        "CloudFormationStackARN": {
+          "shape": "S4"
+        },
         "TagFilters": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Key": {},
+              "Key": {
+                "type": "string",
+                "max": 128,
+                "min": 1,
+                "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+              },
               "Values": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1,
+                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+                }
               }
             }
           }
         }
       }
+    },
+    "S4": {
+      "type": "string",
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sa": {
       "type": "list",
@@ -251,9 +326,15 @@
           "TargetTrackingConfigurations"
         ],
         "members": {
-          "ServiceNamespace": {},
-          "ResourceId": {},
-          "ScalableDimension": {},
+          "ServiceNamespace": {
+            "shape": "Sc"
+          },
+          "ResourceId": {
+            "shape": "Sd"
+          },
+          "ScalableDimension": {
+            "shape": "Se"
+          },
           "MinCapacity": {
             "type": "integer"
           },
@@ -269,6 +350,35 @@
         }
       }
     },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "autoscaling",
+        "ecs",
+        "ec2",
+        "rds",
+        "dynamodb"
+      ]
+    },
+    "Sd": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "autoscaling:autoScalingGroup:DesiredCapacity",
+        "ecs:service:DesiredCount",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "rds:cluster:ReadReplicaCount",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "dynamodb:index:ReadCapacityUnits",
+        "dynamodb:index:WriteCapacityUnits"
+      ]
+    },
     "Sh": {
       "type": "structure",
       "required": [
@@ -281,8 +391,29 @@
             "PredefinedScalingMetricType"
           ],
           "members": {
-            "PredefinedScalingMetricType": {},
-            "ResourceLabel": {}
+            "PredefinedScalingMetricType": {
+              "type": "string",
+              "enum": [
+                "ASGAverageCPUUtilization",
+                "ASGAverageNetworkIn",
+                "ASGAverageNetworkOut",
+                "DynamoDBReadCapacityUtilization",
+                "DynamoDBWriteCapacityUtilization",
+                "ECSServiceAverageCPUUtilization",
+                "ECSServiceAverageMemoryUtilization",
+                "ALBRequestCountPerTarget",
+                "RDSReaderAverageCPUUtilization",
+                "RDSReaderAverageDatabaseConnections",
+                "EC2SpotFleetRequestAverageCPUUtilization",
+                "EC2SpotFleetRequestAverageNetworkIn",
+                "EC2SpotFleetRequestAverageNetworkOut"
+              ]
+            },
+            "ResourceLabel": {
+              "type": "string",
+              "max": 1023,
+              "min": 1
+            }
           }
         },
         "CustomizedScalingMetricSpecification": {
@@ -309,7 +440,16 @@
                 }
               }
             },
-            "Statistic": {},
+            "Statistic": {
+              "type": "string",
+              "enum": [
+                "Average",
+                "Minimum",
+                "Maximum",
+                "SampleCount",
+                "Sum"
+              ]
+            },
             "Unit": {}
           }
         },

--- a/apis/batch-2016-08-10.min.json
+++ b/apis/batch-2016-08-10.min.json
@@ -45,8 +45,12 @@
         ],
         "members": {
           "computeEnvironmentName": {},
-          "type": {},
-          "state": {},
+          "type": {
+            "shape": "S5"
+          },
+          "state": {
+            "shape": "S6"
+          },
           "computeResources": {
             "shape": "S7"
           },
@@ -74,7 +78,9 @@
         ],
         "members": {
           "jobQueueName": {},
-          "state": {},
+          "state": {
+            "shape": "Se"
+          },
           "priority": {
             "type": "integer"
           },
@@ -181,9 +187,23 @@
                 "computeEnvironmentName": {},
                 "computeEnvironmentArn": {},
                 "ecsClusterArn": {},
-                "type": {},
-                "state": {},
-                "status": {},
+                "type": {
+                  "shape": "S5"
+                },
+                "state": {
+                  "shape": "S6"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "CREATING",
+                    "UPDATING",
+                    "DELETING",
+                    "DELETED",
+                    "VALID",
+                    "INVALID"
+                  ]
+                },
                 "statusReason": {},
                 "computeResources": {
                   "shape": "S7"
@@ -287,8 +307,20 @@
               "members": {
                 "jobQueueName": {},
                 "jobQueueArn": {},
-                "state": {},
-                "status": {},
+                "state": {
+                  "shape": "Se"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "CREATING",
+                    "UPDATING",
+                    "DELETING",
+                    "DELETED",
+                    "VALID",
+                    "INVALID"
+                  ]
+                },
                 "statusReason": {},
                 "priority": {
                   "type": "integer"
@@ -337,7 +369,9 @@
                 "jobName": {},
                 "jobId": {},
                 "jobQueue": {},
-                "status": {},
+                "status": {
+                  "shape": "S1k"
+                },
                 "attempts": {
                   "type": "list",
                   "member": {
@@ -463,7 +497,9 @@
         "members": {
           "jobQueue": {},
           "arrayJobId": {},
-          "jobStatus": {},
+          "jobStatus": {
+            "shape": "S1k"
+          },
           "maxResults": {
             "type": "integer"
           },
@@ -490,7 +526,9 @@
                 "createdAt": {
                   "type": "long"
                 },
-                "status": {},
+                "status": {
+                  "shape": "S1k"
+                },
                 "statusReason": {},
                 "startedAt": {
                   "type": "long"
@@ -537,7 +575,12 @@
         ],
         "members": {
           "jobDefinitionName": {},
-          "type": {},
+          "type": {
+            "type": "string",
+            "enum": [
+              "container"
+            ]
+          },
           "parameters": {
             "shape": "Sx"
           },
@@ -665,7 +708,9 @@
         ],
         "members": {
           "computeEnvironment": {},
-          "state": {},
+          "state": {
+            "shape": "S6"
+          },
           "computeResources": {
             "type": "structure",
             "members": {
@@ -702,7 +747,9 @@
         ],
         "members": {
           "jobQueue": {},
-          "state": {},
+          "state": {
+            "shape": "Se"
+          },
           "priority": {
             "type": "integer"
           },
@@ -721,6 +768,20 @@
     }
   },
   "shapes": {
+    "S5": {
+      "type": "string",
+      "enum": [
+        "MANAGED",
+        "UNMANAGED"
+      ]
+    },
+    "S6": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
     "S7": {
       "type": "structure",
       "required": [
@@ -733,7 +794,13 @@
         "instanceRole"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "EC2",
+            "SPOT"
+          ]
+        },
         "minvCpus": {
           "type": "integer"
         },
@@ -769,6 +836,13 @@
     "Sa": {
       "type": "list",
       "member": {}
+    },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
     },
     "Sf": {
       "type": "list",
@@ -905,13 +979,31 @@
         }
       }
     },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "SUBMITTED",
+        "PENDING",
+        "RUNNABLE",
+        "STARTING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
     "S1p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "jobId": {},
-          "type": {}
+          "type": {
+            "type": "string",
+            "enum": [
+              "N_TO_N",
+              "SEQUENTIAL"
+            ]
+          }
         }
       }
     }

--- a/apis/budgets-2016-10-20.min.json
+++ b/apis/budgets-2016-10-20.min.json
@@ -21,7 +21,9 @@
           "Budget"
         ],
         "members": {
-          "AccountId": {},
+          "AccountId": {
+            "shape": "S2"
+          },
           "Budget": {
             "shape": "S3"
           },
@@ -41,7 +43,8 @@
                   "shape": "Sp"
                 }
               }
-            }
+            },
+            "max": 5
           }
         }
       },
@@ -60,8 +63,12 @@
           "Subscribers"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           },
@@ -85,8 +92,12 @@
           "Subscriber"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           },
@@ -108,8 +119,12 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {}
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -126,8 +141,12 @@
           "Notification"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           }
@@ -148,8 +167,12 @@
           "Subscriber"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           },
@@ -171,8 +194,12 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {}
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -191,9 +218,11 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {},
+          "AccountId": {
+            "shape": "S2"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           },
           "NextToken": {}
         }
@@ -219,10 +248,14 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           },
           "NextToken": {}
         }
@@ -249,13 +282,17 @@
           "Notification"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           },
           "NextToken": {}
         }
@@ -278,7 +315,9 @@
           "NewBudget"
         ],
         "members": {
-          "AccountId": {},
+          "AccountId": {
+            "shape": "S2"
+          },
           "NewBudget": {
             "shape": "S3"
           }
@@ -299,8 +338,12 @@
           "NewNotification"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "OldNotification": {
             "shape": "Sk"
           },
@@ -325,8 +368,12 @@
           "NewSubscriber"
         ],
         "members": {
-          "AccountId": {},
-          "BudgetName": {},
+          "AccountId": {
+            "shape": "S2"
+          },
+          "BudgetName": {
+            "shape": "S4"
+          },
           "Notification": {
             "shape": "Sk"
           },
@@ -345,6 +392,11 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 12,
+      "min": 12
+    },
     "S3": {
       "type": "structure",
       "required": [
@@ -353,7 +405,9 @@
         "BudgetType"
       ],
       "members": {
-        "BudgetName": {},
+        "BudgetName": {
+          "shape": "S4"
+        },
         "BudgetLimit": {
           "shape": "S5"
         },
@@ -403,7 +457,15 @@
             }
           }
         },
-        "TimeUnit": {},
+        "TimeUnit": {
+          "type": "string",
+          "enum": [
+            "DAILY",
+            "MONTHLY",
+            "QUARTERLY",
+            "ANNUALLY"
+          ]
+        },
         "TimePeriod": {
           "type": "structure",
           "members": {
@@ -429,8 +491,21 @@
             }
           }
         },
-        "BudgetType": {}
+        "BudgetType": {
+          "type": "string",
+          "enum": [
+            "USAGE",
+            "COST",
+            "RI_UTILIZATION",
+            "RI_COVERAGE"
+          ]
+        }
       }
+    },
+    "S4": {
+      "type": "string",
+      "max": 100,
+      "pattern": "[^:\\\\]+"
     },
     "S5": {
       "type": "structure",
@@ -439,8 +514,14 @@
         "Unit"
       ],
       "members": {
-        "Amount": {},
-        "Unit": {}
+        "Amount": {
+          "type": "string",
+          "pattern": "([0-9]*\\.)?[0-9]+"
+        },
+        "Unit": {
+          "type": "string",
+          "min": 1
+        }
       }
     },
     "Sk": {
@@ -451,19 +532,42 @@
         "Threshold"
       ],
       "members": {
-        "NotificationType": {},
-        "ComparisonOperator": {},
-        "Threshold": {
-          "type": "double"
+        "NotificationType": {
+          "type": "string",
+          "enum": [
+            "ACTUAL",
+            "FORECASTED"
+          ]
         },
-        "ThresholdType": {}
+        "ComparisonOperator": {
+          "type": "string",
+          "enum": [
+            "GREATER_THAN",
+            "LESS_THAN",
+            "EQUAL_TO"
+          ]
+        },
+        "Threshold": {
+          "type": "double",
+          "max": 1000000000,
+          "min": 0.1
+        },
+        "ThresholdType": {
+          "type": "string",
+          "enum": [
+            "PERCENTAGE",
+            "ABSOLUTE_VALUE"
+          ]
+        }
       }
     },
     "Sp": {
       "type": "list",
       "member": {
         "shape": "Sq"
-      }
+      },
+      "max": 11,
+      "min": 1
     },
     "Sq": {
       "type": "structure",
@@ -472,9 +576,23 @@
         "Address"
       ],
       "members": {
-        "SubscriptionType": {},
-        "Address": {}
+        "SubscriptionType": {
+          "type": "string",
+          "enum": [
+            "SNS",
+            "EMAIL"
+          ]
+        },
+        "Address": {
+          "type": "string",
+          "min": 1
+        }
       }
+    },
+    "S17": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     }
   }
 }

--- a/apis/ce-2017-10-25.min.json
+++ b/apis/ce-2017-10-25.min.json
@@ -21,7 +21,9 @@
           "TimePeriod": {
             "shape": "S2"
           },
-          "Granularity": {},
+          "Granularity": {
+            "shape": "S4"
+          },
           "Filter": {
             "shape": "S5"
           },
@@ -89,8 +91,16 @@
           "TimePeriod": {
             "shape": "S2"
           },
-          "Dimension": {},
-          "Context": {},
+          "Dimension": {
+            "shape": "S8"
+          },
+          "Context": {
+            "type": "string",
+            "enum": [
+              "COST_AND_USAGE",
+              "RESERVATIONS"
+            ]
+          },
           "NextPageToken": {}
         }
       },
@@ -137,7 +147,9 @@
           "GroupBy": {
             "shape": "Sf"
           },
-          "Granularity": {},
+          "Granularity": {
+            "shape": "S4"
+          },
           "Filter": {
             "shape": "S5"
           },
@@ -194,15 +206,24 @@
         "members": {
           "AccountId": {},
           "Service": {},
-          "AccountScope": {},
-          "LookbackPeriodInDays": {},
-          "TermInYears": {},
-          "PaymentOption": {},
+          "AccountScope": {
+            "shape": "S1k"
+          },
+          "LookbackPeriodInDays": {
+            "shape": "S1l"
+          },
+          "TermInYears": {
+            "shape": "S1m"
+          },
+          "PaymentOption": {
+            "shape": "S1n"
+          },
           "ServiceSpecification": {
             "shape": "S1o"
           },
           "PageSize": {
-            "type": "integer"
+            "type": "integer",
+            "min": 0
           },
           "NextPageToken": {}
         }
@@ -222,10 +243,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "AccountScope": {},
-                "LookbackPeriodInDays": {},
-                "TermInYears": {},
-                "PaymentOption": {},
+                "AccountScope": {
+                  "shape": "S1k"
+                },
+                "LookbackPeriodInDays": {
+                  "shape": "S1l"
+                },
+                "TermInYears": {
+                  "shape": "S1m"
+                },
+                "PaymentOption": {
+                  "shape": "S1n"
+                },
                 "ServiceSpecification": {
                   "shape": "S1o"
                 },
@@ -365,7 +394,9 @@
           "GroupBy": {
             "shape": "Sf"
           },
-          "Granularity": {},
+          "Granularity": {
+            "shape": "S4"
+          },
           "Filter": {
             "shape": "S5"
           },
@@ -461,9 +492,24 @@
         "End"
       ],
       "members": {
-        "Start": {},
-        "End": {}
+        "Start": {
+          "shape": "S3"
+        },
+        "End": {
+          "shape": "S3"
+        }
       }
+    },
+    "S3": {
+      "type": "string",
+      "pattern": "\\d{4}-\\d{2}-\\d{2}"
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "DAILY",
+        "MONTHLY"
+      ]
     },
     "S5": {
       "type": "structure",
@@ -480,7 +526,9 @@
         "Dimensions": {
           "type": "structure",
           "members": {
-            "Key": {},
+            "Key": {
+              "shape": "S8"
+            },
             "Values": {
               "shape": "S9"
             }
@@ -503,6 +551,31 @@
         "shape": "S5"
       }
     },
+    "S8": {
+      "type": "string",
+      "enum": [
+        "AZ",
+        "INSTANCE_TYPE",
+        "LINKED_ACCOUNT",
+        "OPERATION",
+        "PURCHASE_TYPE",
+        "REGION",
+        "SERVICE",
+        "USAGE_TYPE",
+        "USAGE_TYPE_GROUP",
+        "RECORD_TYPE",
+        "OPERATING_SYSTEM",
+        "TENANCY",
+        "SCOPE",
+        "PLATFORM",
+        "SUBSCRIPTION_ID",
+        "LEGAL_ENTITY_NAME",
+        "DEPLOYMENT_OPTION",
+        "DATABASE_ENGINE",
+        "CACHE_ENGINE",
+        "INSTANCE_TYPE_FAMILY"
+      ]
+    },
     "S9": {
       "type": "list",
       "member": {}
@@ -512,7 +585,13 @@
       "member": {
         "type": "structure",
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "DIMENSION",
+              "TAG"
+            ]
+          },
           "Key": {}
         }
       }
@@ -547,13 +626,52 @@
         }
       }
     },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "PAYER",
+        "LINKED"
+      ]
+    },
+    "S1l": {
+      "type": "string",
+      "enum": [
+        "SEVEN_DAYS",
+        "THIRTY_DAYS",
+        "SIXTY_DAYS"
+      ]
+    },
+    "S1m": {
+      "type": "string",
+      "enum": [
+        "ONE_YEAR",
+        "THREE_YEARS"
+      ]
+    },
+    "S1n": {
+      "type": "string",
+      "enum": [
+        "NO_UPFRONT",
+        "PARTIAL_UPFRONT",
+        "ALL_UPFRONT",
+        "LIGHT_UTILIZATION",
+        "MEDIUM_UTILIZATION",
+        "HEAVY_UTILIZATION"
+      ]
+    },
     "S1o": {
       "type": "structure",
       "members": {
         "EC2Specification": {
           "type": "structure",
           "members": {
-            "OfferingClass": {}
+            "OfferingClass": {
+              "type": "string",
+              "enum": [
+                "STANDARD",
+                "CONVERTIBLE"
+              ]
+            }
           }
         }
       }

--- a/apis/cloud9-2017-09-23.min.json
+++ b/apis/cloud9-2017-09-23.min.json
@@ -20,21 +20,42 @@
           "instanceType"
         ],
         "members": {
-          "name": {},
-          "description": {},
-          "clientRequestToken": {},
-          "instanceType": {},
-          "subnetId": {},
-          "automaticStopTimeMinutes": {
-            "type": "integer"
+          "name": {
+            "shape": "S2"
           },
-          "ownerArn": {}
+          "description": {
+            "shape": "S3"
+          },
+          "clientRequestToken": {
+            "type": "string",
+            "pattern": "[\\x20-\\x7E]{10,128}"
+          },
+          "instanceType": {
+            "type": "string",
+            "max": 20,
+            "min": 5,
+            "pattern": "^[a-z][1-9][.][a-z0-9]+$"
+          },
+          "subnetId": {
+            "type": "string",
+            "max": 30,
+            "min": 5
+          },
+          "automaticStopTimeMinutes": {
+            "type": "integer",
+            "max": 20160
+          },
+          "ownerArn": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "environmentId": {}
+          "environmentId": {
+            "shape": "Sa"
+          }
         }
       },
       "idempotent": true
@@ -48,9 +69,15 @@
           "permissions"
         ],
         "members": {
-          "environmentId": {},
-          "userArn": {},
-          "permissions": {}
+          "environmentId": {
+            "shape": "Sa"
+          },
+          "userArn": {
+            "shape": "S8"
+          },
+          "permissions": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -70,7 +97,9 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {}
+          "environmentId": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -87,8 +116,12 @@
           "userArn"
         ],
         "members": {
-          "environmentId": {},
-          "userArn": {}
+          "environmentId": {
+            "shape": "Sa"
+          },
+          "userArn": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -101,15 +134,21 @@
       "input": {
         "type": "structure",
         "members": {
-          "userArn": {},
-          "environmentId": {},
+          "userArn": {
+            "shape": "S8"
+          },
+          "environmentId": {
+            "shape": "Sa"
+          },
           "permissions": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sf"
+            }
           },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "So"
           }
         }
       },
@@ -133,13 +172,26 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {}
+          "environmentId": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {},
+          "status": {
+            "type": "string",
+            "enum": [
+              "error",
+              "creating",
+              "connecting",
+              "ready",
+              "stopping",
+              "stopped",
+              "deleting"
+            ]
+          },
           "message": {}
         }
       }
@@ -153,7 +205,11 @@
         "members": {
           "environmentIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa"
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -165,10 +221,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {},
-                "name": {},
-                "description": {},
-                "type": {},
+                "id": {
+                  "shape": "Sa"
+                },
+                "name": {
+                  "shape": "S2"
+                },
+                "description": {
+                  "shape": "S3"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ssh",
+                    "ec2"
+                  ]
+                },
                 "arn": {},
                 "ownerArn": {}
               }
@@ -183,7 +251,7 @@
         "members": {
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "So"
           }
         }
       },
@@ -193,7 +261,9 @@
           "nextToken": {},
           "environmentIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa"
+            }
           }
         }
       }
@@ -205,9 +275,15 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {},
-          "name": {},
-          "description": {}
+          "environmentId": {
+            "shape": "Sa"
+          },
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -225,9 +301,15 @@
           "permissions"
         ],
         "members": {
-          "environmentId": {},
-          "userArn": {},
-          "permissions": {}
+          "environmentId": {
+            "shape": "Sa"
+          },
+          "userArn": {
+            "shape": "S8"
+          },
+          "permissions": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -242,17 +324,60 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 60,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "max": 200
+    },
+    "S8": {
+      "type": "string",
+      "pattern": "arn:aws:(iam|sts)::\\d+:\\S+"
+    },
+    "Sa": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{8,32}$"
+    },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "read-write",
+        "read-only"
+      ]
+    },
     "Se": {
       "type": "structure",
       "members": {
-        "permissions": {},
+        "permissions": {
+          "shape": "Sf"
+        },
         "userId": {},
-        "userArn": {},
-        "environmentId": {},
+        "userArn": {
+          "shape": "S8"
+        },
+        "environmentId": {
+          "shape": "Sa"
+        },
         "lastAccess": {
           "type": "timestamp"
         }
       }
+    },
+    "Sf": {
+      "type": "string",
+      "enum": [
+        "owner",
+        "read-write",
+        "read-only"
+      ]
+    },
+    "So": {
+      "type": "integer",
+      "max": 25,
+      "min": 0
     }
   }
 }

--- a/apis/clouddirectory-2016-05-10.min.json
+++ b/apis/clouddirectory-2016-05-10.min.json
@@ -98,7 +98,9 @@
           "ChildReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -247,7 +249,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     },
                     "FacetFilter": {
                       "shape": "S3"
@@ -265,7 +267,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -280,7 +282,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -295,7 +297,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -340,7 +342,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -355,7 +357,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -370,7 +372,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -387,7 +389,7 @@
                       "shape": "Sf"
                     },
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     },
                     "NextToken": {}
                   }
@@ -409,7 +411,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -430,7 +432,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -453,6 +455,7 @@
             }
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -589,7 +592,24 @@
                 "ExceptionResponse": {
                   "type": "structure",
                   "members": {
-                    "Type": {},
+                    "Type": {
+                      "type": "string",
+                      "enum": [
+                        "ValidationException",
+                        "InvalidArnException",
+                        "ResourceNotFoundException",
+                        "InvalidNextTokenException",
+                        "AccessDeniedException",
+                        "NotNodeException",
+                        "FacetValidationException",
+                        "CannotListParentOfRootException",
+                        "NotIndexException",
+                        "NotPolicyException",
+                        "DirectoryNotEnabledException",
+                        "LimitExceededException",
+                        "InternalServiceException"
+                      ]
+                    },
                     "Message": {}
                   }
                 }
@@ -637,7 +657,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -655,7 +677,9 @@
                     "ChildReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {}
+                    "LinkName": {
+                      "shape": "Sl"
+                    }
                   }
                 },
                 "DetachObject": {
@@ -668,7 +692,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -778,7 +804,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -971,7 +999,9 @@
           "SchemaArn"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3y"
+          },
           "SchemaArn": {
             "location": "header",
             "locationName": "x-amz-data-partition"
@@ -988,7 +1018,9 @@
         ],
         "members": {
           "DirectoryArn": {},
-          "Name": {},
+          "Name": {
+            "shape": "S3y"
+          },
           "ObjectIdentifier": {},
           "AppliedSchemaArn": {}
         }
@@ -1012,11 +1044,15 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "Attributes": {
             "shape": "S42"
           },
-          "ObjectType": {}
+          "ObjectType": {
+            "shape": "S4f"
+          }
         }
       },
       "output": {
@@ -1051,7 +1087,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1087,7 +1125,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1109,7 +1149,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S4m"
+          }
         }
       },
       "output": {
@@ -1144,7 +1186,9 @@
               "IdentityAttributeOrder"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "Su"
+              },
               "Attributes": {
                 "shape": "S4q"
               },
@@ -1205,7 +1249,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1282,7 +1328,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -1344,7 +1392,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1530,7 +1580,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1539,8 +1591,12 @@
           "Facet": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "ObjectType": {}
+              "Name": {
+                "shape": "S4"
+              },
+              "ObjectType": {
+                "shape": "S4f"
+              }
             }
           }
         }
@@ -1569,7 +1625,9 @@
           "AttributeNames": {
             "shape": "S1a"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -1603,6 +1661,7 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -1643,6 +1702,7 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1678,7 +1738,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S4m"
+          },
           "Document": {}
         }
       }
@@ -1699,7 +1761,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -1726,7 +1790,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1761,9 +1825,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1789,7 +1854,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1813,9 +1878,11 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "state": {}
+          "state": {
+            "shape": "S5j"
+          }
         }
       },
       "output": {
@@ -1850,10 +1917,12 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1884,7 +1953,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1893,7 +1962,9 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            }
           },
           "NextToken": {}
         }
@@ -1926,9 +1997,11 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -1964,10 +2037,11 @@
             "shape": "Sf"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "NextToken": {},
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2004,9 +2078,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -2046,9 +2121,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2085,7 +2161,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2120,9 +2196,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2134,7 +2211,9 @@
           "Parents": {
             "type": "map",
             "key": {},
-            "value": {}
+            "value": {
+              "shape": "Sl"
+            }
           },
           "NextToken": {}
         }
@@ -2161,9 +2240,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2206,9 +2286,11 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -2242,9 +2324,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2271,7 +2354,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2299,7 +2382,8 @@
           "ResourceArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "min": 50
           }
         }
       },
@@ -2329,10 +2413,12 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "Su"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2363,7 +2449,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2372,7 +2458,9 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Su"
+            }
           },
           "NextToken": {}
         }
@@ -2399,7 +2487,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2430,9 +2518,15 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Version": {},
-          "MinorVersion": {},
-          "Name": {}
+          "Version": {
+            "shape": "S7e"
+          },
+          "MinorVersion": {
+            "shape": "S7e"
+          },
+          "Name": {
+            "shape": "S4m"
+          }
         }
       },
       "output": {
@@ -2566,7 +2660,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2575,11 +2671,15 @@
                 "Attribute": {
                   "shape": "S43"
                 },
-                "Action": {}
+                "Action": {
+                  "shape": "S2y"
+                }
               }
             }
           },
-          "ObjectType": {}
+          "ObjectType": {
+            "shape": "S4f"
+          }
         }
       },
       "output": {
@@ -2667,7 +2767,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4m"
+          }
         }
       },
       "output": {
@@ -2696,7 +2798,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "Su"
+          },
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2709,7 +2813,9 @@
                 "Attribute": {
                   "shape": "S4r"
                 },
-                "Action": {}
+                "Action": {
+                  "shape": "S2y"
+                }
               }
             }
           },
@@ -2767,7 +2873,9 @@
         "members": {
           "DevelopmentSchemaArn": {},
           "PublishedSchemaArn": {},
-          "MinorVersion": {},
+          "MinorVersion": {
+            "shape": "S7e"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -2786,8 +2894,16 @@
       "type": "structure",
       "members": {
         "SchemaArn": {},
-        "FacetName": {}
+        "FacetName": {
+          "shape": "S4"
+        }
       }
+    },
+    "S4": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S5": {
       "type": "list",
@@ -2816,9 +2932,19 @@
       ],
       "members": {
         "SchemaArn": {},
-        "FacetName": {},
-        "Name": {}
+        "FacetName": {
+          "shape": "S4"
+        },
+        "Name": {
+          "shape": "S8"
+        }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S9": {
       "type": "structure",
@@ -2842,6 +2968,12 @@
         "Selector": {}
       }
     },
+    "Sl": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[^\\/\\[\\]\\(\\):\\{\\}#@!?\\s\\\\;]+"
+    },
     "St": {
       "type": "structure",
       "required": [
@@ -2850,8 +2982,14 @@
       ],
       "members": {
         "SchemaArn": {},
-        "TypedLinkName": {}
+        "TypedLinkName": {
+          "shape": "Su"
+        }
       }
+    },
+    "Su": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "Sv": {
       "type": "list",
@@ -2862,7 +3000,9 @@
           "Value"
         ],
         "members": {
-          "AttributeName": {},
+          "AttributeName": {
+            "shape": "S8"
+          },
           "Value": {
             "shape": "S9"
           }
@@ -2892,9 +3032,15 @@
         }
       }
     },
+    "S14": {
+      "type": "integer",
+      "min": 1
+    },
     "S1a": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8"
+      }
     },
     "S1f": {
       "type": "list",
@@ -2917,15 +3063,29 @@
         "EndMode"
       ],
       "members": {
-        "StartMode": {},
+        "StartMode": {
+          "shape": "S1i"
+        },
         "StartValue": {
           "shape": "S9"
         },
-        "EndMode": {},
+        "EndMode": {
+          "shape": "S1i"
+        },
         "EndValue": {
           "shape": "S9"
         }
       }
+    },
+    "S1i": {
+      "type": "string",
+      "enum": [
+        "FIRST",
+        "LAST",
+        "LAST_BEFORE_MISSING_VALUES",
+        "INCLUSIVE",
+        "EXCLUSIVE"
+      ]
     },
     "S1k": {
       "type": "list",
@@ -2935,16 +3095,27 @@
           "Range"
         ],
         "members": {
-          "AttributeName": {},
+          "AttributeName": {
+            "shape": "S8"
+          },
           "Range": {
             "shape": "S1h"
           }
         }
       }
     },
+    "S1o": {
+      "type": "string",
+      "enum": [
+        "SERIALIZABLE",
+        "EVENTUAL"
+      ]
+    },
     "S1v": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sl"
+      },
       "value": {}
     },
     "S1x": {
@@ -3018,7 +3189,9 @@
           "ObjectAttributeAction": {
             "type": "structure",
             "members": {
-              "ObjectAttributeActionType": {},
+              "ObjectAttributeActionType": {
+                "shape": "S2y"
+              },
               "ObjectAttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3026,6 +3199,13 @@
           }
         }
       }
+    },
+    "S2y": {
+      "type": "string",
+      "enum": [
+        "CREATE_OR_UPDATE",
+        "DELETE"
+      ]
     },
     "S35": {
       "type": "list",
@@ -3044,7 +3224,9 @@
           "AttributeAction": {
             "type": "structure",
             "members": {
-              "AttributeActionType": {},
+              "AttributeActionType": {
+                "shape": "S2y"
+              },
               "AttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3052,6 +3234,12 @@
           }
         }
       }
+    },
+    "S3y": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S42": {
       "type": "list",
@@ -3065,14 +3253,18 @@
         "Name"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S8"
+        },
         "AttributeDefinition": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {},
+            "Type": {
+              "shape": "S45"
+            },
             "DefaultValue": {
               "shape": "S9"
             },
@@ -3091,20 +3283,49 @@
             "TargetAttributeName"
           ],
           "members": {
-            "TargetFacetName": {},
-            "TargetAttributeName": {}
+            "TargetFacetName": {
+              "shape": "S4"
+            },
+            "TargetAttributeName": {
+              "shape": "S8"
+            }
           }
         },
-        "RequiredBehavior": {}
+        "RequiredBehavior": {
+          "shape": "S4e"
+        }
       }
+    },
+    "S45": {
+      "type": "string",
+      "enum": [
+        "STRING",
+        "BINARY",
+        "BOOLEAN",
+        "NUMBER",
+        "DATETIME"
+      ]
     },
     "S46": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "max": 64,
+        "min": 1,
+        "pattern": "^[a-zA-Z0-9._-]*$"
+      },
       "value": {
         "type": "structure",
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "BINARY_LENGTH",
+              "NUMBER_COMPARISON",
+              "STRING_FROM_SET",
+              "STRING_LENGTH"
+            ]
+          },
           "Parameters": {
             "type": "map",
             "key": {},
@@ -3112,6 +3333,28 @@
           }
         }
       }
+    },
+    "S4e": {
+      "type": "string",
+      "enum": [
+        "REQUIRED_ALWAYS",
+        "NOT_REQUIRED"
+      ]
+    },
+    "S4f": {
+      "type": "string",
+      "enum": [
+        "NODE",
+        "LEAF_NODE",
+        "POLICY",
+        "INDEX"
+      ]
+    },
+    "S4m": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S4q": {
       "type": "list",
@@ -3127,8 +3370,12 @@
         "RequiredBehavior"
       ],
       "members": {
-        "Name": {},
-        "Type": {},
+        "Name": {
+          "shape": "S8"
+        },
+        "Type": {
+          "shape": "S45"
+        },
         "DefaultValue": {
           "shape": "S9"
         },
@@ -3138,19 +3385,33 @@
         "Rules": {
           "shape": "S46"
         },
-        "RequiredBehavior": {}
+        "RequiredBehavior": {
+          "shape": "S4e"
+        }
       }
     },
     "S5i": {
       "type": "structure",
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S3y"
+        },
         "DirectoryArn": {},
-        "State": {},
+        "State": {
+          "shape": "S5j"
+        },
         "CreationDateTime": {
           "type": "timestamp"
         }
       }
+    },
+    "S5j": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED",
+        "DELETED"
+      ]
     },
     "S61": {
       "type": "list",
@@ -3165,6 +3426,12 @@
           "Value": {}
         }
       }
+    },
+    "S7e": {
+      "type": "string",
+      "max": 10,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     }
   }
 }

--- a/apis/clouddirectory-2017-01-11.min.json
+++ b/apis/clouddirectory-2017-01-11.min.json
@@ -98,7 +98,9 @@
           "ChildReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -247,7 +249,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     },
                     "FacetFilter": {
                       "shape": "S3"
@@ -265,7 +267,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -280,7 +282,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -295,7 +297,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -340,7 +342,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -355,7 +357,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -370,7 +372,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -387,7 +389,7 @@
                       "shape": "Sf"
                     },
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     },
                     "NextToken": {}
                   }
@@ -409,7 +411,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -430,7 +432,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "type": "integer"
+                      "shape": "S14"
                     }
                   }
                 },
@@ -453,6 +455,7 @@
             }
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -589,7 +592,24 @@
                 "ExceptionResponse": {
                   "type": "structure",
                   "members": {
-                    "Type": {},
+                    "Type": {
+                      "type": "string",
+                      "enum": [
+                        "ValidationException",
+                        "InvalidArnException",
+                        "ResourceNotFoundException",
+                        "InvalidNextTokenException",
+                        "AccessDeniedException",
+                        "NotNodeException",
+                        "FacetValidationException",
+                        "CannotListParentOfRootException",
+                        "NotIndexException",
+                        "NotPolicyException",
+                        "DirectoryNotEnabledException",
+                        "LimitExceededException",
+                        "InternalServiceException"
+                      ]
+                    },
                     "Message": {}
                   }
                 }
@@ -637,7 +657,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -655,7 +677,9 @@
                     "ChildReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {}
+                    "LinkName": {
+                      "shape": "Sl"
+                    }
                   }
                 },
                 "DetachObject": {
@@ -668,7 +692,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -778,7 +804,9 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {},
+                    "LinkName": {
+                      "shape": "Sl"
+                    },
                     "BatchReferenceName": {}
                   }
                 },
@@ -971,7 +999,9 @@
           "SchemaArn"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3y"
+          },
           "SchemaArn": {
             "location": "header",
             "locationName": "x-amz-data-partition"
@@ -988,7 +1018,9 @@
         ],
         "members": {
           "DirectoryArn": {},
-          "Name": {},
+          "Name": {
+            "shape": "S3y"
+          },
           "ObjectIdentifier": {},
           "AppliedSchemaArn": {}
         }
@@ -1011,12 +1043,18 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "Attributes": {
             "shape": "S42"
           },
-          "ObjectType": {},
-          "FacetStyle": {}
+          "ObjectType": {
+            "shape": "S4f"
+          },
+          "FacetStyle": {
+            "shape": "S4g"
+          }
         }
       },
       "output": {
@@ -1051,7 +1089,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1087,7 +1127,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1109,7 +1151,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
@@ -1144,7 +1188,9 @@
               "IdentityAttributeOrder"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "Su"
+              },
               "Attributes": {
                 "shape": "S4r"
               },
@@ -1205,7 +1251,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1282,7 +1330,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -1344,7 +1394,9 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {}
+          "LinkName": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1530,7 +1582,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1539,9 +1593,15 @@
           "Facet": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "ObjectType": {},
-              "FacetStyle": {}
+              "Name": {
+                "shape": "S4"
+              },
+              "ObjectType": {
+                "shape": "S4f"
+              },
+              "FacetStyle": {
+                "shape": "S4g"
+              }
             }
           }
         }
@@ -1570,7 +1630,9 @@
           "AttributeNames": {
             "shape": "S1a"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -1604,6 +1666,7 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -1644,6 +1707,7 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1679,7 +1743,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S4n"
+          },
           "Document": {}
         }
       }
@@ -1700,7 +1766,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -1727,7 +1795,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1762,9 +1830,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1790,7 +1859,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1814,9 +1883,11 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "state": {}
+          "state": {
+            "shape": "S5k"
+          }
         }
       },
       "output": {
@@ -1851,10 +1922,12 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1885,7 +1958,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -1894,7 +1967,9 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            }
           },
           "NextToken": {}
         }
@@ -1927,9 +2002,11 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -1965,10 +2042,11 @@
             "shape": "Sf"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "NextToken": {},
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1995,7 +2073,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2030,9 +2108,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -2072,9 +2151,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2111,7 +2191,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2146,9 +2226,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2160,7 +2241,9 @@
           "Parents": {
             "type": "map",
             "key": {},
-            "value": {}
+            "value": {
+              "shape": "Sl"
+            }
           },
           "NextToken": {}
         }
@@ -2187,9 +2270,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2232,9 +2316,11 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "ConsistencyLevel": {}
+          "ConsistencyLevel": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -2268,9 +2354,10 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           },
           "ConsistencyLevel": {
+            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2297,7 +2384,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2325,7 +2412,8 @@
           "ResourceArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "min": 50
           }
         }
       },
@@ -2355,10 +2443,12 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "Su"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2389,7 +2479,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2398,7 +2488,9 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Su"
+            }
           },
           "NextToken": {}
         }
@@ -2425,7 +2517,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S14"
           }
         }
       },
@@ -2456,9 +2548,15 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Version": {},
-          "MinorVersion": {},
-          "Name": {}
+          "Version": {
+            "shape": "S7h"
+          },
+          "MinorVersion": {
+            "shape": "S7h"
+          },
+          "Name": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
@@ -2592,7 +2690,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S4"
+          },
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2601,11 +2701,15 @@
                 "Attribute": {
                   "shape": "S43"
                 },
-                "Action": {}
+                "Action": {
+                  "shape": "S2y"
+                }
               }
             }
           },
-          "ObjectType": {}
+          "ObjectType": {
+            "shape": "S4f"
+          }
         }
       },
       "output": {
@@ -2693,7 +2797,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {}
+          "Name": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
@@ -2722,7 +2828,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {},
+          "Name": {
+            "shape": "Su"
+          },
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2735,7 +2843,9 @@
                 "Attribute": {
                   "shape": "S4s"
                 },
-                "Action": {}
+                "Action": {
+                  "shape": "S2y"
+                }
               }
             }
           },
@@ -2793,7 +2903,9 @@
         "members": {
           "DevelopmentSchemaArn": {},
           "PublishedSchemaArn": {},
-          "MinorVersion": {},
+          "MinorVersion": {
+            "shape": "S7h"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -2812,8 +2924,16 @@
       "type": "structure",
       "members": {
         "SchemaArn": {},
-        "FacetName": {}
+        "FacetName": {
+          "shape": "S4"
+        }
       }
+    },
+    "S4": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S5": {
       "type": "list",
@@ -2842,9 +2962,19 @@
       ],
       "members": {
         "SchemaArn": {},
-        "FacetName": {},
-        "Name": {}
+        "FacetName": {
+          "shape": "S4"
+        },
+        "Name": {
+          "shape": "S8"
+        }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S9": {
       "type": "structure",
@@ -2868,6 +2998,12 @@
         "Selector": {}
       }
     },
+    "Sl": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[^\\/\\[\\]\\(\\):\\{\\}#@!?\\s\\\\;]+"
+    },
     "St": {
       "type": "structure",
       "required": [
@@ -2876,8 +3012,14 @@
       ],
       "members": {
         "SchemaArn": {},
-        "TypedLinkName": {}
+        "TypedLinkName": {
+          "shape": "Su"
+        }
       }
+    },
+    "Su": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "Sv": {
       "type": "list",
@@ -2888,7 +3030,9 @@
           "Value"
         ],
         "members": {
-          "AttributeName": {},
+          "AttributeName": {
+            "shape": "S8"
+          },
           "Value": {
             "shape": "S9"
           }
@@ -2918,9 +3062,15 @@
         }
       }
     },
+    "S14": {
+      "type": "integer",
+      "min": 1
+    },
     "S1a": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8"
+      }
     },
     "S1f": {
       "type": "list",
@@ -2943,15 +3093,29 @@
         "EndMode"
       ],
       "members": {
-        "StartMode": {},
+        "StartMode": {
+          "shape": "S1i"
+        },
         "StartValue": {
           "shape": "S9"
         },
-        "EndMode": {},
+        "EndMode": {
+          "shape": "S1i"
+        },
         "EndValue": {
           "shape": "S9"
         }
       }
+    },
+    "S1i": {
+      "type": "string",
+      "enum": [
+        "FIRST",
+        "LAST",
+        "LAST_BEFORE_MISSING_VALUES",
+        "INCLUSIVE",
+        "EXCLUSIVE"
+      ]
     },
     "S1k": {
       "type": "list",
@@ -2961,16 +3125,27 @@
           "Range"
         ],
         "members": {
-          "AttributeName": {},
+          "AttributeName": {
+            "shape": "S8"
+          },
           "Range": {
             "shape": "S1h"
           }
         }
       }
     },
+    "S1o": {
+      "type": "string",
+      "enum": [
+        "SERIALIZABLE",
+        "EVENTUAL"
+      ]
+    },
     "S1v": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sl"
+      },
       "value": {}
     },
     "S1x": {
@@ -3044,7 +3219,9 @@
           "ObjectAttributeAction": {
             "type": "structure",
             "members": {
-              "ObjectAttributeActionType": {},
+              "ObjectAttributeActionType": {
+                "shape": "S2y"
+              },
               "ObjectAttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3052,6 +3229,13 @@
           }
         }
       }
+    },
+    "S2y": {
+      "type": "string",
+      "enum": [
+        "CREATE_OR_UPDATE",
+        "DELETE"
+      ]
     },
     "S35": {
       "type": "list",
@@ -3070,7 +3254,9 @@
           "AttributeAction": {
             "type": "structure",
             "members": {
-              "AttributeActionType": {},
+              "AttributeActionType": {
+                "shape": "S2y"
+              },
               "AttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3078,6 +3264,12 @@
           }
         }
       }
+    },
+    "S3y": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S42": {
       "type": "list",
@@ -3091,14 +3283,18 @@
         "Name"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S8"
+        },
         "AttributeDefinition": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {},
+            "Type": {
+              "shape": "S45"
+            },
             "DefaultValue": {
               "shape": "S9"
             },
@@ -3117,20 +3313,50 @@
             "TargetAttributeName"
           ],
           "members": {
-            "TargetFacetName": {},
-            "TargetAttributeName": {}
+            "TargetFacetName": {
+              "shape": "S4"
+            },
+            "TargetAttributeName": {
+              "shape": "S8"
+            }
           }
         },
-        "RequiredBehavior": {}
+        "RequiredBehavior": {
+          "shape": "S4e"
+        }
       }
+    },
+    "S45": {
+      "type": "string",
+      "enum": [
+        "STRING",
+        "BINARY",
+        "BOOLEAN",
+        "NUMBER",
+        "DATETIME",
+        "VARIANT"
+      ]
     },
     "S46": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "max": 64,
+        "min": 1,
+        "pattern": "^[a-zA-Z0-9._-]*$"
+      },
       "value": {
         "type": "structure",
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "BINARY_LENGTH",
+              "NUMBER_COMPARISON",
+              "STRING_FROM_SET",
+              "STRING_LENGTH"
+            ]
+          },
           "Parameters": {
             "type": "map",
             "key": {},
@@ -3138,6 +3364,35 @@
           }
         }
       }
+    },
+    "S4e": {
+      "type": "string",
+      "enum": [
+        "REQUIRED_ALWAYS",
+        "NOT_REQUIRED"
+      ]
+    },
+    "S4f": {
+      "type": "string",
+      "enum": [
+        "NODE",
+        "LEAF_NODE",
+        "POLICY",
+        "INDEX"
+      ]
+    },
+    "S4g": {
+      "type": "string",
+      "enum": [
+        "STATIC",
+        "DYNAMIC"
+      ]
+    },
+    "S4n": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S4r": {
       "type": "list",
@@ -3153,8 +3408,12 @@
         "RequiredBehavior"
       ],
       "members": {
-        "Name": {},
-        "Type": {},
+        "Name": {
+          "shape": "S8"
+        },
+        "Type": {
+          "shape": "S45"
+        },
         "DefaultValue": {
           "shape": "S9"
         },
@@ -3164,19 +3423,33 @@
         "Rules": {
           "shape": "S46"
         },
-        "RequiredBehavior": {}
+        "RequiredBehavior": {
+          "shape": "S4e"
+        }
       }
     },
     "S5j": {
       "type": "structure",
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S3y"
+        },
         "DirectoryArn": {},
-        "State": {},
+        "State": {
+          "shape": "S5k"
+        },
         "CreationDateTime": {
           "type": "timestamp"
         }
       }
+    },
+    "S5k": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED",
+        "DELETED"
+      ]
     },
     "S62": {
       "type": "list",
@@ -3191,6 +3464,12 @@
           "Value": {}
         }
       }
+    },
+    "S7h": {
+      "type": "string",
+      "max": 10,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9._-]*$"
     }
   }
 }

--- a/apis/cloudformation-2010-05-15.min.json
+++ b/apis/cloudformation-2010-05-15.min.json
@@ -19,7 +19,9 @@
         ],
         "members": {
           "StackName": {},
-          "ClientRequestToken": {}
+          "ClientRequestToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -30,13 +32,22 @@
           "StackName"
         ],
         "members": {
-          "StackName": {},
-          "RoleARN": {},
+          "StackName": {
+            "shape": "S5"
+          },
+          "RoleARN": {
+            "shape": "S6"
+          },
           "ResourcesToSkip": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "pattern": "[a-zA-Z0-9]+|[a-zA-Z][-a-zA-Z0-9]*\\.[a-zA-Z0-9]+"
+            }
           },
-          "ClientRequestToken": {}
+          "ClientRequestToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -53,9 +64,15 @@
           "ChangeSetName"
         ],
         "members": {
-          "StackName": {},
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "StackName": {
+            "shape": "S5"
+          },
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "UsePreviousTemplate": {
             "type": "boolean"
           },
@@ -68,7 +85,9 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {},
+          "RoleARN": {
+            "shape": "S6"
+          },
           "RollbackConfiguration": {
             "shape": "Sn"
           },
@@ -78,17 +97,33 @@
           "Tags": {
             "shape": "Sv"
           },
-          "ChangeSetName": {},
-          "ClientToken": {},
-          "Description": {},
-          "ChangeSetType": {}
+          "ChangeSetName": {
+            "shape": "Sz"
+          },
+          "ClientToken": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          },
+          "Description": {
+            "shape": "S11"
+          },
+          "ChangeSetType": {
+            "type": "string",
+            "enum": [
+              "CREATE",
+              "UPDATE"
+            ]
+          }
         }
       },
       "output": {
         "resultWrapper": "CreateChangeSetResult",
         "type": "structure",
         "members": {
-          "Id": {},
+          "Id": {
+            "shape": "S14"
+          },
           "StackId": {}
         }
       }
@@ -101,8 +136,12 @@
         ],
         "members": {
           "StackName": {},
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "Parameters": {
             "shape": "Se"
           },
@@ -113,7 +152,7 @@
             "shape": "Sn"
           },
           "TimeoutInMinutes": {
-            "type": "integer"
+            "shape": "S18"
           },
           "NotificationARNs": {
             "shape": "St"
@@ -124,14 +163,29 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {},
-          "OnFailure": {},
-          "StackPolicyBody": {},
-          "StackPolicyURL": {},
+          "RoleARN": {
+            "shape": "S6"
+          },
+          "OnFailure": {
+            "type": "string",
+            "enum": [
+              "DO_NOTHING",
+              "ROLLBACK",
+              "DELETE"
+            ]
+          },
+          "StackPolicyBody": {
+            "shape": "S1a"
+          },
+          "StackPolicyURL": {
+            "shape": "S1b"
+          },
           "Tags": {
             "shape": "Sv"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S3"
+          },
           "EnableTerminationProtection": {
             "type": "boolean"
           }
@@ -168,6 +222,7 @@
             "shape": "S1k"
           },
           "OperationId": {
+            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -176,7 +231,9 @@
         "resultWrapper": "CreateStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -188,9 +245,15 @@
         ],
         "members": {
           "StackSetName": {},
-          "Description": {},
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "Description": {
+            "shape": "S11"
+          },
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "Parameters": {
             "shape": "Se"
           },
@@ -200,9 +263,14 @@
           "Tags": {
             "shape": "Sv"
           },
-          "AdministrationRoleARN": {},
-          "ExecutionRoleName": {},
+          "AdministrationRoleARN": {
+            "shape": "S6"
+          },
+          "ExecutionRoleName": {
+            "shape": "S1r"
+          },
           "ClientRequestToken": {
+            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -222,8 +290,12 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {},
-          "StackName": {}
+          "ChangeSetName": {
+            "shape": "S1v"
+          },
+          "StackName": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -244,8 +316,12 @@
             "type": "list",
             "member": {}
           },
-          "RoleARN": {},
-          "ClientRequestToken": {}
+          "RoleARN": {
+            "shape": "S6"
+          },
+          "ClientRequestToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -273,6 +349,7 @@
             "type": "boolean"
           },
           "OperationId": {
+            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -281,7 +358,9 @@
         "resultWrapper": "DeleteStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -305,7 +384,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -324,7 +405,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -335,28 +418,44 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {},
-          "StackName": {},
-          "NextToken": {}
+          "ChangeSetName": {
+            "shape": "S1v"
+          },
+          "StackName": {
+            "shape": "S5"
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
         "resultWrapper": "DescribeChangeSetResult",
         "type": "structure",
         "members": {
-          "ChangeSetName": {},
-          "ChangeSetId": {},
+          "ChangeSetName": {
+            "shape": "Sz"
+          },
+          "ChangeSetId": {
+            "shape": "S14"
+          },
           "StackId": {},
           "StackName": {},
-          "Description": {},
+          "Description": {
+            "shape": "S11"
+          },
           "Parameters": {
             "shape": "Se"
           },
           "CreationTime": {
             "type": "timestamp"
           },
-          "ExecutionStatus": {},
-          "Status": {},
+          "ExecutionStatus": {
+            "shape": "S2f"
+          },
+          "Status": {
+            "shape": "S2g"
+          },
           "StatusReason": {},
           "NotificationARNs": {
             "shape": "St"
@@ -375,18 +474,41 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {},
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "Resource"
+                  ]
+                },
                 "ResourceChange": {
                   "type": "structure",
                   "members": {
-                    "Action": {},
+                    "Action": {
+                      "type": "string",
+                      "enum": [
+                        "Add",
+                        "Modify",
+                        "Remove"
+                      ]
+                    },
                     "LogicalResourceId": {},
                     "PhysicalResourceId": {},
-                    "ResourceType": {},
-                    "Replacement": {},
+                    "ResourceType": {
+                      "shape": "Sm"
+                    },
+                    "Replacement": {
+                      "type": "string",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Conditional"
+                      ]
+                    },
                     "Scope": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "S2q"
+                      }
                     },
                     "Details": {
                       "type": "list",
@@ -396,13 +518,37 @@
                           "Target": {
                             "type": "structure",
                             "members": {
-                              "Attribute": {},
+                              "Attribute": {
+                                "shape": "S2q"
+                              },
                               "Name": {},
-                              "RequiresRecreation": {}
+                              "RequiresRecreation": {
+                                "type": "string",
+                                "enum": [
+                                  "Never",
+                                  "Conditionally",
+                                  "Always"
+                                ]
+                              }
                             }
                           },
-                          "Evaluation": {},
-                          "ChangeSource": {},
+                          "Evaluation": {
+                            "type": "string",
+                            "enum": [
+                              "Static",
+                              "Dynamic"
+                            ]
+                          },
+                          "ChangeSource": {
+                            "type": "string",
+                            "enum": [
+                              "ResourceReference",
+                              "ParameterReference",
+                              "ResourceAttribute",
+                              "DirectModification",
+                              "Automatic"
+                            ]
+                          },
                           "CausingEntity": {}
                         }
                       }
@@ -412,7 +558,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -421,7 +569,9 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -444,18 +594,26 @@
                 "StackName": {},
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {},
+                "ResourceType": {
+                  "shape": "Sm"
+                },
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {},
+                "ResourceStatus": {
+                  "shape": "S35"
+                },
                 "ResourceStatusReason": {},
                 "ResourceProperties": {},
-                "ClientRequestToken": {}
+                "ClientRequestToken": {
+                  "shape": "S3"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -469,7 +627,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "StackInstanceAccount": {},
+          "StackInstanceAccount": {
+            "shape": "S1h"
+          },
           "StackInstanceRegion": {}
         }
       },
@@ -482,12 +642,16 @@
             "members": {
               "StackSetId": {},
               "Region": {},
-              "Account": {},
+              "Account": {
+                "shape": "S1h"
+              },
               "StackId": {},
               "ParameterOverrides": {
                 "shape": "Se"
               },
-              "Status": {},
+              "Status": {
+                "shape": "S3b"
+              },
               "StatusReason": {}
             }
           }
@@ -523,13 +687,19 @@
               "StackId": {},
               "LogicalResourceId": {},
               "PhysicalResourceId": {},
-              "ResourceType": {},
+              "ResourceType": {
+                "shape": "Sm"
+              },
               "LastUpdatedTimestamp": {
                 "type": "timestamp"
               },
-              "ResourceStatus": {},
+              "ResourceStatus": {
+                "shape": "S35"
+              },
               "ResourceStatusReason": {},
-              "Description": {},
+              "Description": {
+                "shape": "S11"
+              },
               "Metadata": {}
             }
           }
@@ -564,13 +734,19 @@
                 "StackId": {},
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {},
+                "ResourceType": {
+                  "shape": "Sm"
+                },
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {},
+                "ResourceStatus": {
+                  "shape": "S35"
+                },
                 "ResourceStatusReason": {},
-                "Description": {}
+                "Description": {
+                  "shape": "S11"
+                }
               }
             }
           }
@@ -596,9 +772,15 @@
             "members": {
               "StackSetName": {},
               "StackSetId": {},
-              "Description": {},
-              "Status": {},
-              "TemplateBody": {},
+              "Description": {
+                "shape": "S11"
+              },
+              "Status": {
+                "shape": "S3o"
+              },
+              "TemplateBody": {
+                "shape": "Sb"
+              },
               "Parameters": {
                 "shape": "Se"
               },
@@ -609,8 +791,12 @@
                 "shape": "Sv"
               },
               "StackSetARN": {},
-              "AdministrationRoleARN": {},
-              "ExecutionRoleName": {}
+              "AdministrationRoleARN": {
+                "shape": "S6"
+              },
+              "ExecutionRoleName": {
+                "shape": "S1r"
+              }
             }
           }
         }
@@ -625,7 +811,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -635,18 +823,28 @@
           "StackSetOperation": {
             "type": "structure",
             "members": {
-              "OperationId": {},
+              "OperationId": {
+                "shape": "S3"
+              },
               "StackSetId": {},
-              "Action": {},
-              "Status": {},
+              "Action": {
+                "shape": "S3t"
+              },
+              "Status": {
+                "shape": "S3u"
+              },
               "OperationPreferences": {
                 "shape": "S1k"
               },
               "RetainStacks": {
                 "type": "boolean"
               },
-              "AdministrationRoleARN": {},
-              "ExecutionRoleName": {},
+              "AdministrationRoleARN": {
+                "shape": "S6"
+              },
+              "ExecutionRoleName": {
+                "shape": "S1r"
+              },
               "CreationTimestamp": {
                 "type": "timestamp"
               },
@@ -663,7 +861,9 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -682,8 +882,12 @@
               "members": {
                 "StackId": {},
                 "StackName": {},
-                "ChangeSetId": {},
-                "Description": {},
+                "ChangeSetId": {
+                  "shape": "S14"
+                },
+                "Description": {
+                  "shape": "S11"
+                },
                 "Parameters": {
                   "shape": "Se"
                 },
@@ -699,7 +903,9 @@
                 "RollbackConfiguration": {
                   "shape": "Sn"
                 },
-                "StackStatus": {},
+                "StackStatus": {
+                  "shape": "S42"
+                },
                 "StackStatusReason": {},
                 "DisableRollback": {
                   "type": "boolean"
@@ -708,7 +914,7 @@
                   "shape": "St"
                 },
                 "TimeoutInMinutes": {
-                  "type": "integer"
+                  "shape": "S18"
                 },
                 "Capabilities": {
                   "shape": "Sj"
@@ -720,12 +926,16 @@
                     "members": {
                       "OutputKey": {},
                       "OutputValue": {},
-                      "Description": {},
+                      "Description": {
+                        "shape": "S11"
+                      },
                       "ExportName": {}
                     }
                   }
                 },
-                "RoleARN": {},
+                "RoleARN": {
+                  "shape": "S6"
+                },
                 "Tags": {
                   "shape": "Sv"
                 },
@@ -737,7 +947,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -745,8 +957,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "Parameters": {
             "shape": "Se"
           }
@@ -767,9 +983,15 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {},
-          "StackName": {},
-          "ClientRequestToken": {}
+          "ChangeSetName": {
+            "shape": "S1v"
+          },
+          "StackName": {
+            "shape": "S5"
+          },
+          "ClientRequestToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -792,7 +1014,9 @@
         "resultWrapper": "GetStackPolicyResult",
         "type": "structure",
         "members": {
-          "StackPolicyBody": {}
+          "StackPolicyBody": {
+            "shape": "S1a"
+          }
         }
       }
     },
@@ -801,18 +1025,26 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "ChangeSetName": {},
-          "TemplateStage": {}
+          "ChangeSetName": {
+            "shape": "S1v"
+          },
+          "TemplateStage": {
+            "shape": "S4h"
+          }
         }
       },
       "output": {
         "resultWrapper": "GetTemplateResult",
         "type": "structure",
         "members": {
-          "TemplateBody": {},
+          "TemplateBody": {
+            "shape": "Sb"
+          },
           "StagesAvailable": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4h"
+            }
           }
         }
       }
@@ -821,10 +1053,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {},
-          "TemplateURL": {},
-          "StackName": {},
-          "StackSetName": {}
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
+          "StackName": {
+            "shape": "S5"
+          },
+          "StackSetName": {
+            "shape": "S4l"
+          }
         }
       },
       "output": {
@@ -842,7 +1082,9 @@
                 "NoEcho": {
                   "type": "boolean"
                 },
-                "Description": {},
+                "Description": {
+                  "shape": "S11"
+                },
                 "ParameterConstraints": {
                   "type": "structure",
                   "members": {
@@ -855,7 +1097,9 @@
               }
             }
           },
-          "Description": {},
+          "Description": {
+            "shape": "S11"
+          },
           "Capabilities": {
             "shape": "Sj"
           },
@@ -878,8 +1122,12 @@
           "StackName"
         ],
         "members": {
-          "StackName": {},
-          "NextToken": {}
+          "StackName": {
+            "shape": "S5"
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -893,19 +1141,31 @@
               "members": {
                 "StackId": {},
                 "StackName": {},
-                "ChangeSetId": {},
-                "ChangeSetName": {},
-                "ExecutionStatus": {},
-                "Status": {},
+                "ChangeSetId": {
+                  "shape": "S14"
+                },
+                "ChangeSetName": {
+                  "shape": "Sz"
+                },
+                "ExecutionStatus": {
+                  "shape": "S2f"
+                },
+                "Status": {
+                  "shape": "S2g"
+                },
                 "StatusReason": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
-                "Description": {}
+                "Description": {
+                  "shape": "S11"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -913,7 +1173,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -931,7 +1193,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -943,7 +1207,9 @@
         ],
         "members": {
           "ExportName": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -954,7 +1220,9 @@
             "type": "list",
             "member": {}
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -966,11 +1234,15 @@
         ],
         "members": {
           "StackSetName": {},
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "S26"
           },
-          "StackInstanceAccount": {},
+          "MaxResults": {
+            "shape": "S5b"
+          },
+          "StackInstanceAccount": {
+            "shape": "S1h"
+          },
           "StackInstanceRegion": {}
         }
       },
@@ -985,14 +1257,20 @@
               "members": {
                 "StackSetId": {},
                 "Region": {},
-                "Account": {},
+                "Account": {
+                  "shape": "S1h"
+                },
                 "StackId": {},
-                "Status": {},
+                "Status": {
+                  "shape": "S3b"
+                },
                 "StatusReason": {}
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1004,7 +1282,9 @@
         ],
         "members": {
           "StackName": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -1024,16 +1304,22 @@
               "members": {
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {},
+                "ResourceType": {
+                  "shape": "Sm"
+                },
                 "LastUpdatedTimestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {},
+                "ResourceStatus": {
+                  "shape": "S35"
+                },
                 "ResourceStatusReason": {}
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1046,10 +1332,14 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {},
-          "NextToken": {},
+          "OperationId": {
+            "shape": "S3"
+          },
+          "NextToken": {
+            "shape": "S26"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S5b"
           }
         }
       },
@@ -1062,21 +1352,41 @@
             "member": {
               "type": "structure",
               "members": {
-                "Account": {},
+                "Account": {
+                  "shape": "S1h"
+                },
                 "Region": {},
-                "Status": {},
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "PENDING",
+                    "RUNNING",
+                    "SUCCEEDED",
+                    "FAILED",
+                    "CANCELLED"
+                  ]
+                },
                 "StatusReason": {},
                 "AccountGateResult": {
                   "type": "structure",
                   "members": {
-                    "Status": {},
+                    "Status": {
+                      "type": "string",
+                      "enum": [
+                        "SUCCEEDED",
+                        "FAILED",
+                        "SKIPPED"
+                      ]
+                    },
                     "StatusReason": {}
                   }
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1088,9 +1398,11 @@
         ],
         "members": {
           "StackSetName": {},
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S26"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S5b"
           }
         }
       },
@@ -1103,9 +1415,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "OperationId": {},
-                "Action": {},
-                "Status": {},
+                "OperationId": {
+                  "shape": "S3"
+                },
+                "Action": {
+                  "shape": "S3t"
+                },
+                "Status": {
+                  "shape": "S3u"
+                },
                 "CreationTimestamp": {
                   "type": "timestamp"
                 },
@@ -1115,7 +1433,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1123,11 +1443,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "S26"
           },
-          "Status": {}
+          "MaxResults": {
+            "shape": "S5b"
+          },
+          "Status": {
+            "shape": "S3o"
+          }
         }
       },
       "output": {
@@ -1141,12 +1465,18 @@
               "members": {
                 "StackSetName": {},
                 "StackSetId": {},
-                "Description": {},
-                "Status": {}
+                "Description": {
+                  "shape": "S11"
+                },
+                "Status": {
+                  "shape": "S3o"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1154,10 +1484,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S26"
+          },
           "StackStatusFilter": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S42"
+            }
           }
         }
       },
@@ -1187,14 +1521,18 @@
                 "DeletionTime": {
                   "type": "timestamp"
                 },
-                "StackStatus": {},
+                "StackStatus": {
+                  "shape": "S42"
+                },
                 "StackStatusReason": {},
                 "ParentId": {},
                 "RootId": {}
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1206,8 +1544,12 @@
         ],
         "members": {
           "StackName": {},
-          "StackPolicyBody": {},
-          "StackPolicyURL": {}
+          "StackPolicyBody": {
+            "shape": "S1a"
+          },
+          "StackPolicyURL": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -1221,10 +1563,22 @@
           "Status"
         ],
         "members": {
-          "StackName": {},
+          "StackName": {
+            "shape": "S5"
+          },
           "LogicalResourceId": {},
-          "UniqueId": {},
-          "Status": {}
+          "UniqueId": {
+            "type": "string",
+            "max": 64,
+            "min": 1
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILURE"
+            ]
+          }
         }
       }
     },
@@ -1237,7 +1591,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1254,13 +1610,25 @@
         ],
         "members": {
           "StackName": {},
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "UsePreviousTemplate": {
             "type": "boolean"
           },
-          "StackPolicyDuringUpdateBody": {},
-          "StackPolicyDuringUpdateURL": {},
+          "StackPolicyDuringUpdateBody": {
+            "type": "string",
+            "max": 16384,
+            "min": 1
+          },
+          "StackPolicyDuringUpdateURL": {
+            "type": "string",
+            "max": 1350,
+            "min": 1
+          },
           "Parameters": {
             "shape": "Se"
           },
@@ -1270,19 +1638,27 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {},
+          "RoleARN": {
+            "shape": "S6"
+          },
           "RollbackConfiguration": {
             "shape": "Sn"
           },
-          "StackPolicyBody": {},
-          "StackPolicyURL": {},
+          "StackPolicyBody": {
+            "shape": "S1a"
+          },
+          "StackPolicyURL": {
+            "shape": "S1b"
+          },
           "NotificationARNs": {
             "shape": "St"
           },
           "Tags": {
             "shape": "Sv"
           },
-          "ClientRequestToken": {}
+          "ClientRequestToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1302,7 +1678,9 @@
           "Regions"
         ],
         "members": {
-          "StackSetName": {},
+          "StackSetName": {
+            "shape": "S4l"
+          },
           "Accounts": {
             "shape": "S1g"
           },
@@ -1316,6 +1694,7 @@
             "shape": "S1k"
           },
           "OperationId": {
+            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -1324,7 +1703,9 @@
         "resultWrapper": "UpdateStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1336,9 +1717,15 @@
         ],
         "members": {
           "StackSetName": {},
-          "Description": {},
-          "TemplateBody": {},
-          "TemplateURL": {},
+          "Description": {
+            "shape": "S11"
+          },
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          },
           "UsePreviousTemplate": {
             "type": "boolean"
           },
@@ -1354,9 +1741,14 @@
           "OperationPreferences": {
             "shape": "S1k"
           },
-          "AdministrationRoleARN": {},
-          "ExecutionRoleName": {},
+          "AdministrationRoleARN": {
+            "shape": "S6"
+          },
+          "ExecutionRoleName": {
+            "shape": "S1r"
+          },
           "OperationId": {
+            "shape": "S3",
             "idempotencyToken": true
           },
           "Accounts": {
@@ -1371,7 +1763,9 @@
         "resultWrapper": "UpdateStackSetResult",
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1386,7 +1780,9 @@
           "EnableTerminationProtection": {
             "type": "boolean"
           },
-          "StackName": {}
+          "StackName": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -1401,8 +1797,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {},
-          "TemplateURL": {}
+          "TemplateBody": {
+            "shape": "Sb"
+          },
+          "TemplateURL": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -1419,11 +1819,15 @@
                 "NoEcho": {
                   "type": "boolean"
                 },
-                "Description": {}
+                "Description": {
+                  "shape": "S11"
+                }
               }
             }
           },
-          "Description": {},
+          "Description": {
+            "shape": "S11"
+          },
           "Capabilities": {
             "shape": "Sj"
           },
@@ -1436,6 +1840,31 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9][-a-zA-Z0-9]*"
+    },
+    "S5": {
+      "type": "string",
+      "min": 1,
+      "pattern": "([a-zA-Z][-a-zA-Z0-9]*)|(arn:\\b(aws|aws-us-gov|aws-cn)\\b:[-a-zA-Z0-9:/._+]*)"
+    },
+    "S6": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "Sb": {
+      "type": "string",
+      "min": 1
+    },
+    "Sc": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
     "Se": {
       "type": "list",
       "member": {
@@ -1452,11 +1881,24 @@
     },
     "Sj": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ]
+      }
     },
     "Sl": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sm"
+      }
+    },
+    "Sm": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     },
     "Sn": {
       "type": "structure",
@@ -1473,16 +1915,20 @@
               "Arn": {},
               "Type": {}
             }
-          }
+          },
+          "max": 5
         },
         "MonitoringTimeInMinutes": {
-          "type": "integer"
+          "type": "integer",
+          "max": 180,
+          "min": 0
         }
       }
     },
     "St": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 5
     },
     "Sv": {
       "type": "list",
@@ -1493,14 +1939,59 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 50
+    },
+    "Sz": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z][-a-zA-Z0-9]*"
+    },
+    "S11": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S14": {
+      "type": "string",
+      "min": 1,
+      "pattern": "arn:[-a-zA-Z0-9:/]*"
+    },
+    "S18": {
+      "type": "integer",
+      "min": 1
+    },
+    "S1a": {
+      "type": "string",
+      "max": 16384,
+      "min": 1
+    },
+    "S1b": {
+      "type": "string",
+      "max": 1350,
+      "min": 1
     },
     "S1g": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1h"
+      }
+    },
+    "S1h": {
+      "type": "string",
+      "pattern": "[0-9]{12}"
     },
     "S1i": {
       "type": "list",
@@ -1513,22 +2004,163 @@
           "shape": "S1i"
         },
         "FailureToleranceCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 0
         },
         "FailureTolerancePercentage": {
-          "type": "integer"
+          "type": "integer",
+          "max": 100,
+          "min": 0
         },
         "MaxConcurrentCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "MaxConcurrentPercentage": {
-          "type": "integer"
+          "type": "integer",
+          "max": 100,
+          "min": 1
         }
       }
+    },
+    "S1r": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z_0-9+=,.@-]+"
+    },
+    "S1v": {
+      "type": "string",
+      "max": 1600,
+      "min": 1,
+      "pattern": "[a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/]*"
+    },
+    "S26": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S2f": {
+      "type": "string",
+      "enum": [
+        "UNAVAILABLE",
+        "AVAILABLE",
+        "EXECUTE_IN_PROGRESS",
+        "EXECUTE_COMPLETE",
+        "EXECUTE_FAILED",
+        "OBSOLETE"
+      ]
+    },
+    "S2g": {
+      "type": "string",
+      "enum": [
+        "CREATE_PENDING",
+        "CREATE_IN_PROGRESS",
+        "CREATE_COMPLETE",
+        "DELETE_COMPLETE",
+        "FAILED"
+      ]
+    },
+    "S2q": {
+      "type": "string",
+      "enum": [
+        "Properties",
+        "Metadata",
+        "CreationPolicy",
+        "UpdatePolicy",
+        "DeletionPolicy",
+        "Tags"
+      ]
+    },
+    "S35": {
+      "type": "string",
+      "enum": [
+        "CREATE_IN_PROGRESS",
+        "CREATE_FAILED",
+        "CREATE_COMPLETE",
+        "DELETE_IN_PROGRESS",
+        "DELETE_FAILED",
+        "DELETE_COMPLETE",
+        "DELETE_SKIPPED",
+        "UPDATE_IN_PROGRESS",
+        "UPDATE_FAILED",
+        "UPDATE_COMPLETE"
+      ]
+    },
+    "S3b": {
+      "type": "string",
+      "enum": [
+        "CURRENT",
+        "OUTDATED",
+        "INOPERABLE"
+      ]
+    },
+    "S3o": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED"
+      ]
+    },
+    "S3t": {
+      "type": "string",
+      "enum": [
+        "CREATE",
+        "UPDATE",
+        "DELETE"
+      ]
+    },
+    "S3u": {
+      "type": "string",
+      "enum": [
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+        "STOPPING",
+        "STOPPED"
+      ]
+    },
+    "S42": {
+      "type": "string",
+      "enum": [
+        "CREATE_IN_PROGRESS",
+        "CREATE_FAILED",
+        "CREATE_COMPLETE",
+        "ROLLBACK_IN_PROGRESS",
+        "ROLLBACK_FAILED",
+        "ROLLBACK_COMPLETE",
+        "DELETE_IN_PROGRESS",
+        "DELETE_FAILED",
+        "DELETE_COMPLETE",
+        "UPDATE_IN_PROGRESS",
+        "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
+        "UPDATE_COMPLETE",
+        "UPDATE_ROLLBACK_IN_PROGRESS",
+        "UPDATE_ROLLBACK_FAILED",
+        "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
+        "UPDATE_ROLLBACK_COMPLETE",
+        "REVIEW_IN_PROGRESS"
+      ]
+    },
+    "S4h": {
+      "type": "string",
+      "enum": [
+        "Original",
+        "Processed"
+      ]
+    },
+    "S4l": {
+      "type": "string",
+      "pattern": "[a-zA-Z][-a-zA-Z0-9]*(?::[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12})?"
     },
     "S4w": {
       "type": "list",
       "member": {}
+    },
+    "S5b": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     }
   }
 }

--- a/apis/cloudfront-2016-11-25.min.json
+++ b/apis/cloudfront-2016-11-25.min.json
@@ -835,7 +835,9 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {},
+                    "PriceClass": {
+                      "shape": "S1h"
+                    },
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -860,6 +862,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -891,6 +894,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -918,6 +922,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -931,6 +936,7 @@
               "Items": {
                 "type": "list",
                 "member": {
+                  "shape": "S24",
                   "locationName": "Key"
                 }
               }
@@ -1146,7 +1152,9 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1h"
+        },
         "Enabled": {
           "type": "boolean"
         },
@@ -1157,7 +1165,9 @@
           "shape": "S1m"
         },
         "WebACLId": {},
-        "HttpVersion": {},
+        "HttpVersion": {
+          "shape": "S1q"
+        },
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1251,7 +1261,14 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {},
+                  "OriginProtocolPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "http-only",
+                      "match-viewer",
+                      "https-only"
+                    ]
+                  },
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1265,7 +1282,14 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol"
+                          "locationName": "SslProtocol",
+                          "type": "string",
+                          "enum": [
+                            "SSLv3",
+                            "TLSv1",
+                            "TLSv1.1",
+                            "TLSv1.2"
+                          ]
                         }
                       }
                     }
@@ -1273,7 +1297,8 @@
                 }
               }
             }
-          }
+          },
+          "min": 1
         }
       }
     },
@@ -1294,7 +1319,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {},
+        "ViewerProtocolPolicy": {
+          "shape": "S10"
+        },
         "MinTTL": {
           "type": "long"
         },
@@ -1334,7 +1361,14 @@
             "Forward"
           ],
           "members": {
-            "Forward": {},
+            "Forward": {
+              "type": "string",
+              "enum": [
+                "none",
+                "whitelist",
+                "all"
+              ]
+            },
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -1411,6 +1445,14 @@
         }
       }
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "allow-all",
+        "https-only",
+        "redirect-to-https"
+      ]
+    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1444,7 +1486,17 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method"
+        "locationName": "Method",
+        "type": "string",
+        "enum": [
+          "GET",
+          "HEAD",
+          "POST",
+          "PUT",
+          "PATCH",
+          "OPTIONS",
+          "DELETE"
+        ]
       }
     },
     "S16": {
@@ -1463,7 +1515,15 @@
             "type": "structure",
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {}
+              "EventType": {
+                "type": "string",
+                "enum": [
+                  "viewer-request",
+                  "viewer-response",
+                  "origin-request",
+                  "origin-response"
+                ]
+              }
             }
           }
         }
@@ -1500,7 +1560,9 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {},
+              "ViewerProtocolPolicy": {
+                "shape": "S10"
+              },
               "MinTTL": {
                 "type": "long"
               },
@@ -1558,6 +1620,14 @@
         }
       }
     },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "PriceClass_100",
+        "PriceClass_200",
+        "PriceClass_All"
+      ]
+    },
     "S1i": {
       "type": "structure",
       "members": {
@@ -1566,13 +1636,31 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {},
-        "MinimumProtocolVersion": {},
+        "SSLSupportMethod": {
+          "type": "string",
+          "enum": [
+            "sni-only",
+            "vip"
+          ]
+        },
+        "MinimumProtocolVersion": {
+          "type": "string",
+          "enum": [
+            "SSLv3",
+            "TLSv1"
+          ]
+        },
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true
+          "deprecated": true,
+          "type": "string",
+          "enum": [
+            "cloudfront",
+            "iam",
+            "acm"
+          ]
         }
       }
     },
@@ -1589,7 +1677,14 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {},
+            "RestrictionType": {
+              "type": "string",
+              "enum": [
+                "blacklist",
+                "whitelist",
+                "none"
+              ]
+            },
             "Quantity": {
               "type": "integer"
             },
@@ -1602,6 +1697,13 @@
           }
         }
       }
+    },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "http1.1",
+        "http2"
+      ]
     },
     "S1s": {
       "type": "structure",
@@ -1688,12 +1790,25 @@
               "Key"
             ],
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "shape": "S24"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "min": 0,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              }
             }
           }
         }
       }
+    },
+    "S24": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S28": {
       "type": "structure",
@@ -1777,7 +1892,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1h"
+        },
         "Enabled": {
           "type": "boolean"
         }
@@ -1889,7 +2006,9 @@
                 "shape": "S1d"
               },
               "Comment": {},
-              "PriceClass": {},
+              "PriceClass": {
+                "shape": "S1h"
+              },
               "Enabled": {
                 "type": "boolean"
               },
@@ -1900,7 +2019,9 @@
                 "shape": "S1m"
               },
               "WebACLId": {},
-              "HttpVersion": {},
+              "HttpVersion": {
+                "shape": "S1q"
+              },
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -1908,6 +2029,10 @@
           }
         }
       }
+    },
+    "S3q": {
+      "type": "string",
+      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2017-03-25.min.json
+++ b/apis/cloudfront-2017-03-25.min.json
@@ -854,7 +854,9 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {},
+                    "PriceClass": {
+                      "shape": "S1h"
+                    },
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -879,6 +881,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -910,6 +913,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -937,6 +941,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -950,6 +955,7 @@
               "Items": {
                 "type": "list",
                 "member": {
+                  "shape": "S24",
                   "locationName": "Key"
                 }
               }
@@ -1165,7 +1171,9 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1h"
+        },
         "Enabled": {
           "type": "boolean"
         },
@@ -1176,7 +1184,9 @@
           "shape": "S1m"
         },
         "WebACLId": {},
-        "HttpVersion": {},
+        "HttpVersion": {
+          "shape": "S1q"
+        },
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1270,7 +1280,14 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {},
+                  "OriginProtocolPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "http-only",
+                      "match-viewer",
+                      "https-only"
+                    ]
+                  },
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1284,7 +1301,14 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol"
+                          "locationName": "SslProtocol",
+                          "type": "string",
+                          "enum": [
+                            "SSLv3",
+                            "TLSv1",
+                            "TLSv1.1",
+                            "TLSv1.2"
+                          ]
                         }
                       }
                     }
@@ -1298,7 +1322,8 @@
                 }
               }
             }
-          }
+          },
+          "min": 1
         }
       }
     },
@@ -1319,7 +1344,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {},
+        "ViewerProtocolPolicy": {
+          "shape": "S10"
+        },
         "MinTTL": {
           "type": "long"
         },
@@ -1359,7 +1386,14 @@
             "Forward"
           ],
           "members": {
-            "Forward": {},
+            "Forward": {
+              "type": "string",
+              "enum": [
+                "none",
+                "whitelist",
+                "all"
+              ]
+            },
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -1436,6 +1470,14 @@
         }
       }
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "allow-all",
+        "https-only",
+        "redirect-to-https"
+      ]
+    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1469,7 +1511,17 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method"
+        "locationName": "Method",
+        "type": "string",
+        "enum": [
+          "GET",
+          "HEAD",
+          "POST",
+          "PUT",
+          "PATCH",
+          "OPTIONS",
+          "DELETE"
+        ]
       }
     },
     "S16": {
@@ -1488,7 +1540,15 @@
             "type": "structure",
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {}
+              "EventType": {
+                "type": "string",
+                "enum": [
+                  "viewer-request",
+                  "viewer-response",
+                  "origin-request",
+                  "origin-response"
+                ]
+              }
             }
           }
         }
@@ -1525,7 +1585,9 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {},
+              "ViewerProtocolPolicy": {
+                "shape": "S10"
+              },
               "MinTTL": {
                 "type": "long"
               },
@@ -1583,6 +1645,14 @@
         }
       }
     },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "PriceClass_100",
+        "PriceClass_200",
+        "PriceClass_All"
+      ]
+    },
     "S1i": {
       "type": "structure",
       "members": {
@@ -1591,13 +1661,34 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {},
-        "MinimumProtocolVersion": {},
+        "SSLSupportMethod": {
+          "type": "string",
+          "enum": [
+            "sni-only",
+            "vip"
+          ]
+        },
+        "MinimumProtocolVersion": {
+          "type": "string",
+          "enum": [
+            "SSLv3",
+            "TLSv1",
+            "TLSv1_2016",
+            "TLSv1.1_2016",
+            "TLSv1.2_2018"
+          ]
+        },
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true
+          "deprecated": true,
+          "type": "string",
+          "enum": [
+            "cloudfront",
+            "iam",
+            "acm"
+          ]
         }
       }
     },
@@ -1614,7 +1705,14 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {},
+            "RestrictionType": {
+              "type": "string",
+              "enum": [
+                "blacklist",
+                "whitelist",
+                "none"
+              ]
+            },
             "Quantity": {
               "type": "integer"
             },
@@ -1627,6 +1725,13 @@
           }
         }
       }
+    },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "http1.1",
+        "http2"
+      ]
     },
     "S1s": {
       "type": "structure",
@@ -1713,12 +1818,25 @@
               "Key"
             ],
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "shape": "S24"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "min": 0,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              }
             }
           }
         }
       }
+    },
+    "S24": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S28": {
       "type": "structure",
@@ -1802,7 +1920,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1h"
+        },
         "Enabled": {
           "type": "boolean"
         }
@@ -1914,7 +2034,9 @@
                 "shape": "S1d"
               },
               "Comment": {},
-              "PriceClass": {},
+              "PriceClass": {
+                "shape": "S1h"
+              },
               "Enabled": {
                 "type": "boolean"
               },
@@ -1925,7 +2047,9 @@
                 "shape": "S1m"
               },
               "WebACLId": {},
-              "HttpVersion": {},
+              "HttpVersion": {
+                "shape": "S1q"
+              },
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -1933,6 +2057,10 @@
           }
         }
       }
+    },
+    "S3r": {
+      "type": "string",
+      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2017-10-30.min.json
+++ b/apis/cloudfront-2017-10-30.min.json
@@ -1400,7 +1400,9 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {},
+                    "PriceClass": {
+                      "shape": "S1i"
+                    },
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -1425,6 +1427,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -1456,6 +1459,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1483,6 +1487,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1496,6 +1501,7 @@
               "Items": {
                 "type": "list",
                 "member": {
+                  "shape": "S25",
                   "locationName": "Key"
                 }
               }
@@ -1843,7 +1849,9 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1i"
+        },
         "Enabled": {
           "type": "boolean"
         },
@@ -1854,7 +1862,9 @@
           "shape": "S1n"
         },
         "WebACLId": {},
-        "HttpVersion": {},
+        "HttpVersion": {
+          "shape": "S1r"
+        },
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1948,7 +1958,14 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {},
+                  "OriginProtocolPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "http-only",
+                      "match-viewer",
+                      "https-only"
+                    ]
+                  },
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1962,7 +1979,14 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol"
+                          "locationName": "SslProtocol",
+                          "type": "string",
+                          "enum": [
+                            "SSLv3",
+                            "TLSv1",
+                            "TLSv1.1",
+                            "TLSv1.2"
+                          ]
                         }
                       }
                     }
@@ -1976,7 +2000,8 @@
                 }
               }
             }
-          }
+          },
+          "min": 1
         }
       }
     },
@@ -1997,7 +2022,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {},
+        "ViewerProtocolPolicy": {
+          "shape": "S10"
+        },
         "MinTTL": {
           "type": "long"
         },
@@ -2038,7 +2065,14 @@
             "Forward"
           ],
           "members": {
-            "Forward": {},
+            "Forward": {
+              "type": "string",
+              "enum": [
+                "none",
+                "whitelist",
+                "all"
+              ]
+            },
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -2115,6 +2149,14 @@
         }
       }
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "allow-all",
+        "https-only",
+        "redirect-to-https"
+      ]
+    },
     "S12": {
       "type": "structure",
       "required": [
@@ -2148,7 +2190,17 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method"
+        "locationName": "Method",
+        "type": "string",
+        "enum": [
+          "GET",
+          "HEAD",
+          "POST",
+          "PUT",
+          "PATCH",
+          "OPTIONS",
+          "DELETE"
+        ]
       }
     },
     "S16": {
@@ -2171,7 +2223,15 @@
             ],
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {}
+              "EventType": {
+                "type": "string",
+                "enum": [
+                  "viewer-request",
+                  "viewer-response",
+                  "origin-request",
+                  "origin-response"
+                ]
+              }
             }
           }
         }
@@ -2208,7 +2268,9 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {},
+              "ViewerProtocolPolicy": {
+                "shape": "S10"
+              },
               "MinTTL": {
                 "type": "long"
               },
@@ -2267,6 +2329,14 @@
         }
       }
     },
+    "S1i": {
+      "type": "string",
+      "enum": [
+        "PriceClass_100",
+        "PriceClass_200",
+        "PriceClass_All"
+      ]
+    },
     "S1j": {
       "type": "structure",
       "members": {
@@ -2275,13 +2345,34 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {},
-        "MinimumProtocolVersion": {},
+        "SSLSupportMethod": {
+          "type": "string",
+          "enum": [
+            "sni-only",
+            "vip"
+          ]
+        },
+        "MinimumProtocolVersion": {
+          "type": "string",
+          "enum": [
+            "SSLv3",
+            "TLSv1",
+            "TLSv1_2016",
+            "TLSv1.1_2016",
+            "TLSv1.2_2018"
+          ]
+        },
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true
+          "deprecated": true,
+          "type": "string",
+          "enum": [
+            "cloudfront",
+            "iam",
+            "acm"
+          ]
         }
       }
     },
@@ -2298,7 +2389,14 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {},
+            "RestrictionType": {
+              "type": "string",
+              "enum": [
+                "blacklist",
+                "whitelist",
+                "none"
+              ]
+            },
             "Quantity": {
               "type": "integer"
             },
@@ -2311,6 +2409,13 @@
           }
         }
       }
+    },
+    "S1r": {
+      "type": "string",
+      "enum": [
+        "http1.1",
+        "http2"
+      ]
     },
     "S1t": {
       "type": "structure",
@@ -2397,12 +2502,25 @@
               "Key"
             ],
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "shape": "S25"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "min": 0,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              }
             }
           }
         }
       }
+    },
+    "S25": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S29": {
       "type": "structure",
@@ -2485,7 +2603,12 @@
                   "ContentType"
                 ],
                 "members": {
-                  "Format": {},
+                  "Format": {
+                    "type": "string",
+                    "enum": [
+                      "URLEncoded"
+                    ]
+                  },
                   "ProfileId": {},
                   "ContentType": {}
                 }
@@ -2702,7 +2825,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1i"
+        },
         "Enabled": {
           "type": "boolean"
         }
@@ -2814,7 +2939,9 @@
                 "shape": "S1e"
               },
               "Comment": {},
-              "PriceClass": {},
+              "PriceClass": {
+                "shape": "S1i"
+              },
               "Enabled": {
                 "type": "boolean"
               },
@@ -2825,7 +2952,9 @@
                 "shape": "S1n"
               },
               "WebACLId": {},
-              "HttpVersion": {},
+              "HttpVersion": {
+                "shape": "S1r"
+              },
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2833,6 +2962,10 @@
           }
         }
       }
+    },
+    "S5b": {
+      "type": "string",
+      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2018-06-18.min.json
+++ b/apis/cloudfront-2018-06-18.min.json
@@ -1400,7 +1400,9 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {},
+                    "PriceClass": {
+                      "shape": "S1i"
+                    },
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -1425,6 +1427,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -1456,6 +1459,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1483,6 +1487,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1496,6 +1501,7 @@
               "Items": {
                 "type": "list",
                 "member": {
+                  "shape": "S25",
                   "locationName": "Key"
                 }
               }
@@ -1843,7 +1849,9 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1i"
+        },
         "Enabled": {
           "type": "boolean"
         },
@@ -1854,7 +1862,9 @@
           "shape": "S1n"
         },
         "WebACLId": {},
-        "HttpVersion": {},
+        "HttpVersion": {
+          "shape": "S1r"
+        },
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1948,7 +1958,14 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {},
+                  "OriginProtocolPolicy": {
+                    "type": "string",
+                    "enum": [
+                      "http-only",
+                      "match-viewer",
+                      "https-only"
+                    ]
+                  },
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1962,7 +1979,14 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol"
+                          "locationName": "SslProtocol",
+                          "type": "string",
+                          "enum": [
+                            "SSLv3",
+                            "TLSv1",
+                            "TLSv1.1",
+                            "TLSv1.2"
+                          ]
                         }
                       }
                     }
@@ -1976,7 +2000,8 @@
                 }
               }
             }
-          }
+          },
+          "min": 1
         }
       }
     },
@@ -1997,7 +2022,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {},
+        "ViewerProtocolPolicy": {
+          "shape": "S10"
+        },
         "MinTTL": {
           "type": "long"
         },
@@ -2038,7 +2065,14 @@
             "Forward"
           ],
           "members": {
-            "Forward": {},
+            "Forward": {
+              "type": "string",
+              "enum": [
+                "none",
+                "whitelist",
+                "all"
+              ]
+            },
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -2115,6 +2149,14 @@
         }
       }
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "allow-all",
+        "https-only",
+        "redirect-to-https"
+      ]
+    },
     "S12": {
       "type": "structure",
       "required": [
@@ -2148,7 +2190,17 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method"
+        "locationName": "Method",
+        "type": "string",
+        "enum": [
+          "GET",
+          "HEAD",
+          "POST",
+          "PUT",
+          "PATCH",
+          "OPTIONS",
+          "DELETE"
+        ]
       }
     },
     "S16": {
@@ -2171,7 +2223,15 @@
             ],
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {},
+              "EventType": {
+                "type": "string",
+                "enum": [
+                  "viewer-request",
+                  "viewer-response",
+                  "origin-request",
+                  "origin-response"
+                ]
+              },
               "IncludeBody": {
                 "type": "boolean"
               }
@@ -2211,7 +2271,9 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {},
+              "ViewerProtocolPolicy": {
+                "shape": "S10"
+              },
               "MinTTL": {
                 "type": "long"
               },
@@ -2270,6 +2332,14 @@
         }
       }
     },
+    "S1i": {
+      "type": "string",
+      "enum": [
+        "PriceClass_100",
+        "PriceClass_200",
+        "PriceClass_All"
+      ]
+    },
     "S1j": {
       "type": "structure",
       "members": {
@@ -2278,13 +2348,34 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {},
-        "MinimumProtocolVersion": {},
+        "SSLSupportMethod": {
+          "type": "string",
+          "enum": [
+            "sni-only",
+            "vip"
+          ]
+        },
+        "MinimumProtocolVersion": {
+          "type": "string",
+          "enum": [
+            "SSLv3",
+            "TLSv1",
+            "TLSv1_2016",
+            "TLSv1.1_2016",
+            "TLSv1.2_2018"
+          ]
+        },
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true
+          "deprecated": true,
+          "type": "string",
+          "enum": [
+            "cloudfront",
+            "iam",
+            "acm"
+          ]
         }
       }
     },
@@ -2301,7 +2392,14 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {},
+            "RestrictionType": {
+              "type": "string",
+              "enum": [
+                "blacklist",
+                "whitelist",
+                "none"
+              ]
+            },
             "Quantity": {
               "type": "integer"
             },
@@ -2314,6 +2412,13 @@
           }
         }
       }
+    },
+    "S1r": {
+      "type": "string",
+      "enum": [
+        "http1.1",
+        "http2"
+      ]
     },
     "S1t": {
       "type": "structure",
@@ -2400,12 +2505,25 @@
               "Key"
             ],
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "shape": "S25"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "min": 0,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              }
             }
           }
         }
       }
+    },
+    "S25": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S29": {
       "type": "structure",
@@ -2488,7 +2606,12 @@
                   "ContentType"
                 ],
                 "members": {
-                  "Format": {},
+                  "Format": {
+                    "type": "string",
+                    "enum": [
+                      "URLEncoded"
+                    ]
+                  },
                   "ProfileId": {},
                   "ContentType": {}
                 }
@@ -2705,7 +2828,9 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {},
+        "PriceClass": {
+          "shape": "S1i"
+        },
         "Enabled": {
           "type": "boolean"
         }
@@ -2817,7 +2942,9 @@
                 "shape": "S1e"
               },
               "Comment": {},
-              "PriceClass": {},
+              "PriceClass": {
+                "shape": "S1i"
+              },
               "Enabled": {
                 "type": "boolean"
               },
@@ -2828,7 +2955,9 @@
                 "shape": "S1n"
               },
               "WebACLId": {},
-              "HttpVersion": {},
+              "HttpVersion": {
+                "shape": "S1r"
+              },
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2836,6 +2965,10 @@
           }
         }
       }
+    },
+    "S5b": {
+      "type": "string",
+      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudhsm-2014-05-30.min.json
+++ b/apis/cloudhsm-2014-05-30.min.json
@@ -21,7 +21,9 @@
           "TagList"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S2"
+          },
           "TagList": {
             "shape": "S3"
           }
@@ -33,7 +35,9 @@
           "Status"
         ],
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -44,13 +48,17 @@
           "Label"
         ],
         "members": {
-          "Label": {}
+          "Label": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {}
+          "HapgArn": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -65,27 +73,36 @@
         ],
         "members": {
           "SubnetId": {
+            "shape": "Sd",
             "locationName": "SubnetId"
           },
           "SshKey": {
+            "shape": "Se",
             "locationName": "SshKey"
           },
           "EniIp": {
+            "shape": "Sf",
             "locationName": "EniIp"
           },
           "IamRoleArn": {
+            "shape": "Sg",
             "locationName": "IamRoleArn"
           },
           "ExternalId": {
+            "shape": "Sh",
             "locationName": "ExternalId"
           },
           "SubscriptionType": {
+            "shape": "Si",
             "locationName": "SubscriptionType"
           },
           "ClientToken": {
-            "locationName": "ClientToken"
+            "locationName": "ClientToken",
+            "type": "string",
+            "pattern": "[a-zA-Z0-9]{1,64}"
           },
           "SyslogIp": {
+            "shape": "Sf",
             "locationName": "SyslogIp"
           }
         },
@@ -94,7 +111,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {}
+          "HsmArn": {
+            "shape": "Sl"
+          }
         }
       }
     },
@@ -105,14 +124,21 @@
           "Certificate"
         ],
         "members": {
-          "Label": {},
-          "Certificate": {}
+          "Label": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9_.-]{2,64}"
+          },
+          "Certificate": {
+            "shape": "So"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {}
+          "ClientArn": {
+            "shape": "Sq"
+          }
         }
       }
     },
@@ -123,7 +149,9 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {}
+          "HapgArn": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -132,7 +160,9 @@
           "Status"
         ],
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -144,6 +174,7 @@
         ],
         "members": {
           "HsmArn": {
+            "shape": "Sl",
             "locationName": "HsmArn"
           }
         },
@@ -155,7 +186,9 @@
           "Status"
         ],
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -166,7 +199,9 @@
           "ClientArn"
         ],
         "members": {
-          "ClientArn": {}
+          "ClientArn": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -175,7 +210,9 @@
           "Status"
         ],
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -186,14 +223,20 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {}
+          "HapgArn": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {},
-          "HapgSerial": {},
+          "HapgArn": {
+            "shape": "Sb"
+          },
+          "HapgSerial": {
+            "shape": "S2"
+          },
           "HsmsLastActionFailed": {
             "shape": "Sz"
           },
@@ -203,12 +246,23 @@
           "HsmsPendingRegistration": {
             "shape": "Sz"
           },
-          "Label": {},
-          "LastModifiedTimestamp": {},
+          "Label": {
+            "shape": "S9"
+          },
+          "LastModifiedTimestamp": {
+            "shape": "S10"
+          },
           "PartitionSerialList": {
             "shape": "S11"
           },
-          "State": {}
+          "State": {
+            "type": "string",
+            "enum": [
+              "READY",
+              "UPDATING",
+              "DEGRADED"
+            ]
+          }
         }
       }
     },
@@ -216,36 +270,94 @@
       "input": {
         "type": "structure",
         "members": {
-          "HsmArn": {},
-          "HsmSerialNumber": {}
+          "HsmArn": {
+            "shape": "Sl"
+          },
+          "HsmSerialNumber": {
+            "shape": "S15"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {},
-          "Status": {},
-          "StatusDetails": {},
-          "AvailabilityZone": {},
-          "EniId": {},
-          "EniIp": {},
-          "SubscriptionType": {},
-          "SubscriptionStartDate": {},
-          "SubscriptionEndDate": {},
-          "VpcId": {},
-          "SubnetId": {},
-          "IamRoleArn": {},
-          "SerialNumber": {},
-          "VendorName": {},
-          "HsmType": {},
-          "SoftwareVersion": {},
-          "SshPublicKey": {},
-          "SshKeyLastUpdated": {},
-          "ServerCertUri": {},
-          "ServerCertLastUpdated": {},
+          "HsmArn": {
+            "shape": "Sl"
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "RUNNING",
+              "UPDATING",
+              "SUSPENDED",
+              "TERMINATING",
+              "TERMINATED",
+              "DEGRADED"
+            ]
+          },
+          "StatusDetails": {
+            "shape": "S2"
+          },
+          "AvailabilityZone": {
+            "shape": "S18"
+          },
+          "EniId": {
+            "type": "string",
+            "pattern": "eni-[0-9a-f]{8}"
+          },
+          "EniIp": {
+            "shape": "Sf"
+          },
+          "SubscriptionType": {
+            "shape": "Si"
+          },
+          "SubscriptionStartDate": {
+            "shape": "S10"
+          },
+          "SubscriptionEndDate": {
+            "shape": "S10"
+          },
+          "VpcId": {
+            "type": "string",
+            "pattern": "vpc-[0-9a-f]{8}"
+          },
+          "SubnetId": {
+            "shape": "Sd"
+          },
+          "IamRoleArn": {
+            "shape": "Sg"
+          },
+          "SerialNumber": {
+            "shape": "S15"
+          },
+          "VendorName": {
+            "shape": "S2"
+          },
+          "HsmType": {
+            "shape": "S2"
+          },
+          "SoftwareVersion": {
+            "shape": "S2"
+          },
+          "SshPublicKey": {
+            "shape": "Se"
+          },
+          "SshKeyLastUpdated": {
+            "shape": "S10"
+          },
+          "ServerCertUri": {
+            "shape": "S2"
+          },
+          "ServerCertLastUpdated": {
+            "shape": "S10"
+          },
           "Partitions": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hsm-[0-9a-f]{8}/partition-[0-9]{6,12}"
+            }
           }
         }
       }
@@ -254,18 +366,32 @@
       "input": {
         "type": "structure",
         "members": {
-          "ClientArn": {},
-          "CertificateFingerprint": {}
+          "ClientArn": {
+            "shape": "Sq"
+          },
+          "CertificateFingerprint": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {},
-          "Certificate": {},
-          "CertificateFingerprint": {},
-          "LastModifiedTimestamp": {},
-          "Label": {}
+          "ClientArn": {
+            "shape": "Sq"
+          },
+          "Certificate": {
+            "shape": "So"
+          },
+          "CertificateFingerprint": {
+            "shape": "S1e"
+          },
+          "LastModifiedTimestamp": {
+            "shape": "S10"
+          },
+          "Label": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -278,8 +404,16 @@
           "HapgList"
         ],
         "members": {
-          "ClientArn": {},
-          "ClientVersion": {},
+          "ClientArn": {
+            "shape": "Sq"
+          },
+          "ClientVersion": {
+            "type": "string",
+            "enum": [
+              "5.1",
+              "5.3"
+            ]
+          },
           "HapgList": {
             "shape": "S1i"
           }
@@ -288,9 +422,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "ConfigType": {},
-          "ConfigFile": {},
-          "ConfigCred": {}
+          "ConfigType": {
+            "shape": "S2"
+          },
+          "ConfigFile": {
+            "shape": "S2"
+          },
+          "ConfigCred": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -304,7 +444,9 @@
         "members": {
           "AZList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S18"
+            }
           }
         }
       }
@@ -313,7 +455,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -325,7 +469,9 @@
           "HapgList": {
             "shape": "S1i"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -333,7 +479,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -342,7 +490,9 @@
           "HsmList": {
             "shape": "Sz"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -350,7 +500,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
@@ -361,9 +513,13 @@
         "members": {
           "ClientList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sq"
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -374,7 +530,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -396,8 +554,12 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {},
-          "Label": {},
+          "HapgArn": {
+            "shape": "Sb"
+          },
+          "Label": {
+            "shape": "S9"
+          },
           "PartitionSerialList": {
             "shape": "S11"
           }
@@ -406,7 +568,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {}
+          "HapgArn": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -418,21 +582,27 @@
         ],
         "members": {
           "HsmArn": {
+            "shape": "Sl",
             "locationName": "HsmArn"
           },
           "SubnetId": {
+            "shape": "Sd",
             "locationName": "SubnetId"
           },
           "EniIp": {
+            "shape": "Sf",
             "locationName": "EniIp"
           },
           "IamRoleArn": {
+            "shape": "Sg",
             "locationName": "IamRoleArn"
           },
           "ExternalId": {
+            "shape": "Sh",
             "locationName": "ExternalId"
           },
           "SyslogIp": {
+            "shape": "Sf",
             "locationName": "SyslogIp"
           }
         },
@@ -441,7 +611,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {}
+          "HsmArn": {
+            "shape": "Sl"
+          }
         }
       }
     },
@@ -453,14 +625,20 @@
           "Certificate"
         ],
         "members": {
-          "ClientArn": {},
-          "Certificate": {}
+          "ClientArn": {
+            "shape": "Sq"
+          },
+          "Certificate": {
+            "shape": "So"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {}
+          "ClientArn": {
+            "shape": "Sq"
+          }
         }
       }
     },
@@ -472,10 +650,14 @@
           "TagKeyList"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S2"
+          },
           "TagKeyList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            }
           }
         }
       },
@@ -485,12 +667,18 @@
           "Status"
         ],
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "[\\w :+=./\\\\-]*"
+    },
     "S3": {
       "type": "list",
       "member": {
@@ -500,22 +688,108 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S5"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+          }
         }
       }
     },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S9": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9_.-]{1,64}"
+    },
+    "Sb": {
+      "type": "string",
+      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hapg-[0-9a-f]{8}"
+    },
+    "Sd": {
+      "type": "string",
+      "pattern": "subnet-[0-9a-f]{8}"
+    },
+    "Se": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9+/= ._:\\\\@-]*"
+    },
+    "Sf": {
+      "type": "string",
+      "pattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+    },
+    "Sg": {
+      "type": "string",
+      "pattern": "arn:aws(-iso)?:iam::[0-9]{12}:role/[a-zA-Z0-9_\\+=,\\.\\-@]{1,64}"
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "[\\w :+=./-]*"
+    },
+    "Si": {
+      "type": "string",
+      "enum": [
+        "PRODUCTION"
+      ]
+    },
+    "Sl": {
+      "type": "string",
+      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hsm-[0-9a-f]{8}"
+    },
+    "So": {
+      "type": "string",
+      "max": 2400,
+      "min": 600,
+      "pattern": "[\\w :+=./\\n-]*"
+    },
+    "Sq": {
+      "type": "string",
+      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:client-[0-9a-f]{8}"
+    },
     "Sz": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sl"
+      }
+    },
+    "S10": {
+      "type": "string",
+      "pattern": "\\d*"
     },
     "S11": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "pattern": "\\d{6,12}"
+      }
+    },
+    "S15": {
+      "type": "string",
+      "pattern": "\\d{1,16}"
+    },
+    "S18": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9\\-]*"
+    },
+    "S1e": {
+      "type": "string",
+      "pattern": "([0-9a-fA-F][0-9a-fA-F]:){15}[0-9a-fA-F][0-9a-fA-F]"
     },
     "S1i": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      }
+    },
+    "S1o": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9+/]*"
     }
   }
 }

--- a/apis/cloudhsmv2-2017-04-28.min.json
+++ b/apis/cloudhsmv2-2017-04-28.min.json
@@ -22,8 +22,12 @@
           "BackupId"
         ],
         "members": {
-          "DestinationRegion": {},
-          "BackupId": {}
+          "DestinationRegion": {
+            "shape": "S2"
+          },
+          "BackupId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -35,9 +39,15 @@
               "CreateTimestamp": {
                 "type": "timestamp"
               },
-              "SourceRegion": {},
-              "SourceBackup": {},
-              "SourceCluster": {}
+              "SourceRegion": {
+                "shape": "S2"
+              },
+              "SourceBackup": {
+                "shape": "S3"
+              },
+              "SourceCluster": {
+                "shape": "S7"
+              }
             }
           }
         }
@@ -53,10 +63,18 @@
         "members": {
           "SubnetIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa"
+            },
+            "max": 10,
+            "min": 1
           },
-          "HsmType": {},
-          "SourceBackupId": {}
+          "HsmType": {
+            "shape": "Sb"
+          },
+          "SourceBackupId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -76,9 +94,15 @@
           "AvailabilityZone"
         ],
         "members": {
-          "ClusterId": {},
-          "AvailabilityZone": {},
-          "IpAddress": {}
+          "ClusterId": {
+            "shape": "S7"
+          },
+          "AvailabilityZone": {
+            "shape": "Sh"
+          },
+          "IpAddress": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -97,7 +121,9 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {}
+          "BackupId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -116,7 +142,9 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {}
+          "ClusterId": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -135,16 +163,26 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {},
-          "HsmId": {},
-          "EniId": {},
-          "EniIp": {}
+          "ClusterId": {
+            "shape": "S7"
+          },
+          "HsmId": {
+            "shape": "Sk"
+          },
+          "EniId": {
+            "shape": "Si"
+          },
+          "EniIp": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HsmId": {}
+          "HsmId": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -152,9 +190,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           },
           "Filters": {
             "shape": "S18"
@@ -173,7 +213,9 @@
               "shape": "Sz"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -184,9 +226,11 @@
           "Filters": {
             "shape": "S18"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           }
         }
       },
@@ -199,7 +243,9 @@
               "shape": "Sd"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -212,16 +258,26 @@
           "TrustAnchor"
         ],
         "members": {
-          "ClusterId": {},
-          "SignedCert": {},
-          "TrustAnchor": {}
+          "ClusterId": {
+            "shape": "S7"
+          },
+          "SignedCert": {
+            "shape": "Su"
+          },
+          "TrustAnchor": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "State": {},
-          "StateMessage": {}
+          "State": {
+            "shape": "Sp"
+          },
+          "StateMessage": {
+            "shape": "Sq"
+          }
         }
       }
     },
@@ -232,10 +288,14 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {},
-          "NextToken": {},
+          "ResourceId": {
+            "shape": "S7"
+          },
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S17"
           }
         }
       },
@@ -248,7 +308,9 @@
           "TagList": {
             "shape": "S1l"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -259,7 +321,9 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {}
+          "BackupId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -279,7 +343,9 @@
           "TagList"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "S7"
+          },
           "TagList": {
             "shape": "S1l"
           }
@@ -298,10 +364,16 @@
           "TagKeyList"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "S7"
+          },
           "TagKeyList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1n"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -312,11 +384,38 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\\d"
+    },
+    "S3": {
+      "type": "string",
+      "pattern": "backup-[2-7a-zA-Z]{11,16}"
+    },
+    "S7": {
+      "type": "string",
+      "pattern": "cluster-[2-7a-zA-Z]{11,16}"
+    },
+    "Sa": {
+      "type": "string",
+      "pattern": "subnet-[0-9a-fA-F]{8,17}"
+    },
+    "Sb": {
+      "type": "string",
+      "pattern": "(hsm1\\.medium)"
+    },
     "Sd": {
       "type": "structure",
       "members": {
-        "BackupPolicy": {},
-        "ClusterId": {},
+        "BackupPolicy": {
+          "type": "string",
+          "enum": [
+            "DEFAULT"
+          ]
+        },
+        "ClusterId": {
+          "shape": "S7"
+        },
         "CreateTimestamp": {
           "type": "timestamp"
         },
@@ -326,26 +425,58 @@
             "shape": "Sg"
           }
         },
-        "HsmType": {},
-        "PreCoPassword": {},
-        "SecurityGroup": {},
-        "SourceBackupId": {},
-        "State": {},
-        "StateMessage": {},
+        "HsmType": {
+          "shape": "Sb"
+        },
+        "PreCoPassword": {
+          "type": "string",
+          "max": 32,
+          "min": 7
+        },
+        "SecurityGroup": {
+          "type": "string",
+          "pattern": "sg-[0-9a-fA-F]"
+        },
+        "SourceBackupId": {
+          "shape": "S3"
+        },
+        "State": {
+          "shape": "Sp"
+        },
+        "StateMessage": {
+          "shape": "Sq"
+        },
         "SubnetMapping": {
           "type": "map",
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "Sh"
+          },
+          "value": {
+            "shape": "Sa"
+          }
         },
-        "VpcId": {},
+        "VpcId": {
+          "type": "string",
+          "pattern": "vpc-[0-9a-fA-F]"
+        },
         "Certificates": {
           "type": "structure",
           "members": {
-            "ClusterCsr": {},
-            "HsmCertificate": {},
-            "AwsHardwareCertificate": {},
-            "ManufacturerHardwareCertificate": {},
-            "ClusterCertificate": {}
+            "ClusterCsr": {
+              "shape": "Su"
+            },
+            "HsmCertificate": {
+              "shape": "Su"
+            },
+            "AwsHardwareCertificate": {
+              "shape": "Su"
+            },
+            "ManufacturerHardwareCertificate": {
+              "shape": "Su"
+            },
+            "ClusterCertificate": {
+              "shape": "Su"
+            }
           }
         }
       }
@@ -356,15 +487,76 @@
         "HsmId"
       ],
       "members": {
-        "AvailabilityZone": {},
-        "ClusterId": {},
-        "SubnetId": {},
-        "EniId": {},
-        "EniIp": {},
-        "HsmId": {},
-        "State": {},
+        "AvailabilityZone": {
+          "shape": "Sh"
+        },
+        "ClusterId": {
+          "shape": "S7"
+        },
+        "SubnetId": {
+          "shape": "Sa"
+        },
+        "EniId": {
+          "shape": "Si"
+        },
+        "EniIp": {
+          "shape": "Sj"
+        },
+        "HsmId": {
+          "shape": "Sk"
+        },
+        "State": {
+          "type": "string",
+          "enum": [
+            "CREATE_IN_PROGRESS",
+            "ACTIVE",
+            "DEGRADED",
+            "DELETE_IN_PROGRESS",
+            "DELETED"
+          ]
+        },
         "StateMessage": {}
       }
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\\d[a-z]"
+    },
+    "Si": {
+      "type": "string",
+      "pattern": "eni-[0-9a-fA-F]{8,17}"
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
+    },
+    "Sk": {
+      "type": "string",
+      "pattern": "hsm-[2-7a-zA-Z]{11,16}"
+    },
+    "Sp": {
+      "type": "string",
+      "enum": [
+        "CREATE_IN_PROGRESS",
+        "UNINITIALIZED",
+        "INITIALIZE_IN_PROGRESS",
+        "INITIALIZED",
+        "ACTIVE",
+        "UPDATE_IN_PROGRESS",
+        "DELETE_IN_PROGRESS",
+        "DELETED",
+        "DEGRADED"
+      ]
+    },
+    "Sq": {
+      "type": "string",
+      "max": 300,
+      "pattern": ".*"
+    },
+    "Su": {
+      "type": "string",
+      "max": 5000,
+      "pattern": "[a-zA-Z0-9+-/=\\s]*"
     },
     "Sz": {
       "type": "structure",
@@ -372,26 +564,57 @@
         "BackupId"
       ],
       "members": {
-        "BackupId": {},
-        "BackupState": {},
-        "ClusterId": {},
+        "BackupId": {
+          "shape": "S3"
+        },
+        "BackupState": {
+          "type": "string",
+          "enum": [
+            "CREATE_IN_PROGRESS",
+            "READY",
+            "DELETED",
+            "PENDING_DELETION"
+          ]
+        },
+        "ClusterId": {
+          "shape": "S7"
+        },
         "CreateTimestamp": {
           "type": "timestamp"
         },
         "CopyTimestamp": {
           "type": "timestamp"
         },
-        "SourceRegion": {},
-        "SourceBackup": {},
-        "SourceCluster": {},
+        "SourceRegion": {
+          "shape": "S2"
+        },
+        "SourceBackup": {
+          "shape": "S3"
+        },
+        "SourceCluster": {
+          "shape": "S7"
+        },
         "DeleteTimestamp": {
           "type": "timestamp"
         }
       }
     },
+    "S16": {
+      "type": "string",
+      "max": 256,
+      "pattern": ".*"
+    },
+    "S17": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
     "S18": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "pattern": "[a-zA-Z0-9_-]+"
+      },
       "value": {
         "type": "list",
         "member": {}
@@ -406,10 +629,25 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S1n"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
+    },
+    "S1n": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     }
   }
 }

--- a/apis/cloudsearch-2011-02-01.min.json
+++ b/apis/cloudsearch-2011-02-01.min.json
@@ -16,7 +16,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -37,7 +39,9 @@
           "IndexField"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "IndexField": {
             "shape": "Sf"
           }
@@ -64,7 +68,9 @@
           "RankExpression"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "RankExpression": {
             "shape": "S12"
           }
@@ -90,7 +96,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -111,8 +119,12 @@
           "IndexFieldName"
         ],
         "members": {
-          "DomainName": {},
-          "IndexFieldName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "IndexFieldName": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -136,8 +148,12 @@
           "RankName"
         ],
         "members": {
-          "DomainName": {},
-          "RankName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "RankName": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -160,7 +176,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -180,7 +198,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -202,7 +222,9 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           }
         }
       },
@@ -229,7 +251,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "FieldNames": {
             "shape": "S1o"
           }
@@ -258,7 +282,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "RankNames": {
             "shape": "S1o"
           }
@@ -287,7 +313,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -310,7 +338,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -333,7 +363,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -356,7 +388,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -379,7 +413,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -400,7 +436,9 @@
           "MultiAZ"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "MultiAZ": {
             "type": "boolean"
           }
@@ -424,7 +462,9 @@
           "DefaultSearchField"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "DefaultSearchField": {}
         }
       },
@@ -449,7 +489,9 @@
           "AccessPolicies"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AccessPolicies": {}
         }
       },
@@ -474,7 +516,9 @@
           "Stems"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Stems": {}
         }
       },
@@ -499,7 +543,9 @@
           "Stopwords"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Stopwords": {}
         }
       },
@@ -524,7 +570,9 @@
           "Synonyms"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Synonyms": {}
         }
       },
@@ -543,6 +591,12 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 3,
+      "max": 28,
+      "pattern": "[a-z][a-z0-9\\-]+"
+    },
     "S4": {
       "type": "structure",
       "required": [
@@ -551,8 +605,14 @@
         "RequiresIndexDocuments"
       ],
       "members": {
-        "DomainId": {},
-        "DomainName": {},
+        "DomainId": {
+          "type": "string",
+          "min": 1,
+          "max": 64
+        },
+        "DomainName": {
+          "shape": "S2"
+        },
         "Created": {
           "type": "boolean"
         },
@@ -560,7 +620,8 @@
           "type": "boolean"
         },
         "NumSearchableDocs": {
-          "type": "long"
+          "type": "long",
+          "min": 0
         },
         "DocService": {
           "shape": "S8"
@@ -576,10 +637,12 @@
         },
         "SearchInstanceType": {},
         "SearchPartitionCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "SearchInstanceCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         }
       }
     },
@@ -597,20 +660,31 @@
         "IndexFieldType"
       ],
       "members": {
-        "IndexFieldName": {},
-        "IndexFieldType": {},
+        "IndexFieldName": {
+          "shape": "Sg"
+        },
+        "IndexFieldType": {
+          "type": "string",
+          "enum": [
+            "uint",
+            "literal",
+            "text"
+          ]
+        },
         "UIntOptions": {
           "type": "structure",
           "members": {
             "DefaultValue": {
-              "type": "integer"
+              "shape": "Sj"
             }
           }
         },
         "LiteralOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
+            "DefaultValue": {
+              "shape": "Sl"
+            },
             "SearchEnabled": {
               "type": "boolean"
             },
@@ -625,14 +699,18 @@
         "TextOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
+            "DefaultValue": {
+              "shape": "Sl"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
             "ResultEnabled": {
               "type": "boolean"
             },
-            "TextProcessor": {}
+            "TextProcessor": {
+              "shape": "Sg"
+            }
           }
         },
         "SourceAttributes": {
@@ -643,15 +721,26 @@
               "SourceDataFunction"
             ],
             "members": {
-              "SourceDataFunction": {},
+              "SourceDataFunction": {
+                "type": "string",
+                "enum": [
+                  "Copy",
+                  "TrimTitle",
+                  "Map"
+                ]
+              },
               "SourceDataCopy": {
                 "type": "structure",
                 "required": [
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {},
-                  "DefaultValue": {}
+                  "SourceName": {
+                    "shape": "Sg"
+                  },
+                  "DefaultValue": {
+                    "shape": "Sl"
+                  }
                 }
               },
               "SourceDataTrimTitle": {
@@ -660,10 +749,17 @@
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {},
-                  "DefaultValue": {},
+                  "SourceName": {
+                    "shape": "Sg"
+                  },
+                  "DefaultValue": {
+                    "shape": "Sl"
+                  },
                   "Separator": {},
-                  "Language": {}
+                  "Language": {
+                    "type": "string",
+                    "pattern": "[a-zA-Z]{2,8}(?:-[a-zA-Z]{2,8})*"
+                  }
                 }
               },
               "SourceDataMap": {
@@ -672,12 +768,20 @@
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {},
-                  "DefaultValue": {},
+                  "SourceName": {
+                    "shape": "Sg"
+                  },
+                  "DefaultValue": {
+                    "shape": "Sl"
+                  },
                   "Cases": {
                     "type": "map",
-                    "key": {},
-                    "value": {}
+                    "key": {
+                      "shape": "Sl"
+                    },
+                    "value": {
+                      "shape": "Sl"
+                    }
                   }
                 }
               }
@@ -685,6 +789,21 @@
           }
         }
       }
+    },
+    "Sg": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "[a-z][a-z0-9_]*"
+    },
+    "Sj": {
+      "type": "integer",
+      "min": 0
+    },
+    "Sl": {
+      "type": "string",
+      "min": 0,
+      "max": 1024
     },
     "Sx": {
       "type": "structure",
@@ -716,9 +835,16 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "type": "integer"
+          "shape": "Sj"
         },
-        "State": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "RequiresIndexDocuments",
+            "Processing",
+            "Active"
+          ]
+        },
         "PendingDeletion": {
           "type": "boolean"
         }
@@ -731,8 +857,14 @@
         "RankExpression"
       ],
       "members": {
-        "RankName": {},
-        "RankExpression": {}
+        "RankName": {
+          "shape": "Sg"
+        },
+        "RankExpression": {
+          "type": "string",
+          "min": 1,
+          "max": 10240
+        }
       }
     },
     "S15": {
@@ -772,7 +904,9 @@
         "Status"
       ],
       "members": {
-        "Options": {},
+        "Options": {
+          "shape": "Sg"
+        },
         "Status": {
           "shape": "Sy"
         }
@@ -780,7 +914,9 @@
     },
     "S1o": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sg"
+      }
     },
     "S1w": {
       "type": "structure",

--- a/apis/cloudsearch-2013-01-01.min.json
+++ b/apis/cloudsearch-2013-01-01.min.json
@@ -18,7 +18,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -38,7 +40,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -59,7 +63,9 @@
           "AnalysisScheme"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AnalysisScheme": {
             "shape": "Sl"
           }
@@ -86,7 +92,9 @@
           "Expression"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Expression": {
             "shape": "Sy"
           }
@@ -113,7 +121,9 @@
           "IndexField"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "IndexField": {
             "shape": "S13"
           }
@@ -140,7 +150,9 @@
           "Suggester"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Suggester": {
             "shape": "S1p"
           }
@@ -167,8 +179,12 @@
           "AnalysisSchemeName"
         ],
         "members": {
-          "DomainName": {},
-          "AnalysisSchemeName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "AnalysisSchemeName": {
+            "shape": "Sm"
+          }
         }
       },
       "output": {
@@ -191,7 +207,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -212,8 +230,12 @@
           "ExpressionName"
         ],
         "members": {
-          "DomainName": {},
-          "ExpressionName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "ExpressionName": {
+            "shape": "Sm"
+          }
         }
       },
       "output": {
@@ -237,8 +259,12 @@
           "IndexFieldName"
         ],
         "members": {
-          "DomainName": {},
-          "IndexFieldName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "IndexFieldName": {
+            "shape": "S14"
+          }
         }
       },
       "output": {
@@ -262,8 +288,12 @@
           "SuggesterName"
         ],
         "members": {
-          "DomainName": {},
-          "SuggesterName": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "SuggesterName": {
+            "shape": "Sm"
+          }
         }
       },
       "output": {
@@ -286,7 +316,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AnalysisSchemeNames": {
             "shape": "S25"
           },
@@ -318,7 +350,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Deployed": {
             "type": "boolean"
           }
@@ -340,7 +374,9 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           }
         }
       },
@@ -367,7 +403,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "ExpressionNames": {
             "shape": "S25"
           },
@@ -399,10 +437,14 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "FieldNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S14"
+            }
           },
           "Deployed": {
             "type": "boolean"
@@ -432,7 +474,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -455,7 +499,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Deployed": {
             "type": "boolean"
           }
@@ -481,7 +527,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "SuggesterNames": {
             "shape": "S25"
           },
@@ -513,7 +561,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -533,7 +583,9 @@
         "members": {
           "DomainNames": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S2"
+            },
             "value": {}
           }
         }
@@ -547,7 +599,9 @@
           "MultiAZ"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "MultiAZ": {
             "type": "boolean"
           }
@@ -571,7 +625,9 @@
           "ScalingParameters"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "ScalingParameters": {
             "shape": "S2q"
           }
@@ -598,7 +654,9 @@
           "AccessPolicies"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AccessPolicies": {}
         }
       },
@@ -617,9 +675,23 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 3,
+      "max": 28,
+      "pattern": "[a-z][a-z0-9\\-]+"
+    },
     "S4": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5"
+      }
+    },
+    "S5": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "[a-z][a-z0-9_]*"
     },
     "S8": {
       "type": "structure",
@@ -629,8 +701,14 @@
         "RequiresIndexDocuments"
       ],
       "members": {
-        "DomainId": {},
-        "DomainName": {},
+        "DomainId": {
+          "type": "string",
+          "min": 1,
+          "max": 64
+        },
+        "DomainName": {
+          "shape": "S2"
+        },
         "ARN": {},
         "Created": {
           "type": "boolean"
@@ -652,10 +730,12 @@
         },
         "SearchInstanceType": {},
         "SearchPartitionCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "SearchInstanceCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "Limits": {
           "type": "structure",
@@ -665,10 +745,12 @@
           ],
           "members": {
             "MaximumReplicationCount": {
-              "type": "integer"
+              "type": "integer",
+              "min": 1
             },
             "MaximumPartitionCount": {
-              "type": "integer"
+              "type": "integer",
+              "min": 1
             }
           }
         }
@@ -687,8 +769,49 @@
         "AnalysisSchemeLanguage"
       ],
       "members": {
-        "AnalysisSchemeName": {},
-        "AnalysisSchemeLanguage": {},
+        "AnalysisSchemeName": {
+          "shape": "Sm"
+        },
+        "AnalysisSchemeLanguage": {
+          "type": "string",
+          "enum": [
+            "ar",
+            "bg",
+            "ca",
+            "cs",
+            "da",
+            "de",
+            "el",
+            "en",
+            "es",
+            "eu",
+            "fa",
+            "fi",
+            "fr",
+            "ga",
+            "gl",
+            "he",
+            "hi",
+            "hu",
+            "hy",
+            "id",
+            "it",
+            "ja",
+            "ko",
+            "lv",
+            "mul",
+            "nl",
+            "no",
+            "pt",
+            "ro",
+            "ru",
+            "sv",
+            "th",
+            "tr",
+            "zh-Hans",
+            "zh-Hant"
+          ]
+        },
         "AnalysisOptions": {
           "type": "structure",
           "members": {
@@ -696,10 +819,24 @@
             "Stopwords": {},
             "StemmingDictionary": {},
             "JapaneseTokenizationDictionary": {},
-            "AlgorithmicStemming": {}
+            "AlgorithmicStemming": {
+              "type": "string",
+              "enum": [
+                "none",
+                "minimal",
+                "light",
+                "full"
+              ]
+            }
           }
         }
       }
+    },
+    "Sm": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "[a-z][a-z0-9_]*"
     },
     "Ss": {
       "type": "structure",
@@ -731,13 +868,25 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "type": "integer"
+          "shape": "Sv"
         },
-        "State": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "RequiresIndexDocuments",
+            "Processing",
+            "Active",
+            "FailedToValidate"
+          ]
+        },
         "PendingDeletion": {
           "type": "boolean"
         }
       }
+    },
+    "Sv": {
+      "type": "integer",
+      "min": 0
     },
     "Sy": {
       "type": "structure",
@@ -746,8 +895,14 @@
         "ExpressionValue"
       ],
       "members": {
-        "ExpressionName": {},
-        "ExpressionValue": {}
+        "ExpressionName": {
+          "shape": "Sm"
+        },
+        "ExpressionValue": {
+          "type": "string",
+          "min": 1,
+          "max": 10240
+        }
       }
     },
     "S11": {
@@ -772,15 +927,34 @@
         "IndexFieldType"
       ],
       "members": {
-        "IndexFieldName": {},
-        "IndexFieldType": {},
+        "IndexFieldName": {
+          "shape": "S14"
+        },
+        "IndexFieldType": {
+          "type": "string",
+          "enum": [
+            "int",
+            "double",
+            "literal",
+            "text",
+            "date",
+            "latlon",
+            "int-array",
+            "double-array",
+            "literal-array",
+            "text-array",
+            "date-array"
+          ]
+        },
         "IntOptions": {
           "type": "structure",
           "members": {
             "DefaultValue": {
               "type": "long"
             },
-            "SourceField": {},
+            "SourceField": {
+              "shape": "S5"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -801,7 +975,9 @@
             "DefaultValue": {
               "type": "double"
             },
-            "SourceField": {},
+            "SourceField": {
+              "shape": "S5"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -819,8 +995,12 @@
         "LiteralOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceField": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceField": {
+              "shape": "S5"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -838,8 +1018,12 @@
         "TextOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceField": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceField": {
+              "shape": "S5"
+            },
             "ReturnEnabled": {
               "type": "boolean"
             },
@@ -849,14 +1033,20 @@
             "HighlightEnabled": {
               "type": "boolean"
             },
-            "AnalysisScheme": {}
+            "AnalysisScheme": {
+              "shape": "S1d"
+            }
           }
         },
         "DateOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceField": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceField": {
+              "shape": "S5"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -874,8 +1064,12 @@
         "LatLonOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceField": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceField": {
+              "shape": "S5"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -896,7 +1090,9 @@
             "DefaultValue": {
               "type": "long"
             },
-            "SourceFields": {},
+            "SourceFields": {
+              "shape": "S1h"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -914,7 +1110,9 @@
             "DefaultValue": {
               "type": "double"
             },
-            "SourceFields": {},
+            "SourceFields": {
+              "shape": "S1h"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -929,8 +1127,12 @@
         "LiteralArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceFields": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceFields": {
+              "shape": "S1h"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -945,22 +1147,32 @@
         "TextArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceFields": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceFields": {
+              "shape": "S1h"
+            },
             "ReturnEnabled": {
               "type": "boolean"
             },
             "HighlightEnabled": {
               "type": "boolean"
             },
-            "AnalysisScheme": {}
+            "AnalysisScheme": {
+              "shape": "S1d"
+            }
           }
         },
         "DateArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {},
-            "SourceFields": {},
+            "DefaultValue": {
+              "shape": "S1b"
+            },
+            "SourceFields": {
+              "shape": "S1h"
+            },
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -973,6 +1185,25 @@
           }
         }
       }
+    },
+    "S14": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "([a-z][a-z0-9_]*\\*?|\\*[a-z0-9_]*)"
+    },
+    "S1b": {
+      "type": "string",
+      "min": 0,
+      "max": 1024
+    },
+    "S1d": {
+      "type": "string",
+      "pattern": "[\\S]+"
+    },
+    "S1h": {
+      "type": "string",
+      "pattern": "\\s*[a-z*][a-z0-9_]*\\*?\\s*(,\\s*[a-z*][a-z0-9_]*\\*?\\s*)*"
     },
     "S1n": {
       "type": "structure",
@@ -996,15 +1227,26 @@
         "DocumentSuggesterOptions"
       ],
       "members": {
-        "SuggesterName": {},
+        "SuggesterName": {
+          "shape": "Sm"
+        },
         "DocumentSuggesterOptions": {
           "type": "structure",
           "required": [
             "SourceField"
           ],
           "members": {
-            "SourceField": {},
-            "FuzzyMatching": {},
+            "SourceField": {
+              "shape": "S5"
+            },
+            "FuzzyMatching": {
+              "type": "string",
+              "enum": [
+                "none",
+                "low",
+                "high"
+              ]
+            },
             "SortExpression": {}
           }
         }
@@ -1027,7 +1269,9 @@
     },
     "S25": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sm"
+      }
     },
     "S2a": {
       "type": "structure",
@@ -1062,12 +1306,24 @@
     "S2q": {
       "type": "structure",
       "members": {
-        "DesiredInstanceType": {},
+        "DesiredInstanceType": {
+          "type": "string",
+          "enum": [
+            "search.m1.small",
+            "search.m1.large",
+            "search.m2.xlarge",
+            "search.m2.2xlarge",
+            "search.m3.medium",
+            "search.m3.large",
+            "search.m3.xlarge",
+            "search.m3.2xlarge"
+          ]
+        },
         "DesiredReplicationCount": {
-          "type": "integer"
+          "shape": "Sv"
         },
         "DesiredPartitionCount": {
-          "type": "integer"
+          "shape": "Sv"
         }
       }
     },

--- a/apis/cloudsearchdomain-2013-01-01.min.json
+++ b/apis/cloudsearchdomain-2013-01-01.min.json
@@ -58,7 +58,14 @@
           },
           "queryParser": {
             "location": "querystring",
-            "locationName": "q.parser"
+            "locationName": "q.parser",
+            "type": "string",
+            "enum": [
+              "simple",
+              "structured",
+              "lucene",
+              "dismax"
+            ]
           },
           "return": {
             "location": "querystring",
@@ -267,7 +274,12 @@
           },
           "contentType": {
             "location": "header",
-            "locationName": "Content-Type"
+            "locationName": "Content-Type",
+            "type": "string",
+            "enum": [
+              "application/json",
+              "application/xml"
+            ]
           }
         },
         "payload": "documents"

--- a/apis/cloudtrail-2013-11-01.min.json
+++ b/apis/cloudtrail-2013-11-01.min.json
@@ -308,7 +308,17 @@
                 "AttributeValue"
               ],
               "members": {
-                "AttributeKey": {},
+                "AttributeKey": {
+                  "type": "string",
+                  "enum": [
+                    "EventId",
+                    "EventName",
+                    "Username",
+                    "ResourceType",
+                    "ResourceName",
+                    "EventSource"
+                  ]
+                },
                 "AttributeValue": {}
               }
             }
@@ -320,7 +330,9 @@
             "type": "timestamp"
           },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 1
           },
           "NextToken": {}
         }
@@ -507,7 +519,14 @@
       "member": {
         "type": "structure",
         "members": {
-          "ReadWriteType": {},
+          "ReadWriteType": {
+            "type": "string",
+            "enum": [
+              "ReadOnly",
+              "WriteOnly",
+              "All"
+            ]
+          },
           "IncludeManagementEvents": {
             "type": "boolean"
           },

--- a/apis/codebuild-2016-10-06.min.json
+++ b/apis/codebuild-2016-10-06.min.json
@@ -35,7 +35,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {},
+                "id": {
+                  "shape": "S3"
+                },
                 "statusCode": {}
               }
             }
@@ -108,8 +110,12 @@
           "serviceRole"
         ],
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S1i"
+          },
+          "description": {
+            "shape": "S1j"
+          },
           "source": {
             "shape": "Sk"
           },
@@ -128,11 +134,15 @@
           "environment": {
             "shape": "Sx"
           },
-          "serviceRole": {},
-          "timeoutInMinutes": {
-            "type": "integer"
+          "serviceRole": {
+            "shape": "S3"
           },
-          "encryptionKey": {},
+          "timeoutInMinutes": {
+            "shape": "S1p"
+          },
+          "encryptionKey": {
+            "shape": "S3"
+          },
           "tags": {
             "shape": "S1q"
           },
@@ -163,7 +173,9 @@
           "projectName"
         ],
         "members": {
-          "projectName": {},
+          "projectName": {
+            "shape": "S1i"
+          },
           "branchFilter": {}
         }
       },
@@ -183,7 +195,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -198,7 +212,9 @@
           "projectName"
         ],
         "members": {
-          "projectName": {}
+          "projectName": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -213,7 +229,9 @@
           "projectName"
         ],
         "members": {
-          "projectName": {}
+          "projectName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -225,7 +243,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "sortOrder": {},
+          "sortOrder": {
+            "shape": "S28"
+          },
           "nextToken": {}
         }
       },
@@ -246,8 +266,12 @@
           "projectName"
         ],
         "members": {
-          "projectName": {},
-          "sortOrder": {},
+          "projectName": {
+            "shape": "S3"
+          },
+          "sortOrder": {
+            "shape": "S28"
+          },
           "nextToken": {}
         }
       },
@@ -274,13 +298,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "platform": {},
+                "platform": {
+                  "type": "string",
+                  "enum": [
+                    "DEBIAN",
+                    "AMAZON_LINUX",
+                    "UBUNTU",
+                    "WINDOWS_SERVER"
+                  ]
+                },
                 "languages": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "language": {},
+                      "language": {
+                        "type": "string",
+                        "enum": [
+                          "JAVA",
+                          "PYTHON",
+                          "NODE_JS",
+                          "RUBY",
+                          "GOLANG",
+                          "DOCKER",
+                          "ANDROID",
+                          "DOTNET",
+                          "BASE"
+                        ]
+                      },
                       "images": {
                         "type": "list",
                         "member": {
@@ -308,9 +353,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "sortBy": {},
-          "sortOrder": {},
-          "nextToken": {}
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "NAME",
+              "CREATED_TIME",
+              "LAST_MODIFIED_TIME"
+            ]
+          },
+          "sortOrder": {
+            "shape": "S28"
+          },
+          "nextToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -330,7 +386,9 @@
           "projectName"
         ],
         "members": {
-          "projectName": {},
+          "projectName": {
+            "shape": "S3"
+          },
           "secondarySourcesOverride": {
             "shape": "Sq"
           },
@@ -347,13 +405,15 @@
           "environmentVariablesOverride": {
             "shape": "S10"
           },
-          "sourceTypeOverride": {},
+          "sourceTypeOverride": {
+            "shape": "Sl"
+          },
           "sourceLocationOverride": {},
           "sourceAuthOverride": {
             "shape": "Sn"
           },
           "gitCloneDepthOverride": {
-            "type": "integer"
+            "shape": "Sm"
           },
           "buildspecOverride": {},
           "insecureSslOverride": {
@@ -362,19 +422,27 @@
           "reportBuildStatusOverride": {
             "type": "boolean"
           },
-          "environmentTypeOverride": {},
-          "imageOverride": {},
-          "computeTypeOverride": {},
+          "environmentTypeOverride": {
+            "shape": "Sy"
+          },
+          "imageOverride": {
+            "shape": "S3"
+          },
+          "computeTypeOverride": {
+            "shape": "Sz"
+          },
           "certificateOverride": {},
           "cacheOverride": {
             "shape": "Sv"
           },
-          "serviceRoleOverride": {},
+          "serviceRoleOverride": {
+            "shape": "S3"
+          },
           "privilegedModeOverride": {
             "type": "boolean"
           },
           "timeoutInMinutesOverride": {
-            "type": "integer"
+            "shape": "S1p"
           },
           "idempotencyToken": {},
           "logsConfigOverride": {
@@ -398,7 +466,9 @@
           "id"
         ],
         "members": {
-          "id": {}
+          "id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -417,8 +487,12 @@
           "name"
         ],
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S1j"
+          },
           "source": {
             "shape": "Sk"
           },
@@ -437,11 +511,15 @@
           "environment": {
             "shape": "Sx"
           },
-          "serviceRole": {},
-          "timeoutInMinutes": {
-            "type": "integer"
+          "serviceRole": {
+            "shape": "S3"
           },
-          "encryptionKey": {},
+          "timeoutInMinutes": {
+            "shape": "S1p"
+          },
+          "encryptionKey": {
+            "shape": "S3"
+          },
           "tags": {
             "shape": "S1q"
           },
@@ -472,7 +550,9 @@
           "projectName"
         ],
         "members": {
-          "projectName": {},
+          "projectName": {
+            "shape": "S1i"
+          },
           "branchFilter": {},
           "rotateSecret": {
             "type": "boolean"
@@ -492,13 +572,25 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "min": 1
     },
     "Sb": {
       "type": "structure",
       "members": {
-        "id": {},
-        "arn": {},
+        "id": {
+          "shape": "S3"
+        },
+        "arn": {
+          "shape": "S3"
+        },
         "startTime": {
           "type": "timestamp"
         },
@@ -506,16 +598,38 @@
           "type": "timestamp"
         },
         "currentPhase": {},
-        "buildStatus": {},
-        "sourceVersion": {},
-        "projectName": {},
+        "buildStatus": {
+          "shape": "Sd"
+        },
+        "sourceVersion": {
+          "shape": "S3"
+        },
+        "projectName": {
+          "shape": "S3"
+        },
         "phases": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "phaseType": {},
-              "phaseStatus": {},
+              "phaseType": {
+                "type": "string",
+                "enum": [
+                  "SUBMITTED",
+                  "PROVISIONING",
+                  "DOWNLOAD_SOURCE",
+                  "INSTALL",
+                  "PRE_BUILD",
+                  "BUILD",
+                  "POST_BUILD",
+                  "UPLOAD_ARTIFACTS",
+                  "FINALIZING",
+                  "COMPLETED"
+                ]
+              },
+              "phaseStatus": {
+                "shape": "Sd"
+              },
               "startTime": {
                 "type": "timestamp"
               },
@@ -554,7 +668,9 @@
           "type": "list",
           "member": {
             "shape": "St"
-          }
+          },
+          "max": 12,
+          "min": 0
         },
         "cache": {
           "shape": "Sv"
@@ -562,7 +678,9 @@
         "environment": {
           "shape": "Sx"
         },
-        "serviceRole": {},
+        "serviceRole": {
+          "shape": "S3"
+        },
         "logs": {
           "type": "structure",
           "members": {
@@ -591,12 +709,29 @@
         "networkInterface": {
           "type": "structure",
           "members": {
-            "subnetId": {},
-            "networkInterfaceId": {}
+            "subnetId": {
+              "shape": "S3"
+            },
+            "networkInterfaceId": {
+              "shape": "S3"
+            }
           }
         },
-        "encryptionKey": {}
+        "encryptionKey": {
+          "shape": "S3"
+        }
       }
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "SUCCEEDED",
+        "FAILED",
+        "FAULT",
+        "TIMED_OUT",
+        "IN_PROGRESS",
+        "STOPPED"
+      ]
     },
     "Sk": {
       "type": "structure",
@@ -604,10 +739,12 @@
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "shape": "Sl"
+        },
         "location": {},
         "gitCloneDepth": {
-          "type": "integer"
+          "shape": "Sm"
         },
         "buildspec": {},
         "auth": {
@@ -622,13 +759,34 @@
         "sourceIdentifier": {}
       }
     },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "CODECOMMIT",
+        "CODEPIPELINE",
+        "GITHUB",
+        "S3",
+        "BITBUCKET",
+        "GITHUB_ENTERPRISE",
+        "NO_SOURCE"
+      ]
+    },
+    "Sm": {
+      "type": "integer",
+      "min": 0
+    },
     "Sn": {
       "type": "structure",
       "required": [
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "OAUTH"
+          ]
+        },
         "resource": {}
       }
     },
@@ -636,7 +794,9 @@
       "type": "list",
       "member": {
         "shape": "Sk"
-      }
+      },
+      "max": 12,
+      "min": 0
     },
     "Sr": {
       "type": "list",
@@ -650,7 +810,9 @@
           "sourceIdentifier": {},
           "sourceVersion": {}
         }
-      }
+      },
+      "max": 12,
+      "min": 0
     },
     "St": {
       "type": "structure",
@@ -673,7 +835,13 @@
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "NO_CACHE",
+            "S3"
+          ]
+        },
         "location": {}
       }
     },
@@ -685,9 +853,15 @@
         "computeType"
       ],
       "members": {
-        "type": {},
-        "image": {},
-        "computeType": {},
+        "type": {
+          "shape": "Sy"
+        },
+        "image": {
+          "shape": "S3"
+        },
+        "computeType": {
+          "shape": "Sz"
+        },
         "environmentVariables": {
           "shape": "S10"
         },
@@ -696,6 +870,21 @@
         },
         "certificate": {}
       }
+    },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "WINDOWS_CONTAINER",
+        "LINUX_CONTAINER"
+      ]
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "BUILD_GENERAL1_SMALL",
+        "BUILD_GENERAL1_MEDIUM",
+        "BUILD_GENERAL1_LARGE"
+      ]
     },
     "S10": {
       "type": "list",
@@ -706,9 +895,17 @@
           "value"
         ],
         "members": {
-          "name": {},
+          "name": {
+            "shape": "S3"
+          },
           "value": {},
-          "type": {}
+          "type": {
+            "type": "string",
+            "enum": [
+              "PLAINTEXT",
+              "PARAMETER_STORE"
+            ]
+          }
         }
       }
     },
@@ -718,10 +915,19 @@
         "status"
       ],
       "members": {
-        "status": {},
+        "status": {
+          "shape": "S15"
+        },
         "groupName": {},
         "streamName": {}
       }
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
     },
     "S16": {
       "type": "structure",
@@ -729,34 +935,52 @@
         "status"
       ],
       "members": {
-        "status": {},
+        "status": {
+          "shape": "S15"
+        },
         "location": {}
       }
     },
     "S19": {
       "type": "structure",
       "members": {
-        "vpcId": {},
+        "vpcId": {
+          "shape": "S3"
+        },
         "subnets": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S3"
+          },
+          "max": 16
         },
         "securityGroupIds": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S3"
+          },
+          "max": 5
         }
       }
     },
     "S1e": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 100,
+      "min": 1
     },
     "S1h": {
       "type": "structure",
       "members": {
-        "name": {},
+        "name": {
+          "shape": "S1i"
+        },
         "arn": {},
-        "description": {},
+        "description": {
+          "shape": "S1j"
+        },
         "source": {
           "shape": "Sk"
         },
@@ -775,11 +999,15 @@
         "environment": {
           "shape": "Sx"
         },
-        "serviceRole": {},
-        "timeoutInMinutes": {
-          "type": "integer"
+        "serviceRole": {
+          "shape": "S3"
         },
-        "encryptionKey": {},
+        "timeoutInMinutes": {
+          "shape": "S1p"
+        },
+        "encryptionKey": {
+          "shape": "S3"
+        },
         "tags": {
           "shape": "S1q"
         },
@@ -809,18 +1037,48 @@
         }
       }
     },
+    "S1i": {
+      "type": "string",
+      "max": 255,
+      "min": 2,
+      "pattern": "[A-Za-z0-9][A-Za-z0-9\\-_]{1,254}"
+    },
+    "S1j": {
+      "type": "string",
+      "max": 255,
+      "min": 0
+    },
     "S1k": {
       "type": "structure",
       "required": [
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "CODEPIPELINE",
+            "S3",
+            "NO_ARTIFACTS"
+          ]
+        },
         "location": {},
         "path": {},
-        "namespaceType": {},
+        "namespaceType": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "BUILD_ID"
+          ]
+        },
         "name": {},
-        "packaging": {},
+        "packaging": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ZIP"
+          ]
+        },
         "overrideArtifactName": {
           "type": "boolean"
         },
@@ -834,24 +1092,49 @@
       "type": "list",
       "member": {
         "shape": "S1k"
-      }
+      },
+      "max": 12,
+      "min": 0
+    },
+    "S1p": {
+      "type": "integer",
+      "max": 480,
+      "min": 5
     },
     "S1q": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "type": "string",
+            "max": 127,
+            "min": 1,
+            "pattern": "^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=@+\\\\-]*)$"
+          },
+          "value": {
+            "type": "string",
+            "max": 255,
+            "min": 1,
+            "pattern": "^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=@+\\\\-]*)$"
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 0
     },
     "S1u": {
       "type": "structure",
       "members": {
-        "url": {},
-        "payloadUrl": {},
-        "secret": {},
+        "url": {
+          "shape": "S3"
+        },
+        "payloadUrl": {
+          "shape": "S3"
+        },
+        "secret": {
+          "shape": "S3"
+        },
         "branchFilter": {},
         "lastModifiedSecret": {
           "type": "timestamp"
@@ -868,6 +1151,13 @@
           "shape": "S16"
         }
       }
+    },
+    "S28": {
+      "type": "string",
+      "enum": [
+        "ASCENDING",
+        "DESCENDING"
+      ]
     }
   }
 }

--- a/apis/codecommit-2015-04-13.min.json
+++ b/apis/codecommit-2015-04-13.min.json
@@ -22,7 +22,9 @@
         "members": {
           "repositoryNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           }
         }
       },
@@ -37,7 +39,9 @@
           },
           "repositoriesNotFound": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           }
         }
       }
@@ -51,8 +55,12 @@
           "commitId"
         ],
         "members": {
-          "repositoryName": {},
-          "branchName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "branchName": {
+            "shape": "Sa"
+          },
           "commitId": {}
         }
       }
@@ -65,8 +73,12 @@
           "targets"
         ],
         "members": {
-          "title": {},
-          "description": {},
+          "title": {
+            "shape": "Sk"
+          },
+          "description": {
+            "shape": "Sl"
+          },
           "targets": {
             "type": "list",
             "member": {
@@ -76,7 +88,9 @@
                 "sourceReference"
               ],
               "members": {
-                "repositoryName": {},
+                "repositoryName": {
+                  "shape": "S3"
+                },
                 "sourceReference": {},
                 "destinationReference": {}
               }
@@ -106,8 +120,12 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {},
-          "repositoryDescription": {}
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "repositoryDescription": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -127,8 +145,12 @@
           "branchName"
         ],
         "members": {
-          "repositoryName": {},
-          "branchName": {}
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "branchName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -166,7 +188,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {}
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -184,7 +208,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "pullRequestEventType": {},
+          "pullRequestEventType": {
+            "shape": "S1c"
+          },
           "actorArn": {},
           "nextToken": {},
           "maxResults": {
@@ -207,12 +233,16 @@
                 "eventDate": {
                   "type": "timestamp"
                 },
-                "pullRequestEventType": {},
+                "pullRequestEventType": {
+                  "shape": "S1c"
+                },
                 "actorArn": {},
                 "pullRequestCreatedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {},
+                    "repositoryName": {
+                      "shape": "S3"
+                    },
                     "sourceCommitId": {},
                     "destinationCommitId": {},
                     "mergeBase": {}
@@ -221,13 +251,17 @@
                 "pullRequestStatusChangedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "pullRequestStatus": {}
+                    "pullRequestStatus": {
+                      "shape": "St"
+                    }
                   }
                 },
                 "pullRequestSourceReferenceUpdatedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {},
+                    "repositoryName": {
+                      "shape": "S3"
+                    },
                     "beforeCommitId": {},
                     "afterCommitId": {},
                     "mergeBase": {}
@@ -236,7 +270,9 @@
                 "pullRequestMergedStateChangedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {},
+                    "repositoryName": {
+                      "shape": "S3"
+                    },
                     "destinationReference": {},
                     "mergeMetadata": {
                       "shape": "Sw"
@@ -258,7 +294,9 @@
           "blobId"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "blobId": {}
         }
       },
@@ -278,8 +316,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "repositoryName": {},
-          "branchName": {}
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "branchName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -318,7 +360,9 @@
           "afterCommitId"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitId": {},
           "afterCommitId": {},
           "nextToken": {},
@@ -335,7 +379,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "repositoryName": {},
+                "repositoryName": {
+                  "shape": "S3"
+                },
                 "beforeCommitId": {},
                 "afterCommitId": {},
                 "beforeBlobId": {},
@@ -361,7 +407,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitId": {},
           "afterCommitId": {},
           "nextToken": {},
@@ -379,7 +427,9 @@
               "type": "structure",
               "members": {
                 "pullRequestId": {},
-                "repositoryName": {},
+                "repositoryName": {
+                  "shape": "S3"
+                },
                 "beforeCommitId": {},
                 "afterCommitId": {},
                 "beforeBlobId": {},
@@ -405,7 +455,9 @@
           "commitId"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "commitId": {}
         }
       },
@@ -445,7 +497,9 @@
           "afterCommitSpecifier"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitSpecifier": {},
           "afterCommitSpecifier": {},
           "beforePath": {},
@@ -470,7 +524,14 @@
                 "afterBlob": {
                   "shape": "S2o"
                 },
-                "changeType": {}
+                "changeType": {
+                  "type": "string",
+                  "enum": [
+                    "A",
+                    "M",
+                    "D"
+                  ]
+                }
               }
             }
           },
@@ -488,10 +549,17 @@
           "mergeOption"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "destinationCommitSpecifier": {},
           "sourceCommitSpecifier": {},
-          "mergeOption": {}
+          "mergeOption": {
+            "type": "string",
+            "enum": [
+              "FAST_FORWARD_MERGE"
+            ]
+          }
         }
       },
       "output": {
@@ -539,7 +607,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {}
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -558,7 +628,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {}
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -578,7 +650,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "nextToken": {}
         }
       },
@@ -599,9 +673,13 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "authorArn": {},
-          "pullRequestStatus": {},
+          "pullRequestStatus": {
+            "shape": "St"
+          },
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -627,8 +705,20 @@
         "type": "structure",
         "members": {
           "nextToken": {},
-          "sortBy": {},
-          "order": {}
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "repositoryName",
+              "lastModifiedDate"
+            ]
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          }
         }
       },
       "output": {
@@ -639,7 +729,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "repositoryName": {},
+                "repositoryName": {
+                  "shape": "S3"
+                },
                 "repositoryId": {}
               }
             }
@@ -657,7 +749,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "sourceCommitId": {}
         }
       },
@@ -679,7 +773,9 @@
           "content"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitId": {},
           "afterCommitId": {},
           "location": {
@@ -694,7 +790,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitId": {},
           "afterCommitId": {},
           "beforeBlobId": {},
@@ -721,7 +819,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "beforeCommitId": {},
           "afterCommitId": {},
           "location": {
@@ -736,7 +836,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "pullRequestId": {},
           "beforeCommitId": {},
           "afterCommitId": {},
@@ -787,13 +889,25 @@
           "filePath"
         ],
         "members": {
-          "repositoryName": {},
-          "branchName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "branchName": {
+            "shape": "Sa"
+          },
           "fileContent": {
-            "type": "blob"
+            "type": "blob",
+            "max": 6291456
           },
           "filePath": {},
-          "fileMode": {},
+          "fileMode": {
+            "type": "string",
+            "enum": [
+              "EXECUTABLE",
+              "NORMAL",
+              "SYMLINK"
+            ]
+          },
           "parentCommitId": {},
           "commitMessage": {},
           "name": {},
@@ -822,7 +936,9 @@
           "triggers"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "triggers": {
             "shape": "S32"
           }
@@ -843,7 +959,9 @@
           "triggers"
         ],
         "members": {
-          "repositoryName": {},
+          "repositoryName": {
+            "shape": "S3"
+          },
           "triggers": {
             "shape": "S32"
           }
@@ -898,8 +1016,12 @@
           "defaultBranchName"
         ],
         "members": {
-          "repositoryName": {},
-          "defaultBranchName": {}
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "defaultBranchName": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -912,7 +1034,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "description": {}
+          "description": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -936,7 +1060,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "pullRequestStatus": {}
+          "pullRequestStatus": {
+            "shape": "St"
+          }
         }
       },
       "output": {
@@ -960,7 +1086,9 @@
         ],
         "members": {
           "pullRequestId": {},
-          "title": {}
+          "title": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -982,8 +1110,12 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {},
-          "repositoryDescription": {}
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "repositoryDescription": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -995,21 +1127,37 @@
           "newName"
         ],
         "members": {
-          "oldName": {},
-          "newName": {}
+          "oldName": {
+            "shape": "S3"
+          },
+          "newName": {
+            "shape": "S3"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[\\w\\.-]+"
+    },
     "S6": {
       "type": "structure",
       "members": {
         "accountId": {},
         "repositoryId": {},
-        "repositoryName": {},
-        "repositoryDescription": {},
-        "defaultBranch": {},
+        "repositoryName": {
+          "shape": "S3"
+        },
+        "repositoryDescription": {
+          "shape": "S9"
+        },
+        "defaultBranch": {
+          "shape": "Sa"
+        },
         "lastModifiedDate": {
           "type": "timestamp"
         },
@@ -1021,26 +1169,51 @@
         "Arn": {}
       }
     },
+    "S9": {
+      "type": "string",
+      "max": 1000
+    },
+    "Sa": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "Sk": {
+      "type": "string",
+      "max": 150
+    },
+    "Sl": {
+      "type": "string",
+      "max": 10240
+    },
     "Sr": {
       "type": "structure",
       "members": {
         "pullRequestId": {},
-        "title": {},
-        "description": {},
+        "title": {
+          "shape": "Sk"
+        },
+        "description": {
+          "shape": "Sl"
+        },
         "lastActivityDate": {
           "type": "timestamp"
         },
         "creationDate": {
           "type": "timestamp"
         },
-        "pullRequestStatus": {},
+        "pullRequestStatus": {
+          "shape": "St"
+        },
         "authorArn": {},
         "pullRequestTargets": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "repositoryName": {},
+              "repositoryName": {
+                "shape": "S3"
+              },
               "sourceReference": {},
               "destinationReference": {},
               "destinationCommit": {},
@@ -1055,6 +1228,13 @@
         "clientRequestToken": {}
       }
     },
+    "St": {
+      "type": "string",
+      "enum": [
+        "OPEN",
+        "CLOSED"
+      ]
+    },
     "Sw": {
       "type": "structure",
       "members": {
@@ -1067,7 +1247,9 @@
     "S12": {
       "type": "structure",
       "members": {
-        "branchName": {},
+        "branchName": {
+          "shape": "Sa"
+        },
         "commitId": {}
       }
     },
@@ -1090,6 +1272,15 @@
         "clientRequestToken": {}
       }
     },
+    "S1c": {
+      "type": "string",
+      "enum": [
+        "PULL_REQUEST_CREATED",
+        "PULL_REQUEST_STATUS_CHANGED",
+        "PULL_REQUEST_SOURCE_REFERENCE_UPDATED",
+        "PULL_REQUEST_MERGE_STATE_CHANGED"
+      ]
+    },
     "S1z": {
       "type": "structure",
       "members": {
@@ -1097,7 +1288,13 @@
         "filePosition": {
           "type": "long"
         },
-        "relativeFileVersion": {}
+        "relativeFileVersion": {
+          "type": "string",
+          "enum": [
+            "BEFORE",
+            "AFTER"
+          ]
+        }
       }
     },
     "S23": {
@@ -1140,14 +1337,24 @@
           },
           "events": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "all",
+                "updateReference",
+                "createReference",
+                "deleteReference"
+              ]
+            }
           }
         }
       }
     },
     "S36": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sa"
+      }
     }
   }
 }

--- a/apis/codedeploy-2014-10-06.min.json
+++ b/apis/codedeploy-2014-10-06.min.json
@@ -39,7 +39,9 @@
           "revisions"
         ],
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "revisions": {
             "shape": "Sa"
           }
@@ -48,7 +50,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "errorMessage": {},
           "revisions": {
             "type": "list",
@@ -99,7 +103,9 @@
           "deploymentGroupNames"
         ],
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "deploymentGroupNames": {
             "shape": "Sv"
           }
@@ -208,8 +214,12 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {},
-          "computePlatform": {}
+          "applicationName": {
+            "shape": "S9"
+          },
+          "computePlatform": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -226,12 +236,18 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {},
-          "deploymentGroupName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
+          "deploymentGroupName": {
+            "shape": "Sw"
+          },
           "revision": {
             "shape": "Sb"
           },
-          "deploymentConfigName": {},
+          "deploymentConfigName": {
+            "shape": "S1c"
+          },
           "description": {},
           "ignoreApplicationStopFailures": {
             "type": "boolean"
@@ -245,7 +261,9 @@
           "updateOutdatedInstancesOnly": {
             "type": "boolean"
           },
-          "fileExistsBehavior": {}
+          "fileExistsBehavior": {
+            "shape": "S3l"
+          }
         }
       },
       "output": {
@@ -262,14 +280,18 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {},
+          "deploymentConfigName": {
+            "shape": "S1c"
+          },
           "minimumHealthyHosts": {
             "shape": "S40"
           },
           "trafficRoutingConfig": {
             "shape": "S43"
           },
-          "computePlatform": {}
+          "computePlatform": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -288,9 +310,15 @@
           "serviceRoleArn"
         ],
         "members": {
-          "applicationName": {},
-          "deploymentGroupName": {},
-          "deploymentConfigName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
+          "deploymentGroupName": {
+            "shape": "Sw"
+          },
+          "deploymentConfigName": {
+            "shape": "S1c"
+          },
           "ec2TagFilters": {
             "shape": "S1d"
           },
@@ -341,7 +369,9 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {}
+          "applicationName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -352,7 +382,9 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {}
+          "deploymentConfigName": {
+            "shape": "S1c"
+          }
         }
       }
     },
@@ -364,8 +396,12 @@
           "deploymentGroupName"
         ],
         "members": {
-          "applicationName": {},
-          "deploymentGroupName": {}
+          "applicationName": {
+            "shape": "S9"
+          },
+          "deploymentGroupName": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
@@ -409,7 +445,9 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {}
+          "applicationName": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -429,7 +467,9 @@
           "revision"
         ],
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "revision": {
             "shape": "Sb"
           }
@@ -438,7 +478,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "revision": {
             "shape": "Sb"
           },
@@ -474,7 +516,9 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {}
+          "deploymentConfigName": {
+            "shape": "S1c"
+          }
         }
       },
       "output": {
@@ -484,14 +528,18 @@
             "type": "structure",
             "members": {
               "deploymentConfigId": {},
-              "deploymentConfigName": {},
+              "deploymentConfigName": {
+                "shape": "S1c"
+              },
               "minimumHealthyHosts": {
                 "shape": "S40"
               },
               "createTime": {
                 "type": "timestamp"
               },
-              "computePlatform": {},
+              "computePlatform": {
+                "shape": "S16"
+              },
               "trafficRoutingConfig": {
                 "shape": "S43"
               }
@@ -508,8 +556,12 @@
           "deploymentGroupName"
         ],
         "members": {
-          "applicationName": {},
-          "deploymentGroupName": {}
+          "applicationName": {
+            "shape": "S9"
+          },
+          "deploymentGroupName": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
@@ -568,12 +620,34 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {},
-          "sortBy": {},
-          "sortOrder": {},
+          "applicationName": {
+            "shape": "S9"
+          },
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "registerTime",
+              "firstUsedTime",
+              "lastUsedTime"
+            ]
+          },
+          "sortOrder": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
           "s3Bucket": {},
           "s3KeyPrefix": {},
-          "deployed": {},
+          "deployed": {
+            "type": "string",
+            "enum": [
+              "include",
+              "exclude",
+              "ignore"
+            ]
+          },
           "nextToken": {}
         }
       },
@@ -616,7 +690,9 @@
         "members": {
           "deploymentConfigsList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1c"
+            }
           },
           "nextToken": {}
         }
@@ -629,14 +705,18 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "nextToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "deploymentGroups": {
             "shape": "Sv"
           },
@@ -655,11 +735,15 @@
           "nextToken": {},
           "instanceStatusFilter": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2w"
+            }
           },
           "instanceTypeFilter": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S36"
+            }
           }
         }
       },
@@ -677,11 +761,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "applicationName": {},
-          "deploymentGroupName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
+          "deploymentGroupName": {
+            "shape": "Sw"
+          },
           "includeOnlyStatuses": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2l"
+            }
           },
           "createTimeRange": {
             "type": "structure",
@@ -729,7 +819,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "registrationStatus": {},
+          "registrationStatus": {
+            "type": "string",
+            "enum": [
+              "Registered",
+              "Deregistered"
+            ]
+          },
           "tagFilters": {
             "shape": "S1g"
           },
@@ -752,7 +848,9 @@
         "members": {
           "deploymentId": {},
           "lifecycleEventHookExecutionId": {},
-          "status": {}
+          "status": {
+            "shape": "S35"
+          }
         }
       },
       "output": {
@@ -770,7 +868,9 @@
           "revision"
         ],
         "members": {
-          "applicationName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
           "description": {},
           "revision": {
             "shape": "Sb"
@@ -832,7 +932,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {},
+          "status": {
+            "type": "string",
+            "enum": [
+              "Pending",
+              "Succeeded"
+            ]
+          },
           "statusMessage": {}
         }
       }
@@ -841,8 +947,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "applicationName": {},
-          "newApplicationName": {}
+          "applicationName": {
+            "shape": "S9"
+          },
+          "newApplicationName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -854,10 +964,18 @@
           "currentDeploymentGroupName"
         ],
         "members": {
-          "applicationName": {},
-          "currentDeploymentGroupName": {},
-          "newDeploymentGroupName": {},
-          "deploymentConfigName": {},
+          "applicationName": {
+            "shape": "S9"
+          },
+          "currentDeploymentGroupName": {
+            "shape": "Sw"
+          },
+          "newDeploymentGroupName": {
+            "shape": "Sw"
+          },
+          "deploymentConfigName": {
+            "shape": "S1c"
+          },
           "ec2TagFilters": {
             "shape": "S1d"
           },
@@ -919,6 +1037,11 @@
       "type": "list",
       "member": {}
     },
+    "S9": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
     "Sa": {
       "type": "list",
       "member": {
@@ -928,13 +1051,29 @@
     "Sb": {
       "type": "structure",
       "members": {
-        "revisionType": {},
+        "revisionType": {
+          "type": "string",
+          "enum": [
+            "S3",
+            "GitHub",
+            "String"
+          ]
+        },
         "s3Location": {
           "type": "structure",
           "members": {
             "bucket": {},
             "key": {},
-            "bundleType": {},
+            "bundleType": {
+              "type": "string",
+              "enum": [
+                "tar",
+                "tgz",
+                "zip",
+                "YAML",
+                "JSON"
+              ]
+            },
             "version": {},
             "eTag": {}
           }
@@ -975,17 +1114,28 @@
     },
     "Sv": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sw"
+      }
+    },
+    "Sw": {
+      "type": "string",
+      "max": 100,
+      "min": 1
     },
     "Sz": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S9"
+      }
     },
     "S12": {
       "type": "structure",
       "members": {
         "applicationId": {},
-        "applicationName": {},
+        "applicationName": {
+          "shape": "S9"
+        },
         "createTime": {
           "type": "timestamp"
         },
@@ -993,16 +1143,31 @@
           "type": "boolean"
         },
         "gitHubAccountName": {},
-        "computePlatform": {}
+        "computePlatform": {
+          "shape": "S16"
+        }
       }
+    },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "Server",
+        "Lambda"
+      ]
     },
     "S1a": {
       "type": "structure",
       "members": {
-        "applicationName": {},
+        "applicationName": {
+          "shape": "S9"
+        },
         "deploymentGroupId": {},
-        "deploymentGroupName": {},
-        "deploymentConfigName": {},
+        "deploymentGroupName": {
+          "shape": "Sw"
+        },
+        "deploymentConfigName": {
+          "shape": "S1c"
+        },
         "ec2TagFilters": {
           "shape": "S1d"
         },
@@ -1046,8 +1211,15 @@
         "onPremisesTagSet": {
           "shape": "S2o"
         },
-        "computePlatform": {}
+        "computePlatform": {
+          "shape": "S16"
+        }
       }
+    },
+    "S1c": {
+      "type": "string",
+      "max": 100,
+      "min": 1
     },
     "S1d": {
       "type": "list",
@@ -1056,7 +1228,14 @@
         "members": {
           "Key": {},
           "Value": {},
-          "Type": {}
+          "Type": {
+            "type": "string",
+            "enum": [
+              "KEY_ONLY",
+              "VALUE_ONLY",
+              "KEY_AND_VALUE"
+            ]
+          }
         }
       }
     },
@@ -1067,7 +1246,14 @@
         "members": {
           "Key": {},
           "Value": {},
-          "Type": {}
+          "Type": {
+            "type": "string",
+            "enum": [
+              "KEY_ONLY",
+              "VALUE_ONLY",
+              "KEY_AND_VALUE"
+            ]
+          }
         }
       }
     },
@@ -1090,7 +1276,21 @@
           "triggerTargetArn": {},
           "triggerEvents": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "DeploymentStart",
+                "DeploymentSuccess",
+                "DeploymentFailure",
+                "DeploymentStop",
+                "DeploymentRollback",
+                "DeploymentReady",
+                "InstanceStart",
+                "InstanceSuccess",
+                "InstanceFailure",
+                "InstanceReady"
+              ]
+            }
           }
         }
       }
@@ -1123,15 +1323,34 @@
         },
         "events": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "DEPLOYMENT_FAILURE",
+              "DEPLOYMENT_STOP_ON_ALARM",
+              "DEPLOYMENT_STOP_ON_REQUEST"
+            ]
+          }
         }
       }
     },
     "S21": {
       "type": "structure",
       "members": {
-        "deploymentType": {},
-        "deploymentOption": {}
+        "deploymentType": {
+          "type": "string",
+          "enum": [
+            "IN_PLACE",
+            "BLUE_GREEN"
+          ]
+        },
+        "deploymentOption": {
+          "type": "string",
+          "enum": [
+            "WITH_TRAFFIC_CONTROL",
+            "WITHOUT_TRAFFIC_CONTROL"
+          ]
+        }
       }
     },
     "S24": {
@@ -1140,7 +1359,13 @@
         "terminateBlueInstancesOnDeploymentSuccess": {
           "type": "structure",
           "members": {
-            "action": {},
+            "action": {
+              "type": "string",
+              "enum": [
+                "TERMINATE",
+                "KEEP_ALIVE"
+              ]
+            },
             "terminationWaitTimeInMinutes": {
               "type": "integer"
             }
@@ -1149,7 +1374,13 @@
         "deploymentReadyOption": {
           "type": "structure",
           "members": {
-            "actionOnTimeout": {},
+            "actionOnTimeout": {
+              "type": "string",
+              "enum": [
+                "CONTINUE_DEPLOYMENT",
+                "STOP_DEPLOYMENT"
+              ]
+            },
             "waitTimeInMinutes": {
               "type": "integer"
             }
@@ -1158,7 +1389,13 @@
         "greenFleetProvisioningOption": {
           "type": "structure",
           "members": {
-            "action": {}
+            "action": {
+              "type": "string",
+              "enum": [
+                "DISCOVER_EXISTING",
+                "COPY_AUTO_SCALING_GROUP"
+              ]
+            }
           }
         }
       }
@@ -1190,7 +1427,9 @@
       "type": "structure",
       "members": {
         "deploymentId": {},
-        "status": {},
+        "status": {
+          "shape": "S2l"
+        },
         "endTime": {
           "type": "timestamp"
         },
@@ -1198,6 +1437,18 @@
           "type": "timestamp"
         }
       }
+    },
+    "S2l": {
+      "type": "string",
+      "enum": [
+        "Created",
+        "Queued",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Stopped",
+        "Ready"
+      ]
     },
     "S2m": {
       "type": "structure",
@@ -1230,7 +1481,9 @@
       "members": {
         "deploymentId": {},
         "instanceId": {},
-        "status": {},
+        "status": {
+          "shape": "S2w"
+        },
         "lastUpdatedAt": {
           "type": "timestamp"
         },
@@ -1243,7 +1496,17 @@
               "diagnostics": {
                 "type": "structure",
                 "members": {
-                  "errorCode": {},
+                  "errorCode": {
+                    "type": "string",
+                    "enum": [
+                      "Success",
+                      "ScriptMissing",
+                      "ScriptNotExecutable",
+                      "ScriptTimedOut",
+                      "ScriptFailed",
+                      "UnknownError"
+                    ]
+                  },
                   "scriptName": {},
                   "message": {},
                   "logTail": {}
@@ -1255,12 +1518,46 @@
               "endTime": {
                 "type": "timestamp"
               },
-              "status": {}
+              "status": {
+                "shape": "S35"
+              }
             }
           }
         },
-        "instanceType": {}
+        "instanceType": {
+          "shape": "S36"
+        }
       }
+    },
+    "S2w": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Skipped",
+        "Unknown",
+        "Ready"
+      ]
+    },
+    "S35": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Skipped",
+        "Unknown"
+      ]
+    },
+    "S36": {
+      "type": "string",
+      "enum": [
+        "Blue",
+        "Green"
+      ]
     },
     "S38": {
       "type": "list",
@@ -1269,9 +1566,15 @@
     "S3b": {
       "type": "structure",
       "members": {
-        "applicationName": {},
-        "deploymentGroupName": {},
-        "deploymentConfigName": {},
+        "applicationName": {
+          "shape": "S9"
+        },
+        "deploymentGroupName": {
+          "shape": "Sw"
+        },
+        "deploymentConfigName": {
+          "shape": "S1c"
+        },
         "deploymentId": {},
         "previousRevision": {
           "shape": "Sb"
@@ -1279,11 +1582,43 @@
         "revision": {
           "shape": "Sb"
         },
-        "status": {},
+        "status": {
+          "shape": "S2l"
+        },
         "errorInformation": {
           "type": "structure",
           "members": {
-            "code": {},
+            "code": {
+              "type": "string",
+              "enum": [
+                "DEPLOYMENT_GROUP_MISSING",
+                "APPLICATION_MISSING",
+                "REVISION_MISSING",
+                "IAM_ROLE_MISSING",
+                "IAM_ROLE_PERMISSIONS",
+                "NO_EC2_SUBSCRIPTION",
+                "OVER_MAX_INSTANCES",
+                "NO_INSTANCES",
+                "TIMEOUT",
+                "HEALTH_CONSTRAINTS_INVALID",
+                "HEALTH_CONSTRAINTS",
+                "INTERNAL_ERROR",
+                "THROTTLED",
+                "ALARM_ACTIVE",
+                "AGENT_ISSUE",
+                "AUTO_SCALING_IAM_ROLE_PERMISSIONS",
+                "AUTO_SCALING_CONFIGURATION",
+                "MANUAL_STOP",
+                "MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION",
+                "MISSING_ELB_INFORMATION",
+                "MISSING_GITHUB_TOKEN",
+                "ELASTIC_LOAD_BALANCING_INVALID",
+                "ELB_INVALID_INSTANCE",
+                "INVALID_LAMBDA_CONFIGURATION",
+                "INVALID_LAMBDA_FUNCTION",
+                "HOOK_EXECUTION_FAILURE"
+              ]
+            },
             "message": {}
           }
         },
@@ -1320,7 +1655,14 @@
           }
         },
         "description": {},
-        "creator": {},
+        "creator": {
+          "type": "string",
+          "enum": [
+            "user",
+            "autoscaling",
+            "codeDeployRollback"
+          ]
+        },
         "ignoreApplicationStopFailures": {
           "type": "boolean"
         },
@@ -1357,12 +1699,16 @@
           "type": "string",
           "deprecated": true
         },
-        "fileExistsBehavior": {},
+        "fileExistsBehavior": {
+          "shape": "S3l"
+        },
         "deploymentStatusMessages": {
           "type": "list",
           "member": {}
         },
-        "computePlatform": {}
+        "computePlatform": {
+          "shape": "S16"
+        }
       }
     },
     "S3i": {
@@ -1382,6 +1728,14 @@
     "S3j": {
       "type": "list",
       "member": {}
+    },
+    "S3l": {
+      "type": "string",
+      "enum": [
+        "DISALLOW",
+        "OVERWRITE",
+        "RETAIN"
+      ]
     },
     "S3q": {
       "type": "structure",
@@ -1407,13 +1761,26 @@
         "value": {
           "type": "integer"
         },
-        "type": {}
+        "type": {
+          "type": "string",
+          "enum": [
+            "HOST_COUNT",
+            "FLEET_PERCENT"
+          ]
+        }
       }
     },
     "S43": {
       "type": "structure",
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "TimeBasedCanary",
+            "TimeBasedLinear",
+            "AllAtOnce"
+          ]
+        },
         "timeBasedCanary": {
           "type": "structure",
           "members": {

--- a/apis/codepipeline-2015-07-09.min.json
+++ b/apis/codepipeline-2015-07-09.min.json
@@ -21,14 +21,20 @@
           "nonce"
         ],
         "members": {
-          "jobId": {},
-          "nonce": {}
+          "jobId": {
+            "shape": "S2"
+          },
+          "nonce": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {}
+          "status": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -41,15 +47,23 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {},
-          "nonce": {},
-          "clientToken": {}
+          "jobId": {
+            "shape": "S7"
+          },
+          "nonce": {
+            "shape": "S3"
+          },
+          "clientToken": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {}
+          "status": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -64,9 +78,15 @@
           "outputArtifactDetails"
         ],
         "members": {
-          "category": {},
-          "provider": {},
-          "version": {},
+          "category": {
+            "shape": "Sb"
+          },
+          "provider": {
+            "shape": "Sc"
+          },
+          "version": {
+            "shape": "Sd"
+          },
           "settings": {
             "shape": "Se"
           },
@@ -123,9 +143,15 @@
           "version"
         ],
         "members": {
-          "category": {},
-          "provider": {},
-          "version": {}
+          "category": {
+            "shape": "Sb"
+          },
+          "provider": {
+            "shape": "Sc"
+          },
+          "version": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -136,7 +162,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "Sw"
+          }
         }
       }
     },
@@ -147,7 +175,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "S1r"
+          }
         }
       },
       "output": {
@@ -159,7 +189,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "webhookName": {}
+          "webhookName": {
+            "shape": "S1r"
+          }
         }
       },
       "output": {
@@ -177,10 +209,18 @@
           "reason"
         ],
         "members": {
-          "pipelineName": {},
-          "stageName": {},
-          "transitionType": {},
-          "reason": {}
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "stageName": {
+            "shape": "S16"
+          },
+          "transitionType": {
+            "shape": "S1w"
+          },
+          "reason": {
+            "shape": "S1x"
+          }
         }
       }
     },
@@ -193,9 +233,15 @@
           "transitionType"
         ],
         "members": {
-          "pipelineName": {},
-          "stageName": {},
-          "transitionType": {}
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "stageName": {
+            "shape": "S16"
+          },
+          "transitionType": {
+            "shape": "S1w"
+          }
         }
       }
     },
@@ -206,7 +252,9 @@
           "jobId"
         ],
         "members": {
-          "jobId": {}
+          "jobId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -215,11 +263,15 @@
           "jobDetails": {
             "type": "structure",
             "members": {
-              "id": {},
+              "id": {
+                "shape": "S2"
+              },
               "data": {
                 "shape": "S22"
               },
-              "accountId": {}
+              "accountId": {
+                "shape": "S2k"
+              }
             }
           }
         }
@@ -232,9 +284,11 @@
           "name"
         ],
         "members": {
-          "name": {},
+          "name": {
+            "shape": "Sw"
+          },
           "version": {
-            "type": "integer"
+            "shape": "S1m"
           }
         }
       },
@@ -247,7 +301,10 @@
           "metadata": {
             "type": "structure",
             "members": {
-              "pipelineArn": {},
+              "pipelineArn": {
+                "type": "string",
+                "pattern": "arn:aws(-[\\w]+)*:codepipeline:.+:[0-9]{12}:.+"
+              },
               "created": {
                 "type": "timestamp"
               },
@@ -267,8 +324,12 @@
           "pipelineExecutionId"
         ],
         "members": {
-          "pipelineName": {},
-          "pipelineExecutionId": {}
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "pipelineExecutionId": {
+            "shape": "S2r"
+          }
         }
       },
       "output": {
@@ -277,25 +338,41 @@
           "pipelineExecution": {
             "type": "structure",
             "members": {
-              "pipelineName": {},
-              "pipelineVersion": {
-                "type": "integer"
+              "pipelineName": {
+                "shape": "Sw"
               },
-              "pipelineExecutionId": {},
-              "status": {},
+              "pipelineVersion": {
+                "shape": "S1m"
+              },
+              "pipelineExecutionId": {
+                "shape": "S2r"
+              },
+              "status": {
+                "shape": "S2u"
+              },
               "artifactRevisions": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "name": {},
-                    "revisionId": {},
-                    "revisionChangeIdentifier": {},
-                    "revisionSummary": {},
+                    "name": {
+                      "shape": "S1j"
+                    },
+                    "revisionId": {
+                      "shape": "S29"
+                    },
+                    "revisionChangeIdentifier": {
+                      "shape": "S2x"
+                    },
+                    "revisionSummary": {
+                      "shape": "S2y"
+                    },
                     "created": {
                       "type": "timestamp"
                     },
-                    "revisionUrl": {}
+                    "revisionUrl": {
+                      "shape": "Sf"
+                    }
                   }
                 }
               }
@@ -311,22 +388,28 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineName": {},
+          "pipelineName": {
+            "shape": "Sw"
+          },
           "pipelineVersion": {
-            "type": "integer"
+            "shape": "S1m"
           },
           "stageStates": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "stageName": {},
+                "stageName": {
+                  "shape": "S16"
+                },
                 "inboundTransitionState": {
                   "type": "structure",
                   "members": {
@@ -337,7 +420,9 @@
                     "lastChangedAt": {
                       "type": "timestamp"
                     },
-                    "disabledReason": {}
+                    "disabledReason": {
+                      "shape": "S1x"
+                    }
                   }
                 },
                 "actionStates": {
@@ -345,36 +430,57 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "actionName": {},
+                      "actionName": {
+                        "shape": "S1d"
+                      },
                       "currentRevision": {
                         "shape": "S39"
                       },
                       "latestExecution": {
                         "type": "structure",
                         "members": {
-                          "status": {},
-                          "summary": {},
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "InProgress",
+                              "Succeeded",
+                              "Failed"
+                            ]
+                          },
+                          "summary": {
+                            "shape": "S3c"
+                          },
                           "lastStatusChange": {
                             "type": "timestamp"
                           },
                           "token": {},
                           "lastUpdatedBy": {},
-                          "externalExecutionId": {},
-                          "externalExecutionUrl": {},
+                          "externalExecutionId": {
+                            "shape": "S3f"
+                          },
+                          "externalExecutionUrl": {
+                            "shape": "Sf"
+                          },
                           "percentComplete": {
-                            "type": "integer"
+                            "shape": "S3g"
                           },
                           "errorDetails": {
                             "type": "structure",
                             "members": {
                               "code": {},
-                              "message": {}
+                              "message": {
+                                "shape": "S3j"
+                              }
                             }
                           }
                         }
                       },
-                      "entityUrl": {},
-                      "revisionUrl": {}
+                      "entityUrl": {
+                        "shape": "Sf"
+                      },
+                      "revisionUrl": {
+                        "shape": "Sf"
+                      }
                     }
                   }
                 },
@@ -385,8 +491,17 @@
                     "status"
                   ],
                   "members": {
-                    "pipelineExecutionId": {},
-                    "status": {}
+                    "pipelineExecutionId": {
+                      "shape": "S2r"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "InProgress",
+                        "Failed",
+                        "Succeeded"
+                      ]
+                    }
                   }
                 }
               }
@@ -409,8 +524,12 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {},
-          "clientToken": {}
+          "jobId": {
+            "shape": "S7"
+          },
+          "clientToken": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -419,7 +538,9 @@
           "jobDetails": {
             "type": "structure",
             "members": {
-              "id": {},
+              "id": {
+                "shape": "S7"
+              },
               "data": {
                 "type": "structure",
                 "members": {
@@ -441,13 +562,17 @@
                   "artifactCredentials": {
                     "shape": "S2f"
                   },
-                  "continuationToken": {},
+                  "continuationToken": {
+                    "shape": "S2j"
+                  },
                   "encryptionKey": {
                     "shape": "S11"
                   }
                 }
               },
-              "nonce": {}
+              "nonce": {
+                "shape": "S3"
+              }
             }
           }
         }
@@ -457,8 +582,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "actionOwnerFilter": {},
-          "nextToken": {}
+          "actionOwnerFilter": {
+            "shape": "St"
+          },
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       },
       "output": {
@@ -473,7 +602,9 @@
               "shape": "Sr"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       }
     },
@@ -484,11 +615,15 @@
           "pipelineName"
         ],
         "members": {
-          "pipelineName": {},
-          "maxResults": {
-            "type": "integer"
+          "pipelineName": {
+            "shape": "Sw"
           },
-          "nextToken": {}
+          "maxResults": {
+            "shape": "S3v"
+          },
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       },
       "output": {
@@ -499,8 +634,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "pipelineExecutionId": {},
-                "status": {},
+                "pipelineExecutionId": {
+                  "shape": "S2r"
+                },
+                "status": {
+                  "shape": "S2u"
+                },
                 "startTime": {
                   "type": "timestamp"
                 },
@@ -515,17 +654,27 @@
                       "actionName"
                     ],
                     "members": {
-                      "actionName": {},
-                      "revisionId": {},
-                      "revisionSummary": {},
-                      "revisionUrl": {}
+                      "actionName": {
+                        "shape": "S1d"
+                      },
+                      "revisionId": {
+                        "shape": "S29"
+                      },
+                      "revisionSummary": {
+                        "shape": "S2y"
+                      },
+                      "revisionUrl": {
+                        "shape": "Sf"
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       }
     },
@@ -533,7 +682,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       },
       "output": {
@@ -544,9 +695,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {},
+                "name": {
+                  "shape": "Sw"
+                },
                 "version": {
-                  "type": "integer"
+                  "shape": "S1m"
                 },
                 "created": {
                   "type": "timestamp"
@@ -557,7 +710,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3r"
+          }
         }
       }
     },
@@ -565,9 +720,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3r"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S3v"
           }
         }
       },
@@ -580,7 +737,9 @@
               "shape": "S48"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3r"
+          }
         }
       }
     },
@@ -595,12 +754,21 @@
             "shape": "Ss"
           },
           "maxBatchSize": {
-            "type": "integer"
+            "shape": "S4o"
           },
           "queryParam": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "Sj"
+            },
+            "value": {
+              "type": "string",
+              "max": 50,
+              "min": 1,
+              "pattern": "[a-zA-Z0-9_-]+"
+            },
+            "max": 1,
+            "min": 0
           }
         }
       },
@@ -612,12 +780,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {},
+                "id": {
+                  "shape": "S2"
+                },
                 "data": {
                   "shape": "S22"
                 },
-                "nonce": {},
-                "accountId": {}
+                "nonce": {
+                  "shape": "S3"
+                },
+                "accountId": {
+                  "shape": "S2k"
+                }
               }
             }
           }
@@ -635,7 +809,7 @@
             "shape": "Ss"
           },
           "maxBatchSize": {
-            "type": "integer"
+            "shape": "S4o"
           }
         }
       },
@@ -647,8 +821,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "clientId": {},
-                "jobId": {}
+                "clientId": {
+                  "type": "string",
+                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+                },
+                "jobId": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -665,9 +844,15 @@
           "actionRevision"
         ],
         "members": {
-          "pipelineName": {},
-          "stageName": {},
-          "actionName": {},
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "stageName": {
+            "shape": "S16"
+          },
+          "actionName": {
+            "shape": "S1d"
+          },
           "actionRevision": {
             "shape": "S39"
           }
@@ -679,7 +864,9 @@
           "newRevision": {
             "type": "boolean"
           },
-          "pipelineExecutionId": {}
+          "pipelineExecutionId": {
+            "shape": "S2r"
+          }
         }
       }
     },
@@ -694,9 +881,15 @@
           "token"
         ],
         "members": {
-          "pipelineName": {},
-          "stageName": {},
-          "actionName": {},
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "stageName": {
+            "shape": "S16"
+          },
+          "actionName": {
+            "shape": "S1d"
+          },
           "result": {
             "type": "structure",
             "required": [
@@ -704,11 +897,24 @@
               "status"
             ],
             "members": {
-              "summary": {},
-              "status": {}
+              "summary": {
+                "type": "string",
+                "max": 512,
+                "min": 0
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "Approved",
+                  "Rejected"
+                ]
+              }
             }
           },
-          "token": {}
+          "token": {
+            "type": "string",
+            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          }
         }
       },
       "output": {
@@ -728,7 +934,9 @@
           "failureDetails"
         ],
         "members": {
-          "jobId": {},
+          "jobId": {
+            "shape": "S2"
+          },
           "failureDetails": {
             "shape": "S58"
           }
@@ -742,11 +950,15 @@
           "jobId"
         ],
         "members": {
-          "jobId": {},
+          "jobId": {
+            "shape": "S2"
+          },
           "currentRevision": {
             "shape": "S5b"
           },
-          "continuationToken": {},
+          "continuationToken": {
+            "shape": "S2j"
+          },
           "executionDetails": {
             "shape": "S5d"
           }
@@ -762,8 +974,12 @@
           "failureDetails"
         ],
         "members": {
-          "jobId": {},
-          "clientToken": {},
+          "jobId": {
+            "shape": "S7"
+          },
+          "clientToken": {
+            "shape": "S8"
+          },
           "failureDetails": {
             "shape": "S58"
           }
@@ -778,12 +994,18 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {},
-          "clientToken": {},
+          "jobId": {
+            "shape": "S7"
+          },
+          "clientToken": {
+            "shape": "S8"
+          },
           "currentRevision": {
             "shape": "S5b"
           },
-          "continuationToken": {},
+          "continuationToken": {
+            "shape": "S2j"
+          },
           "executionDetails": {
             "shape": "S5d"
           }
@@ -815,7 +1037,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "webhookName": {}
+          "webhookName": {
+            "shape": "S1r"
+          }
         }
       },
       "output": {
@@ -833,16 +1057,29 @@
           "retryMode"
         ],
         "members": {
-          "pipelineName": {},
-          "stageName": {},
-          "pipelineExecutionId": {},
-          "retryMode": {}
+          "pipelineName": {
+            "shape": "Sw"
+          },
+          "stageName": {
+            "shape": "S16"
+          },
+          "pipelineExecutionId": {
+            "shape": "S2r"
+          },
+          "retryMode": {
+            "type": "string",
+            "enum": [
+              "FAILED_ACTIONS"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineExecutionId": {}
+          "pipelineExecutionId": {
+            "shape": "S2r"
+          }
         }
       }
     },
@@ -853,13 +1090,17 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineExecutionId": {}
+          "pipelineExecutionId": {
+            "shape": "S2r"
+          }
         }
       }
     },
@@ -886,14 +1127,86 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "S3": {
+      "type": "string",
+      "max": 50,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "enum": [
+        "Created",
+        "Queued",
+        "Dispatched",
+        "InProgress",
+        "TimedOut",
+        "Succeeded",
+        "Failed"
+      ]
+    },
+    "S7": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
+    "S8": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "Sb": {
+      "type": "string",
+      "enum": [
+        "Source",
+        "Build",
+        "Deploy",
+        "Test",
+        "Invoke",
+        "Approval"
+      ]
+    },
+    "Sc": {
+      "type": "string",
+      "max": 25,
+      "min": 1,
+      "pattern": "[0-9A-Za-z_-]+"
+    },
+    "Sd": {
+      "type": "string",
+      "max": 9,
+      "min": 1,
+      "pattern": "[0-9A-Za-z_-]+"
+    },
     "Se": {
       "type": "structure",
       "members": {
-        "thirdPartyConfigurationUrl": {},
-        "entityUrlTemplate": {},
-        "executionUrlTemplate": {},
-        "revisionUrlTemplate": {}
+        "thirdPartyConfigurationUrl": {
+          "shape": "Sf"
+        },
+        "entityUrlTemplate": {
+          "shape": "Sg"
+        },
+        "executionUrlTemplate": {
+          "shape": "Sg"
+        },
+        "revisionUrlTemplate": {
+          "shape": "Sg"
+        }
       }
+    },
+    "Sf": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "Sg": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
     },
     "Sh": {
       "type": "list",
@@ -906,7 +1219,9 @@
           "secret"
         ],
         "members": {
-          "name": {},
+          "name": {
+            "shape": "Sj"
+          },
           "required": {
             "type": "boolean"
           },
@@ -919,10 +1234,27 @@
           "queryable": {
             "type": "boolean"
           },
-          "description": {},
-          "type": {}
+          "description": {
+            "type": "string",
+            "max": 160,
+            "min": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "String",
+              "Number",
+              "Boolean"
+            ]
+          }
         }
-      }
+      },
+      "max": 10
+    },
+    "Sj": {
+      "type": "string",
+      "max": 50,
+      "min": 1
     },
     "Sn": {
       "type": "structure",
@@ -932,10 +1264,14 @@
       ],
       "members": {
         "minimumCount": {
-          "type": "integer"
+          "type": "integer",
+          "max": 5,
+          "min": 0
         },
         "maximumCount": {
-          "type": "integer"
+          "type": "integer",
+          "max": 5,
+          "min": 0
         }
       }
     },
@@ -973,11 +1309,27 @@
         "version"
       ],
       "members": {
-        "category": {},
-        "owner": {},
-        "provider": {},
-        "version": {}
+        "category": {
+          "shape": "Sb"
+        },
+        "owner": {
+          "shape": "St"
+        },
+        "provider": {
+          "shape": "Sc"
+        },
+        "version": {
+          "shape": "Sd"
+        }
       }
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "AWS",
+        "ThirdParty",
+        "Custom"
+      ]
     },
     "Sv": {
       "type": "structure",
@@ -988,8 +1340,12 @@
         "stages"
       ],
       "members": {
-        "name": {},
-        "roleArn": {},
+        "name": {
+          "shape": "Sw"
+        },
+        "roleArn": {
+          "shape": "Sx"
+        },
         "artifactStore": {
           "type": "structure",
           "required": [
@@ -997,8 +1353,18 @@
             "location"
           ],
           "members": {
-            "type": {},
-            "location": {},
+            "type": {
+              "type": "string",
+              "enum": [
+                "S3"
+              ]
+            },
+            "location": {
+              "type": "string",
+              "max": 63,
+              "min": 3,
+              "pattern": "[a-zA-Z0-9\\-\\.]+"
+            },
             "encryptionKey": {
               "shape": "S11"
             }
@@ -1013,7 +1379,9 @@
               "actions"
             ],
             "members": {
-              "name": {},
+              "name": {
+                "shape": "S16"
+              },
               "blockers": {
                 "type": "list",
                 "member": {
@@ -1023,8 +1391,17 @@
                     "type"
                   ],
                   "members": {
-                    "name": {},
-                    "type": {}
+                    "name": {
+                      "type": "string",
+                      "max": 100,
+                      "min": 1
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "Schedule"
+                      ]
+                    }
                   }
                 }
               },
@@ -1037,12 +1414,16 @@
                     "actionTypeId"
                   ],
                   "members": {
-                    "name": {},
+                    "name": {
+                      "shape": "S1d"
+                    },
                     "actionTypeId": {
                       "shape": "Ss"
                     },
                     "runOrder": {
-                      "type": "integer"
+                      "type": "integer",
+                      "max": 999,
+                      "min": 1
                     },
                     "configuration": {
                       "shape": "S1f"
@@ -1055,7 +1436,9 @@
                           "name"
                         ],
                         "members": {
-                          "name": {}
+                          "name": {
+                            "shape": "S1j"
+                          }
                         }
                       }
                     },
@@ -1067,11 +1450,15 @@
                           "name"
                         ],
                         "members": {
-                          "name": {}
+                          "name": {
+                            "shape": "S1j"
+                          }
                         }
                       }
                     },
-                    "roleArn": {}
+                    "roleArn": {
+                      "shape": "Sx"
+                    }
                   }
                 }
               }
@@ -1079,9 +1466,20 @@
           }
         },
         "version": {
-          "type": "integer"
+          "shape": "S1m"
         }
       }
+    },
+    "Sw": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[A-Za-z0-9.@\\-_]+"
+    },
+    "Sx": {
+      "type": "string",
+      "max": 1024,
+      "pattern": "arn:aws(-[\\w]+)*:iam::[0-9]{12}:role/.*"
     },
     "S11": {
       "type": "structure",
@@ -1090,14 +1488,70 @@
         "type"
       ],
       "members": {
-        "id": {},
-        "type": {}
+        "id": {
+          "type": "string",
+          "max": 100,
+          "min": 1
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "KMS"
+          ]
+        }
       }
+    },
+    "S16": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[A-Za-z0-9.@\\-_]+"
+    },
+    "S1d": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[A-Za-z0-9.@\\-_]+"
     },
     "S1f": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "Sj"
+      },
+      "value": {
+        "type": "string",
+        "max": 1000,
+        "min": 1
+      }
+    },
+    "S1j": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_\\-]+"
+    },
+    "S1m": {
+      "type": "integer",
+      "min": 1
+    },
+    "S1r": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[A-Za-z0-9.@\\-_]+"
+    },
+    "S1w": {
+      "type": "string",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ]
+    },
+    "S1x": {
+      "type": "string",
+      "max": 300,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9!@ \\(\\)\\.\\*\\?\\-]+"
     },
     "S22": {
       "type": "structure",
@@ -1120,7 +1574,9 @@
         "artifactCredentials": {
           "shape": "S2f"
         },
-        "continuationToken": {},
+        "continuationToken": {
+          "shape": "S2j"
+        },
         "encryptionKey": {
           "shape": "S11"
         }
@@ -1137,17 +1593,23 @@
     "S24": {
       "type": "structure",
       "members": {
-        "pipelineName": {},
+        "pipelineName": {
+          "shape": "Sw"
+        },
         "stage": {
           "type": "structure",
           "members": {
-            "name": {}
+            "name": {
+              "shape": "S16"
+            }
           }
         },
         "action": {
           "type": "structure",
           "members": {
-            "name": {}
+            "name": {
+              "shape": "S1d"
+            }
           }
         }
       }
@@ -1157,12 +1619,21 @@
       "member": {
         "type": "structure",
         "members": {
-          "name": {},
-          "revision": {},
+          "name": {
+            "shape": "S1j"
+          },
+          "revision": {
+            "shape": "S29"
+          },
           "location": {
             "type": "structure",
             "members": {
-              "type": {},
+              "type": {
+                "type": "string",
+                "enum": [
+                  "S3"
+                ]
+              },
               "s3Location": {
                 "type": "structure",
                 "required": [
@@ -1179,6 +1650,11 @@
         }
       }
     },
+    "S29": {
+      "type": "string",
+      "max": 1500,
+      "min": 1
+    },
     "S2f": {
       "type": "structure",
       "required": [
@@ -1193,6 +1669,38 @@
       },
       "sensitive": true
     },
+    "S2j": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S2k": {
+      "type": "string",
+      "pattern": "[0-9]{12}"
+    },
+    "S2r": {
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "S2u": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Superseded",
+        "Failed"
+      ]
+    },
+    "S2x": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S2y": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
     "S39": {
       "type": "structure",
       "required": [
@@ -1201,12 +1709,46 @@
         "created"
       ],
       "members": {
-        "revisionId": {},
-        "revisionChangeId": {},
+        "revisionId": {
+          "shape": "S29"
+        },
+        "revisionChangeId": {
+          "shape": "S2x"
+        },
         "created": {
           "type": "timestamp"
         }
       }
+    },
+    "S3c": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S3f": {
+      "type": "string",
+      "max": 1500,
+      "min": 1
+    },
+    "S3g": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
+    },
+    "S3j": {
+      "type": "string",
+      "max": 5000,
+      "min": 1
+    },
+    "S3r": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S3v": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S48": {
       "type": "structure",
@@ -1218,7 +1760,11 @@
         "definition": {
           "shape": "S49"
         },
-        "url": {},
+        "url": {
+          "type": "string",
+          "max": 1000,
+          "min": 1
+        },
         "errorMessage": {},
         "errorCode": {},
         "lastTriggered": {
@@ -1238,9 +1784,15 @@
         "authenticationConfiguration"
       ],
       "members": {
-        "name": {},
-        "targetPipeline": {},
-        "targetAction": {},
+        "name": {
+          "shape": "S1r"
+        },
+        "targetPipeline": {
+          "shape": "Sw"
+        },
+        "targetAction": {
+          "shape": "S1d"
+        },
         "filters": {
           "type": "list",
           "member": {
@@ -1249,20 +1801,48 @@
               "jsonPath"
             ],
             "members": {
-              "jsonPath": {},
-              "matchEquals": {}
+              "jsonPath": {
+                "type": "string",
+                "max": 150,
+                "min": 1
+              },
+              "matchEquals": {
+                "type": "string",
+                "max": 150,
+                "min": 1
+              }
             }
-          }
+          },
+          "max": 5
         },
-        "authentication": {},
+        "authentication": {
+          "type": "string",
+          "enum": [
+            "GITHUB_HMAC",
+            "IP",
+            "UNAUTHENTICATED"
+          ]
+        },
         "authenticationConfiguration": {
           "type": "structure",
           "members": {
-            "AllowedIPRange": {},
-            "SecretToken": {}
+            "AllowedIPRange": {
+              "type": "string",
+              "max": 100,
+              "min": 1
+            },
+            "SecretToken": {
+              "type": "string",
+              "max": 100,
+              "min": 1
+            }
           }
         }
       }
+    },
+    "S4o": {
+      "type": "integer",
+      "min": 1
     },
     "S58": {
       "type": "structure",
@@ -1271,9 +1851,23 @@
         "message"
       ],
       "members": {
-        "type": {},
-        "message": {},
-        "externalExecutionId": {}
+        "type": {
+          "type": "string",
+          "enum": [
+            "JobFailed",
+            "ConfigurationError",
+            "PermissionError",
+            "RevisionOutOfSync",
+            "RevisionUnavailable",
+            "SystemUnavailable"
+          ]
+        },
+        "message": {
+          "shape": "S3j"
+        },
+        "externalExecutionId": {
+          "shape": "S3f"
+        }
       }
     },
     "S5b": {
@@ -1283,21 +1877,31 @@
         "changeIdentifier"
       ],
       "members": {
-        "revision": {},
-        "changeIdentifier": {},
+        "revision": {
+          "shape": "S29"
+        },
+        "changeIdentifier": {
+          "shape": "S2x"
+        },
         "created": {
           "type": "timestamp"
         },
-        "revisionSummary": {}
+        "revisionSummary": {
+          "shape": "S2y"
+        }
       }
     },
     "S5d": {
       "type": "structure",
       "members": {
-        "summary": {},
-        "externalExecutionId": {},
+        "summary": {
+          "shape": "S3c"
+        },
+        "externalExecutionId": {
+          "shape": "S3f"
+        },
         "percentComplete": {
-          "type": "integer"
+          "shape": "S3g"
         }
       }
     }

--- a/apis/codestar-2017-04-19.min.json
+++ b/apis/codestar-2017-04-19.min.json
@@ -22,10 +22,18 @@
           "projectRole"
         ],
         "members": {
-          "projectId": {},
-          "clientRequestToken": {},
-          "userArn": {},
-          "projectRole": {},
+          "projectId": {
+            "shape": "S2"
+          },
+          "clientRequestToken": {
+            "shape": "S3"
+          },
+          "userArn": {
+            "shape": "S4"
+          },
+          "projectRole": {
+            "shape": "S5"
+          },
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -34,7 +42,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "clientRequestToken": {}
+          "clientRequestToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -49,11 +59,15 @@
           "name": {
             "shape": "S9"
           },
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "description": {
             "shape": "Sa"
           },
-          "clientRequestToken": {}
+          "clientRequestToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -63,10 +77,18 @@
           "arn"
         ],
         "members": {
-          "id": {},
-          "arn": {},
-          "clientRequestToken": {},
-          "projectTemplateId": {}
+          "id": {
+            "shape": "S2"
+          },
+          "arn": {
+            "shape": "Sc"
+          },
+          "clientRequestToken": {
+            "shape": "S3"
+          },
+          "projectTemplateId": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -79,12 +101,18 @@
           "emailAddress"
         ],
         "members": {
-          "userArn": {},
-          "displayName": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "displayName": {
+            "shape": "Sf"
+          },
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {}
+          "sshPublicKey": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -93,12 +121,18 @@
           "userArn"
         ],
         "members": {
-          "userArn": {},
-          "displayName": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "displayName": {
+            "shape": "Sf"
+          },
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {},
+          "sshPublicKey": {
+            "shape": "Sh"
+          },
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -115,8 +149,12 @@
           "id"
         ],
         "members": {
-          "id": {},
-          "clientRequestToken": {},
+          "id": {
+            "shape": "S2"
+          },
+          "clientRequestToken": {
+            "shape": "S3"
+          },
           "deleteStack": {
             "type": "boolean"
           }
@@ -125,8 +163,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "stackId": {},
-          "projectArn": {}
+          "stackId": {
+            "shape": "So"
+          },
+          "projectArn": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -137,7 +179,9 @@
           "userArn"
         ],
         "members": {
-          "userArn": {}
+          "userArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -146,7 +190,9 @@
           "userArn"
         ],
         "members": {
-          "userArn": {}
+          "userArn": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -157,7 +203,9 @@
           "id"
         ],
         "members": {
-          "id": {}
+          "id": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -166,17 +214,27 @@
           "name": {
             "shape": "S9"
           },
-          "id": {},
-          "arn": {},
+          "id": {
+            "shape": "S2"
+          },
+          "arn": {
+            "shape": "Sc"
+          },
           "description": {
             "shape": "Sa"
           },
-          "clientRequestToken": {},
+          "clientRequestToken": {
+            "shape": "S3"
+          },
           "createdTimeStamp": {
             "type": "timestamp"
           },
-          "stackId": {},
-          "projectTemplateId": {}
+          "stackId": {
+            "shape": "So"
+          },
+          "projectTemplateId": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -187,7 +245,9 @@
           "userArn"
         ],
         "members": {
-          "userArn": {}
+          "userArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -198,12 +258,18 @@
           "lastModifiedTimestamp"
         ],
         "members": {
-          "userArn": {},
-          "displayName": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "displayName": {
+            "shape": "Sf"
+          },
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {},
+          "sshPublicKey": {
+            "shape": "Sh"
+          },
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -221,8 +287,12 @@
           "userArn"
         ],
         "members": {
-          "projectId": {},
-          "userArn": {}
+          "projectId": {
+            "shape": "S2"
+          },
+          "userArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -234,9 +304,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {},
+          "nextToken": {
+            "shape": "Sy"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sz"
           }
         }
       },
@@ -251,12 +323,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "projectId": {},
-                "projectArn": {}
+                "projectId": {
+                  "shape": "S2"
+                },
+                "projectArn": {
+                  "shape": "Sc"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -267,10 +345,14 @@
           "projectId"
         ],
         "members": {
-          "projectId": {},
-          "nextToken": {},
+          "projectId": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "Sy"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sz"
           }
         }
       },
@@ -285,11 +367,17 @@
                 "id"
               ],
               "members": {
-                "id": {}
+                "id": {
+                  "type": "string",
+                  "min": 11,
+                  "pattern": "^arn\\:aws\\:\\S.*\\:.*"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -300,10 +388,14 @@
           "id"
         ],
         "members": {
-          "id": {},
-          "nextToken": {},
+          "id": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "Sy"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sz"
           }
         }
       },
@@ -313,7 +405,9 @@
           "tags": {
             "shape": "S1a"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -324,10 +418,14 @@
           "projectId"
         ],
         "members": {
-          "projectId": {},
-          "nextToken": {},
+          "projectId": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "Sy"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sz"
           }
         }
       },
@@ -346,15 +444,21 @@
                 "projectRole"
               ],
               "members": {
-                "userArn": {},
-                "projectRole": {},
+                "userArn": {
+                  "shape": "S4"
+                },
+                "projectRole": {
+                  "shape": "S5"
+                },
                 "remoteAccessAllowed": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -362,9 +466,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {},
+          "nextToken": {
+            "shape": "Sy"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sz"
           }
         }
       },
@@ -379,16 +485,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "userArn": {},
-                "displayName": {},
+                "userArn": {
+                  "shape": "S4"
+                },
+                "displayName": {
+                  "shape": "Sf"
+                },
                 "emailAddress": {
                   "shape": "Sg"
                 },
-                "sshPublicKey": {}
+                "sshPublicKey": {
+                  "shape": "Sh"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -400,7 +514,9 @@
           "tags"
         ],
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "tags": {
             "shape": "S1a"
           }
@@ -423,10 +539,14 @@
           "tags"
         ],
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "tags": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1b"
+            }
           }
         }
       },
@@ -442,7 +562,9 @@
           "id"
         ],
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "name": {
             "shape": "S9"
           },
@@ -464,9 +586,15 @@
           "userArn"
         ],
         "members": {
-          "projectId": {},
-          "userArn": {},
-          "projectRole": {},
+          "projectId": {
+            "shape": "S2"
+          },
+          "userArn": {
+            "shape": "S4"
+          },
+          "projectRole": {
+            "shape": "S5"
+          },
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -475,8 +603,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "userArn": {},
-          "projectRole": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "projectRole": {
+            "shape": "S5"
+          },
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -490,12 +622,18 @@
           "userArn"
         ],
         "members": {
-          "userArn": {},
-          "displayName": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "displayName": {
+            "shape": "Sf"
+          },
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {}
+          "sshPublicKey": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -504,12 +642,18 @@
           "userArn"
         ],
         "members": {
-          "userArn": {},
-          "displayName": {},
+          "userArn": {
+            "shape": "S4"
+          },
+          "displayName": {
+            "shape": "Sf"
+          },
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {},
+          "sshPublicKey": {
+            "shape": "Sh"
+          },
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -521,22 +665,99 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 15,
+      "min": 2,
+      "pattern": "^[a-z][a-z0-9-]+$"
+    },
+    "S3": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^[\\w:/-]+$"
+    },
+    "S4": {
+      "type": "string",
+      "max": 95,
+      "min": 32,
+      "pattern": "^arn:aws:iam::\\d{12}:user(?:(\\u002F)|(\\u002F[\\u0021-\\u007E]+\\u002F))[\\w+=,.@-]+$"
+    },
+    "S5": {
+      "type": "string",
+      "pattern": "^(Owner|Viewer|Contributor)$"
+    },
     "S9": {
       "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^\\S(.*\\S)?$",
       "sensitive": true
     },
     "Sa": {
       "type": "string",
+      "max": 1024,
+      "pattern": "^$|^\\S(.*\\S)?$",
       "sensitive": true
+    },
+    "Sc": {
+      "type": "string",
+      "pattern": "^arn:aws[^:\\s]*:codestar:[^:\\s]+:[0-9]{12}:project\\/[a-z]([a-z0-9|-])+$"
+    },
+    "Sd": {
+      "type": "string",
+      "min": 1,
+      "pattern": "^arn:aws[^:\\s]{0,5}:codestar:[^:\\s]+::project-template\\/[a-z0-9-]+$"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^\\S(.*\\S)?$"
     },
     "Sg": {
       "type": "string",
+      "max": 128,
+      "min": 3,
+      "pattern": "^[\\w-.+]+@[\\w-.+]+$",
       "sensitive": true
+    },
+    "Sh": {
+      "type": "string",
+      "max": 16384,
+      "pattern": "^[\\t\\r\\n\\u0020-\\u00FF]*$"
+    },
+    "So": {
+      "type": "string",
+      "pattern": "^arn:aws[^:\\s]*:cloudformation:[^:\\s]+:[0-9]{12}:stack\\/[^:\\s]+\\/[^:\\s]+$"
+    },
+    "Sy": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "^[\\w/+=]+$"
+    },
+    "Sz": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S1a": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S1b"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
+    },
+    "S1b": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     }
   }
 }

--- a/apis/cognito-identity-2014-06-30.min.json
+++ b/apis/cognito-identity-2014-06-30.min.json
@@ -20,14 +20,18 @@
           "AllowUnauthenticatedIdentities"
         ],
         "members": {
-          "IdentityPoolName": {},
+          "IdentityPoolName": {
+            "shape": "S2"
+          },
           "AllowUnauthenticatedIdentities": {
             "type": "boolean"
           },
           "SupportedLoginProviders": {
             "shape": "S4"
           },
-          "DeveloperProviderName": {},
+          "DeveloperProviderName": {
+            "shape": "S7"
+          },
           "OpenIdConnectProviderARNs": {
             "shape": "S8"
           },
@@ -52,7 +56,11 @@
         "members": {
           "IdentityIdsToDelete": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sk"
+            },
+            "max": 60,
+            "min": 1
           }
         }
       },
@@ -64,10 +72,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "IdentityId": {},
-                "ErrorCode": {}
+                "IdentityId": {
+                  "shape": "Sk"
+                },
+                "ErrorCode": {
+                  "type": "string",
+                  "enum": [
+                    "AccessDenied",
+                    "InternalServerError"
+                  ]
+                }
               }
-            }
+            },
+            "max": 60
           }
         }
       }
@@ -79,7 +96,9 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {}
+          "IdentityPoolId": {
+            "shape": "Sh"
+          }
         }
       }
     },
@@ -90,7 +109,9 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {}
+          "IdentityId": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -104,7 +125,9 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {}
+          "IdentityPoolId": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -118,17 +141,23 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Logins": {
             "shape": "Sw"
           },
-          "CustomRoleArn": {}
+          "CustomRoleArn": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Credentials": {
             "type": "structure",
             "members": {
@@ -150,8 +179,15 @@
           "IdentityPoolId"
         ],
         "members": {
-          "AccountId": {},
-          "IdentityPoolId": {},
+          "AccountId": {
+            "type": "string",
+            "max": 15,
+            "min": 1,
+            "pattern": "\\d+"
+          },
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
           "Logins": {
             "shape": "Sw"
           }
@@ -160,7 +196,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {}
+          "IdentityId": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -171,13 +209,17 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {}
+          "IdentityPoolId": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
           "Roles": {
             "shape": "S18"
           },
@@ -194,7 +236,9 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Logins": {
             "shape": "Sw"
           }
@@ -203,7 +247,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Token": {}
         }
       }
@@ -216,20 +262,28 @@
           "Logins"
         ],
         "members": {
-          "IdentityPoolId": {},
-          "IdentityId": {},
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Logins": {
             "shape": "Sw"
           },
           "TokenDuration": {
-            "type": "long"
+            "type": "long",
+            "max": 86400,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Token": {}
         }
       }
@@ -242,11 +296,15 @@
           "MaxResults"
         ],
         "members": {
-          "IdentityPoolId": {},
-          "MaxResults": {
-            "type": "integer"
+          "IdentityPoolId": {
+            "shape": "Sh"
           },
-          "NextToken": {},
+          "MaxResults": {
+            "shape": "S1r"
+          },
+          "NextToken": {
+            "shape": "S1s"
+          },
           "HideDisabled": {
             "type": "boolean"
           }
@@ -255,14 +313,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
           "Identities": {
             "type": "list",
             "member": {
               "shape": "Sr"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1s"
+          }
         }
       }
     },
@@ -274,9 +336,11 @@
         ],
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1r"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -287,12 +351,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "IdentityPoolId": {},
-                "IdentityPoolName": {}
+                "IdentityPoolId": {
+                  "shape": "Sh"
+                },
+                "IdentityPoolName": {
+                  "shape": "S2"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1s"
+          }
         }
       }
     },
@@ -303,24 +373,38 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {},
-          "IdentityId": {},
-          "DeveloperUserIdentifier": {},
-          "MaxResults": {
-            "type": "integer"
+          "IdentityPoolId": {
+            "shape": "Sh"
           },
-          "NextToken": {}
+          "IdentityId": {
+            "shape": "Sk"
+          },
+          "DeveloperUserIdentifier": {
+            "shape": "S21"
+          },
+          "MaxResults": {
+            "shape": "S1r"
+          },
+          "NextToken": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "DeveloperUserIdentifierList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S21"
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1s"
+          }
         }
       }
     },
@@ -334,16 +418,26 @@
           "IdentityPoolId"
         ],
         "members": {
-          "SourceUserIdentifier": {},
-          "DestinationUserIdentifier": {},
-          "DeveloperProviderName": {},
-          "IdentityPoolId": {}
+          "SourceUserIdentifier": {
+            "shape": "S21"
+          },
+          "DestinationUserIdentifier": {
+            "shape": "S21"
+          },
+          "DeveloperProviderName": {
+            "shape": "S7"
+          },
+          "IdentityPoolId": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {}
+          "IdentityId": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -355,7 +449,9 @@
           "Roles"
         ],
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
           "Roles": {
             "shape": "S18"
           },
@@ -375,10 +471,18 @@
           "DeveloperUserIdentifier"
         ],
         "members": {
-          "IdentityId": {},
-          "IdentityPoolId": {},
-          "DeveloperProviderName": {},
-          "DeveloperUserIdentifier": {}
+          "IdentityId": {
+            "shape": "Sk"
+          },
+          "IdentityPoolId": {
+            "shape": "Sh"
+          },
+          "DeveloperProviderName": {
+            "shape": "S7"
+          },
+          "DeveloperUserIdentifier": {
+            "shape": "S21"
+          }
         }
       }
     },
@@ -391,7 +495,9 @@
           "LoginsToRemove"
         ],
         "members": {
-          "IdentityId": {},
+          "IdentityId": {
+            "shape": "Sk"
+          },
           "Logins": {
             "shape": "Sw"
           },
@@ -411,22 +517,64 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w ]+"
+    },
     "S4": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S5"
+      },
+      "value": {
+        "type": "string",
+        "max": 128,
+        "min": 1,
+        "pattern": "[\\w.;_/-]+"
+      },
+      "max": 10
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w._-]+"
     },
     "S8": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S9"
+      }
+    },
+    "S9": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
     },
     "Sa": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ProviderName": {},
-          "ClientId": {},
+          "ProviderName": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[\\w._:/-]+"
+          },
+          "ClientId": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[\\w_]+"
+          },
           "ServerSideTokenCheck": {
             "type": "boolean"
           }
@@ -435,7 +583,9 @@
     },
     "Sf": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S9"
+      }
     },
     "Sg": {
       "type": "structure",
@@ -445,15 +595,21 @@
         "AllowUnauthenticatedIdentities"
       ],
       "members": {
-        "IdentityPoolId": {},
-        "IdentityPoolName": {},
+        "IdentityPoolId": {
+          "shape": "Sh"
+        },
+        "IdentityPoolName": {
+          "shape": "S2"
+        },
         "AllowUnauthenticatedIdentities": {
           "type": "boolean"
         },
         "SupportedLoginProviders": {
           "shape": "S4"
         },
-        "DeveloperProviderName": {},
+        "DeveloperProviderName": {
+          "shape": "S7"
+        },
         "OpenIdConnectProviderARNs": {
           "shape": "S8"
         },
@@ -465,10 +621,24 @@
         }
       }
     },
+    "Sh": {
+      "type": "string",
+      "max": 55,
+      "min": 1,
+      "pattern": "[\\w-]+:[0-9a-f-]+"
+    },
+    "Sk": {
+      "type": "string",
+      "max": 55,
+      "min": 1,
+      "pattern": "[\\w-]+:[0-9a-f-]+"
+    },
     "Sr": {
       "type": "structure",
       "members": {
-        "IdentityId": {},
+        "IdentityId": {
+          "shape": "Sk"
+        },
         "Logins": {
           "shape": "Ss"
         },
@@ -482,29 +652,58 @@
     },
     "Ss": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5"
+      }
     },
     "Sw": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S5"
+      },
+      "value": {
+        "type": "string",
+        "max": 50000,
+        "min": 1
+      },
+      "max": 10
     },
     "S18": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "pattern": "(un)?authenticated"
+      },
+      "value": {
+        "shape": "S9"
+      },
+      "max": 2
     },
     "S1a": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S5"
+      },
       "value": {
         "type": "structure",
         "required": [
           "Type"
         ],
         "members": {
-          "Type": {},
-          "AmbiguousRoleResolution": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "Token",
+              "Rules"
+            ]
+          },
+          "AmbiguousRoleResolution": {
+            "type": "string",
+            "enum": [
+              "AuthenticatedRole",
+              "Deny"
+            ]
+          },
           "RulesConfiguration": {
             "type": "structure",
             "required": [
@@ -522,17 +721,54 @@
                     "RoleARN"
                   ],
                   "members": {
-                    "Claim": {},
-                    "MatchType": {},
-                    "Value": {},
-                    "RoleARN": {}
+                    "Claim": {
+                      "type": "string",
+                      "max": 64,
+                      "min": 1,
+                      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+                    },
+                    "MatchType": {
+                      "type": "string",
+                      "enum": [
+                        "Equals",
+                        "Contains",
+                        "StartsWith",
+                        "NotEqual"
+                      ]
+                    },
+                    "Value": {
+                      "type": "string",
+                      "max": 128,
+                      "min": 1
+                    },
+                    "RoleARN": {
+                      "shape": "S9"
+                    }
                   }
-                }
+                },
+                "max": 25,
+                "min": 1
               }
             }
           }
         }
-      }
+      },
+      "max": 10
+    },
+    "S1r": {
+      "type": "integer",
+      "max": 60,
+      "min": 1
+    },
+    "S1s": {
+      "type": "string",
+      "min": 1,
+      "pattern": "[\\S]+"
+    },
+    "S21": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
     }
   }
 }

--- a/apis/cognito-idp-2016-04-18.min.json
+++ b/apis/cognito-idp-2016-04-18.min.json
@@ -20,12 +20,16 @@
           "CustomAttributes"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "CustomAttributes": {
             "type": "list",
             "member": {
               "shape": "S4"
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -43,11 +47,15 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "GroupName": {}
+          "GroupName": {
+            "shape": "Se"
+          }
         }
       }
     },
@@ -59,7 +67,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -78,7 +88,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
@@ -94,10 +106,18 @@
           "ForceAliasCreation": {
             "type": "boolean"
           },
-          "MessageAction": {},
+          "MessageAction": {
+            "type": "string",
+            "enum": [
+              "RESEND",
+              "SUPPRESS"
+            ]
+          },
           "DesiredDeliveryMediums": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sq"
+            }
           }
         }
       },
@@ -118,7 +138,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -134,7 +156,9 @@
           "UserAttributeNames"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
@@ -175,7 +199,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -194,7 +220,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -214,11 +242,15 @@
           "DeviceKey"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "DeviceKey": {}
+          "DeviceKey": {
+            "shape": "S1a"
+          }
         }
       }
     },
@@ -231,8 +263,12 @@
           "Username"
         ],
         "members": {
-          "DeviceKey": {},
-          "UserPoolId": {},
+          "DeviceKey": {
+            "shape": "S1a"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -258,7 +294,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -285,7 +323,9 @@
           "Enabled": {
             "type": "boolean"
           },
-          "UserStatus": {},
+          "UserStatus": {
+            "shape": "Su"
+          },
           "MFAOptions": {
             "shape": "Sv"
           },
@@ -305,11 +345,15 @@
           "AuthFlow"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           },
-          "AuthFlow": {},
+          "AuthFlow": {
+            "shape": "S1j"
+          },
           "AuthParameters": {
             "shape": "S1k"
           },
@@ -327,8 +371,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {},
-          "Session": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
+          "Session": {
+            "shape": "S1s"
+          },
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -369,14 +417,18 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S21"
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S22"
+          }
         }
       },
       "output": {
@@ -385,7 +437,9 @@
           "Devices": {
             "shape": "S24"
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S22"
+          }
         }
       }
     },
@@ -400,11 +454,15 @@
           "Username": {
             "shape": "Sd"
           },
-          "UserPoolId": {},
-          "Limit": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "Limit": {
+            "shape": "S21"
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -413,7 +471,9 @@
           "Groups": {
             "shape": "S28"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -425,14 +485,18 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S21"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -444,16 +508,43 @@
               "type": "structure",
               "members": {
                 "EventId": {},
-                "EventType": {},
+                "EventType": {
+                  "type": "string",
+                  "enum": [
+                    "SignIn",
+                    "SignUp",
+                    "ForgotPassword"
+                  ]
+                },
                 "CreationDate": {
                   "type": "timestamp"
                 },
-                "EventResponse": {},
+                "EventResponse": {
+                  "type": "string",
+                  "enum": [
+                    "Success",
+                    "Failure"
+                  ]
+                },
                 "EventRisk": {
                   "type": "structure",
                   "members": {
-                    "RiskDecision": {},
-                    "RiskLevel": {}
+                    "RiskDecision": {
+                      "type": "string",
+                      "enum": [
+                        "NoRisk",
+                        "AccountTakeover",
+                        "Block"
+                      ]
+                    },
+                    "RiskLevel": {
+                      "type": "string",
+                      "enum": [
+                        "Low",
+                        "Medium",
+                        "High"
+                      ]
+                    }
                   }
                 },
                 "ChallengeResponses": {
@@ -461,8 +552,20 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ChallengeName": {},
-                      "ChallengeResponse": {}
+                      "ChallengeName": {
+                        "type": "string",
+                        "enum": [
+                          "Password",
+                          "Mfa"
+                        ]
+                      },
+                      "ChallengeResponse": {
+                        "type": "string",
+                        "enum": [
+                          "Success",
+                          "Failure"
+                        ]
+                      }
                     }
                   }
                 },
@@ -483,7 +586,9 @@
                     "Provider"
                   ],
                   "members": {
-                    "FeedbackValue": {},
+                    "FeedbackValue": {
+                      "shape": "S2s"
+                    },
                     "Provider": {},
                     "FeedbackDate": {
                       "type": "timestamp"
@@ -493,7 +598,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -506,11 +613,15 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "GroupName": {}
+          "GroupName": {
+            "shape": "Se"
+          }
         }
       }
     },
@@ -522,7 +633,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -542,15 +655,21 @@
           "ChallengeName"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           },
-          "ChallengeName": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
           "ChallengeResponses": {
             "shape": "S2x"
           },
-          "Session": {},
+          "Session": {
+            "shape": "S1s"
+          },
           "AnalyticsMetadata": {
             "shape": "S1m"
           },
@@ -562,8 +681,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {},
-          "Session": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
+          "Session": {
+            "shape": "S1s"
+          },
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -590,7 +713,9 @@
           "Username": {
             "shape": "Sd"
           },
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -607,7 +732,9 @@
           "MFAOptions"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
@@ -631,12 +758,18 @@
           "FeedbackValue"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "EventId": {},
-          "FeedbackValue": {}
+          "EventId": {
+            "shape": "S36"
+          },
+          "FeedbackValue": {
+            "shape": "S2s"
+          }
         }
       },
       "output": {
@@ -653,12 +786,18 @@
           "DeviceKey"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "DeviceKey": {},
-          "DeviceRememberedStatus": {}
+          "DeviceKey": {
+            "shape": "S1a"
+          },
+          "DeviceRememberedStatus": {
+            "shape": "S39"
+          }
         }
       },
       "output": {
@@ -675,7 +814,9 @@
           "UserAttributes"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
@@ -697,7 +838,9 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           }
@@ -715,7 +858,9 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "Session": {}
+          "Session": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -723,9 +868,13 @@
         "members": {
           "SecretCode": {
             "type": "string",
+            "min": 16,
+            "pattern": "[A-Za-z0-9]+",
             "sensitive": true
           },
-          "Session": {}
+          "Session": {
+            "shape": "S1s"
+          }
         }
       }
     },
@@ -766,7 +915,9 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {},
+          "DeviceKey": {
+            "shape": "S1a"
+          },
           "DeviceSecretVerifierConfig": {
             "type": "structure",
             "members": {
@@ -774,7 +925,11 @@
               "Salt": {}
             }
           },
-          "DeviceName": {}
+          "DeviceName": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
+          }
         }
       },
       "output": {
@@ -805,7 +960,9 @@
           "Username": {
             "shape": "Sd"
           },
-          "ConfirmationCode": {},
+          "ConfirmationCode": {
+            "shape": "S3q"
+          },
           "Password": {
             "shape": "Sm"
           },
@@ -841,7 +998,9 @@
           "Username": {
             "shape": "Sd"
           },
-          "ConfirmationCode": {},
+          "ConfirmationCode": {
+            "shape": "S3q"
+          },
           "ForceAliasCreation": {
             "type": "boolean"
           },
@@ -867,12 +1026,20 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {},
-          "UserPoolId": {},
-          "Description": {},
-          "RoleArn": {},
+          "GroupName": {
+            "shape": "Se"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S2a"
+          },
+          "RoleArn": {
+            "shape": "S2b"
+          },
           "Precedence": {
-            "type": "integer"
+            "shape": "S2c"
           }
         }
       },
@@ -895,9 +1062,18 @@
           "ProviderDetails"
         ],
         "members": {
-          "UserPoolId": {},
-          "ProviderName": {},
-          "ProviderType": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "ProviderName": {
+            "type": "string",
+            "max": 32,
+            "min": 1,
+            "pattern": "[^_][\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}][^_]+"
+          },
+          "ProviderType": {
+            "shape": "S3z"
+          },
           "ProviderDetails": {
             "shape": "S40"
           },
@@ -930,9 +1106,15 @@
           "Name"
         ],
         "members": {
-          "UserPoolId": {},
-          "Identifier": {},
-          "Name": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Identifier": {
+            "shape": "S48"
+          },
+          "Name": {
+            "shape": "S49"
+          },
           "Scopes": {
             "shape": "S4a"
           }
@@ -959,9 +1141,15 @@
           "CloudWatchLogsRoleArn"
         ],
         "members": {
-          "JobName": {},
-          "UserPoolId": {},
-          "CloudWatchLogsRoleArn": {}
+          "JobName": {
+            "shape": "S4h"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "CloudWatchLogsRoleArn": {
+            "shape": "S2b"
+          }
         }
       },
       "output": {
@@ -980,7 +1168,9 @@
           "PoolName"
         ],
         "members": {
-          "PoolName": {},
+          "PoolName": {
+            "shape": "S4q"
+          },
           "Policies": {
             "shape": "S4r"
           },
@@ -996,14 +1186,24 @@
           "UsernameAttributes": {
             "shape": "S4z"
           },
-          "SmsVerificationMessage": {},
-          "EmailVerificationMessage": {},
-          "EmailVerificationSubject": {},
+          "SmsVerificationMessage": {
+            "shape": "S51"
+          },
+          "EmailVerificationMessage": {
+            "shape": "S52"
+          },
+          "EmailVerificationSubject": {
+            "shape": "S53"
+          },
           "VerificationMessageTemplate": {
             "shape": "S54"
           },
-          "SmsAuthenticationMessage": {},
-          "MfaConfiguration": {},
+          "SmsAuthenticationMessage": {
+            "shape": "S51"
+          },
+          "MfaConfiguration": {
+            "shape": "S58"
+          },
           "DeviceConfiguration": {
             "shape": "S59"
           },
@@ -1044,13 +1244,17 @@
           "ClientName"
         ],
         "members": {
-          "UserPoolId": {},
-          "ClientName": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "ClientName": {
+            "shape": "S5p"
+          },
           "GenerateSecret": {
             "type": "boolean"
           },
           "RefreshTokenValidity": {
-            "type": "integer"
+            "shape": "S5r"
           },
           "ReadAttributes": {
             "shape": "S5s"
@@ -1070,7 +1274,9 @@
           "LogoutURLs": {
             "shape": "S5z"
           },
-          "DefaultRedirectURI": {},
+          "DefaultRedirectURI": {
+            "shape": "S5y"
+          },
           "AllowedOAuthFlows": {
             "shape": "S60"
           },
@@ -1102,8 +1308,12 @@
           "UserPoolId"
         ],
         "members": {
-          "Domain": {},
-          "UserPoolId": {},
+          "Domain": {
+            "shape": "S5n"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "CustomDomainConfig": {
             "shape": "S6a"
           }
@@ -1112,7 +1322,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "CloudFrontDomain": {}
+          "CloudFrontDomain": {
+            "shape": "S5n"
+          }
         }
       }
     },
@@ -1124,8 +1336,12 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {},
-          "UserPoolId": {}
+          "GroupName": {
+            "shape": "Se"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1137,8 +1353,12 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {},
-          "ProviderName": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "ProviderName": {
+            "shape": "S13"
+          }
         }
       }
     },
@@ -1150,8 +1370,12 @@
           "Identifier"
         ],
         "members": {
-          "UserPoolId": {},
-          "Identifier": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Identifier": {
+            "shape": "S48"
+          }
         }
       }
     },
@@ -1198,7 +1422,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1210,7 +1436,9 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           }
@@ -1225,8 +1453,12 @@
           "UserPoolId"
         ],
         "members": {
-          "Domain": {},
-          "UserPoolId": {}
+          "Domain": {
+            "shape": "S5n"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1242,8 +1474,12 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {},
-          "ProviderName": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "ProviderName": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
@@ -1266,8 +1502,12 @@
           "Identifier"
         ],
         "members": {
-          "UserPoolId": {},
-          "Identifier": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Identifier": {
+            "shape": "S48"
+          }
         }
       },
       "output": {
@@ -1289,7 +1529,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           }
@@ -1315,8 +1557,12 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {},
-          "JobId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "JobId": {
+            "shape": "S4k"
+          }
         }
       },
       "output": {
@@ -1335,7 +1581,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1355,7 +1603,9 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           }
@@ -1377,7 +1627,9 @@
           "Domain"
         ],
         "members": {
-          "Domain": {}
+          "Domain": {
+            "shape": "S5n"
+          }
         }
       },
       "output": {
@@ -1386,13 +1638,35 @@
           "DomainDescription": {
             "type": "structure",
             "members": {
-              "UserPoolId": {},
+              "UserPoolId": {
+                "shape": "S2"
+              },
               "AWSAccountId": {},
-              "Domain": {},
-              "S3Bucket": {},
+              "Domain": {
+                "shape": "S5n"
+              },
+              "S3Bucket": {
+                "type": "string",
+                "max": 1024,
+                "min": 3,
+                "pattern": "^[0-9A-Za-z\\.\\-_]*(?<!\\.)$"
+              },
               "CloudFrontDistribution": {},
-              "Version": {},
-              "Status": {},
+              "Version": {
+                "type": "string",
+                "max": 20,
+                "min": 1
+              },
+              "Status": {
+                "type": "string",
+                "enum": [
+                  "CREATING",
+                  "DELETING",
+                  "UPDATING",
+                  "ACTIVE",
+                  "FAILED"
+                ]
+              },
               "CustomDomainConfig": {
                 "shape": "S6a"
               }
@@ -1411,7 +1685,9 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {}
+          "DeviceKey": {
+            "shape": "S1a"
+          }
         }
       }
     },
@@ -1457,13 +1733,17 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "CSVHeader": {
             "type": "list",
             "member": {}
@@ -1478,7 +1758,9 @@
           "DeviceKey"
         ],
         "members": {
-          "DeviceKey": {},
+          "DeviceKey": {
+            "shape": "S1a"
+          },
           "AccessToken": {
             "shape": "S1v"
           }
@@ -1504,8 +1786,12 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {},
-          "UserPoolId": {}
+          "GroupName": {
+            "shape": "Se"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1525,8 +1811,12 @@
           "IdpIdentifier"
         ],
         "members": {
-          "UserPoolId": {},
-          "IdpIdentifier": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "IdpIdentifier": {
+            "shape": "S44"
+          }
         }
       },
       "output": {
@@ -1548,7 +1838,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1565,7 +1857,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           }
@@ -1630,7 +1924,9 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "AttributeName": {}
+          "AttributeName": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -1650,7 +1946,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1662,7 +1960,9 @@
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {}
+          "MfaConfiguration": {
+            "shape": "S58"
+          }
         }
       }
     },
@@ -1691,7 +1991,9 @@
           "ClientId"
         ],
         "members": {
-          "AuthFlow": {},
+          "AuthFlow": {
+            "shape": "S1j"
+          },
           "AuthParameters": {
             "shape": "S1k"
           },
@@ -1712,8 +2014,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {},
-          "Session": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
+          "Session": {
+            "shape": "S1s"
+          },
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -1734,9 +2040,11 @@
             "shape": "S1v"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S21"
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S22"
+          }
         }
       },
       "output": {
@@ -1745,7 +2053,9 @@
           "Devices": {
             "shape": "S24"
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S22"
+          }
         }
       }
     },
@@ -1756,11 +2066,15 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
-          "Limit": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "Limit": {
+            "shape": "S21"
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -1769,7 +2083,9 @@
           "Groups": {
             "shape": "S28"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1780,11 +2096,17 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
-          "MaxResults": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "MaxResults": {
+            "type": "integer",
+            "max": 60,
+            "min": 1
+          },
+          "NextToken": {
+            "shape": "S8q"
+          }
         }
       },
       "output": {
@@ -1798,8 +2120,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProviderName": {},
-                "ProviderType": {},
+                "ProviderName": {
+                  "shape": "S13"
+                },
+                "ProviderType": {
+                  "shape": "S3z"
+                },
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
@@ -1807,9 +2133,13 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 50,
+            "min": 0
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S8q"
+          }
         }
       }
     },
@@ -1820,11 +2150,17 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
-          "MaxResults": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "MaxResults": {
+            "type": "integer",
+            "max": 50,
+            "min": 1
+          },
+          "NextToken": {
+            "shape": "S8q"
+          }
         }
       },
       "output": {
@@ -1839,7 +2175,9 @@
               "shape": "S4f"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S8q"
+          }
         }
       }
     },
@@ -1851,11 +2189,15 @@
           "MaxResults"
         ],
         "members": {
-          "UserPoolId": {},
-          "MaxResults": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "PaginationToken": {}
+          "MaxResults": {
+            "shape": "S8z"
+          },
+          "PaginationToken": {
+            "shape": "S8q"
+          }
         }
       },
       "output": {
@@ -1865,9 +2207,13 @@
             "type": "list",
             "member": {
               "shape": "S4j"
-            }
+            },
+            "max": 50,
+            "min": 1
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S8q"
+          }
         }
       }
     },
@@ -1878,11 +2224,17 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
-          "MaxResults": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "MaxResults": {
+            "type": "integer",
+            "max": 60,
+            "min": 1
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -1896,12 +2248,18 @@
                 "ClientId": {
                   "shape": "S1i"
                 },
-                "UserPoolId": {},
-                "ClientName": {}
+                "UserPoolId": {
+                  "shape": "S2"
+                },
+                "ClientName": {
+                  "shape": "S5p"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -1912,9 +2270,11 @@
           "MaxResults"
         ],
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S8q"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S8z"
           }
         }
       },
@@ -1926,12 +2286,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Name": {},
+                "Id": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S4q"
+                },
                 "LambdaConfig": {
                   "shape": "S4u"
                 },
-                "Status": {},
+                "Status": {
+                  "shape": "S5m"
+                },
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
@@ -1941,7 +2307,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S8q"
+          }
         }
       }
     },
@@ -1952,16 +2320,25 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "AttributesToGet": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sk"
+            }
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S21"
           },
-          "PaginationToken": {},
-          "Filter": {}
+          "PaginationToken": {
+            "shape": "S22"
+          },
+          "Filter": {
+            "type": "string",
+            "max": 256
+          }
         }
       },
       "output": {
@@ -1970,7 +2347,9 @@
           "Users": {
             "shape": "S9f"
           },
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S22"
+          }
         }
       }
     },
@@ -1982,12 +2361,18 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {},
-          "GroupName": {},
-          "Limit": {
-            "type": "integer"
+          "UserPoolId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "GroupName": {
+            "shape": "Se"
+          },
+          "Limit": {
+            "shape": "S21"
+          },
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       },
       "output": {
@@ -1996,7 +2381,9 @@
           "Users": {
             "shape": "S9f"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S26"
+          }
         }
       }
     },
@@ -2046,8 +2433,12 @@
           "ClientId": {
             "shape": "S1i"
           },
-          "ChallengeName": {},
-          "Session": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
+          "Session": {
+            "shape": "S1s"
+          },
           "ChallengeResponses": {
             "shape": "S2x"
           },
@@ -2062,8 +2453,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {},
-          "Session": {},
+          "ChallengeName": {
+            "shape": "S1r"
+          },
+          "Session": {
+            "shape": "S1s"
+          },
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -2080,7 +2475,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           },
@@ -2114,7 +2511,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           },
@@ -2166,14 +2565,18 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "SmsMfaConfiguration": {
             "shape": "S8e"
           },
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {}
+          "MfaConfiguration": {
+            "shape": "S58"
+          }
         }
       },
       "output": {
@@ -2185,7 +2588,9 @@
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {}
+          "MfaConfiguration": {
+            "shape": "S58"
+          }
         }
       }
     },
@@ -2272,8 +2677,12 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {},
-          "JobId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "JobId": {
+            "shape": "S4k"
+          }
         }
       },
       "output": {
@@ -2293,8 +2702,12 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {},
-          "JobId": {}
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "JobId": {
+            "shape": "S4k"
+          }
         }
       },
       "output": {
@@ -2317,15 +2730,21 @@
           "FeedbackValue"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Username": {
             "shape": "Sd"
           },
-          "EventId": {},
+          "EventId": {
+            "shape": "S36"
+          },
           "FeedbackToken": {
             "shape": "S1v"
           },
-          "FeedbackValue": {}
+          "FeedbackValue": {
+            "shape": "S2s"
+          }
         }
       },
       "output": {
@@ -2344,8 +2763,12 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {},
-          "DeviceRememberedStatus": {}
+          "DeviceKey": {
+            "shape": "S1a"
+          },
+          "DeviceRememberedStatus": {
+            "shape": "S39"
+          }
         }
       },
       "output": {
@@ -2361,12 +2784,20 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {},
-          "UserPoolId": {},
-          "Description": {},
-          "RoleArn": {},
+          "GroupName": {
+            "shape": "Se"
+          },
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S2a"
+          },
+          "RoleArn": {
+            "shape": "S2b"
+          },
           "Precedence": {
-            "type": "integer"
+            "shape": "S2c"
           }
         }
       },
@@ -2387,8 +2818,12 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {},
-          "ProviderName": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "ProviderName": {
+            "shape": "S13"
+          },
           "ProviderDetails": {
             "shape": "S40"
           },
@@ -2421,9 +2856,15 @@
           "Name"
         ],
         "members": {
-          "UserPoolId": {},
-          "Identifier": {},
-          "Name": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
+          "Identifier": {
+            "shape": "S48"
+          },
+          "Name": {
+            "shape": "S49"
+          },
           "Scopes": {
             "shape": "S4a"
           }
@@ -2477,7 +2918,9 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "Policies": {
             "shape": "S4r"
           },
@@ -2487,14 +2930,24 @@
           "AutoVerifiedAttributes": {
             "shape": "S4v"
           },
-          "SmsVerificationMessage": {},
-          "EmailVerificationMessage": {},
-          "EmailVerificationSubject": {},
+          "SmsVerificationMessage": {
+            "shape": "S51"
+          },
+          "EmailVerificationMessage": {
+            "shape": "S52"
+          },
+          "EmailVerificationSubject": {
+            "shape": "S53"
+          },
           "VerificationMessageTemplate": {
             "shape": "S54"
           },
-          "SmsAuthenticationMessage": {},
-          "MfaConfiguration": {},
+          "SmsAuthenticationMessage": {
+            "shape": "S51"
+          },
+          "MfaConfiguration": {
+            "shape": "S58"
+          },
           "DeviceConfiguration": {
             "shape": "S59"
           },
@@ -2528,13 +2981,17 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {},
+          "UserPoolId": {
+            "shape": "S2"
+          },
           "ClientId": {
             "shape": "S1i"
           },
-          "ClientName": {},
+          "ClientName": {
+            "shape": "S5p"
+          },
           "RefreshTokenValidity": {
-            "type": "integer"
+            "shape": "S5r"
           },
           "ReadAttributes": {
             "shape": "S5s"
@@ -2554,7 +3011,9 @@
           "LogoutURLs": {
             "shape": "S5z"
           },
-          "DefaultRedirectURI": {},
+          "DefaultRedirectURI": {
+            "shape": "S5y"
+          },
           "AllowedOAuthFlows": {
             "shape": "S60"
           },
@@ -2588,16 +3047,31 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "Session": {},
-          "UserCode": {},
+          "Session": {
+            "shape": "S1s"
+          },
+          "UserCode": {
+            "type": "string",
+            "max": 6,
+            "min": 6,
+            "pattern": "[0-9]+"
+          },
           "FriendlyDeviceName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {},
-          "Session": {}
+          "Status": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "ERROR"
+            ]
+          },
+          "Session": {
+            "shape": "S1s"
+          }
         }
       }
     },
@@ -2613,8 +3087,12 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "AttributeName": {},
-          "Code": {}
+          "AttributeName": {
+            "shape": "Sk"
+          },
+          "Code": {
+            "shape": "S3q"
+          }
         }
       },
       "output": {
@@ -2625,11 +3103,30 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 55,
+      "min": 1,
+      "pattern": "[\\w-]+_[0-9a-zA-Z]+"
+    },
     "S4": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "AttributeDataType": {},
+        "Name": {
+          "type": "string",
+          "max": 20,
+          "min": 1,
+          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+        },
+        "AttributeDataType": {
+          "type": "string",
+          "enum": [
+            "String",
+            "Number",
+            "DateTime",
+            "Boolean"
+          ]
+        },
         "DeveloperOnlyAttribute": {
           "type": "boolean"
         },
@@ -2657,7 +3154,16 @@
     },
     "Sd": {
       "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+",
       "sensitive": true
+    },
+    "Se": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
     },
     "Si": {
       "type": "list",
@@ -2667,17 +3173,36 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "Sk"
+          },
           "Value": {
             "type": "string",
+            "max": 2048,
             "sensitive": true
           }
         }
       }
     },
+    "Sk": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+    },
     "Sm": {
       "type": "string",
+      "max": 256,
+      "min": 6,
+      "pattern": "[\\S]+",
       "sensitive": true
+    },
+    "Sq": {
+      "type": "string",
+      "enum": [
+        "SMS",
+        "EMAIL"
+      ]
     },
     "Ss": {
       "type": "structure",
@@ -2697,38 +3222,74 @@
         "Enabled": {
           "type": "boolean"
         },
-        "UserStatus": {},
+        "UserStatus": {
+          "shape": "Su"
+        },
         "MFAOptions": {
           "shape": "Sv"
         }
       }
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "UNCONFIRMED",
+        "CONFIRMED",
+        "ARCHIVED",
+        "COMPROMISED",
+        "UNKNOWN",
+        "RESET_REQUIRED",
+        "FORCE_CHANGE_PASSWORD"
+      ]
     },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "DeliveryMedium": {},
-          "AttributeName": {}
+          "DeliveryMedium": {
+            "shape": "Sq"
+          },
+          "AttributeName": {
+            "shape": "Sk"
+          }
         }
       }
     },
     "Sz": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sk"
+      }
     },
     "S12": {
       "type": "structure",
       "members": {
-        "ProviderName": {},
+        "ProviderName": {
+          "shape": "S13"
+        },
         "ProviderAttributeName": {},
         "ProviderAttributeValue": {}
       }
     },
+    "S13": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+    },
+    "S1a": {
+      "type": "string",
+      "max": 55,
+      "min": 1,
+      "pattern": "[\\w-]+_[0-9a-f-]+"
+    },
     "S1d": {
       "type": "structure",
       "members": {
-        "DeviceKey": {},
+        "DeviceKey": {
+          "shape": "S1a"
+        },
         "DeviceAttributes": {
           "shape": "Si"
         },
@@ -2749,7 +3310,21 @@
     },
     "S1i": {
       "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+]+",
       "sensitive": true
+    },
+    "S1j": {
+      "type": "string",
+      "enum": [
+        "USER_SRP_AUTH",
+        "REFRESH_TOKEN_AUTH",
+        "REFRESH_TOKEN",
+        "CUSTOM_AUTH",
+        "ADMIN_NO_SRP_AUTH",
+        "USER_PASSWORD_AUTH"
+      ]
     },
     "S1k": {
       "type": "map",
@@ -2792,6 +3367,26 @@
         "EncodedData": {}
       }
     },
+    "S1r": {
+      "type": "string",
+      "enum": [
+        "SMS_MFA",
+        "SOFTWARE_TOKEN_MFA",
+        "SELECT_MFA_TYPE",
+        "MFA_SETUP",
+        "PASSWORD_VERIFIER",
+        "CUSTOM_CHALLENGE",
+        "DEVICE_SRP_AUTH",
+        "DEVICE_PASSWORD_VERIFIER",
+        "ADMIN_NO_SRP_AUTH",
+        "NEW_PASSWORD_REQUIRED"
+      ]
+    },
+    "S1s": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
     "S1t": {
       "type": "map",
       "key": {},
@@ -2816,7 +3411,9 @@
         "NewDeviceMetadata": {
           "type": "structure",
           "members": {
-            "DeviceKey": {},
+            "DeviceKey": {
+              "shape": "S1a"
+            },
             "DeviceGroupKey": {}
           }
         }
@@ -2824,13 +3421,29 @@
     },
     "S1v": {
       "type": "string",
+      "pattern": "[A-Za-z0-9-_=.]+",
       "sensitive": true
+    },
+    "S21": {
+      "type": "integer",
+      "max": 60,
+      "min": 0
+    },
+    "S22": {
+      "type": "string",
+      "min": 1,
+      "pattern": "[\\S]+"
     },
     "S24": {
       "type": "list",
       "member": {
         "shape": "S1d"
       }
+    },
+    "S26": {
+      "type": "string",
+      "min": 1,
+      "pattern": "[\\S]+"
     },
     "S28": {
       "type": "list",
@@ -2841,12 +3454,20 @@
     "S29": {
       "type": "structure",
       "members": {
-        "GroupName": {},
-        "UserPoolId": {},
-        "Description": {},
-        "RoleArn": {},
+        "GroupName": {
+          "shape": "Se"
+        },
+        "UserPoolId": {
+          "shape": "S2"
+        },
+        "Description": {
+          "shape": "S2a"
+        },
+        "RoleArn": {
+          "shape": "S2b"
+        },
         "Precedence": {
-          "type": "integer"
+          "shape": "S2c"
         },
         "LastModifiedDate": {
           "type": "timestamp"
@@ -2855,6 +3476,27 @@
           "type": "timestamp"
         }
       }
+    },
+    "S2a": {
+      "type": "string",
+      "max": 2048
+    },
+    "S2b": {
+      "type": "string",
+      "max": 2048,
+      "min": 20,
+      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:([\\w+=/,.@-]*)?:[0-9]+:[\\w+=/,.@-]+(:[\\w+=/,.@-]+)?(:[\\w+=/,.@-]+)?"
+    },
+    "S2c": {
+      "type": "integer",
+      "min": 0
+    },
+    "S2s": {
+      "type": "string",
+      "enum": [
+        "Valid",
+        "Invalid"
+      ]
     },
     "S2x": {
       "type": "map",
@@ -2883,15 +3525,47 @@
         }
       }
     },
+    "S36": {
+      "type": "string",
+      "max": 50,
+      "min": 1,
+      "pattern": "[\\w+-]+"
+    },
+    "S39": {
+      "type": "string",
+      "enum": [
+        "remembered",
+        "not_remembered"
+      ]
+    },
     "S3p": {
       "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=/]+",
       "sensitive": true
+    },
+    "S3q": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "[\\S]+"
     },
     "S3r": {
       "type": "structure",
       "members": {
         "EncodedData": {}
       }
+    },
+    "S3z": {
+      "type": "string",
+      "enum": [
+        "SAML",
+        "Facebook",
+        "Google",
+        "LoginWithAmazon",
+        "OIDC"
+      ]
     },
     "S40": {
       "type": "map",
@@ -2900,19 +3574,39 @@
     },
     "S41": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "max": 32,
+        "min": 1
+      },
       "value": {}
     },
     "S43": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S44"
+      },
+      "max": 50,
+      "min": 0
+    },
+    "S44": {
+      "type": "string",
+      "max": 40,
+      "min": 1,
+      "pattern": "[\\w\\s+=.@-]+"
     },
     "S46": {
       "type": "structure",
       "members": {
-        "UserPoolId": {},
-        "ProviderName": {},
-        "ProviderType": {},
+        "UserPoolId": {
+          "shape": "S2"
+        },
+        "ProviderName": {
+          "shape": "S13"
+        },
+        "ProviderType": {
+          "shape": "S3z"
+        },
         "ProviderDetails": {
           "shape": "S40"
         },
@@ -2930,6 +3624,18 @@
         }
       }
     },
+    "S48": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\x21\\x23-\\x5B\\x5D-\\x7E]+"
+    },
+    "S49": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\w\\s+=,.@-]+"
+    },
     "S4a": {
       "type": "list",
       "member": {
@@ -2939,29 +3645,61 @@
           "ScopeDescription"
         ],
         "members": {
-          "ScopeName": {},
-          "ScopeDescription": {}
+          "ScopeName": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "pattern": "[\\x21\\x23-\\x2E\\x30-\\x5B\\x5D-\\x7E]+"
+          },
+          "ScopeDescription": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 25
     },
     "S4f": {
       "type": "structure",
       "members": {
-        "UserPoolId": {},
-        "Identifier": {},
-        "Name": {},
+        "UserPoolId": {
+          "shape": "S2"
+        },
+        "Identifier": {
+          "shape": "S48"
+        },
+        "Name": {
+          "shape": "S49"
+        },
         "Scopes": {
           "shape": "S4a"
         }
       }
     },
+    "S4h": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w\\s+=,.@-]+"
+    },
     "S4j": {
       "type": "structure",
       "members": {
-        "JobName": {},
-        "JobId": {},
-        "UserPoolId": {},
-        "PreSignedUrl": {},
+        "JobName": {
+          "shape": "S4h"
+        },
+        "JobId": {
+          "shape": "S4k"
+        },
+        "UserPoolId": {
+          "shape": "S2"
+        },
+        "PreSignedUrl": {
+          "type": "string",
+          "max": 2048,
+          "min": 0
+        },
         "CreationDate": {
           "type": "timestamp"
         },
@@ -2971,8 +3709,22 @@
         "CompletionDate": {
           "type": "timestamp"
         },
-        "Status": {},
-        "CloudWatchLogsRoleArn": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Created",
+            "Pending",
+            "InProgress",
+            "Stopping",
+            "Expired",
+            "Stopped",
+            "Failed",
+            "Succeeded"
+          ]
+        },
+        "CloudWatchLogsRoleArn": {
+          "shape": "S2b"
+        },
         "ImportedUsers": {
           "type": "long"
         },
@@ -2982,8 +3734,25 @@
         "FailedUsers": {
           "type": "long"
         },
-        "CompletionMessage": {}
+        "CompletionMessage": {
+          "type": "string",
+          "max": 128,
+          "min": 1,
+          "pattern": "[\\w]+"
+        }
       }
+    },
+    "S4k": {
+      "type": "string",
+      "max": 55,
+      "min": 1,
+      "pattern": "import-[0-9a-zA-Z-]+"
+    },
+    "S4q": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w\\s+=,.@-]+"
     },
     "S4r": {
       "type": "structure",
@@ -2992,7 +3761,9 @@
           "type": "structure",
           "members": {
             "MinimumLength": {
-              "type": "integer"
+              "type": "integer",
+              "max": 99,
+              "min": 6
             },
             "RequireUppercase": {
               "type": "boolean"
@@ -3013,40 +3784,127 @@
     "S4u": {
       "type": "structure",
       "members": {
-        "PreSignUp": {},
-        "CustomMessage": {},
-        "PostConfirmation": {},
-        "PreAuthentication": {},
-        "PostAuthentication": {},
-        "DefineAuthChallenge": {},
-        "CreateAuthChallenge": {},
-        "VerifyAuthChallengeResponse": {},
-        "PreTokenGeneration": {},
-        "UserMigration": {}
+        "PreSignUp": {
+          "shape": "S2b"
+        },
+        "CustomMessage": {
+          "shape": "S2b"
+        },
+        "PostConfirmation": {
+          "shape": "S2b"
+        },
+        "PreAuthentication": {
+          "shape": "S2b"
+        },
+        "PostAuthentication": {
+          "shape": "S2b"
+        },
+        "DefineAuthChallenge": {
+          "shape": "S2b"
+        },
+        "CreateAuthChallenge": {
+          "shape": "S2b"
+        },
+        "VerifyAuthChallengeResponse": {
+          "shape": "S2b"
+        },
+        "PreTokenGeneration": {
+          "shape": "S2b"
+        },
+        "UserMigration": {
+          "shape": "S2b"
+        }
       }
     },
     "S4v": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "phone_number",
+          "email"
+        ]
+      }
     },
     "S4x": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "phone_number",
+          "email",
+          "preferred_username"
+        ]
+      }
     },
     "S4z": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "phone_number",
+          "email"
+        ]
+      }
+    },
+    "S51": {
+      "type": "string",
+      "max": 140,
+      "min": 6,
+      "pattern": ".*\\{####\\}.*"
+    },
+    "S52": {
+      "type": "string",
+      "max": 20000,
+      "min": 6,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*\\{####\\}[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*"
+    },
+    "S53": {
+      "type": "string",
+      "max": 140,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
     },
     "S54": {
       "type": "structure",
       "members": {
-        "SmsMessage": {},
-        "EmailMessage": {},
-        "EmailSubject": {},
-        "EmailMessageByLink": {},
-        "EmailSubjectByLink": {},
-        "DefaultEmailOption": {}
+        "SmsMessage": {
+          "shape": "S51"
+        },
+        "EmailMessage": {
+          "shape": "S52"
+        },
+        "EmailSubject": {
+          "shape": "S53"
+        },
+        "EmailMessageByLink": {
+          "type": "string",
+          "max": 20000,
+          "min": 6,
+          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*\\{##[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*##\\}[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*"
+        },
+        "EmailSubjectByLink": {
+          "type": "string",
+          "max": 140,
+          "min": 1,
+          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
+        },
+        "DefaultEmailOption": {
+          "type": "string",
+          "enum": [
+            "CONFIRM_WITH_LINK",
+            "CONFIRM_WITH_CODE"
+          ]
+        }
       }
+    },
+    "S58": {
+      "type": "string",
+      "enum": [
+        "OFF",
+        "ON",
+        "OPTIONAL"
+      ]
     },
     "S59": {
       "type": "structure",
@@ -3062,8 +3920,13 @@
     "S5a": {
       "type": "structure",
       "members": {
-        "SourceArn": {},
-        "ReplyToEmailAddress": {}
+        "SourceArn": {
+          "shape": "S2b"
+        },
+        "ReplyToEmailAddress": {
+          "type": "string",
+          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+@[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+        }
       }
     },
     "S5c": {
@@ -3072,7 +3935,9 @@
         "SnsCallerArn"
       ],
       "members": {
-        "SnsCallerArn": {},
+        "SnsCallerArn": {
+          "shape": "S2b"
+        },
         "ExternalId": {}
       }
     },
@@ -3088,14 +3953,22 @@
           "type": "boolean"
         },
         "UnusedAccountValidityDays": {
-          "type": "integer"
+          "type": "integer",
+          "max": 365,
+          "min": 0
         },
         "InviteMessageTemplate": {
           "type": "structure",
           "members": {
-            "SMSMessage": {},
-            "EmailMessage": {},
-            "EmailSubject": {}
+            "SMSMessage": {
+              "shape": "S51"
+            },
+            "EmailMessage": {
+              "shape": "S52"
+            },
+            "EmailSubject": {
+              "shape": "S53"
+            }
           }
         }
       }
@@ -3104,7 +3977,9 @@
       "type": "list",
       "member": {
         "shape": "S4"
-      }
+      },
+      "max": 50,
+      "min": 1
     },
     "S5i": {
       "type": "structure",
@@ -3112,21 +3987,34 @@
         "AdvancedSecurityMode"
       ],
       "members": {
-        "AdvancedSecurityMode": {}
+        "AdvancedSecurityMode": {
+          "type": "string",
+          "enum": [
+            "OFF",
+            "AUDIT",
+            "ENFORCED"
+          ]
+        }
       }
     },
     "S5l": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Name": {},
+        "Id": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S4q"
+        },
         "Policies": {
           "shape": "S4r"
         },
         "LambdaConfig": {
           "shape": "S4u"
         },
-        "Status": {},
+        "Status": {
+          "shape": "S5m"
+        },
         "LastModifiedDate": {
           "type": "timestamp"
         },
@@ -3145,14 +4033,24 @@
         "UsernameAttributes": {
           "shape": "S4z"
         },
-        "SmsVerificationMessage": {},
-        "EmailVerificationMessage": {},
-        "EmailVerificationSubject": {},
+        "SmsVerificationMessage": {
+          "shape": "S51"
+        },
+        "EmailVerificationMessage": {
+          "shape": "S52"
+        },
+        "EmailVerificationSubject": {
+          "shape": "S53"
+        },
         "VerificationMessageTemplate": {
           "shape": "S54"
         },
-        "SmsAuthenticationMessage": {},
-        "MfaConfiguration": {},
+        "SmsAuthenticationMessage": {
+          "shape": "S51"
+        },
+        "MfaConfiguration": {
+          "shape": "S58"
+        },
         "DeviceConfiguration": {
           "shape": "S59"
         },
@@ -3170,44 +4068,116 @@
         },
         "SmsConfigurationFailure": {},
         "EmailConfigurationFailure": {},
-        "Domain": {},
-        "CustomDomain": {},
+        "Domain": {
+          "shape": "S5n"
+        },
+        "CustomDomain": {
+          "shape": "S5n"
+        },
         "AdminCreateUserConfig": {
           "shape": "S5e"
         },
         "UserPoolAddOns": {
           "shape": "S5i"
         },
-        "Arn": {}
+        "Arn": {
+          "shape": "S2b"
+        }
       }
+    },
+    "S5m": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ]
+    },
+    "S5n": {
+      "type": "string",
+      "max": 63,
+      "min": 1,
+      "pattern": "^[a-z0-9](?:[a-z0-9\\-]{0,61}[a-z0-9])?$"
+    },
+    "S5p": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w\\s+=,.@-]+"
+    },
+    "S5r": {
+      "type": "integer",
+      "max": 3650,
+      "min": 0
     },
     "S5s": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 2048,
+        "min": 1
+      }
     },
     "S5u": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "ADMIN_NO_SRP_AUTH",
+          "CUSTOM_AUTH_FLOW_ONLY",
+          "USER_PASSWORD_AUTH"
+        ]
+      }
     },
     "S5w": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S13"
+      }
     },
     "S5x": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5y"
+      },
+      "max": 100,
+      "min": 0
+    },
+    "S5y": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
     },
     "S5z": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5y"
+      },
+      "max": 100,
+      "min": 0
     },
     "S60": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "code",
+          "implicit",
+          "client_credentials"
+        ]
+      },
+      "max": 3,
+      "min": 0
     },
     "S62": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 256,
+        "min": 1,
+        "pattern": "[\\x21\\x23-\\x5B\\x5D-\\x7E]+"
+      },
+      "max": 25
     },
     "S64": {
       "type": "structure",
@@ -3217,8 +4187,13 @@
         "ExternalId"
       ],
       "members": {
-        "ApplicationId": {},
-        "RoleArn": {},
+        "ApplicationId": {
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]+$"
+        },
+        "RoleArn": {
+          "shape": "S2b"
+        },
         "ExternalId": {},
         "UserDataShared": {
           "type": "boolean"
@@ -3228,13 +4203,20 @@
     "S67": {
       "type": "structure",
       "members": {
-        "UserPoolId": {},
-        "ClientName": {},
+        "UserPoolId": {
+          "shape": "S2"
+        },
+        "ClientName": {
+          "shape": "S5p"
+        },
         "ClientId": {
           "shape": "S1i"
         },
         "ClientSecret": {
           "type": "string",
+          "max": 64,
+          "min": 1,
+          "pattern": "[\\w+]+",
           "sensitive": true
         },
         "LastModifiedDate": {
@@ -3244,7 +4226,7 @@
           "type": "timestamp"
         },
         "RefreshTokenValidity": {
-          "type": "integer"
+          "shape": "S5r"
         },
         "ReadAttributes": {
           "shape": "S5s"
@@ -3264,7 +4246,9 @@
         "LogoutURLs": {
           "shape": "S5z"
         },
-        "DefaultRedirectURI": {},
+        "DefaultRedirectURI": {
+          "shape": "S5y"
+        },
         "AllowedOAuthFlows": {
           "shape": "S60"
         },
@@ -3285,13 +4269,17 @@
         "CertificateArn"
       ],
       "members": {
-        "CertificateArn": {}
+        "CertificateArn": {
+          "shape": "S2b"
+        }
       }
     },
     "S6s": {
       "type": "structure",
       "members": {
-        "UserPoolId": {},
+        "UserPoolId": {
+          "shape": "S2"
+        },
         "ClientId": {
           "shape": "S1i"
         },
@@ -3317,7 +4305,14 @@
       "members": {
         "EventFilter": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "SIGN_IN",
+              "PASSWORD_CHANGE",
+              "SIGN_UP"
+            ]
+          }
         },
         "Actions": {
           "type": "structure",
@@ -3325,7 +4320,13 @@
             "EventAction"
           ],
           "members": {
-            "EventAction": {}
+            "EventAction": {
+              "type": "string",
+              "enum": [
+                "BLOCK",
+                "NO_ACTION"
+              ]
+            }
           }
         }
       }
@@ -3344,7 +4345,9 @@
           "members": {
             "From": {},
             "ReplyTo": {},
-            "SourceArn": {},
+            "SourceArn": {
+              "shape": "S2b"
+            },
             "BlockEmail": {
               "shape": "S70"
             },
@@ -3378,10 +4381,25 @@
         "Subject"
       ],
       "members": {
-        "Subject": {},
-        "HtmlBody": {},
-        "TextBody": {}
+        "Subject": {
+          "type": "string",
+          "max": 140,
+          "min": 1,
+          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
+        },
+        "HtmlBody": {
+          "shape": "S72"
+        },
+        "TextBody": {
+          "shape": "S72"
+        }
       }
+    },
+    "S72": {
+      "type": "string",
+      "max": 20000,
+      "min": 6,
+      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]+"
     },
     "S74": {
       "type": "structure",
@@ -3393,7 +4411,15 @@
         "Notify": {
           "type": "boolean"
         },
-        "EventAction": {}
+        "EventAction": {
+          "type": "string",
+          "enum": [
+            "BLOCK",
+            "MFA_IF_CONFIGURED",
+            "MFA_REQUIRED",
+            "NO_ACTION"
+          ]
+        }
       }
     },
     "S77": {
@@ -3401,11 +4427,13 @@
       "members": {
         "BlockedIPRangeList": {
           "type": "list",
-          "member": {}
+          "member": {},
+          "max": 20
         },
         "SkippedIPRangeList": {
           "type": "list",
-          "member": {}
+          "member": {},
+          "max": 20
         }
       }
     },
@@ -3413,14 +4441,20 @@
       "type": "structure",
       "members": {
         "Destination": {},
-        "DeliveryMedium": {},
-        "AttributeName": {}
+        "DeliveryMedium": {
+          "shape": "Sq"
+        },
+        "AttributeName": {
+          "shape": "Sk"
+        }
       }
     },
     "S84": {
       "type": "structure",
       "members": {
-        "UserPoolId": {},
+        "UserPoolId": {
+          "shape": "S2"
+        },
         "ClientId": {
           "shape": "S1i"
         },
@@ -3438,7 +4472,9 @@
     "S8e": {
       "type": "structure",
       "members": {
-        "SmsAuthenticationMessage": {},
+        "SmsAuthenticationMessage": {
+          "shape": "S51"
+        },
         "SmsConfiguration": {
           "shape": "S5c"
         }
@@ -3451,6 +4487,16 @@
           "type": "boolean"
         }
       }
+    },
+    "S8q": {
+      "type": "string",
+      "min": 1,
+      "pattern": "[\\S]+"
+    },
+    "S8z": {
+      "type": "integer",
+      "max": 60,
+      "min": 1
     },
     "S9f": {
       "type": "list",

--- a/apis/cognito-sync-2014-06-30.min.json
+++ b/apis/cognito-sync-2014-06-30.min.json
@@ -23,6 +23,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -31,7 +32,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {}
+          "IdentityPoolId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -50,14 +53,17 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           }
@@ -87,14 +93,17 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           }
@@ -122,6 +131,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -150,10 +160,12 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           }
@@ -165,8 +177,12 @@
           "IdentityUsage": {
             "type": "structure",
             "members": {
-              "IdentityId": {},
-              "IdentityPoolId": {},
+              "IdentityId": {
+                "shape": "S5"
+              },
+              "IdentityPoolId": {
+                "shape": "S2"
+              },
               "LastModifiedDate": {
                 "type": "timestamp"
               },
@@ -193,6 +209,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -201,14 +218,24 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "S2"
+          },
           "BulkPublishStartTime": {
             "type": "timestamp"
           },
           "BulkPublishCompleteTime": {
             "type": "timestamp"
           },
-          "BulkPublishStatus": {},
+          "BulkPublishStatus": {
+            "type": "string",
+            "enum": [
+              "NOT_STARTED",
+              "IN_PROGRESS",
+              "FAILED",
+              "SUCCEEDED"
+            ]
+          },
           "FailureMessage": {}
         }
       }
@@ -226,6 +253,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -253,6 +281,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -261,7 +290,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "S2"
+          },
           "PushSync": {
             "shape": "Sv"
           },
@@ -285,10 +316,12 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
@@ -373,14 +406,17 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
@@ -447,21 +483,33 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
-          "Platform": {},
+          "Platform": {
+            "type": "string",
+            "enum": [
+              "APNS",
+              "APNS_SANDBOX",
+              "GCM",
+              "ADM"
+            ]
+          },
           "Token": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DeviceId": {}
+          "DeviceId": {
+            "shape": "S1m"
+          }
         }
       }
     },
@@ -478,6 +526,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
@@ -499,6 +548,7 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
@@ -513,7 +563,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {},
+          "IdentityPoolId": {
+            "shape": "S2"
+          },
           "PushSync": {
             "shape": "Sv"
           },
@@ -538,18 +590,22 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
           "DeviceId": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "DeviceId"
           }
@@ -576,18 +632,22 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
           "DeviceId": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "DeviceId"
           }
@@ -613,18 +673,23 @@
         ],
         "members": {
           "IdentityPoolId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
-          "DeviceId": {},
+          "DeviceId": {
+            "shape": "S1m"
+          },
           "RecordPatches": {
             "type": "list",
             "member": {
@@ -635,9 +700,19 @@
                 "SyncCount"
               ],
               "members": {
-                "Op": {},
-                "Key": {},
-                "Value": {},
+                "Op": {
+                  "type": "string",
+                  "enum": [
+                    "replace",
+                    "remove"
+                  ]
+                },
+                "Key": {
+                  "shape": "S1e"
+                },
+                "Value": {
+                  "shape": "S1f"
+                },
                 "SyncCount": {
                   "type": "long"
                 },
@@ -665,11 +740,33 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 1,
+      "max": 55,
+      "pattern": "[\\w-]+:[0-9a-f-]+"
+    },
+    "S5": {
+      "type": "string",
+      "min": 1,
+      "max": 55,
+      "pattern": "[\\w-]+:[0-9a-f-]+"
+    },
+    "S6": {
+      "type": "string",
+      "min": 1,
+      "max": 128,
+      "pattern": "[a-zA-Z0-9_.:-]+"
+    },
     "S8": {
       "type": "structure",
       "members": {
-        "IdentityId": {},
-        "DatasetName": {},
+        "IdentityId": {
+          "shape": "S5"
+        },
+        "DatasetName": {
+          "shape": "S6"
+        },
         "CreationDate": {
           "type": "timestamp"
         },
@@ -688,7 +785,9 @@
     "Sg": {
       "type": "structure",
       "members": {
-        "IdentityPoolId": {},
+        "IdentityPoolId": {
+          "shape": "S2"
+        },
         "SyncSessionsCount": {
           "type": "long"
         },
@@ -703,24 +802,48 @@
     "Sq": {
       "type": "map",
       "key": {},
-      "value": {}
+      "value": {},
+      "max": 1
     },
     "Sv": {
       "type": "structure",
       "members": {
         "ApplicationArns": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "pattern": "arn:aws:sns:[-0-9a-z]+:\\d+:app/[A-Z_]+/[a-zA-Z0-9_.-]+"
+          }
         },
-        "RoleArn": {}
+        "RoleArn": {
+          "shape": "Sy"
+        }
       }
+    },
+    "Sy": {
+      "type": "string",
+      "min": 20,
+      "max": 2048,
+      "pattern": "arn:aws:iam::\\d+:role/.*"
     },
     "Sz": {
       "type": "structure",
       "members": {
-        "StreamName": {},
-        "RoleArn": {},
-        "StreamingStatus": {}
+        "StreamName": {
+          "type": "string",
+          "min": 1,
+          "max": 128
+        },
+        "RoleArn": {
+          "shape": "Sy"
+        },
+        "StreamingStatus": {
+          "type": "string",
+          "enum": [
+            "ENABLED",
+            "DISABLED"
+          ]
+        }
       }
     },
     "S1c": {
@@ -728,8 +851,12 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {},
+          "Key": {
+            "shape": "S1e"
+          },
+          "Value": {
+            "shape": "S1f"
+          },
           "SyncCount": {
             "type": "long"
           },
@@ -742,6 +869,20 @@
           }
         }
       }
+    },
+    "S1e": {
+      "type": "string",
+      "min": 1,
+      "max": 1024
+    },
+    "S1f": {
+      "type": "string",
+      "max": 1048575
+    },
+    "S1m": {
+      "type": "string",
+      "min": 1,
+      "max": 256
     }
   },
   "examples": {}

--- a/apis/comprehend-2017-11-27.min.json
+++ b/apis/comprehend-2017-11-27.min.json
@@ -63,7 +63,9 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {}
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -104,7 +106,9 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {}
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -145,7 +149,9 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {}
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -163,7 +169,9 @@
                 "Index": {
                   "type": "integer"
                 },
-                "Sentiment": {},
+                "Sentiment": {
+                  "shape": "Sv"
+                },
                 "SentimentScore": {
                   "shape": "Sw"
                 }
@@ -187,7 +195,9 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {}
+          "LanguageCode": {
+            "shape": "Sy"
+          }
         }
       },
       "output": {
@@ -224,7 +234,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
@@ -243,7 +255,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
@@ -262,7 +276,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
@@ -281,7 +297,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
@@ -300,7 +318,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
@@ -319,7 +339,9 @@
           "Text"
         ],
         "members": {
-          "Text": {}
+          "Text": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -339,8 +361,12 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {},
-          "LanguageCode": {}
+          "Text": {
+            "shape": "S3"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -360,8 +386,12 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {},
-          "LanguageCode": {}
+          "Text": {
+            "shape": "S3"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -381,14 +411,20 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {},
-          "LanguageCode": {}
+          "Text": {
+            "shape": "S3"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Sentiment": {},
+          "Sentiment": {
+            "shape": "Sv"
+          },
           "SentimentScore": {
             "shape": "Sw"
           }
@@ -403,8 +439,12 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {},
-          "LanguageCode": {}
+          "Text": {
+            "shape": "S3"
+          },
+          "LanguageCode": {
+            "shape": "Sy"
+          }
         }
       },
       "output": {
@@ -423,8 +463,12 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "JobStatus": {},
+              "JobName": {
+                "shape": "S1a"
+              },
+              "JobStatus": {
+                "shape": "S1b"
+              },
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -433,9 +477,11 @@
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S27"
           }
         }
       },
@@ -448,7 +494,9 @@
               "shape": "S19"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -459,8 +507,12 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "JobStatus": {},
+              "JobName": {
+                "shape": "S1a"
+              },
+              "JobStatus": {
+                "shape": "S1b"
+              },
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -469,9 +521,11 @@
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S27"
           }
         }
       },
@@ -484,7 +538,9 @@
               "shape": "S1l"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -495,8 +551,12 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "JobStatus": {},
+              "JobName": {
+                "shape": "S1a"
+              },
+              "JobStatus": {
+                "shape": "S1b"
+              },
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -505,9 +565,11 @@
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S27"
           }
         }
       },
@@ -520,7 +582,9 @@
               "shape": "S1o"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -531,8 +595,12 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "JobStatus": {},
+              "JobName": {
+                "shape": "S1a"
+              },
+              "JobStatus": {
+                "shape": "S1b"
+              },
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -541,9 +609,11 @@
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S27"
           }
         }
       },
@@ -556,7 +626,9 @@
               "shape": "S1r"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -567,8 +639,12 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "JobStatus": {},
+              "JobName": {
+                "shape": "S1a"
+              },
+              "JobStatus": {
+                "shape": "S1b"
+              },
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -577,9 +653,11 @@
               }
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S27"
           }
         }
       },
@@ -592,7 +670,9 @@
               "shape": "S1u"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -611,9 +691,14 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {},
-          "JobName": {},
+          "DataAccessRoleArn": {
+            "shape": "S1i"
+          },
+          "JobName": {
+            "shape": "S1a"
+          },
           "ClientRequestToken": {
+            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -621,8 +706,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -642,10 +731,17 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {},
-          "JobName": {},
-          "LanguageCode": {},
+          "DataAccessRoleArn": {
+            "shape": "S1i"
+          },
+          "JobName": {
+            "shape": "S1a"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          },
           "ClientRequestToken": {
+            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -653,8 +749,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -674,10 +774,17 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {},
-          "JobName": {},
-          "LanguageCode": {},
+          "DataAccessRoleArn": {
+            "shape": "S1i"
+          },
+          "JobName": {
+            "shape": "S1a"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          },
           "ClientRequestToken": {
+            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -685,8 +792,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -706,10 +817,17 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {},
-          "JobName": {},
-          "LanguageCode": {},
+          "DataAccessRoleArn": {
+            "shape": "S1i"
+          },
+          "JobName": {
+            "shape": "S1a"
+          },
+          "LanguageCode": {
+            "shape": "Se"
+          },
           "ClientRequestToken": {
+            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -717,8 +835,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -737,12 +859,19 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {},
-          "JobName": {},
+          "DataAccessRoleArn": {
+            "shape": "S1i"
+          },
+          "JobName": {
+            "shape": "S1a"
+          },
           "NumberOfTopics": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           },
           "ClientRequestToken": {
+            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -750,8 +879,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -762,14 +895,20 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -780,14 +919,20 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -798,14 +943,20 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -816,14 +967,20 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S17"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobStatus": {}
+          "JobId": {
+            "shape": "S17"
+          },
+          "JobStatus": {
+            "shape": "S1b"
+          }
         }
       }
     }
@@ -831,14 +988,22 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
+    },
+    "S3": {
+      "type": "string",
+      "min": 1
     },
     "S8": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "LanguageCode": {},
+          "LanguageCode": {
+            "shape": "S3"
+          },
           "Score": {
             "type": "float"
           }
@@ -853,10 +1018,21 @@
           "Index": {
             "type": "integer"
           },
-          "ErrorCode": {},
-          "ErrorMessage": {}
+          "ErrorCode": {
+            "shape": "S3"
+          },
+          "ErrorMessage": {
+            "shape": "S3"
+          }
         }
       }
+    },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "en",
+        "es"
+      ]
     },
     "Si": {
       "type": "list",
@@ -866,8 +1042,23 @@
           "Score": {
             "type": "float"
           },
-          "Type": {},
-          "Text": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "PERSON",
+              "LOCATION",
+              "ORGANIZATION",
+              "COMMERCIAL_ITEM",
+              "EVENT",
+              "DATE",
+              "QUANTITY",
+              "TITLE",
+              "OTHER"
+            ]
+          },
+          "Text": {
+            "shape": "S3"
+          },
           "BeginOffset": {
             "type": "integer"
           },
@@ -885,7 +1076,9 @@
           "Score": {
             "type": "float"
           },
-          "Text": {},
+          "Text": {
+            "shape": "S3"
+          },
           "BeginOffset": {
             "type": "integer"
           },
@@ -894,6 +1087,15 @@
           }
         }
       }
+    },
+    "Sv": {
+      "type": "string",
+      "enum": [
+        "POSITIVE",
+        "NEGATIVE",
+        "NEUTRAL",
+        "MIXED"
+      ]
     },
     "Sw": {
       "type": "structure",
@@ -912,6 +1114,12 @@
         }
       }
     },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "en"
+      ]
+    },
     "S12": {
       "type": "list",
       "member": {
@@ -920,7 +1128,9 @@
           "TokenId": {
             "type": "integer"
           },
-          "Text": {},
+          "Text": {
+            "shape": "S3"
+          },
           "BeginOffset": {
             "type": "integer"
           },
@@ -930,7 +1140,28 @@
           "PartOfSpeech": {
             "type": "structure",
             "members": {
-              "Tag": {},
+              "Tag": {
+                "type": "string",
+                "enum": [
+                  "ADJ",
+                  "ADP",
+                  "ADV",
+                  "AUX",
+                  "CONJ",
+                  "DET",
+                  "INTJ",
+                  "NOUN",
+                  "NUM",
+                  "O",
+                  "PART",
+                  "PRON",
+                  "PROPN",
+                  "PUNCT",
+                  "SCONJ",
+                  "SYM",
+                  "VERB"
+                ]
+              },
               "Score": {
                 "type": "float"
               }
@@ -939,12 +1170,23 @@
         }
       }
     },
+    "S17": {
+      "type": "string",
+      "max": 32,
+      "min": 1
+    },
     "S19": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobName": {},
-        "JobStatus": {},
+        "JobId": {
+          "shape": "S17"
+        },
+        "JobName": {
+          "shape": "S1a"
+        },
+        "JobStatus": {
+          "shape": "S1b"
+        },
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -958,8 +1200,27 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "DataAccessRoleArn": {}
+        "DataAccessRoleArn": {
+          "shape": "S1i"
+        }
       }
+    },
+    "S1a": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+    },
+    "S1b": {
+      "type": "string",
+      "enum": [
+        "SUBMITTED",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "FAILED",
+        "STOP_REQUESTED",
+        "STOPPED"
+      ]
     },
     "S1e": {
       "type": "structure",
@@ -967,9 +1228,22 @@
         "S3Uri"
       ],
       "members": {
-        "S3Uri": {},
-        "InputFormat": {}
+        "S3Uri": {
+          "shape": "S1f"
+        },
+        "InputFormat": {
+          "type": "string",
+          "enum": [
+            "ONE_DOC_PER_FILE",
+            "ONE_DOC_PER_LINE"
+          ]
+        }
       }
+    },
+    "S1f": {
+      "type": "string",
+      "max": 1024,
+      "pattern": "s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?"
     },
     "S1h": {
       "type": "structure",
@@ -977,15 +1251,27 @@
         "S3Uri"
       ],
       "members": {
-        "S3Uri": {}
+        "S3Uri": {
+          "shape": "S1f"
+        }
       }
+    },
+    "S1i": {
+      "type": "string",
+      "pattern": "arn:aws(-[^:]+)?:iam::[0-9]{12}:role/.+"
     },
     "S1l": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobName": {},
-        "JobStatus": {},
+        "JobId": {
+          "shape": "S17"
+        },
+        "JobName": {
+          "shape": "S1a"
+        },
+        "JobStatus": {
+          "shape": "S1b"
+        },
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -999,16 +1285,26 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {},
-        "DataAccessRoleArn": {}
+        "LanguageCode": {
+          "shape": "Se"
+        },
+        "DataAccessRoleArn": {
+          "shape": "S1i"
+        }
       }
     },
     "S1o": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobName": {},
-        "JobStatus": {},
+        "JobId": {
+          "shape": "S17"
+        },
+        "JobName": {
+          "shape": "S1a"
+        },
+        "JobStatus": {
+          "shape": "S1b"
+        },
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1022,16 +1318,26 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {},
-        "DataAccessRoleArn": {}
+        "LanguageCode": {
+          "shape": "Se"
+        },
+        "DataAccessRoleArn": {
+          "shape": "S1i"
+        }
       }
     },
     "S1r": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobName": {},
-        "JobStatus": {},
+        "JobId": {
+          "shape": "S17"
+        },
+        "JobName": {
+          "shape": "S1a"
+        },
+        "JobStatus": {
+          "shape": "S1b"
+        },
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1045,16 +1351,26 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {},
-        "DataAccessRoleArn": {}
+        "LanguageCode": {
+          "shape": "Se"
+        },
+        "DataAccessRoleArn": {
+          "shape": "S1i"
+        }
       }
     },
     "S1u": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobName": {},
-        "JobStatus": {},
+        "JobId": {
+          "shape": "S17"
+        },
+        "JobName": {
+          "shape": "S1a"
+        },
+        "JobStatus": {
+          "shape": "S1b"
+        },
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1072,6 +1388,17 @@
           "type": "integer"
         }
       }
+    },
+    "S27": {
+      "type": "integer",
+      "max": 500,
+      "min": 1
+    },
+    "S2r": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9-]+$"
     }
   }
 }

--- a/apis/config-2014-11-12.min.json
+++ b/apis/config-2014-11-12.min.json
@@ -34,17 +34,27 @@
               "type": "structure",
               "members": {
                 "version": {},
-                "accountId": {},
+                "accountId": {
+                  "shape": "Sa"
+                },
                 "configurationItemCaptureTime": {
                   "type": "timestamp"
                 },
-                "configurationItemStatus": {},
+                "configurationItemStatus": {
+                  "shape": "Sc"
+                },
                 "configurationStateId": {},
                 "arn": {},
-                "resourceType": {},
-                "resourceId": {},
+                "resourceType": {
+                  "shape": "S4"
+                },
+                "resourceId": {
+                  "shape": "S5"
+                },
                 "resourceName": {},
-                "awsRegion": {},
+                "awsRegion": {
+                  "shape": "Sg"
+                },
                 "availabilityZone": {},
                 "resourceCreationTime": {
                   "type": "timestamp"
@@ -70,8 +80,12 @@
           "AuthorizedAwsRegion"
         ],
         "members": {
-          "AuthorizedAccountId": {},
-          "AuthorizedAwsRegion": {}
+          "AuthorizedAccountId": {
+            "shape": "Sa"
+          },
+          "AuthorizedAwsRegion": {
+            "shape": "Sg"
+          }
         }
       }
     },
@@ -82,7 +96,9 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {}
+          "ConfigRuleName": {
+            "shape": "Sp"
+          }
         }
       }
     },
@@ -93,7 +109,9 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {}
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -104,7 +122,9 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {}
+          "ConfigurationRecorderName": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -115,7 +135,9 @@
           "DeliveryChannelName"
         ],
         "members": {
-          "DeliveryChannelName": {}
+          "DeliveryChannelName": {
+            "shape": "Sv"
+          }
         }
       }
     },
@@ -126,7 +148,9 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {}
+          "ConfigRuleName": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
@@ -142,8 +166,12 @@
           "RequesterAwsRegion"
         ],
         "members": {
-          "RequesterAccountId": {},
-          "RequesterAwsRegion": {}
+          "RequesterAccountId": {
+            "shape": "Sa"
+          },
+          "RequesterAwsRegion": {
+            "shape": "Sg"
+          }
         }
       }
     },
@@ -154,7 +182,9 @@
           "RetentionConfigurationName"
         ],
         "members": {
-          "RetentionConfigurationName": {}
+          "RetentionConfigurationName": {
+            "shape": "S10"
+          }
         }
       }
     },
@@ -165,7 +195,9 @@
           "deliveryChannelName"
         ],
         "members": {
-          "deliveryChannelName": {}
+          "deliveryChannelName": {
+            "shape": "Sv"
+          }
         }
       },
       "output": {
@@ -182,18 +214,28 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {},
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          },
           "Filters": {
             "type": "structure",
             "members": {
-              "ConfigRuleName": {},
-              "ComplianceType": {},
-              "AccountId": {},
-              "AwsRegion": {}
+              "ConfigRuleName": {
+                "shape": "S16"
+              },
+              "ComplianceType": {
+                "shape": "S17"
+              },
+              "AccountId": {
+                "shape": "Sa"
+              },
+              "AwsRegion": {
+                "shape": "Sg"
+              }
             }
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S18"
           },
           "NextToken": {}
         }
@@ -206,12 +248,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {},
+                "ConfigRuleName": {
+                  "shape": "S16"
+                },
                 "Compliance": {
                   "shape": "S1d"
                 },
-                "AccountId": {},
-                "AwsRegion": {}
+                "AccountId": {
+                  "shape": "Sa"
+                },
+                "AwsRegion": {
+                  "shape": "Sg"
+                }
               }
             }
           },
@@ -224,7 +272,7 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "NextToken": {}
         }
@@ -263,7 +311,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {},
+                "ConfigRuleName": {
+                  "shape": "Sp"
+                },
                 "Compliance": {
                   "shape": "S1d"
                 }
@@ -278,13 +328,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "ResourceType": {},
-          "ResourceId": {},
+          "ResourceType": {
+            "shape": "S1u"
+          },
+          "ResourceId": {
+            "shape": "S1v"
+          },
           "ComplianceTypes": {
             "shape": "S1p"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "NextToken": {}
         }
@@ -297,8 +351,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "ResourceType": {},
-                "ResourceId": {},
+                "ResourceType": {
+                  "shape": "S1u"
+                },
+                "ResourceId": {
+                  "shape": "S1v"
+                },
                 "Compliance": {
                   "shape": "S1d"
                 }
@@ -318,7 +376,9 @@
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 0
           }
         }
       },
@@ -330,7 +390,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {},
+                "ConfigRuleName": {
+                  "shape": "Sp"
+                },
                 "ConfigRuleArn": {},
                 "ConfigRuleId": {},
                 "LastSuccessfulInvocationTime": {
@@ -390,14 +452,19 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {},
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          },
           "UpdateStatus": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2n"
+            },
+            "min": 1
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           }
         }
       },
@@ -410,9 +477,19 @@
               "type": "structure",
               "members": {
                 "SourceId": {},
-                "SourceType": {},
-                "AwsRegion": {},
-                "LastUpdateStatus": {},
+                "SourceType": {
+                  "type": "string",
+                  "enum": [
+                    "ACCOUNT",
+                    "ORGANIZATION"
+                  ]
+                },
+                "AwsRegion": {
+                  "shape": "Sg"
+                },
+                "LastUpdateStatus": {
+                  "shape": "S2n"
+                },
                 "LastUpdateTime": {
                   "type": "timestamp"
                 },
@@ -431,11 +508,15 @@
         "members": {
           "ConfigurationAggregatorNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sr"
+            },
+            "max": 10,
+            "min": 0
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           }
         }
       },
@@ -479,7 +560,14 @@
                 "recording": {
                   "type": "boolean"
                 },
-                "lastStatus": {},
+                "lastStatus": {
+                  "type": "string",
+                  "enum": [
+                    "Pending",
+                    "Success",
+                    "Failure"
+                  ]
+                },
                 "lastErrorCode": {},
                 "lastErrorMessage": {},
                 "lastStatusChangeTime": {
@@ -539,7 +627,9 @@
                 "configStreamDeliveryInfo": {
                   "type": "structure",
                   "members": {
-                    "lastStatus": {},
+                    "lastStatus": {
+                      "shape": "S3n"
+                    },
                     "lastErrorCode": {},
                     "lastErrorMessage": {},
                     "lastStatusChangeTime": {
@@ -579,7 +669,9 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 20,
+            "min": 0
           },
           "NextToken": {}
         }
@@ -592,8 +684,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "RequesterAccountId": {},
-                "RequesterAwsRegion": {}
+                "RequesterAccountId": {
+                  "shape": "Sa"
+                },
+                "RequesterAwsRegion": {
+                  "shape": "Sg"
+                }
               }
             }
           },
@@ -607,7 +703,11 @@
         "members": {
           "RetentionConfigurationNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S10"
+            },
+            "max": 1,
+            "min": 0
           },
           "NextToken": {}
         }
@@ -635,13 +735,23 @@
           "AwsRegion"
         ],
         "members": {
-          "ConfigurationAggregatorName": {},
-          "ConfigRuleName": {},
-          "AccountId": {},
-          "AwsRegion": {},
-          "ComplianceType": {},
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          },
+          "ConfigRuleName": {
+            "shape": "S16"
+          },
+          "AccountId": {
+            "shape": "Sa"
+          },
+          "AwsRegion": {
+            "shape": "Sg"
+          },
+          "ComplianceType": {
+            "shape": "S17"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "NextToken": {}
         }
@@ -657,16 +767,24 @@
                 "EvaluationResultIdentifier": {
                   "shape": "S49"
                 },
-                "ComplianceType": {},
+                "ComplianceType": {
+                  "shape": "S17"
+                },
                 "ResultRecordedTime": {
                   "type": "timestamp"
                 },
                 "ConfigRuleInvokedTime": {
                   "type": "timestamp"
                 },
-                "Annotation": {},
-                "AccountId": {},
-                "AwsRegion": {}
+                "Annotation": {
+                  "shape": "S1u"
+                },
+                "AccountId": {
+                  "shape": "Sa"
+                },
+                "AwsRegion": {
+                  "shape": "Sg"
+                }
               }
             }
           },
@@ -681,17 +799,29 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {},
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          },
           "Filters": {
             "type": "structure",
             "members": {
-              "AccountId": {},
-              "AwsRegion": {}
+              "AccountId": {
+                "shape": "Sa"
+              },
+              "AwsRegion": {
+                "shape": "Sg"
+              }
             }
           },
-          "GroupByKey": {},
+          "GroupByKey": {
+            "type": "string",
+            "enum": [
+              "ACCOUNT_ID",
+              "AWS_REGION"
+            ]
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S18"
           },
           "NextToken": {}
         }
@@ -699,13 +829,17 @@
       "output": {
         "type": "structure",
         "members": {
-          "GroupByKey": {},
+          "GroupByKey": {
+            "shape": "S1u"
+          },
           "AggregateComplianceCounts": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "GroupName": {},
+                "GroupName": {
+                  "shape": "S1u"
+                },
                 "ComplianceSummary": {
                   "shape": "S4h"
                 }
@@ -723,12 +857,14 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {},
+          "ConfigRuleName": {
+            "shape": "Sp"
+          },
           "ComplianceTypes": {
             "shape": "S1p"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "NextToken": {}
         }
@@ -751,8 +887,12 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceType": {},
-          "ResourceId": {},
+          "ResourceType": {
+            "shape": "S1u"
+          },
+          "ResourceId": {
+            "shape": "S1v"
+          },
           "ComplianceTypes": {
             "shape": "S1p"
           },
@@ -796,7 +936,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ResourceType": {},
+                "ResourceType": {
+                  "shape": "S1u"
+                },
                 "ComplianceSummary": {
                   "shape": "S4h"
                 }
@@ -814,7 +956,7 @@
             "shape": "S4q"
           },
           "limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "nextToken": {}
         }
@@ -830,7 +972,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "resourceType": {},
+                "resourceType": {
+                  "shape": "S4"
+                },
                 "count": {
                   "type": "long"
                 }
@@ -849,17 +993,27 @@
           "resourceId"
         ],
         "members": {
-          "resourceType": {},
-          "resourceId": {},
+          "resourceType": {
+            "shape": "S4"
+          },
+          "resourceId": {
+            "shape": "S5"
+          },
           "laterTime": {
             "type": "timestamp"
           },
           "earlierTime": {
             "type": "timestamp"
           },
-          "chronologicalOrder": {},
+          "chronologicalOrder": {
+            "type": "string",
+            "enum": [
+              "Reverse",
+              "Forward"
+            ]
+          },
           "limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "nextToken": {}
         }
@@ -873,18 +1027,28 @@
               "type": "structure",
               "members": {
                 "version": {},
-                "accountId": {},
+                "accountId": {
+                  "shape": "Sa"
+                },
                 "configurationItemCaptureTime": {
                   "type": "timestamp"
                 },
-                "configurationItemStatus": {},
+                "configurationItemStatus": {
+                  "shape": "Sc"
+                },
                 "configurationStateId": {},
                 "configurationItemMD5Hash": {},
                 "arn": {},
-                "resourceType": {},
-                "resourceId": {},
+                "resourceType": {
+                  "shape": "S4"
+                },
+                "resourceId": {
+                  "shape": "S5"
+                },
                 "resourceName": {},
-                "awsRegion": {},
+                "awsRegion": {
+                  "shape": "Sg"
+                },
                 "availabilityZone": {},
                 "resourceCreationTime": {
                   "type": "timestamp"
@@ -903,8 +1067,12 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "resourceType": {},
-                      "resourceId": {},
+                      "resourceType": {
+                        "shape": "S4"
+                      },
+                      "resourceId": {
+                        "shape": "S5"
+                      },
                       "resourceName": {},
                       "relationshipName": {}
                     }
@@ -928,14 +1096,18 @@
           "resourceType"
         ],
         "members": {
-          "resourceType": {},
+          "resourceType": {
+            "shape": "S4"
+          },
           "resourceIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            }
           },
           "resourceName": {},
           "limit": {
-            "type": "integer"
+            "shape": "S1i"
           },
           "includeDeletedResources": {
             "type": "boolean"
@@ -951,8 +1123,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "resourceType": {},
-                "resourceId": {},
+                "resourceType": {
+                  "shape": "S4"
+                },
+                "resourceId": {
+                  "shape": "S5"
+                },
                 "resourceName": {},
                 "resourceDeletionTime": {
                   "type": "timestamp"
@@ -972,8 +1148,12 @@
           "AuthorizedAwsRegion"
         ],
         "members": {
-          "AuthorizedAccountId": {},
-          "AuthorizedAwsRegion": {}
+          "AuthorizedAccountId": {
+            "shape": "Sa"
+          },
+          "AuthorizedAwsRegion": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -1005,7 +1185,9 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {},
+          "ConfigurationAggregatorName": {
+            "shape": "Sr"
+          },
           "AccountAggregationSources": {
             "shape": "S2y"
           },
@@ -1082,7 +1264,7 @@
         ],
         "members": {
           "RetentionPeriodInDays": {
-            "type": "integer"
+            "shape": "S44"
           }
         }
       },
@@ -1101,7 +1283,11 @@
         "members": {
           "ConfigRuleNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sp"
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -1117,7 +1303,9 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {}
+          "ConfigurationRecorderName": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -1128,7 +1316,9 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {}
+          "ConfigurationRecorderName": {
+            "shape": "St"
+          }
         }
       }
     }
@@ -1143,20 +1333,161 @@
           "resourceId"
         ],
         "members": {
-          "resourceType": {},
-          "resourceId": {}
+          "resourceType": {
+            "shape": "S4"
+          },
+          "resourceId": {
+            "shape": "S5"
+          }
         }
-      }
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "AWS::EC2::CustomerGateway",
+        "AWS::EC2::EIP",
+        "AWS::EC2::Host",
+        "AWS::EC2::Instance",
+        "AWS::EC2::InternetGateway",
+        "AWS::EC2::NetworkAcl",
+        "AWS::EC2::NetworkInterface",
+        "AWS::EC2::RouteTable",
+        "AWS::EC2::SecurityGroup",
+        "AWS::EC2::Subnet",
+        "AWS::CloudTrail::Trail",
+        "AWS::EC2::Volume",
+        "AWS::EC2::VPC",
+        "AWS::EC2::VPNConnection",
+        "AWS::EC2::VPNGateway",
+        "AWS::IAM::Group",
+        "AWS::IAM::Policy",
+        "AWS::IAM::Role",
+        "AWS::IAM::User",
+        "AWS::ACM::Certificate",
+        "AWS::RDS::DBInstance",
+        "AWS::RDS::DBSubnetGroup",
+        "AWS::RDS::DBSecurityGroup",
+        "AWS::RDS::DBSnapshot",
+        "AWS::RDS::EventSubscription",
+        "AWS::ElasticLoadBalancingV2::LoadBalancer",
+        "AWS::S3::Bucket",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::Redshift::Cluster",
+        "AWS::Redshift::ClusterSnapshot",
+        "AWS::Redshift::ClusterParameterGroup",
+        "AWS::Redshift::ClusterSecurityGroup",
+        "AWS::Redshift::ClusterSubnetGroup",
+        "AWS::Redshift::EventSubscription",
+        "AWS::CloudWatch::Alarm",
+        "AWS::CloudFormation::Stack",
+        "AWS::DynamoDB::Table",
+        "AWS::AutoScaling::AutoScalingGroup",
+        "AWS::AutoScaling::LaunchConfiguration",
+        "AWS::AutoScaling::ScalingPolicy",
+        "AWS::AutoScaling::ScheduledAction",
+        "AWS::CodeBuild::Project",
+        "AWS::WAF::RateBasedRule",
+        "AWS::WAF::Rule",
+        "AWS::WAF::WebACL",
+        "AWS::WAFRegional::RateBasedRule",
+        "AWS::WAFRegional::Rule",
+        "AWS::WAFRegional::WebACL",
+        "AWS::CloudFront::Distribution",
+        "AWS::CloudFront::StreamingDistribution",
+        "AWS::WAF::RuleGroup",
+        "AWS::WAFRegional::RuleGroup",
+        "AWS::Lambda::Function",
+        "AWS::ElasticBeanstalk::Application",
+        "AWS::ElasticBeanstalk::ApplicationVersion",
+        "AWS::ElasticBeanstalk::Environment",
+        "AWS::ElasticLoadBalancing::LoadBalancer",
+        "AWS::XRay::EncryptionConfig"
+      ]
+    },
+    "S5": {
+      "type": "string",
+      "max": 768,
+      "min": 1
+    },
+    "Sa": {
+      "type": "string",
+      "pattern": "\\d{12}"
+    },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "OK",
+        "ResourceDiscovered",
+        "ResourceNotRecorded",
+        "ResourceDeleted",
+        "ResourceDeletedNotRecorded"
+      ]
+    },
+    "Sg": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "Sk": {
       "type": "map",
       "key": {},
       "value": {}
     },
+    "Sp": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "Sr": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\w\\-]+"
+    },
+    "St": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "Sv": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\w\\-]+"
+    },
+    "S16": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "S17": {
+      "type": "string",
+      "enum": [
+        "COMPLIANT",
+        "NON_COMPLIANT",
+        "NOT_APPLICABLE",
+        "INSUFFICIENT_DATA"
+      ]
+    },
+    "S18": {
+      "type": "integer",
+      "max": 1000,
+      "min": 0
+    },
     "S1d": {
       "type": "structure",
       "members": {
-        "ComplianceType": {},
+        "ComplianceType": {
+          "shape": "S17"
+        },
         "ComplianceContributorCount": {
           "shape": "S1e"
         }
@@ -1173,12 +1504,21 @@
         }
       }
     },
+    "S1i": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
+    },
     "S1l": {
       "type": "structure",
       "members": {
         "AggregationAuthorizationArn": {},
-        "AuthorizedAccountId": {},
-        "AuthorizedAwsRegion": {},
+        "AuthorizedAccountId": {
+          "shape": "Sa"
+        },
+        "AuthorizedAwsRegion": {
+          "shape": "Sg"
+        },
         "CreationTime": {
           "type": "timestamp"
         }
@@ -1186,11 +1526,29 @@
     },
     "S1o": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sp"
+      },
+      "max": 25,
+      "min": 0
     },
     "S1p": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S17"
+      },
+      "max": 3,
+      "min": 0
+    },
+    "S1u": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S1v": {
+      "type": "string",
+      "max": 768,
+      "min": 1
     },
     "S27": {
       "type": "structure",
@@ -1198,20 +1556,38 @@
         "Source"
       ],
       "members": {
-        "ConfigRuleName": {},
+        "ConfigRuleName": {
+          "shape": "Sp"
+        },
         "ConfigRuleArn": {},
         "ConfigRuleId": {},
-        "Description": {},
+        "Description": {
+          "type": "string",
+          "max": 256,
+          "min": 0
+        },
         "Scope": {
           "type": "structure",
           "members": {
             "ComplianceResourceTypes": {
               "type": "list",
-              "member": {}
+              "member": {
+                "shape": "S1u"
+              },
+              "max": 100,
+              "min": 0
             },
-            "TagKey": {},
-            "TagValue": {},
-            "ComplianceResourceId": {}
+            "TagKey": {
+              "type": "string",
+              "max": 128,
+              "min": 1
+            },
+            "TagValue": {
+              "shape": "S1u"
+            },
+            "ComplianceResourceId": {
+              "shape": "S1v"
+            }
           }
         },
         "Source": {
@@ -1221,32 +1597,96 @@
             "SourceIdentifier"
           ],
           "members": {
-            "Owner": {},
-            "SourceIdentifier": {},
+            "Owner": {
+              "type": "string",
+              "enum": [
+                "CUSTOM_LAMBDA",
+                "AWS"
+              ]
+            },
+            "SourceIdentifier": {
+              "shape": "S1u"
+            },
             "SourceDetails": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "EventSource": {},
-                  "MessageType": {},
-                  "MaximumExecutionFrequency": {}
+                  "EventSource": {
+                    "type": "string",
+                    "enum": [
+                      "aws.config"
+                    ]
+                  },
+                  "MessageType": {
+                    "type": "string",
+                    "enum": [
+                      "ConfigurationItemChangeNotification",
+                      "ConfigurationSnapshotDeliveryCompleted",
+                      "ScheduledNotification",
+                      "OversizedConfigurationItemChangeNotification"
+                    ]
+                  },
+                  "MaximumExecutionFrequency": {
+                    "shape": "S2i"
+                  }
                 }
-              }
+              },
+              "max": 25,
+              "min": 0
             }
           }
         },
-        "InputParameters": {},
-        "MaximumExecutionFrequency": {},
-        "ConfigRuleState": {},
-        "CreatedBy": {}
+        "InputParameters": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        },
+        "MaximumExecutionFrequency": {
+          "shape": "S2i"
+        },
+        "ConfigRuleState": {
+          "type": "string",
+          "enum": [
+            "ACTIVE",
+            "DELETING",
+            "DELETING_RESULTS",
+            "EVALUATING"
+          ]
+        },
+        "CreatedBy": {
+          "shape": "S1u"
+        }
       }
+    },
+    "S2i": {
+      "type": "string",
+      "enum": [
+        "One_Hour",
+        "Three_Hours",
+        "Six_Hours",
+        "Twelve_Hours",
+        "TwentyFour_Hours"
+      ]
+    },
+    "S2n": {
+      "type": "string",
+      "enum": [
+        "FAILED",
+        "SUCCEEDED",
+        "OUTDATED"
+      ]
     },
     "S2w": {
       "type": "structure",
       "members": {
-        "ConfigurationAggregatorName": {},
-        "ConfigurationAggregatorArn": {},
+        "ConfigurationAggregatorName": {
+          "shape": "Sr"
+        },
+        "ConfigurationAggregatorArn": {
+          "type": "string",
+          "pattern": "arn:aws[a-z\\-]*:config:[a-z\\-\\d]+:\\d+:config-aggregator/config-aggregator-[a-z\\d]+"
+        },
         "AccountAggregationSources": {
           "shape": "S2y"
         },
@@ -1271,7 +1711,10 @@
         "members": {
           "AccountIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa"
+            },
+            "min": 1
           },
           "AllAwsRegions": {
             "type": "boolean"
@@ -1280,11 +1723,14 @@
             "shape": "S31"
           }
         }
-      }
+      },
+      "max": 1,
+      "min": 0
     },
     "S31": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "min": 1
     },
     "S32": {
       "type": "structure",
@@ -1303,12 +1749,16 @@
     },
     "S34": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "St"
+      }
     },
     "S3c": {
       "type": "structure",
       "members": {
-        "name": {},
+        "name": {
+          "shape": "St"
+        },
         "roleARN": {},
         "recordingGroup": {
           "type": "structure",
@@ -1321,7 +1771,9 @@
             },
             "resourceTypes": {
               "type": "list",
-              "member": {}
+              "member": {
+                "shape": "S4"
+              }
             }
           }
         }
@@ -1329,12 +1781,16 @@
     },
     "S3i": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sv"
+      }
     },
     "S3m": {
       "type": "structure",
       "members": {
-        "lastStatus": {},
+        "lastStatus": {
+          "shape": "S3n"
+        },
         "lastErrorCode": {},
         "lastErrorMessage": {},
         "lastAttemptTime": {
@@ -1348,17 +1804,29 @@
         }
       }
     },
+    "S3n": {
+      "type": "string",
+      "enum": [
+        "Success",
+        "Failure",
+        "Not_Applicable"
+      ]
+    },
     "S3s": {
       "type": "structure",
       "members": {
-        "name": {},
+        "name": {
+          "shape": "Sv"
+        },
         "s3BucketName": {},
         "s3KeyPrefix": {},
         "snsTopicARN": {},
         "configSnapshotDeliveryProperties": {
           "type": "structure",
           "members": {
-            "deliveryFrequency": {}
+            "deliveryFrequency": {
+              "shape": "S2i"
+            }
           }
         }
       }
@@ -1370,11 +1838,18 @@
         "RetentionPeriodInDays"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S10"
+        },
         "RetentionPeriodInDays": {
-          "type": "integer"
+          "shape": "S44"
         }
       }
+    },
+    "S44": {
+      "type": "integer",
+      "max": 2557,
+      "min": 30
     },
     "S49": {
       "type": "structure",
@@ -1382,9 +1857,15 @@
         "EvaluationResultQualifier": {
           "type": "structure",
           "members": {
-            "ConfigRuleName": {},
-            "ResourceType": {},
-            "ResourceId": {}
+            "ConfigRuleName": {
+              "shape": "Sp"
+            },
+            "ResourceType": {
+              "shape": "S1u"
+            },
+            "ResourceId": {
+              "shape": "S1v"
+            }
           }
         },
         "OrderingTimestamp": {
@@ -1414,21 +1895,29 @@
           "EvaluationResultIdentifier": {
             "shape": "S49"
           },
-          "ComplianceType": {},
+          "ComplianceType": {
+            "shape": "S17"
+          },
           "ResultRecordedTime": {
             "type": "timestamp"
           },
           "ConfigRuleInvokedTime": {
             "type": "timestamp"
           },
-          "Annotation": {},
+          "Annotation": {
+            "shape": "S1u"
+          },
           "ResultToken": {}
         }
       }
     },
     "S4q": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1u"
+      },
+      "max": 20,
+      "min": 0
     },
     "S5t": {
       "type": "list",
@@ -1441,15 +1930,25 @@
           "OrderingTimestamp"
         ],
         "members": {
-          "ComplianceResourceType": {},
-          "ComplianceResourceId": {},
-          "ComplianceType": {},
-          "Annotation": {},
+          "ComplianceResourceType": {
+            "shape": "S1u"
+          },
+          "ComplianceResourceId": {
+            "shape": "S1v"
+          },
+          "ComplianceType": {
+            "shape": "S17"
+          },
+          "Annotation": {
+            "shape": "S1u"
+          },
           "OrderingTimestamp": {
             "type": "timestamp"
           }
         }
-      }
+      },
+      "max": 100,
+      "min": 0
     }
   }
 }

--- a/apis/connect-2017-08-08.min.json
+++ b/apis/connect-2017-08-08.min.json
@@ -28,8 +28,13 @@
           "InstanceId"
         ],
         "members": {
-          "Username": {},
-          "Password": {},
+          "Username": {
+            "shape": "S2"
+          },
+          "Password": {
+            "type": "string",
+            "pattern": "/^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d\\S]{8,64}$/"
+          },
           "IdentityInfo": {
             "shape": "S4"
           },
@@ -43,6 +48,7 @@
           "RoutingProfileId": {},
           "HierarchyGroupId": {},
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -69,6 +75,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -96,6 +103,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -109,7 +117,9 @@
             "members": {
               "Id": {},
               "Arn": {},
-              "Username": {},
+              "Username": {
+                "shape": "S2"
+              },
               "IdentityInfo": {
                 "shape": "S4"
               },
@@ -144,6 +154,7 @@
             "locationName": "HierarchyGroupId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -196,6 +207,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -240,6 +252,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -257,7 +270,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1f"
           }
         }
       },
@@ -308,6 +321,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -351,6 +365,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -374,7 +389,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1f"
           }
         }
       },
@@ -422,6 +437,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -430,9 +446,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
+            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -446,7 +462,11 @@
               "members": {
                 "Id": {},
                 "Arn": {},
-                "Name": {}
+                "Name": {
+                  "type": "string",
+                  "max": 100,
+                  "min": 1
+                }
               }
             }
           },
@@ -466,6 +486,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -474,9 +495,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
+            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -510,6 +531,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -518,9 +540,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
+            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -549,6 +571,7 @@
         ],
         "members": {
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -557,9 +580,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
+            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -573,7 +596,9 @@
               "members": {
                 "Id": {},
                 "Arn": {},
-                "Username": {}
+                "Username": {
+                  "shape": "S2"
+                }
               }
             }
           },
@@ -595,10 +620,17 @@
         ],
         "members": {
           "DestinationPhoneNumber": {},
-          "ContactFlowId": {},
-          "InstanceId": {},
+          "ContactFlowId": {
+            "type": "string",
+            "max": 500
+          },
+          "InstanceId": {
+            "shape": "Si"
+          },
           "ClientToken": {
-            "idempotencyToken": true
+            "idempotencyToken": true,
+            "type": "string",
+            "max": 500
           },
           "SourcePhoneNumber": {},
           "QueueId": {},
@@ -610,7 +642,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContactId": {}
+          "ContactId": {
+            "shape": "S2v"
+          }
         }
       }
     },
@@ -625,8 +659,12 @@
           "InstanceId"
         ],
         "members": {
-          "ContactId": {},
-          "InstanceId": {}
+          "ContactId": {
+            "shape": "S2v"
+          },
+          "InstanceId": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -646,8 +684,12 @@
           "Attributes"
         ],
         "members": {
-          "InitialContactId": {},
-          "InstanceId": {},
+          "InitialContactId": {
+            "shape": "S2v"
+          },
+          "InstanceId": {
+            "shape": "Si"
+          },
           "Attributes": {
             "shape": "S2r"
           }
@@ -675,6 +717,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -701,6 +744,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -727,6 +771,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -751,6 +796,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -777,6 +823,7 @@
             "locationName": "UserId"
           },
           "InstanceId": {
+            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -785,11 +832,25 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 20,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\_\\-\\.]+"
+    },
     "S4": {
       "type": "structure",
       "members": {
-        "FirstName": {},
-        "LastName": {},
+        "FirstName": {
+          "type": "string",
+          "max": 100,
+          "min": 1
+        },
+        "LastName": {
+          "type": "string",
+          "max": 100,
+          "min": 1
+        },
         "Email": {}
       }
     },
@@ -799,19 +860,33 @@
         "PhoneType"
       ],
       "members": {
-        "PhoneType": {},
+        "PhoneType": {
+          "type": "string",
+          "enum": [
+            "SOFT_PHONE",
+            "DESK_PHONE"
+          ]
+        },
         "AutoAccept": {
           "type": "boolean"
         },
         "AfterContactWorkTimeLimit": {
-          "type": "integer"
+          "type": "integer",
+          "min": 0
         },
         "DeskPhoneNumber": {}
       }
     },
     "Se": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 10,
+      "min": 1
+    },
+    "Si": {
+      "type": "string",
+      "max": 100,
+      "min": 1
     },
     "Sw": {
       "type": "structure",
@@ -834,24 +909,71 @@
       "members": {
         "Queues": {
           "type": "list",
-          "member": {}
+          "member": {},
+          "max": 100,
+          "min": 1
         },
         "Channels": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S17"
+          },
+          "max": 1
         }
       }
     },
+    "S17": {
+      "type": "string",
+      "enum": [
+        "VOICE"
+      ]
+    },
     "S18": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "QUEUE",
+          "CHANNEL"
+        ]
+      },
+      "max": 2
     },
     "S1b": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Unit": {}
+        "Name": {
+          "type": "string",
+          "enum": [
+            "AGENTS_ONLINE",
+            "AGENTS_AVAILABLE",
+            "AGENTS_ON_CALL",
+            "AGENTS_NON_PRODUCTIVE",
+            "AGENTS_AFTER_CONTACT_WORK",
+            "AGENTS_ERROR",
+            "AGENTS_STAFFED",
+            "CONTACTS_IN_QUEUE",
+            "OLDEST_CONTACT_AGE",
+            "CONTACTS_SCHEDULED"
+          ]
+        },
+        "Unit": {
+          "shape": "S1d"
+        }
       }
+    },
+    "S1d": {
+      "type": "string",
+      "enum": [
+        "SECONDS",
+        "COUNT",
+        "PERCENT"
+      ]
+    },
+    "S1f": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S1j": {
       "type": "structure",
@@ -863,7 +985,9 @@
             "Arn": {}
           }
         },
-        "Channel": {}
+        "Channel": {
+          "shape": "S17"
+        }
       }
     },
     "S1s": {
@@ -873,24 +997,85 @@
     "S1v": {
       "type": "structure",
       "members": {
-        "Name": {},
+        "Name": {
+          "type": "string",
+          "enum": [
+            "CONTACTS_QUEUED",
+            "CONTACTS_HANDLED",
+            "CONTACTS_ABANDONED",
+            "CONTACTS_CONSULTED",
+            "CONTACTS_AGENT_HUNG_UP_FIRST",
+            "CONTACTS_HANDLED_INCOMING",
+            "CONTACTS_HANDLED_OUTBOUND",
+            "CONTACTS_HOLD_ABANDONS",
+            "CONTACTS_TRANSFERRED_IN",
+            "CONTACTS_TRANSFERRED_OUT",
+            "CONTACTS_TRANSFERRED_IN_FROM_QUEUE",
+            "CONTACTS_TRANSFERRED_OUT_FROM_QUEUE",
+            "CONTACTS_MISSED",
+            "CALLBACK_CONTACTS_HANDLED",
+            "API_CONTACTS_HANDLED",
+            "OCCUPANCY",
+            "HANDLE_TIME",
+            "AFTER_CONTACT_WORK_TIME",
+            "QUEUED_TIME",
+            "ABANDON_TIME",
+            "QUEUE_ANSWER_TIME",
+            "HOLD_TIME",
+            "INTERACTION_TIME",
+            "INTERACTION_AND_HOLD_TIME",
+            "SERVICE_LEVEL"
+          ]
+        },
         "Threshold": {
           "type": "structure",
           "members": {
-            "Comparison": {},
+            "Comparison": {
+              "type": "string",
+              "enum": [
+                "LT"
+              ]
+            },
             "ThresholdValue": {
               "type": "double"
             }
           }
         },
-        "Statistic": {},
-        "Unit": {}
+        "Statistic": {
+          "type": "string",
+          "enum": [
+            "SUM",
+            "MAX",
+            "AVG"
+          ]
+        },
+        "Unit": {
+          "shape": "S1d"
+        }
       }
+    },
+    "S27": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
     },
     "S2r": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 32767,
+        "min": 1
+      },
+      "value": {
+        "type": "string",
+        "max": 32767,
+        "min": 0
+      }
+    },
+    "S2v": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     }
   }
 }

--- a/apis/cur-2017-01-06.min.json
+++ b/apis/cur-2017-01-06.min.json
@@ -17,7 +17,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ReportName": {}
+          "ReportName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -32,7 +34,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 5,
+            "min": 5
           },
           "NextToken": {}
         }
@@ -69,6 +73,11 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 256,
+      "pattern": "[0-9A-Za-z!\\-_.*\\'()]+"
+    },
     "Sa": {
       "type": "structure",
       "required": [
@@ -82,20 +91,69 @@
         "S3Region"
       ],
       "members": {
-        "ReportName": {},
-        "TimeUnit": {},
-        "Format": {},
-        "Compression": {},
+        "ReportName": {
+          "shape": "S2"
+        },
+        "TimeUnit": {
+          "type": "string",
+          "enum": [
+            "HOURLY",
+            "DAILY"
+          ]
+        },
+        "Format": {
+          "type": "string",
+          "enum": [
+            "textORcsv"
+          ]
+        },
+        "Compression": {
+          "type": "string",
+          "enum": [
+            "ZIP",
+            "GZIP"
+          ]
+        },
         "AdditionalSchemaElements": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "RESOURCES"
+            ]
+          }
         },
-        "S3Bucket": {},
-        "S3Prefix": {},
-        "S3Region": {},
+        "S3Bucket": {
+          "type": "string",
+          "max": 256
+        },
+        "S3Prefix": {
+          "type": "string",
+          "max": 256,
+          "pattern": "[0-9A-Za-z!\\-_.*\\'()/]*"
+        },
+        "S3Region": {
+          "type": "string",
+          "enum": [
+            "us-east-1",
+            "us-west-1",
+            "us-west-2",
+            "eu-central-1",
+            "eu-west-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-northeast-1"
+          ]
+        },
         "AdditionalArtifacts": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "REDSHIFT",
+              "QUICKSIGHT"
+            ]
+          }
         }
       }
     }

--- a/apis/datapipeline-2012-10-29.min.json
+++ b/apis/datapipeline-2012-10-29.min.json
@@ -19,7 +19,9 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "parameterValues": {
             "shape": "S3"
           },
@@ -41,7 +43,9 @@
           "tags"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "tags": {
             "shape": "Sa"
           }
@@ -60,9 +64,15 @@
           "uniqueId"
         ],
         "members": {
-          "name": {},
-          "uniqueId": {},
-          "description": {},
+          "name": {
+            "shape": "S2"
+          },
+          "uniqueId": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "Sg"
+          },
           "tags": {
             "shape": "Sa"
           }
@@ -74,7 +84,9 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {}
+          "pipelineId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -85,7 +97,9 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "cancelActive": {
             "type": "boolean"
           }
@@ -103,7 +117,9 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {}
+          "pipelineId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -115,14 +131,18 @@
           "objectIds"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "objectIds": {
             "shape": "Sn"
           },
           "evaluateExpressions": {
             "type": "boolean"
           },
-          "marker": {}
+          "marker": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -134,7 +154,9 @@
           "pipelineObjects": {
             "shape": "Sq"
           },
-          "marker": {},
+          "marker": {
+            "shape": "Sg"
+          },
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -169,12 +191,18 @@
                 "fields"
               ],
               "members": {
-                "pipelineId": {},
-                "name": {},
+                "pipelineId": {
+                  "shape": "S2"
+                },
+                "name": {
+                  "shape": "S2"
+                },
                 "fields": {
                   "shape": "Ss"
                 },
-                "description": {},
+                "description": {
+                  "shape": "Sg"
+                },
                 "tags": {
                   "shape": "Sa"
                 }
@@ -193,9 +221,15 @@
           "expression"
         ],
         "members": {
-          "pipelineId": {},
-          "objectId": {},
-          "expression": {}
+          "pipelineId": {
+            "shape": "S2"
+          },
+          "objectId": {
+            "shape": "S2"
+          },
+          "expression": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -204,7 +238,9 @@
           "evaluatedExpression"
         ],
         "members": {
-          "evaluatedExpression": {}
+          "evaluatedExpression": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -215,8 +251,12 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {},
-          "version": {}
+          "pipelineId": {
+            "shape": "S2"
+          },
+          "version": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -238,7 +278,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "marker": {}
+          "marker": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -252,12 +294,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {},
-                "name": {}
+                "id": {
+                  "shape": "S2"
+                },
+                "name": {
+                  "shape": "S2"
+                }
               }
             }
           },
-          "marker": {},
+          "marker": {
+            "shape": "Sg"
+          },
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -271,13 +319,21 @@
           "workerGroup"
         ],
         "members": {
-          "workerGroup": {},
-          "hostname": {},
+          "workerGroup": {
+            "shape": "Sg"
+          },
+          "hostname": {
+            "shape": "S2"
+          },
           "instanceIdentity": {
             "type": "structure",
             "members": {
-              "document": {},
-              "signature": {}
+              "document": {
+                "shape": "Sg"
+              },
+              "signature": {
+                "shape": "Sg"
+              }
             }
           }
         }
@@ -288,12 +344,20 @@
           "taskObject": {
             "type": "structure",
             "members": {
-              "taskId": {},
-              "pipelineId": {},
-              "attemptId": {},
+              "taskId": {
+                "shape": "S1h"
+              },
+              "pipelineId": {
+                "shape": "S2"
+              },
+              "attemptId": {
+                "shape": "S2"
+              },
               "objects": {
                 "type": "map",
-                "key": {},
+                "key": {
+                  "shape": "S2"
+                },
                 "value": {
                   "shape": "Sr"
                 }
@@ -311,7 +375,9 @@
           "pipelineObjects"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "pipelineObjects": {
             "shape": "Sq"
           },
@@ -349,7 +415,9 @@
           "sphere"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "query": {
             "type": "structure",
             "members": {
@@ -358,11 +426,22 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "fieldName": {},
+                    "fieldName": {
+                      "shape": "Sg"
+                    },
                     "operator": {
                       "type": "structure",
                       "members": {
-                        "type": {},
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "EQ",
+                            "REF_EQ",
+                            "LE",
+                            "GE",
+                            "BETWEEN"
+                          ]
+                        },
                         "values": {
                           "shape": "S1x"
                         }
@@ -373,8 +452,12 @@
               }
             }
           },
-          "sphere": {},
-          "marker": {},
+          "sphere": {
+            "shape": "Sg"
+          },
+          "marker": {
+            "shape": "Sg"
+          },
           "limit": {
             "type": "integer"
           }
@@ -386,7 +469,9 @@
           "ids": {
             "shape": "Sn"
           },
-          "marker": {},
+          "marker": {
+            "shape": "Sg"
+          },
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -401,7 +486,9 @@
           "tagKeys"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "tagKeys": {
             "shape": "S1x"
           }
@@ -419,7 +506,9 @@
           "taskId"
         ],
         "members": {
-          "taskId": {},
+          "taskId": {
+            "shape": "S1h"
+          },
           "fields": {
             "shape": "Ss"
           }
@@ -444,9 +533,15 @@
           "taskrunnerId"
         ],
         "members": {
-          "taskrunnerId": {},
-          "workerGroup": {},
-          "hostname": {}
+          "taskrunnerId": {
+            "shape": "S2"
+          },
+          "workerGroup": {
+            "shape": "Sg"
+          },
+          "hostname": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -470,11 +565,15 @@
           "status"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "objectIds": {
             "shape": "Sn"
           },
-          "status": {}
+          "status": {
+            "shape": "Sg"
+          }
         }
       }
     },
@@ -486,11 +585,24 @@
           "taskStatus"
         ],
         "members": {
-          "taskId": {},
-          "taskStatus": {},
-          "errorId": {},
+          "taskId": {
+            "shape": "S1h"
+          },
+          "taskStatus": {
+            "type": "string",
+            "enum": [
+              "FINISHED",
+              "FAILED",
+              "FALSE"
+            ]
+          },
+          "errorId": {
+            "shape": "Sg"
+          },
           "errorMessage": {},
-          "errorStackTrace": {}
+          "errorStackTrace": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
@@ -506,7 +618,9 @@
           "pipelineObjects"
         ],
         "members": {
-          "pipelineId": {},
+          "pipelineId": {
+            "shape": "S2"
+          },
           "pipelineObjects": {
             "shape": "Sq"
           },
@@ -538,6 +652,12 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S3": {
       "type": "list",
       "member": {
@@ -547,10 +667,26 @@
           "stringValue"
         ],
         "members": {
-          "id": {},
-          "stringValue": {}
+          "id": {
+            "shape": "S5"
+          },
+          "stringValue": {
+            "shape": "S6"
+          }
         }
       }
+    },
+    "S5": {
+      "type": "string",
+      "min": 1,
+      "max": 256,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S6": {
+      "type": "string",
+      "min": 0,
+      "max": 10240,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sa": {
       "type": "list",
@@ -561,14 +697,32 @@
           "value"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "type": "string",
+            "min": 1,
+            "max": 128
+          },
+          "value": {
+            "type": "string",
+            "min": 0,
+            "max": 256
+          }
         }
-      }
+      },
+      "min": 0,
+      "max": 10
+    },
+    "Sg": {
+      "type": "string",
+      "min": 0,
+      "max": 1024,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sn": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "Sq": {
       "type": "list",
@@ -584,8 +738,12 @@
         "fields"
       ],
       "members": {
-        "id": {},
-        "name": {},
+        "id": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S2"
+        },
         "fields": {
           "shape": "Ss"
         }
@@ -599,11 +757,23 @@
           "key"
         ],
         "members": {
-          "key": {},
-          "stringValue": {},
-          "refValue": {}
+          "key": {
+            "shape": "S5"
+          },
+          "stringValue": {
+            "shape": "S6"
+          },
+          "refValue": {
+            "shape": "S5"
+          }
         }
       }
+    },
+    "Sz": {
+      "type": "string",
+      "min": 0,
+      "max": 20971520,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S13": {
       "type": "list",
@@ -614,7 +784,9 @@
           "attributes"
         ],
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S5"
+          },
           "attributes": {
             "type": "list",
             "member": {
@@ -624,20 +796,38 @@
                 "stringValue"
               ],
               "members": {
-                "key": {},
-                "stringValue": {}
+                "key": {
+                  "type": "string",
+                  "min": 1,
+                  "max": 256,
+                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+                },
+                "stringValue": {
+                  "type": "string",
+                  "min": 0,
+                  "max": 10240,
+                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+                }
               }
             }
           }
         }
       }
     },
+    "S1h": {
+      "type": "string",
+      "min": 1,
+      "max": 2048,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S1l": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "errors": {
             "shape": "S1n"
           }
@@ -646,14 +836,21 @@
     },
     "S1n": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "min": 0,
+        "max": 10000,
+        "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      }
     },
     "S1p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "id": {},
+          "id": {
+            "shape": "S2"
+          },
           "warnings": {
             "shape": "S1n"
           }
@@ -662,7 +859,9 @@
     },
     "S1x": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sg"
+      }
     }
   }
 }

--- a/apis/dax-2017-04-19.min.json
+++ b/apis/dax-2017-04-19.min.json
@@ -243,7 +243,9 @@
         "type": "structure",
         "members": {
           "SourceName": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S1j"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -269,7 +271,9 @@
               "type": "structure",
               "members": {
                 "SourceName": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S1j"
+                },
                 "Message": {},
                 "Date": {
                   "type": "timestamp"
@@ -645,7 +649,15 @@
         "SSEDescription": {
           "type": "structure",
           "members": {
-            "Status": {}
+            "Status": {
+              "type": "string",
+              "enum": [
+                "ENABLING",
+                "ENABLED",
+                "DISABLING",
+                "DISABLED"
+              ]
+            }
           }
         }
       }
@@ -698,7 +710,13 @@
         "type": "structure",
         "members": {
           "ParameterName": {},
-          "ParameterType": {},
+          "ParameterType": {
+            "type": "string",
+            "enum": [
+              "DEFAULT",
+              "NODE_TYPE_SPECIFIC"
+            ]
+          },
           "ParameterValue": {},
           "NodeTypeSpecificValues": {
             "type": "list",
@@ -714,10 +732,31 @@
           "Source": {},
           "DataType": {},
           "AllowedValues": {},
-          "IsModifiable": {},
-          "ChangeType": {}
+          "IsModifiable": {
+            "type": "string",
+            "enum": [
+              "TRUE",
+              "FALSE",
+              "CONDITIONAL"
+            ]
+          },
+          "ChangeType": {
+            "type": "string",
+            "enum": [
+              "IMMEDIATE",
+              "REQUIRES_REBOOT"
+            ]
+          }
         }
       }
+    },
+    "S1j": {
+      "type": "string",
+      "enum": [
+        "CLUSTER",
+        "PARAMETER_GROUP",
+        "SUBNET_GROUP"
+      ]
     }
   }
 }

--- a/apis/devicefarm-2015-06-23.min.json
+++ b/apis/devicefarm-2015-06-23.min.json
@@ -21,9 +21,15 @@
           "rules"
         ],
         "members": {
-          "projectArn": {},
-          "name": {},
-          "description": {},
+          "projectArn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
           "rules": {
             "shape": "S5"
           }
@@ -45,8 +51,12 @@
           "name"
         ],
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
           "packageCleanup": {
             "type": "boolean"
           },
@@ -75,10 +85,18 @@
           "name"
         ],
         "members": {
-          "projectArn": {},
-          "name": {},
-          "description": {},
-          "type": {},
+          "projectArn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
+          "type": {
+            "shape": "Sj"
+          },
           "uplinkBandwidthBits": {
             "type": "long"
           },
@@ -98,10 +116,10 @@
             "type": "long"
           },
           "uplinkLossPercent": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "downlinkLossPercent": {
-            "type": "integer"
+            "shape": "Sl"
           }
         }
       },
@@ -121,7 +139,9 @@
           "name"
         ],
         "members": {
-          "name": {},
+          "name": {
+            "shape": "S3"
+          },
           "defaultJobTimeoutMinutes": {
             "type": "integer"
           }
@@ -144,29 +164,49 @@
           "deviceArn"
         ],
         "members": {
-          "projectArn": {},
-          "deviceArn": {},
-          "instanceArn": {},
-          "sshPublicKey": {},
+          "projectArn": {
+            "shape": "S2"
+          },
+          "deviceArn": {
+            "shape": "S2"
+          },
+          "instanceArn": {
+            "shape": "S2"
+          },
+          "sshPublicKey": {
+            "type": "string",
+            "max": 8192,
+            "min": 0
+          },
           "remoteDebugEnabled": {
             "type": "boolean"
           },
           "remoteRecordEnabled": {
             "type": "boolean"
           },
-          "remoteRecordAppArn": {},
-          "name": {},
-          "clientId": {},
+          "remoteRecordAppArn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "clientId": {
+            "shape": "Sv"
+          },
           "configuration": {
             "type": "structure",
             "members": {
-              "billingMethod": {},
+              "billingMethod": {
+                "shape": "Sx"
+              },
               "vpceConfigurationArns": {
                 "shape": "Sy"
               }
             }
           },
-          "interactionMode": {},
+          "interactionMode": {
+            "shape": "Sz"
+          },
           "skipAppResign": {
             "type": "boolean"
           }
@@ -190,10 +230,18 @@
           "type"
         ],
         "members": {
-          "projectArn": {},
-          "name": {},
-          "type": {},
-          "contentType": {}
+          "projectArn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "type": {
+            "shape": "S1j"
+          },
+          "contentType": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -214,10 +262,18 @@
           "serviceDnsName"
         ],
         "members": {
-          "vpceConfigurationName": {},
-          "vpceServiceName": {},
-          "serviceDnsName": {},
-          "vpceConfigurationDescription": {}
+          "vpceConfigurationName": {
+            "shape": "S1s"
+          },
+          "vpceServiceName": {
+            "shape": "S1t"
+          },
+          "serviceDnsName": {
+            "shape": "S1u"
+          },
+          "vpceConfigurationDescription": {
+            "shape": "S1v"
+          }
         }
       },
       "output": {
@@ -236,7 +292,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -251,7 +309,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -266,7 +326,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -281,7 +343,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -296,7 +360,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -311,7 +377,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -326,7 +394,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -341,7 +411,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -360,7 +432,11 @@
           "accountSettings": {
             "type": "structure",
             "members": {
-              "awsAccountNumber": {},
+              "awsAccountNumber": {
+                "type": "string",
+                "max": 16,
+                "min": 2
+              },
               "unmeteredDevices": {
                 "shape": "S2i"
               },
@@ -406,7 +482,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -425,7 +503,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -444,7 +524,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -463,9 +545,15 @@
           "devicePoolArn"
         ],
         "members": {
-          "devicePoolArn": {},
-          "appArn": {},
-          "testType": {},
+          "devicePoolArn": {
+            "shape": "S2"
+          },
+          "appArn": {
+            "shape": "S2"
+          },
+          "testType": {
+            "shape": "S2s"
+          },
           "test": {
             "shape": "S2t"
           },
@@ -493,7 +581,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -512,7 +602,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -531,7 +623,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -547,7 +641,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -559,7 +655,9 @@
           "nextPeriod": {
             "shape": "S3k"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -570,7 +668,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -589,7 +689,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -608,7 +710,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -627,7 +731,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -646,7 +752,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -665,7 +773,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -684,7 +794,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -704,8 +816,12 @@
           "appArn"
         ],
         "members": {
-          "remoteAccessSessionArn": {},
-          "appArn": {}
+          "remoteAccessSessionArn": {
+            "shape": "S2"
+          },
+          "appArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -725,9 +841,20 @@
           "type"
         ],
         "members": {
-          "arn": {},
-          "type": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SCREENSHOT",
+              "FILE",
+              "LOG"
+            ]
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -738,15 +865,55 @@
             "member": {
               "type": "structure",
               "members": {
-                "arn": {},
-                "name": {},
-                "type": {},
+                "arn": {
+                  "shape": "S2"
+                },
+                "name": {
+                  "shape": "S3"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "UNKNOWN",
+                    "SCREENSHOT",
+                    "DEVICE_LOG",
+                    "MESSAGE_LOG",
+                    "VIDEO_LOG",
+                    "RESULT_LOG",
+                    "SERVICE_LOG",
+                    "WEBKIT_LOG",
+                    "INSTRUMENTATION_OUTPUT",
+                    "EXERCISER_MONKEY_OUTPUT",
+                    "CALABASH_JSON_OUTPUT",
+                    "CALABASH_PRETTY_OUTPUT",
+                    "CALABASH_STANDARD_OUTPUT",
+                    "CALABASH_JAVA_XML_OUTPUT",
+                    "AUTOMATION_OUTPUT",
+                    "APPIUM_SERVER_OUTPUT",
+                    "APPIUM_JAVA_OUTPUT",
+                    "APPIUM_JAVA_XML_OUTPUT",
+                    "APPIUM_PYTHON_OUTPUT",
+                    "APPIUM_PYTHON_XML_OUTPUT",
+                    "EXPLORER_EVENT_LOG",
+                    "EXPLORER_SUMMARY_LOG",
+                    "APPLICATION_CRASH_REPORT",
+                    "XCTEST_LOG",
+                    "VIDEO",
+                    "CUSTOMER_ARTIFACT",
+                    "CUSTOMER_ARTIFACT_LOG",
+                    "TESTSPEC_OUTPUT"
+                  ]
+                },
                 "extension": {},
-                "url": {}
+                "url": {
+                  "shape": "S1o"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -757,7 +924,9 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -766,7 +935,9 @@
           "deviceInstances": {
             "shape": "S1b"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -777,9 +948,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "type": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "type": {
+            "shape": "Sc"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -791,7 +968,9 @@
               "shape": "Sb"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -799,8 +978,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -812,7 +995,9 @@
               "shape": "S14"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -823,7 +1008,9 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -835,7 +1022,9 @@
               "shape": "Sh"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -846,8 +1035,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -859,7 +1052,9 @@
               "shape": "S3c"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -870,9 +1065,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "type": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "type": {
+            "shape": "Sj"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -884,7 +1085,9 @@
               "shape": "Sn"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -892,7 +1095,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -903,12 +1108,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {},
-                "description": {}
+                "id": {
+                  "shape": "S56"
+                },
+                "description": {
+                  "shape": "S4"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -916,7 +1127,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -928,7 +1141,9 @@
               "shape": "S5a"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -936,7 +1151,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -948,7 +1165,9 @@
               "shape": "S3o"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -956,8 +1175,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -969,7 +1192,9 @@
               "shape": "Sr"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -980,8 +1205,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -993,7 +1222,9 @@
               "shape": "S11"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1004,8 +1235,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1017,7 +1252,9 @@
               "shape": "S41"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1028,8 +1265,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1040,13 +1281,40 @@
             "member": {
               "type": "structure",
               "members": {
-                "arn": {},
-                "type": {},
-                "url": {}
+                "arn": {
+                  "shape": "S2"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "CPU",
+                    "MEMORY",
+                    "THREADS",
+                    "RX_RATE",
+                    "TX_RATE",
+                    "RX",
+                    "TX",
+                    "NATIVE_FRAMES",
+                    "NATIVE_FPS",
+                    "NATIVE_MIN_DRAWTIME",
+                    "NATIVE_AVG_DRAWTIME",
+                    "NATIVE_MAX_DRAWTIME",
+                    "OPENGL_FRAMES",
+                    "OPENGL_FPS",
+                    "OPENGL_MIN_DRAWTIME",
+                    "OPENGL_AVG_DRAWTIME",
+                    "OPENGL_MAX_DRAWTIME"
+                  ]
+                },
+                "url": {
+                  "shape": "S1o"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1057,8 +1325,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1070,7 +1342,9 @@
               "shape": "S45"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1081,8 +1355,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1094,7 +1372,9 @@
               "shape": "S48"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1105,8 +1385,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1114,13 +1398,17 @@
         "members": {
           "uniqueProblems": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S13"
+            },
             "value": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "message": {},
+                  "message": {
+                    "shape": "S4"
+                  },
                   "problems": {
                     "type": "list",
                     "member": {
@@ -1141,8 +1429,12 @@
                         "device": {
                           "shape": "S14"
                         },
-                        "result": {},
-                        "message": {}
+                        "result": {
+                          "shape": "S13"
+                        },
+                        "message": {
+                          "shape": "S4"
+                        }
                       }
                     }
                   }
@@ -1150,7 +1442,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1161,9 +1455,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "type": {},
-          "nextToken": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "type": {
+            "shape": "S1j"
+          },
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1175,7 +1475,9 @@
               "shape": "S1m"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1186,7 +1488,9 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       },
       "output": {
@@ -1198,7 +1502,9 @@
               "shape": "S1x"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S3i"
+          }
         }
       }
     },
@@ -1206,11 +1512,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "offeringId": {},
+          "offeringId": {
+            "shape": "S3l"
+          },
           "quantity": {
             "type": "integer"
           },
-          "offeringPromotionId": {}
+          "offeringPromotionId": {
+            "shape": "S56"
+          }
         }
       },
       "output": {
@@ -1226,7 +1536,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "offeringId": {},
+          "offeringId": {
+            "shape": "S3l"
+          },
           "quantity": {
             "type": "integer"
           }
@@ -1250,10 +1562,18 @@
           "test"
         ],
         "members": {
-          "projectArn": {},
-          "appArn": {},
-          "devicePoolArn": {},
-          "name": {},
+          "projectArn": {
+            "shape": "S2"
+          },
+          "appArn": {
+            "shape": "S2"
+          },
+          "devicePoolArn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
           "test": {
             "shape": "S2t"
           },
@@ -1298,7 +1618,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1317,7 +1639,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1336,7 +1660,9 @@
           "arn"
         ],
         "members": {
-          "arn": {}
+          "arn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1355,8 +1681,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "profileArn": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "profileArn": {
+            "shape": "S2"
+          },
           "labels": {
             "shape": "S1d"
           }
@@ -1378,9 +1708,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "name": {},
-          "description": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
           "rules": {
             "shape": "S5"
           }
@@ -1402,9 +1738,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "name": {},
-          "description": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
           "packageCleanup": {
             "type": "boolean"
           },
@@ -1432,10 +1774,18 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "name": {},
-          "description": {},
-          "type": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "description": {
+            "shape": "S4"
+          },
+          "type": {
+            "shape": "Sj"
+          },
           "uplinkBandwidthBits": {
             "type": "long"
           },
@@ -1455,10 +1805,10 @@
             "type": "long"
           },
           "uplinkLossPercent": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "downlinkLossPercent": {
-            "type": "integer"
+            "shape": "Sl"
           }
         }
       },
@@ -1478,8 +1828,12 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "name": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
           "defaultJobTimeoutMinutes": {
             "type": "integer"
           }
@@ -1501,9 +1855,15 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "name": {},
-          "contentType": {},
+          "arn": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S3"
+          },
+          "contentType": {
+            "shape": "S1k"
+          },
           "editContent": {
             "type": "boolean"
           }
@@ -1525,11 +1885,21 @@
           "arn"
         ],
         "members": {
-          "arn": {},
-          "vpceConfigurationName": {},
-          "vpceServiceName": {},
-          "serviceDnsName": {},
-          "vpceConfigurationDescription": {}
+          "arn": {
+            "shape": "S2"
+          },
+          "vpceConfigurationName": {
+            "shape": "S1s"
+          },
+          "vpceServiceName": {
+            "shape": "S1t"
+          },
+          "serviceDnsName": {
+            "shape": "S1u"
+          },
+          "vpceConfigurationDescription": {
+            "shape": "S1v"
+          }
         }
       },
       "output": {
@@ -1543,28 +1913,84 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "min": 32
+    },
+    "S3": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "S4": {
+      "type": "string",
+      "max": 16384,
+      "min": 0
+    },
     "S5": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "attribute": {},
-          "operator": {},
+          "attribute": {
+            "shape": "S7"
+          },
+          "operator": {
+            "type": "string",
+            "enum": [
+              "EQUALS",
+              "LESS_THAN",
+              "GREATER_THAN",
+              "IN",
+              "NOT_IN",
+              "CONTAINS"
+            ]
+          },
           "value": {}
         }
       }
     },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "ARN",
+        "PLATFORM",
+        "FORM_FACTOR",
+        "MANUFACTURER",
+        "REMOTE_ACCESS_ENABLED",
+        "REMOTE_DEBUG_ENABLED",
+        "APPIUM_VERSION",
+        "INSTANCE_ARN",
+        "INSTANCE_LABELS",
+        "FLEET_TYPE"
+      ]
+    },
     "Sb": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "description": {},
-        "type": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "description": {
+          "shape": "S4"
+        },
+        "type": {
+          "shape": "Sc"
+        },
         "rules": {
           "shape": "S5"
         }
       }
+    },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "CURATED",
+        "PRIVATE"
+      ]
     },
     "Sf": {
       "type": "list",
@@ -1573,7 +1999,9 @@
     "Sh": {
       "type": "structure",
       "members": {
-        "arn": {},
+        "arn": {
+          "shape": "S2"
+        },
         "packageCleanup": {
           "type": "boolean"
         },
@@ -1583,17 +2011,41 @@
         "rebootAfterUse": {
           "type": "boolean"
         },
-        "name": {},
-        "description": {}
+        "name": {
+          "shape": "S3"
+        },
+        "description": {
+          "shape": "S4"
+        }
       }
+    },
+    "Sj": {
+      "type": "string",
+      "enum": [
+        "CURATED",
+        "PRIVATE"
+      ]
+    },
+    "Sl": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "description": {},
-        "type": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "description": {
+          "shape": "S4"
+        },
+        "type": {
+          "shape": "Sj"
+        },
         "uplinkBandwidthBits": {
           "type": "long"
         },
@@ -1613,18 +2065,22 @@
           "type": "long"
         },
         "uplinkLossPercent": {
-          "type": "integer"
+          "shape": "Sl"
         },
         "downlinkLossPercent": {
-          "type": "integer"
+          "shape": "Sl"
         }
       }
     },
     "Sr": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
         "defaultJobTimeoutMinutes": {
           "type": "integer"
         },
@@ -1633,21 +2089,55 @@
         }
       }
     },
+    "Sv": {
+      "type": "string",
+      "max": 64,
+      "min": 0
+    },
+    "Sx": {
+      "type": "string",
+      "enum": [
+        "METERED",
+        "UNMETERED"
+      ]
+    },
     "Sy": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "INTERACTIVE",
+        "NO_VIDEO",
+        "VIDEO_ONLY"
+      ],
+      "max": 64,
+      "min": 0
     },
     "S11": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
         "created": {
           "type": "timestamp"
         },
-        "status": {},
-        "result": {},
-        "message": {},
+        "status": {
+          "shape": "S12"
+        },
+        "result": {
+          "shape": "S13"
+        },
+        "message": {
+          "shape": "S4"
+        },
         "started": {
           "type": "timestamp"
         },
@@ -1657,38 +2147,89 @@
         "device": {
           "shape": "S14"
         },
-        "instanceArn": {},
+        "instanceArn": {
+          "shape": "S2"
+        },
         "remoteDebugEnabled": {
           "type": "boolean"
         },
         "remoteRecordEnabled": {
           "type": "boolean"
         },
-        "remoteRecordAppArn": {},
-        "hostAddress": {},
-        "clientId": {},
-        "billingMethod": {},
+        "remoteRecordAppArn": {
+          "shape": "S2"
+        },
+        "hostAddress": {
+          "type": "string",
+          "max": 1024
+        },
+        "clientId": {
+          "shape": "Sv"
+        },
+        "billingMethod": {
+          "shape": "Sx"
+        },
         "deviceMinutes": {
           "shape": "S1g"
         },
         "endpoint": {},
         "deviceUdid": {},
-        "interactionMode": {},
+        "interactionMode": {
+          "shape": "Sz"
+        },
         "skipAppResign": {
           "type": "boolean"
         }
       }
     },
+    "S12": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "PENDING_CONCURRENCY",
+        "PENDING_DEVICE",
+        "PROCESSING",
+        "SCHEDULING",
+        "PREPARING",
+        "RUNNING",
+        "COMPLETED",
+        "STOPPING"
+      ]
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "PASSED",
+        "WARNED",
+        "FAILED",
+        "SKIPPED",
+        "ERRORED",
+        "STOPPED"
+      ]
+    },
     "S14": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
         "manufacturer": {},
         "model": {},
         "modelId": {},
-        "formFactor": {},
-        "platform": {},
+        "formFactor": {
+          "type": "string",
+          "enum": [
+            "PHONE",
+            "TABLET"
+          ]
+        },
+        "platform": {
+          "shape": "S16"
+        },
         "os": {},
         "cpu": {
           "type": "structure",
@@ -1733,6 +2274,13 @@
         }
       }
     },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "ANDROID",
+        "IOS"
+      ]
+    },
     "S1b": {
       "type": "list",
       "member": {
@@ -1742,12 +2290,24 @@
     "S1c": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "deviceArn": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "deviceArn": {
+          "shape": "S2"
+        },
         "labels": {
           "shape": "S1d"
         },
-        "status": {},
+        "status": {
+          "type": "string",
+          "enum": [
+            "IN_USE",
+            "PREPARING",
+            "AVAILABLE",
+            "NOT_AVAILABLE"
+          ]
+        },
         "udid": {},
         "instanceProfile": {
           "shape": "Sh"
@@ -1772,39 +2332,162 @@
         }
       }
     },
+    "S1j": {
+      "type": "string",
+      "enum": [
+        "ANDROID_APP",
+        "IOS_APP",
+        "WEB_APP",
+        "EXTERNAL_DATA",
+        "APPIUM_JAVA_JUNIT_TEST_PACKAGE",
+        "APPIUM_JAVA_TESTNG_TEST_PACKAGE",
+        "APPIUM_PYTHON_TEST_PACKAGE",
+        "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE",
+        "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE",
+        "APPIUM_WEB_PYTHON_TEST_PACKAGE",
+        "CALABASH_TEST_PACKAGE",
+        "INSTRUMENTATION_TEST_PACKAGE",
+        "UIAUTOMATION_TEST_PACKAGE",
+        "UIAUTOMATOR_TEST_PACKAGE",
+        "XCTEST_TEST_PACKAGE",
+        "XCTEST_UI_TEST_PACKAGE",
+        "APPIUM_JAVA_JUNIT_TEST_SPEC",
+        "APPIUM_JAVA_TESTNG_TEST_SPEC",
+        "APPIUM_PYTHON_TEST_SPEC",
+        "APPIUM_WEB_JAVA_JUNIT_TEST_SPEC",
+        "APPIUM_WEB_JAVA_TESTNG_TEST_SPEC",
+        "APPIUM_WEB_PYTHON_TEST_SPEC",
+        "INSTRUMENTATION_TEST_SPEC",
+        "XCTEST_UI_TEST_SPEC"
+      ]
+    },
+    "S1k": {
+      "type": "string",
+      "max": 64,
+      "min": 0
+    },
     "S1m": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
         "created": {
           "type": "timestamp"
         },
-        "type": {},
-        "status": {},
-        "url": {},
-        "metadata": {},
-        "contentType": {},
-        "message": {},
-        "category": {}
+        "type": {
+          "shape": "S1j"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "INITIALIZED",
+            "PROCESSING",
+            "SUCCEEDED",
+            "FAILED"
+          ]
+        },
+        "url": {
+          "shape": "S1o"
+        },
+        "metadata": {
+          "type": "string",
+          "max": 8192,
+          "min": 0
+        },
+        "contentType": {
+          "shape": "S1k"
+        },
+        "message": {
+          "shape": "S4"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "CURATED",
+            "PRIVATE"
+          ]
+        }
       }
+    },
+    "S1o": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
+    },
+    "S1s": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
+    "S1t": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
+    },
+    "S1u": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
+    },
+    "S1v": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
     },
     "S1x": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "vpceConfigurationName": {},
-        "vpceServiceName": {},
-        "serviceDnsName": {},
-        "vpceConfigurationDescription": {}
+        "arn": {
+          "shape": "S2"
+        },
+        "vpceConfigurationName": {
+          "shape": "S1s"
+        },
+        "vpceServiceName": {
+          "shape": "S1t"
+        },
+        "serviceDnsName": {
+          "shape": "S1u"
+        },
+        "vpceConfigurationDescription": {
+          "shape": "S1v"
+        }
       }
     },
     "S2i": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S16"
+      },
       "value": {
         "type": "integer"
       }
+    },
+    "S2s": {
+      "type": "string",
+      "enum": [
+        "BUILTIN_FUZZ",
+        "BUILTIN_EXPLORER",
+        "WEB_PERFORMANCE_PROFILE",
+        "APPIUM_JAVA_JUNIT",
+        "APPIUM_JAVA_TESTNG",
+        "APPIUM_PYTHON",
+        "APPIUM_WEB_JAVA_JUNIT",
+        "APPIUM_WEB_JAVA_TESTNG",
+        "APPIUM_WEB_PYTHON",
+        "CALABASH",
+        "INSTRUMENTATION",
+        "UIAUTOMATION",
+        "UIAUTOMATOR",
+        "XCTEST",
+        "XCTEST_UI",
+        "REMOTE_ACCESS_RECORD",
+        "REMOTE_ACCESS_REPLAY"
+      ]
     },
     "S2t": {
       "type": "structure",
@@ -1812,10 +2495,20 @@
         "type"
       ],
       "members": {
-        "type": {},
-        "testPackageArn": {},
-        "testSpecArn": {},
-        "filter": {},
+        "type": {
+          "shape": "S2s"
+        },
+        "testPackageArn": {
+          "shape": "S2"
+        },
+        "testSpecArn": {
+          "shape": "S2"
+        },
+        "filter": {
+          "type": "string",
+          "max": 8192,
+          "min": 0
+        },
         "parameters": {
           "type": "map",
           "key": {},
@@ -1826,8 +2519,12 @@
     "S2w": {
       "type": "structure",
       "members": {
-        "extraDataPackageArn": {},
-        "networkProfileArn": {},
+        "extraDataPackageArn": {
+          "shape": "S2"
+        },
+        "networkProfileArn": {
+          "shape": "S2"
+        },
         "locale": {},
         "location": {
           "shape": "S2x"
@@ -1844,7 +2541,9 @@
         "auxiliaryApps": {
           "shape": "Sy"
         },
-        "billingMethod": {}
+        "billingMethod": {
+          "shape": "Sx"
+        }
       }
     },
     "S2x": {
@@ -1912,8 +2611,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "message": {},
-                "type": {}
+                "message": {
+                  "shape": "S4"
+                },
+                "type": {
+                  "shape": "S7"
+                }
               }
             }
           }
@@ -1923,14 +2626,24 @@
     "S3c": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "type": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "type": {
+          "shape": "S2s"
+        },
         "created": {
           "type": "timestamp"
         },
-        "status": {},
-        "result": {},
+        "status": {
+          "shape": "S12"
+        },
+        "result": {
+          "shape": "S13"
+        },
         "started": {
           "type": "timestamp"
         },
@@ -1940,11 +2653,15 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {},
+        "message": {
+          "shape": "S4"
+        },
         "device": {
           "shape": "S14"
         },
-        "instanceArn": {},
+        "instanceArn": {
+          "shape": "S2"
+        },
         "deviceMinutes": {
           "shape": "S1g"
         },
@@ -1980,17 +2697,35 @@
         }
       }
     },
+    "S3i": {
+      "type": "string",
+      "max": 1024,
+      "min": 4
+    },
     "S3k": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3l"
+      },
       "value": {
         "shape": "S3m"
       }
     },
+    "S3l": {
+      "type": "string",
+      "min": 32
+    },
     "S3m": {
       "type": "structure",
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "PURCHASE",
+            "RENEW",
+            "SYSTEM"
+          ]
+        },
         "offering": {
           "shape": "S3o"
         },
@@ -2005,10 +2740,21 @@
     "S3o": {
       "type": "structure",
       "members": {
-        "id": {},
-        "description": {},
-        "type": {},
-        "platform": {},
+        "id": {
+          "shape": "S3l"
+        },
+        "description": {
+          "shape": "S4"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "RECURRING"
+          ]
+        },
+        "platform": {
+          "shape": "S16"
+        },
         "recurringCharges": {
           "type": "list",
           "member": {
@@ -2017,7 +2763,12 @@
               "cost": {
                 "shape": "S3s"
               },
-              "frequency": {}
+              "frequency": {
+                "type": "string",
+                "enum": [
+                  "MONTHLY"
+                ]
+              }
             }
           }
         }
@@ -2029,21 +2780,38 @@
         "amount": {
           "type": "double"
         },
-        "currencyCode": {}
+        "currencyCode": {
+          "type": "string",
+          "enum": [
+            "USD"
+          ]
+        }
       }
     },
     "S41": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "type": {},
-        "platform": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "type": {
+          "shape": "S2s"
+        },
+        "platform": {
+          "shape": "S16"
+        },
         "created": {
           "type": "timestamp"
         },
-        "status": {},
-        "result": {},
+        "status": {
+          "shape": "S12"
+        },
+        "result": {
+          "shape": "S13"
+        },
         "started": {
           "type": "timestamp"
         },
@@ -2053,14 +2821,18 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {},
+        "message": {
+          "shape": "S4"
+        },
         "totalJobs": {
           "type": "integer"
         },
         "completedJobs": {
           "type": "integer"
         },
-        "billingMethod": {},
+        "billingMethod": {
+          "shape": "Sx"
+        },
         "deviceMinutes": {
           "shape": "S1g"
         },
@@ -2068,18 +2840,28 @@
           "shape": "Sn"
         },
         "parsingResultUrl": {},
-        "resultCode": {},
+        "resultCode": {
+          "type": "string",
+          "enum": [
+            "PARSING_FAILED",
+            "VPC_ENDPOINT_SETUP_FAILED"
+          ]
+        },
         "seed": {
           "type": "integer"
         },
-        "appUpload": {},
+        "appUpload": {
+          "shape": "S2"
+        },
         "eventCount": {
           "type": "integer"
         },
         "jobTimeoutMinutes": {
           "type": "integer"
         },
-        "devicePoolArn": {},
+        "devicePoolArn": {
+          "shape": "S2"
+        },
         "locale": {},
         "radios": {
           "shape": "S32"
@@ -2094,20 +2876,32 @@
         "skipAppResign": {
           "type": "boolean"
         },
-        "testSpecArn": {}
+        "testSpecArn": {
+          "shape": "S2"
+        }
       }
     },
     "S45": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "type": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "type": {
+          "shape": "S2s"
+        },
         "created": {
           "type": "timestamp"
         },
-        "status": {},
-        "result": {},
+        "status": {
+          "shape": "S12"
+        },
+        "result": {
+          "shape": "S13"
+        },
         "started": {
           "type": "timestamp"
         },
@@ -2117,7 +2911,9 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {},
+        "message": {
+          "shape": "S4"
+        },
         "deviceMinutes": {
           "shape": "S1g"
         }
@@ -2126,14 +2922,24 @@
     "S48": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {},
-        "type": {},
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        },
+        "type": {
+          "shape": "S2s"
+        },
         "created": {
           "type": "timestamp"
         },
-        "status": {},
-        "result": {},
+        "status": {
+          "shape": "S12"
+        },
+        "result": {
+          "shape": "S13"
+        },
         "started": {
           "type": "timestamp"
         },
@@ -2143,11 +2949,17 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {},
+        "message": {
+          "shape": "S4"
+        },
         "deviceMinutes": {
           "shape": "S1g"
         }
       }
+    },
+    "S56": {
+      "type": "string",
+      "min": 4
     },
     "S5a": {
       "type": "structure",
@@ -2155,8 +2967,13 @@
         "offeringStatus": {
           "shape": "S3m"
         },
-        "transactionId": {},
-        "offeringPromotionId": {},
+        "transactionId": {
+          "type": "string",
+          "min": 32
+        },
+        "offeringPromotionId": {
+          "shape": "S56"
+        },
         "createdOn": {
           "type": "timestamp"
         },
@@ -2168,8 +2985,12 @@
     "S66": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "name": {}
+        "arn": {
+          "shape": "S2"
+        },
+        "name": {
+          "shape": "S3"
+        }
       }
     }
   }

--- a/apis/directconnect-2012-10-25.min.json
+++ b/apis/directconnect-2012-10-25.min.json
@@ -88,7 +88,9 @@
               },
               "authKey": {},
               "amazonAddress": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "customerAddress": {}
             }
           }
@@ -127,7 +129,9 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "routeFilterPrefixes": {
                 "shape": "Sy"
               }
@@ -200,7 +204,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "connectionState": {}
+          "connectionState": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -219,7 +225,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {}
+          "virtualInterfaceState": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -236,7 +244,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {}
+          "virtualInterfaceState": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -252,7 +262,9 @@
                 "type": "integer"
               },
               "authKey": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "amazonAddress": {},
               "customerAddress": {}
             }
@@ -399,7 +411,9 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "virtualGatewayId": {},
               "directConnectGatewayId": {}
             }
@@ -437,7 +451,9 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "routeFilterPrefixes": {
                 "shape": "Sy"
               }
@@ -536,7 +552,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "interconnectState": {}
+          "interconnectState": {
+            "shape": "S1y"
+          }
         }
       }
     },
@@ -567,7 +585,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {}
+          "virtualInterfaceState": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -580,7 +600,9 @@
         "members": {
           "connectionId": {},
           "providerName": {},
-          "loaContentType": {}
+          "loaContentType": {
+            "shape": "S2o"
+          }
         }
       },
       "output": {
@@ -668,7 +690,15 @@
                 "virtualInterfaceId": {},
                 "virtualInterfaceRegion": {},
                 "virtualInterfaceOwnerAccount": {},
-                "attachmentState": {},
+                "attachmentState": {
+                  "type": "string",
+                  "enum": [
+                    "attaching",
+                    "attached",
+                    "detaching",
+                    "detached"
+                  ]
+                },
                 "stateChangeError": {}
               }
             }
@@ -724,7 +754,9 @@
         "members": {
           "interconnectId": {},
           "providerName": {},
-          "loaContentType": {}
+          "loaContentType": {
+            "shape": "S2o"
+          }
         }
       },
       "output": {
@@ -784,7 +816,9 @@
         "members": {
           "connectionId": {},
           "providerName": {},
-          "loaContentType": {}
+          "loaContentType": {
+            "shape": "S2o"
+          }
         }
       },
       "output": {
@@ -923,7 +957,9 @@
           "resourceArn": {},
           "tagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3v"
+            }
           }
         }
       },
@@ -958,7 +994,9 @@
         "ownerAccount": {},
         "connectionId": {},
         "connectionName": {},
-        "connectionState": {},
+        "connectionState": {
+          "shape": "S9"
+        },
         "region": {},
         "location": {},
         "bandwidth": {},
@@ -976,9 +1014,29 @@
         "awsDeviceV2": {}
       }
     },
+    "S9": {
+      "type": "string",
+      "enum": [
+        "ordering",
+        "requested",
+        "pending",
+        "available",
+        "down",
+        "deleting",
+        "deleted",
+        "rejected"
+      ]
+    },
     "Sf": {
       "type": "string",
       "deprecated": true
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "ipv4",
+        "ipv6"
+      ]
     },
     "Sq": {
       "type": "structure",
@@ -1001,8 +1059,12 @@
         "authKey": {},
         "amazonAddress": {},
         "customerAddress": {},
-        "addressFamily": {},
-        "virtualInterfaceState": {},
+        "addressFamily": {
+          "shape": "So"
+        },
+        "virtualInterfaceState": {
+          "shape": "Su"
+        },
         "customerRouterConfig": {},
         "virtualGatewayId": {},
         "directConnectGatewayId": {},
@@ -1018,11 +1080,28 @@
                 "type": "integer"
               },
               "authKey": {},
-              "addressFamily": {},
+              "addressFamily": {
+                "shape": "So"
+              },
               "amazonAddress": {},
               "customerAddress": {},
-              "bgpPeerState": {},
-              "bgpStatus": {},
+              "bgpPeerState": {
+                "type": "string",
+                "enum": [
+                  "verifying",
+                  "pending",
+                  "available",
+                  "deleting",
+                  "deleted"
+                ]
+              },
+              "bgpStatus": {
+                "type": "string",
+                "enum": [
+                  "up",
+                  "down"
+                ]
+              },
               "awsDeviceV2": {}
             }
           }
@@ -1030,6 +1109,19 @@
         "region": {},
         "awsDeviceV2": {}
       }
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "confirming",
+        "verifying",
+        "pending",
+        "available",
+        "down",
+        "deleting",
+        "deleted",
+        "rejected"
+      ]
     },
     "Sy": {
       "type": "list",
@@ -1049,7 +1141,15 @@
           "type": "long"
         },
         "ownerAccount": {},
-        "directConnectGatewayState": {},
+        "directConnectGatewayState": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "available",
+            "deleting",
+            "deleted"
+          ]
+        },
         "stateChangeError": {}
       }
     },
@@ -1060,7 +1160,15 @@
         "virtualGatewayId": {},
         "virtualGatewayRegion": {},
         "virtualGatewayOwnerAccount": {},
-        "associationState": {},
+        "associationState": {
+          "type": "string",
+          "enum": [
+            "associating",
+            "associated",
+            "disassociating",
+            "disassociated"
+          ]
+        },
         "stateChangeError": {}
       }
     },
@@ -1069,7 +1177,9 @@
       "members": {
         "interconnectId": {},
         "interconnectName": {},
-        "interconnectState": {},
+        "interconnectState": {
+          "shape": "S1y"
+        },
         "region": {},
         "location": {},
         "bandwidth": {},
@@ -1083,6 +1193,17 @@
         "awsDeviceV2": {}
       }
     },
+    "S1y": {
+      "type": "string",
+      "enum": [
+        "requested",
+        "pending",
+        "available",
+        "down",
+        "deleting",
+        "deleted"
+      ]
+    },
     "S22": {
       "type": "structure",
       "members": {
@@ -1093,7 +1214,17 @@
         "lagId": {},
         "ownerAccount": {},
         "lagName": {},
-        "lagState": {},
+        "lagState": {
+          "type": "string",
+          "enum": [
+            "requested",
+            "pending",
+            "available",
+            "down",
+            "deleting",
+            "deleted"
+          ]
+        },
         "location": {},
         "region": {},
         "minimumLinks": {
@@ -1117,13 +1248,21 @@
         "shape": "S7"
       }
     },
+    "S2o": {
+      "type": "string",
+      "enum": [
+        "application/pdf"
+      ]
+    },
     "S2q": {
       "type": "structure",
       "members": {
         "loaContent": {
           "type": "blob"
         },
-        "loaContentType": {}
+        "loaContentType": {
+          "shape": "S2o"
+        }
       }
     },
     "S2t": {
@@ -1142,10 +1281,24 @@
           "key"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "S3v"
+          },
+          "value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "min": 1
+    },
+    "S3v": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     }
   }
 }

--- a/apis/discovery-2015-11-01.min.json
+++ b/apis/discovery-2015-11-01.min.json
@@ -146,7 +146,17 @@
                 },
                 "connectorId": {},
                 "version": {},
-                "health": {},
+                "health": {
+                  "type": "string",
+                  "enum": [
+                    "HEALTHY",
+                    "UNHEALTHY",
+                    "RUNNING",
+                    "UNKNOWN",
+                    "BLACKLISTED",
+                    "SHUTDOWN"
+                  ]
+                },
                 "lastHealthPingTime": {},
                 "collectionStatus": {},
                 "agentType": {},
@@ -193,7 +203,9 @@
             "member": {}
           },
           "maxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           },
           "nextToken": {}
         }
@@ -207,8 +219,23 @@
               "type": "structure",
               "members": {
                 "exportId": {},
-                "status": {},
-                "statusDetail": {},
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "START_IN_PROGRESS",
+                    "START_FAILED",
+                    "ACTIVE",
+                    "ERROR",
+                    "STOP_IN_PROGRESS",
+                    "STOP_FAILED",
+                    "INACTIVE"
+                  ]
+                },
+                "statusDetail": {
+                  "type": "string",
+                  "max": 255,
+                  "min": 1
+                },
                 "s3Bucket": {},
                 "startTime": {
                   "type": "timestamp"
@@ -216,7 +243,9 @@
                 "stopTime": {
                   "type": "timestamp"
                 },
-                "dataSource": {},
+                "dataSource": {
+                  "shape": "S1f"
+                },
                 "schemaStorageConfig": {
                   "shape": "S1g"
                 }
@@ -311,7 +340,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "configurationType": {},
+                "configurationType": {
+                  "shape": "S23"
+                },
                 "configurationId": {},
                 "key": {},
                 "value": {},
@@ -453,7 +484,9 @@
           "configurationType"
         ],
         "members": {
-          "configurationType": {},
+          "configurationType": {
+            "shape": "S23"
+          },
           "filters": {
             "shape": "Sn"
           },
@@ -470,7 +503,13 @@
               ],
               "members": {
                 "fieldName": {},
-                "sortOrder": {}
+                "sortOrder": {
+                  "type": "string",
+                  "enum": [
+                    "ASC",
+                    "DESC"
+                  ]
+                }
               }
             }
           }
@@ -559,7 +598,9 @@
           "startTime": {
             "type": "timestamp"
           },
-          "dataSource": {},
+          "dataSource": {
+            "shape": "S1f"
+          },
           "schemaStorageConfig": {
             "shape": "S1g"
           }
@@ -593,7 +634,13 @@
         "members": {
           "exportDataFormat": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "CSV",
+                "GRAPHML"
+              ]
+            }
           },
           "filters": {
             "shape": "S1t"
@@ -719,9 +766,19 @@
       "type": "list",
       "member": {}
     },
+    "S1f": {
+      "type": "string",
+      "enum": [
+        "AGENT"
+      ]
+    },
     "S1g": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "max": 252,
+        "min": 1
+      },
       "value": {}
     },
     "S1j": {
@@ -740,7 +797,14 @@
         ],
         "members": {
           "exportId": {},
-          "exportStatus": {},
+          "exportStatus": {
+            "type": "string",
+            "enum": [
+              "FAILED",
+              "SUCCEEDED",
+              "IN_PROGRESS"
+            ]
+          },
           "statusMessage": {},
           "configurationsDownloadUrl": {},
           "exportRequestTime": {
@@ -775,6 +839,15 @@
           "condition": {}
         }
       }
+    },
+    "S23": {
+      "type": "string",
+      "enum": [
+        "SERVER",
+        "PROCESS",
+        "CONNECTION",
+        "APPLICATION"
+      ]
     },
     "S2s": {
       "type": "list",

--- a/apis/dlm-2018-01-12.min.json
+++ b/apis/dlm-2018-01-12.min.json
@@ -27,8 +27,12 @@
         ],
         "members": {
           "ExecutionRoleArn": {},
-          "Description": {},
-          "State": {},
+          "Description": {
+            "shape": "S3"
+          },
+          "State": {
+            "shape": "S4"
+          },
           "PolicyDetails": {
             "shape": "S5"
           }
@@ -78,6 +82,7 @@
             "member": {}
           },
           "State": {
+            "shape": "Ss",
             "location": "querystring",
             "locationName": "state"
           },
@@ -90,13 +95,17 @@
             "location": "querystring",
             "locationName": "targetTags",
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 50,
+            "min": 1
           },
           "TagsToAdd": {
             "location": "querystring",
             "locationName": "tagsToAdd",
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 50,
+            "min": 0
           }
         }
       },
@@ -109,8 +118,12 @@
               "type": "structure",
               "members": {
                 "PolicyId": {},
-                "Description": {},
-                "State": {}
+                "Description": {
+                  "shape": "S3"
+                },
+                "State": {
+                  "shape": "Ss"
+                }
               }
             }
           }
@@ -141,8 +154,12 @@
             "type": "structure",
             "members": {
               "PolicyId": {},
-              "Description": {},
-              "State": {},
+              "Description": {
+                "shape": "S3"
+              },
+              "State": {
+                "shape": "Ss"
+              },
               "ExecutionRoleArn": {},
               "DateCreated": {
                 "type": "timestamp"
@@ -174,8 +191,12 @@
             "locationName": "policyId"
           },
           "ExecutionRoleArn": {},
-          "State": {},
-          "Description": {},
+          "State": {
+            "shape": "S4"
+          },
+          "Description": {
+            "shape": "S3"
+          },
           "PolicyDetails": {
             "shape": "S5"
           }
@@ -188,6 +209,18 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 500,
+      "min": 0
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
     "S5": {
       "type": "structure",
       "members": {
@@ -198,19 +231,27 @@
           "type": "list",
           "member": {
             "shape": "S9"
-          }
+          },
+          "max": 50,
+          "min": 1
         },
         "Schedules": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Name": {},
+              "Name": {
+                "type": "string",
+                "max": 500,
+                "min": 0
+              },
               "TagsToAdd": {
                 "type": "list",
                 "member": {
                   "shape": "S9"
-                }
+                },
+                "max": 50,
+                "min": 0
               },
               "CreateRule": {
                 "type": "structure",
@@ -220,12 +261,22 @@
                 ],
                 "members": {
                   "Interval": {
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 1
                   },
-                  "IntervalUnit": {},
+                  "IntervalUnit": {
+                    "type": "string",
+                    "enum": [
+                      "HOURS"
+                    ]
+                  },
                   "Times": {
                     "type": "list",
-                    "member": {}
+                    "member": {
+                      "type": "string",
+                      "pattern": "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"
+                    },
+                    "max": 1
                   }
                 }
               },
@@ -236,18 +287,29 @@
                 ],
                 "members": {
                   "Count": {
-                    "type": "integer"
+                    "type": "integer",
+                    "max": 1000,
+                    "min": 1
                   }
                 }
               }
             }
-          }
+          },
+          "max": 1,
+          "min": 1
         }
       }
     },
     "S6": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "VOLUME"
+        ]
+      },
+      "max": 1,
+      "min": 1
     },
     "S9": {
       "type": "structure",
@@ -259,6 +321,14 @@
         "Key": {},
         "Value": {}
       }
+    },
+    "Ss": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED",
+        "ERROR"
+      ]
     }
   }
 }

--- a/apis/dms-2016-01-01.min.json
+++ b/apis/dms-2016-01-01.min.json
@@ -41,7 +41,9 @@
         ],
         "members": {
           "EndpointIdentifier": {},
-          "EndpointType": {},
+          "EndpointType": {
+            "shape": "S7"
+          },
           "EngineName": {},
           "Username": {},
           "Password": {
@@ -58,7 +60,9 @@
             "shape": "S3"
           },
           "CertificateArn": {},
-          "SslMode": {},
+          "SslMode": {
+            "shape": "Sa"
+          },
           "ServiceAccessRoleArn": {},
           "ExternalTableDefinition": {},
           "DynamoDbSettings": {
@@ -206,7 +210,9 @@
           "SourceEndpointArn": {},
           "TargetEndpointArn": {},
           "ReplicationInstanceArn": {},
-          "MigrationType": {},
+          "MigrationType": {
+            "shape": "S1b"
+          },
           "TableMappings": {},
           "ReplicationTaskSettings": {},
           "CdcStartTime": {
@@ -442,7 +448,9 @@
                 "SupportsCDC": {
                   "type": "boolean"
                 },
-                "EndpointType": {},
+                "EndpointType": {
+                  "shape": "S7"
+                },
                 "EngineDisplayName": {}
               }
             }
@@ -536,7 +544,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S2n"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -568,7 +578,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S2n"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "Sm"
@@ -940,7 +952,9 @@
         "members": {
           "EndpointArn": {},
           "EndpointIdentifier": {},
-          "EndpointType": {},
+          "EndpointType": {
+            "shape": "S7"
+          },
           "EngineName": {},
           "Username": {},
           "Password": {
@@ -953,7 +967,9 @@
           "DatabaseName": {},
           "ExtraConnectionAttributes": {},
           "CertificateArn": {},
-          "SslMode": {},
+          "SslMode": {
+            "shape": "Sa"
+          },
           "ServiceAccessRoleArn": {},
           "ExternalTableDefinition": {},
           "DynamoDbSettings": {
@@ -1080,7 +1096,9 @@
         "members": {
           "ReplicationTaskArn": {},
           "ReplicationTaskIdentifier": {},
-          "MigrationType": {},
+          "MigrationType": {
+            "shape": "S1b"
+          },
           "TableMappings": {},
           "ReplicationTaskSettings": {},
           "CdcStartTime": {
@@ -1161,7 +1179,13 @@
               }
             }
           },
-          "ReloadOption": {}
+          "ReloadOption": {
+            "type": "string",
+            "enum": [
+              "data-reload",
+              "validate-only"
+            ]
+          }
         }
       },
       "output": {
@@ -1200,7 +1224,14 @@
         ],
         "members": {
           "ReplicationTaskArn": {},
-          "StartReplicationTaskType": {},
+          "StartReplicationTaskType": {
+            "type": "string",
+            "enum": [
+              "start-replication",
+              "resume-processing",
+              "reload-target"
+            ]
+          },
           "CdcStartTime": {
             "type": "timestamp"
           },
@@ -1288,9 +1319,25 @@
         }
       }
     },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "source",
+        "target"
+      ]
+    },
     "S8": {
       "type": "string",
       "sensitive": true
+    },
+    "Sa": {
+      "type": "string",
+      "enum": [
+        "none",
+        "require",
+        "verify-ca",
+        "verify-full"
+      ]
     },
     "Sb": {
       "type": "structure",
@@ -1310,7 +1357,13 @@
         "CsvDelimiter": {},
         "BucketFolder": {},
         "BucketName": {},
-        "CompressionType": {}
+        "CompressionType": {
+          "type": "string",
+          "enum": [
+            "none",
+            "gzip"
+          ]
+        }
       }
     },
     "Se": {
@@ -1332,9 +1385,28 @@
           "type": "integer"
         },
         "DatabaseName": {},
-        "AuthType": {},
-        "AuthMechanism": {},
-        "NestingLevel": {},
+        "AuthType": {
+          "type": "string",
+          "enum": [
+            "no",
+            "password"
+          ]
+        },
+        "AuthMechanism": {
+          "type": "string",
+          "enum": [
+            "default",
+            "mongodb_cr",
+            "scram_sha_1"
+          ]
+        },
+        "NestingLevel": {
+          "type": "string",
+          "enum": [
+            "none",
+            "one"
+          ]
+        },
         "ExtractDocId": {},
         "DocsToInvestigate": {},
         "AuthSource": {},
@@ -1345,7 +1417,9 @@
       "type": "structure",
       "members": {
         "EndpointIdentifier": {},
-        "EndpointType": {},
+        "EndpointType": {
+          "shape": "S7"
+        },
         "EngineName": {},
         "EngineDisplayName": {},
         "Username": {},
@@ -1359,7 +1433,9 @@
         "KmsKeyId": {},
         "EndpointArn": {},
         "CertificateArn": {},
-        "SslMode": {},
+        "SslMode": {
+          "shape": "Sa"
+        },
         "ServiceAccessRoleArn": {},
         "ExternalTableDefinition": {},
         "ExternalId": {},
@@ -1510,6 +1586,14 @@
       "type": "list",
       "member": {}
     },
+    "S1b": {
+      "type": "string",
+      "enum": [
+        "full-load",
+        "cdc",
+        "full-load-and-cdc"
+      ]
+    },
     "S1d": {
       "type": "structure",
       "members": {
@@ -1517,7 +1601,9 @@
         "SourceEndpointArn": {},
         "TargetEndpointArn": {},
         "ReplicationInstanceArn": {},
-        "MigrationType": {},
+        "MigrationType": {
+          "shape": "S1b"
+        },
         "TableMappings": {},
         "ReplicationTaskSettings": {},
         "Status": {},
@@ -1611,12 +1697,25 @@
         "ReplicationInstanceIdentifier": {}
       }
     },
+    "S2n": {
+      "type": "string",
+      "enum": [
+        "replication-instance"
+      ]
+    },
     "S2x": {
       "type": "structure",
       "members": {
         "EndpointArn": {},
         "ReplicationInstanceArn": {},
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "successful",
+            "failed",
+            "refreshing"
+          ]
+        },
         "LastRefreshDate": {
           "type": "timestamp"
         },

--- a/apis/ds-2015-04-16.min.json
+++ b/apis/ds-2015-04-16.min.json
@@ -20,7 +20,9 @@
           "SharedDirectoryId"
         ],
         "members": {
-          "SharedDirectoryId": {}
+          "SharedDirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -40,14 +42,20 @@
           "IpRoutes"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "IpRoutes": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "CidrIp": {},
-                "Description": {}
+                "CidrIp": {
+                  "shape": "Se"
+                },
+                "Description": {
+                  "shape": "Sf"
+                }
               }
             }
           },
@@ -69,7 +77,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "Sj"
+          },
           "Tags": {
             "shape": "Sk"
           }
@@ -88,8 +98,12 @@
           "SchemaExtensionId"
         ],
         "members": {
-          "DirectoryId": {},
-          "SchemaExtensionId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "SchemaExtensionId": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -107,13 +121,21 @@
           "ConnectSettings"
         ],
         "members": {
-          "Name": {},
-          "ShortName": {},
+          "Name": {
+            "shape": "St"
+          },
+          "ShortName": {
+            "shape": "Su"
+          },
           "Password": {
             "shape": "Sv"
           },
-          "Description": {},
-          "Size": {},
+          "Description": {
+            "shape": "Sf"
+          },
+          "Size": {
+            "shape": "Sw"
+          },
           "ConnectSettings": {
             "type": "structure",
             "required": [
@@ -123,14 +145,18 @@
               "CustomerUserName"
             ],
             "members": {
-              "VpcId": {},
+              "VpcId": {
+                "shape": "Sy"
+              },
               "SubnetIds": {
                 "shape": "Sz"
               },
               "CustomerDnsIps": {
                 "shape": "S11"
               },
-              "CustomerUserName": {}
+              "CustomerUserName": {
+                "shape": "S13"
+              }
             }
           }
         }
@@ -138,7 +164,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -150,15 +178,23 @@
           "Alias"
         ],
         "members": {
-          "DirectoryId": {},
-          "Alias": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "Alias": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {},
-          "Alias": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "Alias": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -171,13 +207,24 @@
           "Password"
         ],
         "members": {
-          "DirectoryId": {},
-          "ComputerName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "ComputerName": {
+            "shape": "S19"
+          },
           "Password": {
             "type": "string",
+            "max": 64,
+            "min": 8,
+            "pattern": "[\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "OrganizationalUnitDistinguishedName": {},
+          "OrganizationalUnitDistinguishedName": {
+            "type": "string",
+            "max": 2000,
+            "min": 1
+          },
           "ComputerAttributes": {
             "shape": "S1c"
           }
@@ -189,8 +236,15 @@
           "Computer": {
             "type": "structure",
             "members": {
-              "ComputerId": {},
-              "ComputerName": {},
+              "ComputerId": {
+                "type": "string",
+                "max": 256,
+                "min": 1,
+                "pattern": "[&\\w+-.@]+"
+              },
+              "ComputerName": {
+                "shape": "S19"
+              },
               "ComputerAttributes": {
                 "shape": "S1c"
               }
@@ -208,8 +262,12 @@
           "DnsIpAddrs"
         ],
         "members": {
-          "DirectoryId": {},
-          "RemoteDomainName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "RemoteDomainName": {
+            "shape": "S1k"
+          },
           "DnsIpAddrs": {
             "shape": "S11"
           }
@@ -229,13 +287,21 @@
           "Size"
         ],
         "members": {
-          "Name": {},
-          "ShortName": {},
+          "Name": {
+            "shape": "St"
+          },
+          "ShortName": {
+            "shape": "Su"
+          },
           "Password": {
             "shape": "S1n"
           },
-          "Description": {},
-          "Size": {},
+          "Description": {
+            "shape": "Sf"
+          },
+          "Size": {
+            "shape": "Sw"
+          },
           "VpcSettings": {
             "shape": "S1o"
           }
@@ -244,7 +310,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -256,8 +324,12 @@
           "LogGroupName"
         ],
         "members": {
-          "DirectoryId": {},
-          "LogGroupName": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "LogGroupName": {
+            "shape": "S1r"
+          }
         }
       },
       "output": {
@@ -274,22 +346,32 @@
           "VpcSettings"
         ],
         "members": {
-          "Name": {},
-          "ShortName": {},
+          "Name": {
+            "shape": "St"
+          },
+          "ShortName": {
+            "shape": "Su"
+          },
           "Password": {
             "shape": "S1n"
           },
-          "Description": {},
+          "Description": {
+            "shape": "Sf"
+          },
           "VpcSettings": {
             "shape": "S1o"
           },
-          "Edition": {}
+          "Edition": {
+            "shape": "S1u"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -300,14 +382,20 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
-          "Name": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S1x"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {}
+          "SnapshotId": {
+            "shape": "S1z"
+          }
         }
       }
     },
@@ -321,14 +409,24 @@
           "TrustDirection"
         ],
         "members": {
-          "DirectoryId": {},
-          "RemoteDomainName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "RemoteDomainName": {
+            "shape": "S1k"
+          },
           "TrustPassword": {
             "type": "string",
+            "max": 128,
+            "min": 1,
             "sensitive": true
           },
-          "TrustDirection": {},
-          "TrustType": {},
+          "TrustDirection": {
+            "shape": "S22"
+          },
+          "TrustType": {
+            "shape": "S23"
+          },
           "ConditionalForwarderIpAddrs": {
             "shape": "S11"
           }
@@ -337,7 +435,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {}
+          "TrustId": {
+            "shape": "S25"
+          }
         }
       }
     },
@@ -349,8 +449,12 @@
           "RemoteDomainName"
         ],
         "members": {
-          "DirectoryId": {},
-          "RemoteDomainName": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "RemoteDomainName": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -365,13 +469,17 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -382,7 +490,9 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -397,13 +507,17 @@
           "SnapshotId"
         ],
         "members": {
-          "SnapshotId": {}
+          "SnapshotId": {
+            "shape": "S1z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {}
+          "SnapshotId": {
+            "shape": "S1z"
+          }
         }
       }
     },
@@ -414,7 +528,9 @@
           "TrustId"
         ],
         "members": {
-          "TrustId": {},
+          "TrustId": {
+            "shape": "S25"
+          },
           "DeleteAssociatedConditionalForwarder": {
             "type": "boolean"
           }
@@ -423,7 +539,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {}
+          "TrustId": {
+            "shape": "S25"
+          }
         }
       }
     },
@@ -435,8 +553,12 @@
           "TopicName"
         ],
         "members": {
-          "DirectoryId": {},
-          "TopicName": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "TopicName": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
@@ -451,10 +573,14 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "RemoteDomainNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1k"
+            }
           }
         }
       },
@@ -466,11 +592,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "RemoteDomainName": {},
+                "RemoteDomainName": {
+                  "shape": "S1k"
+                },
                 "DnsIpAddrs": {
                   "shape": "S11"
                 },
-                "ReplicationScope": {}
+                "ReplicationScope": {
+                  "type": "string",
+                  "enum": [
+                    "Domain"
+                  ]
+                }
               }
             }
           }
@@ -486,7 +619,7 @@
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -498,20 +631,57 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "Name": {},
-                "ShortName": {},
-                "Size": {},
-                "Edition": {},
-                "Alias": {},
-                "AccessUrl": {},
-                "Description": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "St"
+                },
+                "ShortName": {
+                  "shape": "Su"
+                },
+                "Size": {
+                  "shape": "Sw"
+                },
+                "Edition": {
+                  "shape": "S1u"
+                },
+                "Alias": {
+                  "shape": "S16"
+                },
+                "AccessUrl": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
+                "Description": {
+                  "shape": "Sf"
+                },
                 "DnsIpAddrs": {
                   "shape": "S11"
                 },
-                "Stage": {},
-                "ShareStatus": {},
-                "ShareMethod": {},
+                "Stage": {
+                  "type": "string",
+                  "enum": [
+                    "Requested",
+                    "Creating",
+                    "Created",
+                    "Active",
+                    "Inoperable",
+                    "Impaired",
+                    "Restoring",
+                    "RestoreFailed",
+                    "Deleting",
+                    "Deleted",
+                    "Failed"
+                  ]
+                },
+                "ShareStatus": {
+                  "shape": "S7"
+                },
+                "ShareMethod": {
+                  "shape": "S6"
+                },
                 "ShareNotes": {
                   "shape": "S8"
                 },
@@ -521,44 +691,66 @@
                 "StageLastUpdatedDateTime": {
                   "type": "timestamp"
                 },
-                "Type": {},
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "SimpleAD",
+                    "ADConnector",
+                    "MicrosoftAD",
+                    "SharedMicrosoftAD"
+                  ]
+                },
                 "VpcSettings": {
                   "shape": "S31"
                 },
                 "ConnectSettings": {
                   "type": "structure",
                   "members": {
-                    "VpcId": {},
+                    "VpcId": {
+                      "shape": "Sy"
+                    },
                     "SubnetIds": {
                       "shape": "Sz"
                     },
-                    "CustomerUserName": {},
-                    "SecurityGroupId": {},
+                    "CustomerUserName": {
+                      "shape": "S13"
+                    },
+                    "SecurityGroupId": {
+                      "shape": "S32"
+                    },
                     "AvailabilityZones": {
                       "shape": "S33"
                     },
                     "ConnectIps": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "S12"
+                      }
                     }
                   }
                 },
                 "RadiusSettings": {
                   "shape": "S37"
                 },
-                "RadiusStatus": {},
+                "RadiusStatus": {
+                  "shape": "S3h"
+                },
                 "StageReason": {},
                 "SsoEnabled": {
                   "type": "boolean"
                 },
                 "DesiredNumberOfDomainControllers": {
-                  "type": "integer"
+                  "shape": "S3k"
                 },
                 "OwnerDirectoryDescription": {
                   "type": "structure",
                   "members": {
-                    "DirectoryId": {},
-                    "AccountId": {},
+                    "DirectoryId": {
+                      "shape": "S2"
+                    },
+                    "AccountId": {
+                      "shape": "S5"
+                    },
                     "DnsIpAddrs": {
                       "shape": "S11"
                     },
@@ -568,7 +760,9 @@
                     "RadiusSettings": {
                       "shape": "S37"
                     },
-                    "RadiusStatus": {}
+                    "RadiusStatus": {
+                      "shape": "S3h"
+                    }
                   }
                 }
               }
@@ -585,14 +779,18 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "DomainControllerIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3o"
+            }
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -604,13 +802,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "DomainControllerId": {},
-                "DnsIpAddr": {},
-                "VpcId": {},
-                "SubnetId": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "DomainControllerId": {
+                  "shape": "S3o"
+                },
+                "DnsIpAddr": {
+                  "shape": "S12"
+                },
+                "VpcId": {
+                  "shape": "Sy"
+                },
+                "SubnetId": {
+                  "shape": "S10"
+                },
                 "AvailabilityZone": {},
-                "Status": {},
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Creating",
+                    "Active",
+                    "Impaired",
+                    "Restoring",
+                    "Deleting",
+                    "Deleted",
+                    "Failed"
+                  ]
+                },
                 "StatusReason": {},
                 "LaunchTime": {
                   "type": "timestamp"
@@ -629,10 +848,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "TopicNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2i"
+            }
           }
         }
       },
@@ -644,13 +867,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "TopicName": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "TopicName": {
+                  "shape": "S2i"
+                },
                 "TopicArn": {},
                 "CreatedDateTime": {
                   "type": "timestamp"
                 },
-                "Status": {}
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Registered",
+                    "Topic not found",
+                    "Failed",
+                    "Deleted"
+                  ]
+                }
               }
             }
           }
@@ -664,13 +899,15 @@
           "OwnerDirectoryId"
         ],
         "members": {
-          "OwnerDirectoryId": {},
+          "OwnerDirectoryId": {
+            "shape": "S2"
+          },
           "SharedDirectoryIds": {
             "shape": "S2r"
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -691,14 +928,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "SnapshotIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1z"
+            }
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -710,11 +951,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "SnapshotId": {},
-                "Type": {},
-                "Name": {},
-                "Status": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "SnapshotId": {
+                  "shape": "S1z"
+                },
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "Auto",
+                    "Manual"
+                  ]
+                },
+                "Name": {
+                  "shape": "S1x"
+                },
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Creating",
+                    "Completed",
+                    "Failed"
+                  ]
+                },
                 "StartTime": {
                   "type": "timestamp"
                 }
@@ -729,14 +989,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "TrustIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S25"
+            }
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -748,12 +1012,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "TrustId": {},
-                "RemoteDomainName": {},
-                "TrustType": {},
-                "TrustDirection": {},
-                "TrustState": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "TrustId": {
+                  "shape": "S25"
+                },
+                "RemoteDomainName": {
+                  "shape": "S1k"
+                },
+                "TrustType": {
+                  "shape": "S23"
+                },
+                "TrustDirection": {
+                  "shape": "S22"
+                },
+                "TrustState": {
+                  "type": "string",
+                  "enum": [
+                    "Creating",
+                    "Created",
+                    "Verifying",
+                    "VerifyFailed",
+                    "Verified",
+                    "Deleting",
+                    "Deleted",
+                    "Failed"
+                  ]
+                },
                 "CreatedDateTime": {
                   "type": "timestamp"
                 },
@@ -778,7 +1064,9 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -793,8 +1081,12 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
-          "UserName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "UserName": {
+            "shape": "S13"
+          },
           "Password": {
             "shape": "Sv"
           }
@@ -813,7 +1105,9 @@
           "RadiusSettings"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "RadiusSettings": {
             "shape": "S37"
           }
@@ -831,8 +1125,12 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
-          "UserName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "UserName": {
+            "shape": "S13"
+          },
           "Password": {
             "shape": "Sv"
           }
@@ -855,28 +1153,28 @@
             "type": "structure",
             "members": {
               "CloudOnlyDirectoriesLimit": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "CloudOnlyDirectoriesCurrentCount": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "CloudOnlyDirectoriesLimitReached": {
                 "type": "boolean"
               },
               "CloudOnlyMicrosoftADLimit": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "CloudOnlyMicrosoftADCurrentCount": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "CloudOnlyMicrosoftADLimitReached": {
                 "type": "boolean"
               },
               "ConnectedDirectoriesLimit": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "ConnectedDirectoriesCurrentCount": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "ConnectedDirectoriesLimitReached": {
                 "type": "boolean"
@@ -893,7 +1191,9 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {}
+          "DirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -903,10 +1203,10 @@
             "type": "structure",
             "members": {
               "ManualSnapshotsLimit": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "ManualSnapshotsCurrentCount": {
-                "type": "integer"
+                "shape": "S2t"
               },
               "ManualSnapshotsLimitReached": {
                 "type": "boolean"
@@ -923,10 +1223,12 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -938,14 +1240,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "CidrIp": {},
-                "IpRouteStatusMsg": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "CidrIp": {
+                  "shape": "Se"
+                },
+                "IpRouteStatusMsg": {
+                  "type": "string",
+                  "enum": [
+                    "Adding",
+                    "Added",
+                    "Removing",
+                    "Removed",
+                    "AddFailed",
+                    "RemoveFailed"
+                  ]
+                },
                 "AddedDateTime": {
                   "type": "timestamp"
                 },
                 "IpRouteStatusReason": {},
-                "Description": {}
+                "Description": {
+                  "shape": "Sf"
+                }
               }
             }
           },
@@ -957,10 +1275,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -972,8 +1292,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "LogGroupName": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "LogGroupName": {
+                  "shape": "S1r"
+                },
                 "SubscriptionCreatedDateTime": {
                   "type": "timestamp"
                 }
@@ -991,10 +1315,12 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -1006,10 +1332,29 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
-                "SchemaExtensionId": {},
-                "Description": {},
-                "SchemaExtensionStatus": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
+                "SchemaExtensionId": {
+                  "shape": "Sq"
+                },
+                "Description": {
+                  "shape": "Sf"
+                },
+                "SchemaExtensionStatus": {
+                  "type": "string",
+                  "enum": [
+                    "Initializing",
+                    "CreatingSnapshot",
+                    "UpdatingSchema",
+                    "Replicating",
+                    "CancelInProgress",
+                    "RollbackInProgress",
+                    "Cancelled",
+                    "Failed",
+                    "Completed"
+                  ]
+                },
                 "SchemaExtensionStatusReason": {},
                 "StartDateTime": {
                   "type": "timestamp"
@@ -1031,10 +1376,12 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "Sj"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S2t"
           }
         }
       },
@@ -1056,8 +1403,12 @@
           "TopicName"
         ],
         "members": {
-          "DirectoryId": {},
-          "TopicName": {}
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "TopicName": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
@@ -1072,13 +1423,17 @@
           "SharedDirectoryId"
         ],
         "members": {
-          "SharedDirectoryId": {}
+          "SharedDirectoryId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {}
+          "SharedDirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1090,10 +1445,14 @@
           "CidrIps"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "CidrIps": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Se"
+            }
           }
         }
       },
@@ -1110,10 +1469,14 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "Sj"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sm"
+            }
           }
         }
       },
@@ -1131,10 +1494,19 @@
           "NewPassword"
         ],
         "members": {
-          "DirectoryId": {},
-          "UserName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "UserName": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "^(?!.*\\\\|.*\"|.*\\/|.*\\[|.*\\]|.*:|.*;|.*\\||.*=|.*,|.*\\+|.*\\*|.*\\?|.*<|.*>|.*@).*$"
+          },
           "NewPassword": {
             "type": "string",
+            "max": 127,
+            "min": 1,
             "sensitive": true
           }
         }
@@ -1151,7 +1523,9 @@
           "SnapshotId"
         ],
         "members": {
-          "SnapshotId": {}
+          "SnapshotId": {
+            "shape": "S1z"
+          }
         }
       },
       "output": {
@@ -1168,7 +1542,9 @@
           "ShareMethod"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "ShareNotes": {
             "shape": "S8"
           },
@@ -1179,17 +1555,25 @@
               "Type"
             ],
             "members": {
-              "Id": {},
-              "Type": {}
+              "Id": {
+                "shape": "S65"
+              },
+              "Type": {
+                "shape": "S66"
+              }
             }
           },
-          "ShareMethod": {}
+          "ShareMethod": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {}
+          "SharedDirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1203,18 +1587,28 @@
           "Description"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "CreateSnapshotBeforeSchemaExtension": {
             "type": "boolean"
           },
-          "LdifContent": {},
-          "Description": {}
+          "LdifContent": {
+            "type": "string",
+            "max": 500000,
+            "min": 1
+          },
+          "Description": {
+            "shape": "Sf"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SchemaExtensionId": {}
+          "SchemaExtensionId": {
+            "shape": "Sq"
+          }
         }
       }
     },
@@ -1226,7 +1620,9 @@
           "UnshareTarget"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "UnshareTarget": {
             "type": "structure",
             "required": [
@@ -1234,8 +1630,12 @@
               "Type"
             ],
             "members": {
-              "Id": {},
-              "Type": {}
+              "Id": {
+                "shape": "S65"
+              },
+              "Type": {
+                "shape": "S66"
+              }
             }
           }
         }
@@ -1243,7 +1643,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {}
+          "SharedDirectoryId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1256,8 +1658,12 @@
           "DnsIpAddrs"
         ],
         "members": {
-          "DirectoryId": {},
-          "RemoteDomainName": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "RemoteDomainName": {
+            "shape": "S1k"
+          },
           "DnsIpAddrs": {
             "shape": "S11"
           }
@@ -1276,9 +1682,11 @@
           "DesiredNumber"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "DesiredNumber": {
-            "type": "integer"
+            "shape": "S3k"
           }
         }
       },
@@ -1295,7 +1703,9 @@
           "RadiusSettings"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "RadiusSettings": {
             "shape": "S37"
           }
@@ -1313,27 +1723,47 @@
           "TrustId"
         ],
         "members": {
-          "TrustId": {}
+          "TrustId": {
+            "shape": "S25"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {}
+          "TrustId": {
+            "shape": "S25"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "^d-[0-9a-f]{10}$"
+    },
     "S4": {
       "type": "structure",
       "members": {
-        "OwnerAccountId": {},
-        "OwnerDirectoryId": {},
-        "ShareMethod": {},
-        "SharedAccountId": {},
-        "SharedDirectoryId": {},
-        "ShareStatus": {},
+        "OwnerAccountId": {
+          "shape": "S5"
+        },
+        "OwnerDirectoryId": {
+          "shape": "S2"
+        },
+        "ShareMethod": {
+          "shape": "S6"
+        },
+        "SharedAccountId": {
+          "shape": "S5"
+        },
+        "SharedDirectoryId": {
+          "shape": "S2"
+        },
+        "ShareStatus": {
+          "shape": "S7"
+        },
         "ShareNotes": {
           "shape": "S8"
         },
@@ -1345,9 +1775,49 @@
         }
       }
     },
+    "S5": {
+      "type": "string",
+      "pattern": "^(\\d{12})$"
+    },
+    "S6": {
+      "type": "string",
+      "enum": [
+        "ORGANIZATIONS",
+        "HANDSHAKE"
+      ]
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "Shared",
+        "PendingAcceptance",
+        "Rejected",
+        "Rejecting",
+        "RejectFailed",
+        "Sharing",
+        "ShareFailed",
+        "Deleted",
+        "Deleting"
+      ]
+    },
     "S8": {
       "type": "string",
+      "max": 1024,
       "sensitive": true
+    },
+    "Se": {
+      "type": "string",
+      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([1-9]|[1-2][0-9]|3[0-2]))$"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 128,
+      "min": 0,
+      "pattern": "^([a-zA-Z0-9_])[\\\\a-zA-Z0-9_@#%*+=:?./!\\s-]*$"
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "^[d]-[0-9a-f]{10}$"
     },
     "Sk": {
       "type": "list",
@@ -1358,35 +1828,109 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Sm"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
       }
     },
+    "Sm": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "Sq": {
+      "type": "string",
+      "pattern": "^e-[0-9a-f]{10}$"
+    },
+    "St": {
+      "type": "string",
+      "pattern": "^([a-zA-Z0-9]+[\\\\.-])+([a-zA-Z0-9])+$"
+    },
+    "Su": {
+      "type": "string",
+      "pattern": "^[^\\\\/:*?\\\"\\<\\>|.]+[^\\\\/:*?\\\"<>|]*$"
+    },
     "Sv": {
       "type": "string",
+      "max": 128,
+      "min": 1,
       "sensitive": true
+    },
+    "Sw": {
+      "type": "string",
+      "enum": [
+        "Small",
+        "Large"
+      ]
+    },
+    "Sy": {
+      "type": "string",
+      "pattern": "^(vpc-[0-9a-f]{8}|vpc-[0-9a-f]{17})$"
     },
     "Sz": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S10"
+      }
+    },
+    "S10": {
+      "type": "string",
+      "pattern": "^(subnet-[0-9a-f]{8}|subnet-[0-9a-f]{17})$"
     },
     "S11": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S12"
+      }
+    },
+    "S12": {
+      "type": "string",
+      "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    },
+    "S13": {
+      "type": "string",
+      "min": 1,
+      "pattern": "[a-zA-Z0-9._-]+"
+    },
+    "S16": {
+      "type": "string",
+      "max": 62,
+      "min": 1,
+      "pattern": "^(?!d-)([\\da-zA-Z]+)([-]*[\\da-zA-Z])*"
+    },
+    "S19": {
+      "type": "string",
+      "max": 15,
+      "min": 1
     },
     "S1c": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "type": "string",
+            "min": 1
+          },
           "Value": {}
         }
       }
     },
+    "S1k": {
+      "type": "string",
+      "pattern": "^([a-zA-Z0-9]+[\\\\.-])+([a-zA-Z0-9])+[.]?$"
+    },
     "S1n": {
       "type": "string",
+      "pattern": "(?=^.{8,64}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9\\s])(?=.*[a-z])|(?=.*[^A-Za-z0-9\\s])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9\\s]))^.*",
       "sensitive": true
     },
     "S1o": {
@@ -1396,28 +1940,91 @@
         "SubnetIds"
       ],
       "members": {
-        "VpcId": {},
+        "VpcId": {
+          "shape": "Sy"
+        },
         "SubnetIds": {
           "shape": "Sz"
         }
       }
     },
+    "S1r": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[-._/#A-Za-z0-9]+"
+    },
+    "S1u": {
+      "type": "string",
+      "enum": [
+        "Enterprise",
+        "Standard"
+      ]
+    },
+    "S1x": {
+      "type": "string",
+      "max": 128,
+      "min": 0,
+      "pattern": "^([a-zA-Z0-9_])[\\\\a-zA-Z0-9_@#%*+=:?./!\\s-]*$"
+    },
+    "S1z": {
+      "type": "string",
+      "pattern": "^s-[0-9a-f]{10}$"
+    },
+    "S22": {
+      "type": "string",
+      "enum": [
+        "One-Way: Outgoing",
+        "One-Way: Incoming",
+        "Two-Way"
+      ]
+    },
+    "S23": {
+      "type": "string",
+      "enum": [
+        "Forest"
+      ]
+    },
+    "S25": {
+      "type": "string",
+      "pattern": "^t-[0-9a-f]{10}$"
+    },
+    "S2i": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
     "S2r": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
+    },
+    "S2t": {
+      "type": "integer",
+      "min": 0
     },
     "S31": {
       "type": "structure",
       "members": {
-        "VpcId": {},
+        "VpcId": {
+          "shape": "Sy"
+        },
         "SubnetIds": {
           "shape": "Sz"
         },
-        "SecurityGroupId": {},
+        "SecurityGroupId": {
+          "shape": "S32"
+        },
         "AvailabilityZones": {
           "shape": "S33"
         }
       }
+    },
+    "S32": {
+      "type": "string",
+      "pattern": "^(sg-[0-9a-f]{8}|sg-[0-9a-f]{17})$"
     },
     "S33": {
       "type": "list",
@@ -1428,27 +2035,78 @@
       "members": {
         "RadiusServers": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+          }
         },
         "RadiusPort": {
-          "type": "integer"
+          "type": "integer",
+          "max": 65535,
+          "min": 1025
         },
         "RadiusTimeout": {
-          "type": "integer"
+          "type": "integer",
+          "max": 20,
+          "min": 1
         },
         "RadiusRetries": {
-          "type": "integer"
+          "type": "integer",
+          "max": 10,
+          "min": 0
         },
         "SharedSecret": {
           "type": "string",
+          "max": 512,
+          "min": 8,
           "sensitive": true
         },
-        "AuthenticationProtocol": {},
-        "DisplayLabel": {},
+        "AuthenticationProtocol": {
+          "type": "string",
+          "enum": [
+            "PAP",
+            "CHAP",
+            "MS-CHAPv1",
+            "MS-CHAPv2"
+          ]
+        },
+        "DisplayLabel": {
+          "type": "string",
+          "max": 64,
+          "min": 1
+        },
         "UseSameUsername": {
           "type": "boolean"
         }
       }
+    },
+    "S3h": {
+      "type": "string",
+      "enum": [
+        "Creating",
+        "Completed",
+        "Failed"
+      ]
+    },
+    "S3k": {
+      "type": "integer",
+      "min": 2
+    },
+    "S3o": {
+      "type": "string",
+      "pattern": "^dc-[0-9a-f]{10}$"
+    },
+    "S65": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "S66": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT"
+      ]
     }
   }
 }

--- a/apis/dynamodb-2011-12-05.min.json
+++ b/apis/dynamodb-2011-12-05.min.json
@@ -30,7 +30,9 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "type": "structure",
               "members": {
@@ -66,7 +68,9 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "type": "structure",
               "members": {
@@ -91,7 +95,9 @@
           "ProvisionedThroughput"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "KeySchema": {
             "shape": "Sy"
           },
@@ -117,14 +123,18 @@
           "Key"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {}
+          "ReturnValues": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
@@ -146,7 +156,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -165,7 +177,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -185,7 +199,9 @@
           "Key"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
@@ -213,9 +229,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartTableName": {},
+          "ExclusiveStartTableName": {
+            "shape": "S3"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -224,9 +244,13 @@
         "members": {
           "TableNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           },
-          "LastEvaluatedTableName": {}
+          "LastEvaluatedTableName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -238,14 +262,18 @@
           "Item"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Item": {
             "shape": "Ss"
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {}
+          "ReturnValues": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
@@ -268,12 +296,14 @@
           "HashKeyValue"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "AttributesToGet": {
             "shape": "Se"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S1t"
           },
           "ConsistentRead": {
             "type": "boolean"
@@ -320,12 +350,14 @@
           "TableName"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "AttributesToGet": {
             "shape": "Se"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S1t"
           },
           "Count": {
             "type": "boolean"
@@ -372,27 +404,40 @@
           "AttributeUpdates"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
           "AttributeUpdates": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "Sf"
+            },
             "value": {
               "type": "structure",
               "members": {
                 "Value": {
                   "shape": "S7"
                 },
-                "Action": {}
+                "Action": {
+                  "type": "string",
+                  "enum": [
+                    "ADD",
+                    "PUT",
+                    "DELETE"
+                  ]
+                }
               }
             }
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {}
+          "ReturnValues": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
@@ -415,7 +460,9 @@
           "ProvisionedThroughput"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "ProvisionedThroughput": {
             "shape": "S12"
           }
@@ -434,7 +481,9 @@
   "shapes": {
     "S2": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3"
+      },
       "value": {
         "type": "structure",
         "required": [
@@ -445,7 +494,9 @@
             "type": "list",
             "member": {
               "shape": "S6"
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "AttributesToGet": {
             "shape": "Se"
@@ -454,7 +505,15 @@
             "type": "boolean"
           }
         }
-      }
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9_.-]+"
     },
     "S6": {
       "type": "structure",
@@ -496,7 +555,14 @@
     },
     "Se": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sf"
+      },
+      "min": 1
+    },
+    "Sf": {
+      "type": "string",
+      "max": 65535
     },
     "Sk": {
       "type": "list",
@@ -506,14 +572,18 @@
     },
     "Sl": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sf"
+      },
       "value": {
         "shape": "S7"
       }
     },
     "So": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3"
+      },
       "value": {
         "type": "list",
         "member": {
@@ -542,12 +612,18 @@
               }
             }
           }
-        }
-      }
+        },
+        "max": 25,
+        "min": 1
+      },
+      "max": 25,
+      "min": 1
     },
     "Ss": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sf"
+      },
       "value": {
         "shape": "S7"
       }
@@ -573,8 +649,19 @@
         "AttributeType"
       ],
       "members": {
-        "AttributeName": {},
-        "AttributeType": {}
+        "AttributeName": {
+          "type": "string",
+          "max": 255,
+          "min": 1
+        },
+        "AttributeType": {
+          "type": "string",
+          "enum": [
+            "S",
+            "N",
+            "B"
+          ]
+        }
       }
     },
     "S12": {
@@ -585,21 +672,35 @@
       ],
       "members": {
         "ReadCapacityUnits": {
-          "type": "long"
+          "shape": "S13"
         },
         "WriteCapacityUnits": {
-          "type": "long"
+          "shape": "S13"
         }
       }
+    },
+    "S13": {
+      "type": "long",
+      "min": 1
     },
     "S15": {
       "type": "structure",
       "members": {
-        "TableName": {},
+        "TableName": {
+          "shape": "S3"
+        },
         "KeySchema": {
           "shape": "Sy"
         },
-        "TableStatus": {},
+        "TableStatus": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "UPDATING",
+            "DELETING",
+            "ACTIVE"
+          ]
+        },
         "CreationDateTime": {
           "type": "timestamp"
         },
@@ -613,13 +714,13 @@
               "type": "timestamp"
             },
             "NumberOfDecreasesToday": {
-              "type": "long"
+              "shape": "S13"
             },
             "ReadCapacityUnits": {
-              "type": "long"
+              "shape": "S13"
             },
             "WriteCapacityUnits": {
-              "type": "long"
+              "shape": "S13"
             }
           }
         },
@@ -633,7 +734,9 @@
     },
     "S1b": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sf"
+      },
       "value": {
         "type": "structure",
         "members": {
@@ -645,6 +748,20 @@
           }
         }
       }
+    },
+    "S1e": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "ALL_OLD",
+        "UPDATED_OLD",
+        "ALL_NEW",
+        "UPDATED_NEW"
+      ]
+    },
+    "S1t": {
+      "type": "integer",
+      "min": 1
     },
     "S1u": {
       "type": "structure",
@@ -658,7 +775,24 @@
             "shape": "S7"
           }
         },
-        "ComparisonOperator": {}
+        "ComparisonOperator": {
+          "type": "string",
+          "enum": [
+            "EQ",
+            "NE",
+            "IN",
+            "LE",
+            "LT",
+            "GE",
+            "GT",
+            "BETWEEN",
+            "NOT_NULL",
+            "NULL",
+            "CONTAINS",
+            "NOT_CONTAINS",
+            "BEGINS_WITH"
+          ]
+        }
       }
     }
   }

--- a/apis/dynamodb-2012-08-10.min.json
+++ b/apis/dynamodb-2012-08-10.min.json
@@ -23,7 +23,9 @@
           "RequestItems": {
             "shape": "S2"
           },
-          "ReturnConsumedCapacity": {}
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -31,7 +33,9 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "shape": "Sr"
             }
@@ -56,8 +60,12 @@
           "RequestItems": {
             "shape": "S10"
           },
-          "ReturnConsumedCapacity": {},
-          "ReturnItemCollectionMetrics": {}
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
+          "ReturnItemCollectionMetrics": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -68,7 +76,9 @@
           },
           "ItemCollectionMetrics": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "type": "list",
               "member": {
@@ -91,8 +101,12 @@
           "BackupName"
         ],
         "members": {
-          "TableName": {},
-          "BackupName": {}
+          "TableName": {
+            "shape": "S3"
+          },
+          "BackupName": {
+            "shape": "S1f"
+          }
         }
       },
       "output": {
@@ -113,7 +127,9 @@
           "ReplicationGroup"
         ],
         "members": {
-          "GlobalTableName": {},
+          "GlobalTableName": {
+            "shape": "S3"
+          },
           "ReplicationGroup": {
             "shape": "S1p"
           }
@@ -142,7 +158,9 @@
           "AttributeDefinitions": {
             "shape": "S1z"
           },
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "KeySchema": {
             "shape": "S23"
           },
@@ -156,7 +174,9 @@
                 "Projection"
               ],
               "members": {
-                "IndexName": {},
+                "IndexName": {
+                  "shape": "Sy"
+                },
                 "KeySchema": {
                   "shape": "S23"
                 },
@@ -177,7 +197,9 @@
                 "ProvisionedThroughput"
               ],
               "members": {
-                "IndexName": {},
+                "IndexName": {
+                  "shape": "Sy"
+                },
                 "KeySchema": {
                   "shape": "S23"
                 },
@@ -218,7 +240,9 @@
           "BackupArn"
         ],
         "members": {
-          "BackupArn": {}
+          "BackupArn": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -239,17 +263,27 @@
           "Key"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ConditionalOperator": {},
-          "ReturnValues": {},
-          "ReturnConsumedCapacity": {},
-          "ReturnItemCollectionMetrics": {},
+          "ConditionalOperator": {
+            "shape": "S3r"
+          },
+          "ReturnValues": {
+            "shape": "S3s"
+          },
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
+          "ReturnItemCollectionMetrics": {
+            "shape": "S16"
+          },
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -282,7 +316,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -302,7 +338,9 @@
           "BackupArn"
         ],
         "members": {
-          "BackupArn": {}
+          "BackupArn": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -322,7 +360,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -373,7 +413,9 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {}
+          "GlobalTableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -393,13 +435,17 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {}
+          "GlobalTableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GlobalTableName": {},
+          "GlobalTableName": {
+            "shape": "S3"
+          },
           "ReplicaSettings": {
             "shape": "S4f"
           }
@@ -416,16 +462,16 @@
         "type": "structure",
         "members": {
           "AccountMaxReadCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "AccountMaxWriteCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "TableMaxReadCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "TableMaxWriteCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           }
         }
       },
@@ -438,7 +484,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -458,7 +506,9 @@
           "TableName"
         ],
         "members": {
-          "TableName": {}
+          "TableName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -479,7 +529,9 @@
           "Key"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
@@ -489,7 +541,9 @@
           "ConsistentRead": {
             "type": "boolean"
           },
-          "ReturnConsumedCapacity": {},
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
           "ProjectionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -513,9 +567,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           },
           "TimeRangeLowerBound": {
             "type": "timestamp"
@@ -523,8 +581,17 @@
           "TimeRangeUpperBound": {
             "type": "timestamp"
           },
-          "ExclusiveStartBackupArn": {},
-          "BackupType": {}
+          "ExclusiveStartBackupArn": {
+            "shape": "S1i"
+          },
+          "BackupType": {
+            "type": "string",
+            "enum": [
+              "USER",
+              "SYSTEM",
+              "ALL"
+            ]
+          }
         }
       },
       "output": {
@@ -535,26 +602,40 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {},
-                "TableId": {},
+                "TableName": {
+                  "shape": "S3"
+                },
+                "TableId": {
+                  "shape": "S2t"
+                },
                 "TableArn": {},
-                "BackupArn": {},
-                "BackupName": {},
+                "BackupArn": {
+                  "shape": "S1i"
+                },
+                "BackupName": {
+                  "shape": "S1f"
+                },
                 "BackupCreationDateTime": {
                   "type": "timestamp"
                 },
                 "BackupExpiryDateTime": {
                   "type": "timestamp"
                 },
-                "BackupStatus": {},
-                "BackupType": {},
+                "BackupStatus": {
+                  "shape": "S1k"
+                },
+                "BackupType": {
+                  "shape": "S1l"
+                },
                 "BackupSizeBytes": {
-                  "type": "long"
+                  "shape": "S1j"
                 }
               }
             }
           },
-          "LastEvaluatedBackupArn": {}
+          "LastEvaluatedBackupArn": {
+            "shape": "S1i"
+          }
         }
       },
       "endpointdiscovery": {}
@@ -563,9 +644,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartGlobalTableName": {},
+          "ExclusiveStartGlobalTableName": {
+            "shape": "S3"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S58"
           },
           "RegionName": {}
         }
@@ -578,14 +661,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "GlobalTableName": {},
+                "GlobalTableName": {
+                  "shape": "S3"
+                },
                 "ReplicationGroup": {
                   "shape": "S1p"
                 }
               }
             }
           },
-          "LastEvaluatedGlobalTableName": {}
+          "LastEvaluatedGlobalTableName": {
+            "shape": "S3"
+          }
         }
       },
       "endpointdiscovery": {}
@@ -594,9 +681,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartTableName": {},
+          "ExclusiveStartTableName": {
+            "shape": "S3"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -605,9 +696,13 @@
         "members": {
           "TableNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           },
-          "LastEvaluatedTableName": {}
+          "LastEvaluatedTableName": {
+            "shape": "S3"
+          }
         }
       },
       "endpointdiscovery": {}
@@ -619,7 +714,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S5h"
+          },
           "NextToken": {}
         }
       },
@@ -642,17 +739,27 @@
           "Item"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Item": {
             "shape": "S14"
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ReturnValues": {},
-          "ReturnConsumedCapacity": {},
-          "ReturnItemCollectionMetrics": {},
-          "ConditionalOperator": {},
+          "ReturnValues": {
+            "shape": "S3s"
+          },
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
+          "ReturnItemCollectionMetrics": {
+            "shape": "S16"
+          },
+          "ConditionalOperator": {
+            "shape": "S3r"
+          },
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -685,21 +792,29 @@
           "TableName"
         ],
         "members": {
-          "TableName": {},
-          "IndexName": {},
-          "Select": {},
+          "TableName": {
+            "shape": "S3"
+          },
+          "IndexName": {
+            "shape": "Sy"
+          },
+          "Select": {
+            "shape": "S5r"
+          },
           "AttributesToGet": {
             "shape": "Sj"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S58"
           },
           "ConsistentRead": {
             "type": "boolean"
           },
           "KeyConditions": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S7"
+            },
             "value": {
               "shape": "S5t"
             }
@@ -707,14 +822,18 @@
           "QueryFilter": {
             "shape": "S5u"
           },
-          "ConditionalOperator": {},
+          "ConditionalOperator": {
+            "shape": "S3r"
+          },
           "ScanIndexForward": {
             "type": "boolean"
           },
           "ExclusiveStartKey": {
             "shape": "S6"
           },
-          "ReturnConsumedCapacity": {},
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
           "ProjectionExpression": {},
           "FilterExpression": {},
           "KeyConditionExpression": {},
@@ -756,8 +875,12 @@
           "BackupArn"
         ],
         "members": {
-          "TargetTableName": {},
-          "BackupArn": {}
+          "TargetTableName": {
+            "shape": "S3"
+          },
+          "BackupArn": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -778,8 +901,12 @@
           "TargetTableName"
         ],
         "members": {
-          "SourceTableName": {},
-          "TargetTableName": {},
+          "SourceTableName": {
+            "shape": "S3"
+          },
+          "TargetTableName": {
+            "shape": "S3"
+          },
           "UseLatestRestorableTime": {
             "type": "boolean"
           },
@@ -805,28 +932,42 @@
           "TableName"
         ],
         "members": {
-          "TableName": {},
-          "IndexName": {},
+          "TableName": {
+            "shape": "S3"
+          },
+          "IndexName": {
+            "shape": "Sy"
+          },
           "AttributesToGet": {
             "shape": "Sj"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S58"
           },
-          "Select": {},
+          "Select": {
+            "shape": "S5r"
+          },
           "ScanFilter": {
             "shape": "S5u"
           },
-          "ConditionalOperator": {},
+          "ConditionalOperator": {
+            "shape": "S3r"
+          },
           "ExclusiveStartKey": {
             "shape": "S6"
           },
-          "ReturnConsumedCapacity": {},
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
           "TotalSegments": {
-            "type": "integer"
+            "type": "integer",
+            "max": 1000000,
+            "min": 1
           },
           "Segment": {
-            "type": "integer"
+            "type": "integer",
+            "max": 999999,
+            "min": 0
           },
           "ProjectionExpression": {},
           "FilterExpression": {},
@@ -871,7 +1012,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S5h"
+          },
           "Tags": {
             "shape": "S5k"
           }
@@ -887,10 +1030,14 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S5h"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5m"
+            }
           }
         }
       },
@@ -904,7 +1051,9 @@
           "PointInTimeRecoverySpecification"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "PointInTimeRecoverySpecification": {
             "type": "structure",
             "required": [
@@ -936,7 +1085,9 @@
           "ReplicaUpdates"
         ],
         "members": {
-          "GlobalTableName": {},
+          "GlobalTableName": {
+            "shape": "S3"
+          },
           "ReplicaUpdates": {
             "type": "list",
             "member": {
@@ -982,9 +1133,11 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {},
+          "GlobalTableName": {
+            "shape": "S3"
+          },
           "GlobalTableProvisionedWriteCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate": {
             "shape": "S6j"
@@ -997,15 +1150,19 @@
                 "IndexName"
               ],
               "members": {
-                "IndexName": {},
+                "IndexName": {
+                  "shape": "Sy"
+                },
                 "ProvisionedWriteCapacityUnits": {
-                  "type": "long"
+                  "shape": "S2f"
                 },
                 "ProvisionedWriteCapacityAutoScalingSettingsUpdate": {
                   "shape": "S6j"
                 }
               }
-            }
+            },
+            "max": 20,
+            "min": 1
           },
           "ReplicaSettingsUpdate": {
             "type": "list",
@@ -1017,7 +1174,7 @@
               "members": {
                 "RegionName": {},
                 "ReplicaProvisionedReadCapacityUnits": {
-                  "type": "long"
+                  "shape": "S2f"
                 },
                 "ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate": {
                   "shape": "S6j"
@@ -1030,25 +1187,33 @@
                       "IndexName"
                     ],
                     "members": {
-                      "IndexName": {},
+                      "IndexName": {
+                        "shape": "Sy"
+                      },
                       "ProvisionedReadCapacityUnits": {
-                        "type": "long"
+                        "shape": "S2f"
                       },
                       "ProvisionedReadCapacityAutoScalingSettingsUpdate": {
                         "shape": "S6j"
                       }
                     }
-                  }
+                  },
+                  "max": 20,
+                  "min": 1
                 }
               }
-            }
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GlobalTableName": {},
+          "GlobalTableName": {
+            "shape": "S3"
+          },
           "ReplicaSettings": {
             "shape": "S4f"
           }
@@ -1064,30 +1229,49 @@
           "Key"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "Key": {
             "shape": "S6"
           },
           "AttributeUpdates": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S7"
+            },
             "value": {
               "type": "structure",
               "members": {
                 "Value": {
                   "shape": "S8"
                 },
-                "Action": {}
+                "Action": {
+                  "type": "string",
+                  "enum": [
+                    "ADD",
+                    "PUT",
+                    "DELETE"
+                  ]
+                }
               }
             }
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ConditionalOperator": {},
-          "ReturnValues": {},
-          "ReturnConsumedCapacity": {},
-          "ReturnItemCollectionMetrics": {},
+          "ConditionalOperator": {
+            "shape": "S3r"
+          },
+          "ReturnValues": {
+            "shape": "S3s"
+          },
+          "ReturnConsumedCapacity": {
+            "shape": "So"
+          },
+          "ReturnItemCollectionMetrics": {
+            "shape": "S16"
+          },
           "UpdateExpression": {},
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
@@ -1124,7 +1308,9 @@
           "AttributeDefinitions": {
             "shape": "S1z"
           },
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "ProvisionedThroughput": {
             "shape": "S2e"
           },
@@ -1140,7 +1326,9 @@
                     "ProvisionedThroughput"
                   ],
                   "members": {
-                    "IndexName": {},
+                    "IndexName": {
+                      "shape": "Sy"
+                    },
                     "ProvisionedThroughput": {
                       "shape": "S2e"
                     }
@@ -1155,7 +1343,9 @@
                     "ProvisionedThroughput"
                   ],
                   "members": {
-                    "IndexName": {},
+                    "IndexName": {
+                      "shape": "Sy"
+                    },
                     "KeySchema": {
                       "shape": "S23"
                     },
@@ -1173,7 +1363,9 @@
                     "IndexName"
                   ],
                   "members": {
-                    "IndexName": {}
+                    "IndexName": {
+                      "shape": "Sy"
+                    }
                   }
                 }
               }
@@ -1205,7 +1397,9 @@
           "TimeToLiveSpecification"
         ],
         "members": {
-          "TableName": {},
+          "TableName": {
+            "shape": "S3"
+          },
           "TimeToLiveSpecification": {
             "shape": "S78"
           }
@@ -1225,7 +1419,9 @@
   "shapes": {
     "S2": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3"
+      },
       "value": {
         "type": "structure",
         "required": [
@@ -1236,7 +1432,9 @@
             "type": "list",
             "member": {
               "shape": "S6"
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "AttributesToGet": {
             "shape": "Sj"
@@ -1249,14 +1447,28 @@
             "shape": "Sm"
           }
         }
-      }
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9_.-]+"
     },
     "S6": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S7"
+      },
       "value": {
         "shape": "S8"
       }
+    },
+    "S7": {
+      "type": "string",
+      "max": 65535
     },
     "S8": {
       "type": "structure",
@@ -1282,7 +1494,9 @@
         },
         "M": {
           "type": "map",
-          "key": {},
+          "key": {
+            "shape": "S7"
+          },
           "value": {
             "shape": "S8"
           }
@@ -1303,12 +1517,25 @@
     },
     "Sj": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S7"
+      },
+      "min": 1
     },
     "Sm": {
       "type": "map",
       "key": {},
-      "value": {}
+      "value": {
+        "shape": "S7"
+      }
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "INDEXES",
+        "TOTAL",
+        "NONE"
+      ]
     },
     "Sr": {
       "type": "list",
@@ -1318,7 +1545,9 @@
     },
     "Ss": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S7"
+      },
       "value": {
         "shape": "S8"
       }
@@ -1332,7 +1561,9 @@
     "Su": {
       "type": "structure",
       "members": {
-        "TableName": {},
+        "TableName": {
+          "shape": "S3"
+        },
         "CapacityUnits": {
           "type": "double"
         },
@@ -1357,14 +1588,24 @@
     },
     "Sx": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sy"
+      },
       "value": {
         "shape": "Sw"
       }
     },
+    "Sy": {
+      "type": "string",
+      "max": 255,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
     "S10": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3"
+      },
       "value": {
         "type": "list",
         "member": {
@@ -1393,22 +1634,37 @@
               }
             }
           }
-        }
-      }
+        },
+        "max": 25,
+        "min": 1
+      },
+      "max": 25,
+      "min": 1
     },
     "S14": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S7"
+      },
       "value": {
         "shape": "S8"
       }
+    },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "SIZE",
+        "NONE"
+      ]
     },
     "S1a": {
       "type": "structure",
       "members": {
         "ItemCollectionKey": {
           "type": "map",
-          "key": {},
+          "key": {
+            "shape": "S7"
+          },
           "value": {
             "shape": "S8"
           }
@@ -1421,6 +1677,12 @@
         }
       }
     },
+    "S1f": {
+      "type": "string",
+      "max": 255,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
     "S1h": {
       "type": "structure",
       "required": [
@@ -1431,13 +1693,21 @@
         "BackupCreationDateTime"
       ],
       "members": {
-        "BackupArn": {},
-        "BackupName": {},
-        "BackupSizeBytes": {
-          "type": "long"
+        "BackupArn": {
+          "shape": "S1i"
         },
-        "BackupStatus": {},
-        "BackupType": {},
+        "BackupName": {
+          "shape": "S1f"
+        },
+        "BackupSizeBytes": {
+          "shape": "S1j"
+        },
+        "BackupStatus": {
+          "shape": "S1k"
+        },
+        "BackupType": {
+          "shape": "S1l"
+        },
         "BackupCreationDateTime": {
           "type": "timestamp"
         },
@@ -1445,6 +1715,30 @@
           "type": "timestamp"
         }
       }
+    },
+    "S1i": {
+      "type": "string",
+      "max": 1024,
+      "min": 37
+    },
+    "S1j": {
+      "type": "long",
+      "min": 0
+    },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "DELETED",
+        "AVAILABLE"
+      ]
+    },
+    "S1l": {
+      "type": "string",
+      "enum": [
+        "USER",
+        "SYSTEM"
+      ]
     },
     "S1p": {
       "type": "list",
@@ -1471,8 +1765,18 @@
         "CreationDateTime": {
           "type": "timestamp"
         },
-        "GlobalTableStatus": {},
-        "GlobalTableName": {}
+        "GlobalTableStatus": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "UPDATING"
+          ]
+        },
+        "GlobalTableName": {
+          "shape": "S3"
+        }
       }
     },
     "S1z": {
@@ -1484,10 +1788,24 @@
           "AttributeType"
         ],
         "members": {
-          "AttributeName": {},
-          "AttributeType": {}
+          "AttributeName": {
+            "shape": "S21"
+          },
+          "AttributeType": {
+            "type": "string",
+            "enum": [
+              "S",
+              "N",
+              "B"
+            ]
+          }
         }
       }
+    },
+    "S21": {
+      "type": "string",
+      "max": 255,
+      "min": 1
     },
     "S23": {
       "type": "list",
@@ -1498,18 +1816,41 @@
           "KeyType"
         ],
         "members": {
-          "AttributeName": {},
-          "KeyType": {}
+          "AttributeName": {
+            "shape": "S21"
+          },
+          "KeyType": {
+            "type": "string",
+            "enum": [
+              "HASH",
+              "RANGE"
+            ]
+          }
         }
-      }
+      },
+      "max": 2,
+      "min": 1
     },
     "S28": {
       "type": "structure",
       "members": {
-        "ProjectionType": {},
+        "ProjectionType": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "KEYS_ONLY",
+            "INCLUDE"
+          ]
+        },
         "NonKeyAttributes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "max": 255,
+            "min": 1
+          },
+          "max": 20,
+          "min": 1
         }
       }
     },
@@ -1521,12 +1862,16 @@
       ],
       "members": {
         "ReadCapacityUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "WriteCapacityUnits": {
-          "type": "long"
+          "shape": "S2f"
         }
       }
+    },
+    "S2f": {
+      "type": "long",
+      "min": 1
     },
     "S2g": {
       "type": "structure",
@@ -1534,7 +1879,15 @@
         "StreamEnabled": {
           "type": "boolean"
         },
-        "StreamViewType": {}
+        "StreamViewType": {
+          "type": "string",
+          "enum": [
+            "NEW_IMAGE",
+            "OLD_IMAGE",
+            "NEW_AND_OLD_IMAGES",
+            "KEYS_ONLY"
+          ]
+        }
       }
     },
     "S2j": {
@@ -1543,9 +1896,18 @@
         "Enabled": {
           "type": "boolean"
         },
-        "SSEType": {},
+        "SSEType": {
+          "shape": "S2l"
+        },
         "KMSMasterKeyId": {}
       }
+    },
+    "S2l": {
+      "type": "string",
+      "enum": [
+        "AES256",
+        "KMS"
+      ]
     },
     "S2o": {
       "type": "structure",
@@ -1553,11 +1915,21 @@
         "AttributeDefinitions": {
           "shape": "S1z"
         },
-        "TableName": {},
+        "TableName": {
+          "shape": "S3"
+        },
         "KeySchema": {
           "shape": "S23"
         },
-        "TableStatus": {},
+        "TableStatus": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "UPDATING",
+            "DELETING",
+            "ACTIVE"
+          ]
+        },
         "CreationDateTime": {
           "type": "timestamp"
         },
@@ -1571,13 +1943,17 @@
           "type": "long"
         },
         "TableArn": {},
-        "TableId": {},
+        "TableId": {
+          "shape": "S2t"
+        },
         "LocalSecondaryIndexes": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "IndexName": {},
+              "IndexName": {
+                "shape": "Sy"
+              },
               "KeySchema": {
                 "shape": "S23"
               },
@@ -1599,14 +1975,18 @@
           "member": {
             "type": "structure",
             "members": {
-              "IndexName": {},
+              "IndexName": {
+                "shape": "Sy"
+              },
               "KeySchema": {
                 "shape": "S23"
               },
               "Projection": {
                 "shape": "S28"
               },
-              "IndexStatus": {},
+              "IndexStatus": {
+                "shape": "S2y"
+              },
               "Backfilling": {
                 "type": "boolean"
               },
@@ -1627,7 +2007,11 @@
           "shape": "S2g"
         },
         "LatestStreamLabel": {},
-        "LatestStreamArn": {},
+        "LatestStreamArn": {
+          "type": "string",
+          "max": 1024,
+          "min": 37
+        },
         "RestoreSummary": {
           "type": "structure",
           "required": [
@@ -1635,7 +2019,9 @@
             "RestoreInProgress"
           ],
           "members": {
-            "SourceBackupArn": {},
+            "SourceBackupArn": {
+              "shape": "S1i"
+            },
             "SourceTableArn": {},
             "RestoreDateTime": {
               "type": "timestamp"
@@ -1660,21 +2046,45 @@
           "type": "timestamp"
         },
         "NumberOfDecreasesToday": {
-          "type": "long"
+          "shape": "S2f"
         },
         "ReadCapacityUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "WriteCapacityUnits": {
-          "type": "long"
+          "shape": "S2f"
         }
       }
+    },
+    "S2t": {
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "S2y": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "UPDATING",
+        "DELETING",
+        "ACTIVE"
+      ]
     },
     "S34": {
       "type": "structure",
       "members": {
-        "Status": {},
-        "SSEType": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "ENABLING",
+            "ENABLED",
+            "DISABLING",
+            "DISABLED",
+            "UPDATING"
+          ]
+        },
+        "SSEType": {
+          "shape": "S2l"
+        },
         "KMSMasterKeyArn": {}
       }
     },
@@ -1694,8 +2104,12 @@
             "ProvisionedThroughput"
           ],
           "members": {
-            "TableName": {},
-            "TableId": {},
+            "TableName": {
+              "shape": "S3"
+            },
+            "TableId": {
+              "shape": "S2t"
+            },
             "TableArn": {},
             "TableSizeBytes": {
               "type": "long"
@@ -1710,7 +2124,8 @@
               "shape": "S2e"
             },
             "ItemCount": {
-              "type": "long"
+              "type": "long",
+              "min": 0
             }
           }
         },
@@ -1722,7 +2137,9 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "IndexName": {},
+                  "IndexName": {
+                    "shape": "Sy"
+                  },
                   "KeySchema": {
                     "shape": "S23"
                   },
@@ -1737,7 +2154,9 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "IndexName": {},
+                  "IndexName": {
+                    "shape": "Sy"
+                  },
                   "KeySchema": {
                     "shape": "S23"
                   },
@@ -1766,13 +2185,30 @@
     "S3i": {
       "type": "structure",
       "members": {
-        "TimeToLiveStatus": {},
-        "AttributeName": {}
+        "TimeToLiveStatus": {
+          "type": "string",
+          "enum": [
+            "ENABLING",
+            "DISABLING",
+            "ENABLED",
+            "DISABLED"
+          ]
+        },
+        "AttributeName": {
+          "shape": "S3k"
+        }
       }
+    },
+    "S3k": {
+      "type": "string",
+      "max": 255,
+      "min": 1
     },
     "S3m": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S7"
+      },
       "value": {
         "type": "structure",
         "members": {
@@ -1782,18 +2218,55 @@
           "Exists": {
             "type": "boolean"
           },
-          "ComparisonOperator": {},
+          "ComparisonOperator": {
+            "shape": "S3p"
+          },
           "AttributeValueList": {
             "shape": "S3q"
           }
         }
       }
     },
+    "S3p": {
+      "type": "string",
+      "enum": [
+        "EQ",
+        "NE",
+        "IN",
+        "LE",
+        "LT",
+        "GE",
+        "GT",
+        "BETWEEN",
+        "NOT_NULL",
+        "NULL",
+        "CONTAINS",
+        "NOT_CONTAINS",
+        "BEGINS_WITH"
+      ]
+    },
     "S3q": {
       "type": "list",
       "member": {
         "shape": "S8"
       }
+    },
+    "S3r": {
+      "type": "string",
+      "enum": [
+        "AND",
+        "OR"
+      ]
+    },
+    "S3s": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "ALL_OLD",
+        "UPDATED_OLD",
+        "ALL_NEW",
+        "UPDATED_NEW"
+      ]
     },
     "S3u": {
       "type": "map",
@@ -1808,11 +2281,23 @@
         "ContinuousBackupsStatus"
       ],
       "members": {
-        "ContinuousBackupsStatus": {},
+        "ContinuousBackupsStatus": {
+          "type": "string",
+          "enum": [
+            "ENABLED",
+            "DISABLED"
+          ]
+        },
         "PointInTimeRecoveryDescription": {
           "type": "structure",
           "members": {
-            "PointInTimeRecoveryStatus": {},
+            "PointInTimeRecoveryStatus": {
+              "type": "string",
+              "enum": [
+                "ENABLED",
+                "DISABLED"
+              ]
+            },
             "EarliestRestorableDateTime": {
               "type": "timestamp"
             },
@@ -1832,15 +2317,23 @@
         ],
         "members": {
           "RegionName": {},
-          "ReplicaStatus": {},
+          "ReplicaStatus": {
+            "type": "string",
+            "enum": [
+              "CREATING",
+              "UPDATING",
+              "DELETING",
+              "ACTIVE"
+            ]
+          },
           "ReplicaProvisionedReadCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "ReplicaProvisionedReadCapacityAutoScalingSettings": {
             "shape": "S4i"
           },
           "ReplicaProvisionedWriteCapacityUnits": {
-            "type": "long"
+            "shape": "S2f"
           },
           "ReplicaProvisionedWriteCapacityAutoScalingSettings": {
             "shape": "S4i"
@@ -1853,16 +2346,20 @@
                 "IndexName"
               ],
               "members": {
-                "IndexName": {},
-                "IndexStatus": {},
+                "IndexName": {
+                  "shape": "Sy"
+                },
+                "IndexStatus": {
+                  "shape": "S2y"
+                },
                 "ProvisionedReadCapacityUnits": {
-                  "type": "long"
+                  "shape": "S2f"
                 },
                 "ProvisionedReadCapacityAutoScalingSettings": {
                   "shape": "S4i"
                 },
                 "ProvisionedWriteCapacityUnits": {
-                  "type": "long"
+                  "shape": "S2f"
                 },
                 "ProvisionedWriteCapacityAutoScalingSettings": {
                   "shape": "S4i"
@@ -1877,10 +2374,10 @@
       "type": "structure",
       "members": {
         "MinimumUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "MaximumUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "AutoScalingDisabled": {
           "type": "boolean"
@@ -1891,7 +2388,9 @@
           "member": {
             "type": "structure",
             "members": {
-              "PolicyName": {},
+              "PolicyName": {
+                "shape": "S4l"
+              },
               "TargetTrackingScalingPolicyConfiguration": {
                 "type": "structure",
                 "required": [
@@ -1917,6 +2416,21 @@
         }
       }
     },
+    "S4l": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "\\p{Print}+"
+    },
+    "S58": {
+      "type": "integer",
+      "min": 1
+    },
+    "S5h": {
+      "type": "string",
+      "max": 1283,
+      "min": 1
+    },
     "S5k": {
       "type": "list",
       "member": {
@@ -1926,10 +2440,30 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S5m"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+          }
         }
       }
+    },
+    "S5m": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S5r": {
+      "type": "string",
+      "enum": [
+        "ALL_ATTRIBUTES",
+        "ALL_PROJECTED_ATTRIBUTES",
+        "SPECIFIC_ATTRIBUTES",
+        "COUNT"
+      ]
     },
     "S5t": {
       "type": "structure",
@@ -1940,12 +2474,16 @@
         "AttributeValueList": {
           "shape": "S3q"
         },
-        "ComparisonOperator": {}
+        "ComparisonOperator": {
+          "shape": "S3p"
+        }
       }
     },
     "S5u": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S7"
+      },
       "value": {
         "shape": "S5t"
       }
@@ -1954,22 +2492,29 @@
       "type": "structure",
       "members": {
         "MinimumUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "MaximumUnits": {
-          "type": "long"
+          "shape": "S2f"
         },
         "AutoScalingDisabled": {
           "type": "boolean"
         },
-        "AutoScalingRoleArn": {},
+        "AutoScalingRoleArn": {
+          "type": "string",
+          "max": 1600,
+          "min": 1,
+          "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+        },
         "ScalingPolicyUpdate": {
           "type": "structure",
           "required": [
             "TargetTrackingScalingPolicyConfiguration"
           ],
           "members": {
-            "PolicyName": {},
+            "PolicyName": {
+              "shape": "S4l"
+            },
             "TargetTrackingScalingPolicyConfiguration": {
               "type": "structure",
               "required": [
@@ -2004,7 +2549,9 @@
         "Enabled": {
           "type": "boolean"
         },
-        "AttributeName": {}
+        "AttributeName": {
+          "shape": "S3k"
+        }
       }
     }
   }

--- a/apis/ec2-2016-11-15.min.json
+++ b/apis/ec2-2016-11-15.min.json
@@ -96,7 +96,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "Domain": {},
+          "Domain": {
+            "shape": "Su"
+          },
           "Address": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -114,6 +116,7 @@
             "locationName": "allocationId"
           },
           "Domain": {
+            "shape": "Su",
             "locationName": "domain"
           }
         }
@@ -129,6 +132,7 @@
         ],
         "members": {
           "AutoPlacement": {
+            "shape": "Sx",
             "locationName": "autoPlacement"
           },
           "AvailabilityZone": {
@@ -759,9 +763,11 @@
               ],
               "members": {
                 "CurrentSpotFleetRequestState": {
+                  "shape": "S3e",
                   "locationName": "currentSpotFleetRequestState"
                 },
                 "PreviousSpotFleetRequestState": {
+                  "shape": "S3e",
                   "locationName": "previousSpotFleetRequestState"
                 },
                 "SpotFleetRequestId": {
@@ -790,7 +796,14 @@
                   ],
                   "members": {
                     "Code": {
-                      "locationName": "code"
+                      "locationName": "code",
+                      "type": "string",
+                      "enum": [
+                        "fleetRequestIdDoesNotExist",
+                        "fleetRequestIdMalformed",
+                        "fleetRequestNotInCancellableState",
+                        "unexpectedError"
+                      ]
                     },
                     "Message": {
                       "locationName": "message"
@@ -837,7 +850,15 @@
                   "locationName": "spotInstanceRequestId"
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "active",
+                    "open",
+                    "closed",
+                    "cancelled",
+                    "completed"
+                  ]
                 }
               }
             }
@@ -991,7 +1012,9 @@
           "PublicIp": {
             "locationName": "IpAddress"
           },
-          "Type": {},
+          "Type": {
+            "shape": "S3y"
+          },
           "DryRun": {
             "locationName": "dryRun",
             "type": "boolean"
@@ -1132,8 +1155,12 @@
           "SpotOptions": {
             "type": "structure",
             "members": {
-              "AllocationStrategy": {},
-              "InstanceInterruptionBehavior": {},
+              "AllocationStrategy": {
+                "shape": "S4u"
+              },
+              "InstanceInterruptionBehavior": {
+                "shape": "S4v"
+              },
               "InstancePoolsToUseCount": {
                 "type": "integer"
               }
@@ -1142,10 +1169,14 @@
           "OnDemandOptions": {
             "type": "structure",
             "members": {
-              "AllocationStrategy": {}
+              "AllocationStrategy": {
+                "shape": "S4x"
+              }
             }
           },
-          "ExcessCapacityTerminationPolicy": {},
+          "ExcessCapacityTerminationPolicy": {
+            "shape": "S4y"
+          },
           "LaunchTemplateConfigs": {
             "type": "list",
             "member": {
@@ -1156,7 +1187,9 @@
                   "type": "structure",
                   "members": {
                     "LaunchTemplateId": {},
-                    "LaunchTemplateName": {},
+                    "LaunchTemplateName": {
+                      "shape": "S52"
+                    },
                     "Version": {}
                   }
                 },
@@ -1166,7 +1199,9 @@
                     "locationName": "item",
                     "type": "structure",
                     "members": {
-                      "InstanceType": {},
+                      "InstanceType": {
+                        "shape": "S55"
+                      },
                       "MaxPrice": {},
                       "SubnetId": {},
                       "AvailabilityZone": {},
@@ -1177,10 +1212,12 @@
                         "type": "double"
                       }
                     }
-                  }
+                  },
+                  "max": 50
                 }
               }
-            }
+            },
+            "max": 50
           },
           "TargetCapacitySpecification": {
             "shape": "S56"
@@ -1188,7 +1225,9 @@
           "TerminateInstancesWithExpiration": {
             "type": "boolean"
           },
-          "Type": {},
+          "Type": {
+            "shape": "S58"
+          },
           "ValidFrom": {
             "type": "timestamp"
           },
@@ -1232,9 +1271,20 @@
             "shape": "Sa",
             "locationName": "ResourceId"
           },
-          "ResourceType": {},
-          "TrafficType": {},
-          "LogDestinationType": {},
+          "ResourceType": {
+            "type": "string",
+            "enum": [
+              "VPC",
+              "Subnet",
+              "NetworkInterface"
+            ]
+          },
+          "TrafficType": {
+            "shape": "S5d"
+          },
+          "LogDestinationType": {
+            "shape": "S5e"
+          },
           "LogDestination": {}
         }
       },
@@ -1343,9 +1393,11 @@
             "type": "structure",
             "members": {
               "ContainerFormat": {
+                "shape": "S5r",
                 "locationName": "containerFormat"
               },
               "DiskImageFormat": {
+                "shape": "S5s",
                 "locationName": "diskImageFormat"
               },
               "S3Bucket": {
@@ -1360,6 +1412,7 @@
             "locationName": "instanceId"
           },
           "TargetEnvironment": {
+            "shape": "S5t",
             "locationName": "targetEnvironment"
           }
         }
@@ -1435,8 +1488,12 @@
             "type": "boolean"
           },
           "ClientToken": {},
-          "LaunchTemplateName": {},
-          "VersionDescription": {},
+          "LaunchTemplateName": {
+            "shape": "S52"
+          },
+          "VersionDescription": {
+            "shape": "S65"
+          },
           "LaunchTemplateData": {
             "shape": "S66"
           }
@@ -1464,9 +1521,13 @@
           },
           "ClientToken": {},
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {},
+          "LaunchTemplateName": {
+            "shape": "S52"
+          },
           "SourceVersion": {},
-          "VersionDescription": {},
+          "VersionDescription": {
+            "shape": "S65"
+          },
           "LaunchTemplateData": {
             "shape": "S66"
           }
@@ -1574,6 +1635,7 @@
             "locationName": "protocol"
           },
           "RuleAction": {
+            "shape": "S81",
             "locationName": "ruleAction"
           },
           "RuleNumber": {
@@ -1646,7 +1708,9 @@
           "NetworkInterfaceId": {},
           "AwsAccountId": {},
           "AwsService": {},
-          "Permission": {},
+          "Permission": {
+            "shape": "S8h"
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -1678,6 +1742,7 @@
             "locationName": "groupName"
           },
           "Strategy": {
+            "shape": "S8n",
             "locationName": "strategy"
           }
         }
@@ -1708,6 +1773,7 @@
               "type": "structure",
               "members": {
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Price": {
@@ -1963,7 +2029,9 @@
             "type": "integer"
           },
           "SnapshotId": {},
-          "VolumeType": {},
+          "VolumeType": {
+            "shape": "S5n"
+          },
           "DryRun": {
             "locationName": "dryRun",
             "type": "boolean"
@@ -1995,6 +2063,7 @@
             "type": "boolean"
           },
           "InstanceTenancy": {
+            "shape": "S4a",
             "locationName": "instanceTenancy"
           }
         }
@@ -2020,7 +2089,9 @@
           "DryRun": {
             "type": "boolean"
           },
-          "VpcEndpointType": {},
+          "VpcEndpointType": {
+            "shape": "S9q"
+          },
           "VpcId": {},
           "ServiceName": {},
           "PolicyDocument": {},
@@ -2221,7 +2292,9 @@
         ],
         "members": {
           "AvailabilityZone": {},
-          "Type": {},
+          "Type": {
+            "shape": "S3y"
+          },
           "AmazonSideAsn": {
             "type": "long"
           },
@@ -2325,9 +2398,11 @@
               "type": "structure",
               "members": {
                 "CurrentFleetState": {
+                  "shape": "Sb4",
                   "locationName": "currentFleetState"
                 },
                 "PreviousFleetState": {
+                  "shape": "Sb4",
                   "locationName": "previousFleetState"
                 },
                 "FleetId": {
@@ -2348,7 +2423,14 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code"
+                      "locationName": "code",
+                      "type": "string",
+                      "enum": [
+                        "fleetIdDoesNotExist",
+                        "fleetIdMalformed",
+                        "fleetNotInDeletableState",
+                        "unexpectedError"
+                      ]
                     },
                     "Message": {
                       "locationName": "message"
@@ -2453,7 +2535,9 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {}
+          "LaunchTemplateName": {
+            "shape": "S52"
+          }
         }
       },
       "output": {
@@ -2477,7 +2561,9 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {},
+          "LaunchTemplateName": {
+            "shape": "S52"
+          },
           "Versions": {
             "shape": "Sbi",
             "locationName": "LaunchTemplateVersion"
@@ -2529,7 +2615,16 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code"
+                      "locationName": "code",
+                      "type": "string",
+                      "enum": [
+                        "launchTemplateIdDoesNotExist",
+                        "launchTemplateIdMalformed",
+                        "launchTemplateNameDoesNotExist",
+                        "launchTemplateNameMalformed",
+                        "launchTemplateVersionDoesNotExist",
+                        "unexpectedError"
+                      ]
                     },
                     "Message": {
                       "locationName": "message"
@@ -2981,7 +3076,12 @@
             "locationName": "attributeName",
             "type": "list",
             "member": {
-              "locationName": "attributeName"
+              "locationName": "attributeName",
+              "type": "string",
+              "enum": [
+                "supported-platforms",
+                "default-vpc"
+              ]
             }
           },
           "DryRun": {
@@ -3073,6 +3173,7 @@
                   "locationName": "associationId"
                 },
                 "Domain": {
+                  "shape": "Su",
                   "locationName": "domain"
                 },
                 "NetworkInterfaceId": {
@@ -3149,7 +3250,14 @@
               "type": "structure",
               "members": {
                 "State": {
-                  "locationName": "zoneState"
+                  "locationName": "zoneState",
+                  "type": "string",
+                  "enum": [
+                    "available",
+                    "information",
+                    "impaired",
+                    "unavailable"
+                  ]
                 },
                 "Messages": {
                   "locationName": "messageSet",
@@ -3455,12 +3563,21 @@
                   "type": "structure",
                   "members": {
                     "Status": {
-                      "locationName": "status"
+                      "locationName": "status",
+                      "type": "string",
+                      "enum": [
+                        "OK",
+                        "IMPAIRED"
+                      ]
                     }
                   }
                 },
                 "ElasticGpuState": {
-                  "locationName": "elasticGpuState"
+                  "locationName": "elasticGpuState",
+                  "type": "string",
+                  "enum": [
+                    "ATTACHED"
+                  ]
                 },
                 "InstanceId": {
                   "locationName": "instanceId"
@@ -3516,7 +3633,9 @@
           "DryRun": {
             "type": "boolean"
           },
-          "EventType": {},
+          "EventType": {
+            "shape": "Sem"
+          },
           "MaxResults": {
             "type": "integer"
           },
@@ -3542,6 +3661,7 @@
                   "locationName": "eventInformation"
                 },
                 "EventType": {
+                  "shape": "Sem",
                   "locationName": "eventType"
                 },
                 "Timestamp": {
@@ -3640,7 +3760,14 @@
               "type": "structure",
               "members": {
                 "ActivityStatus": {
-                  "locationName": "activityStatus"
+                  "locationName": "activityStatus",
+                  "type": "string",
+                  "enum": [
+                    "error",
+                    "pending-fulfillment",
+                    "pending-termination",
+                    "fulfilled"
+                  ]
                 },
                 "CreateTime": {
                   "locationName": "createTime",
@@ -3650,12 +3777,14 @@
                   "locationName": "fleetId"
                 },
                 "FleetState": {
+                  "shape": "Sb4",
                   "locationName": "fleetState"
                 },
                 "ClientToken": {
                   "locationName": "clientToken"
                 },
                 "ExcessCapacityTerminationPolicy": {
+                  "shape": "S4y",
                   "locationName": "excessCapacityTerminationPolicy"
                 },
                 "FulfilledCapacity": {
@@ -3685,6 +3814,7 @@
                           "type": "structure",
                           "members": {
                             "InstanceType": {
+                              "shape": "S55",
                               "locationName": "instanceType"
                             },
                             "MaxPrice": {
@@ -3727,6 +3857,7 @@
                       "type": "integer"
                     },
                     "DefaultTargetCapacityType": {
+                      "shape": "S57",
                       "locationName": "defaultTargetCapacityType"
                     }
                   }
@@ -3736,6 +3867,7 @@
                   "type": "boolean"
                 },
                 "Type": {
+                  "shape": "S58",
                   "locationName": "type"
                 },
                 "ValidFrom": {
@@ -3755,9 +3887,11 @@
                   "type": "structure",
                   "members": {
                     "AllocationStrategy": {
+                      "shape": "S4u",
                       "locationName": "allocationStrategy"
                     },
                     "InstanceInterruptionBehavior": {
+                      "shape": "S4v",
                       "locationName": "instanceInterruptionBehavior"
                     },
                     "InstancePoolsToUseCount": {
@@ -3771,6 +3905,7 @@
                   "type": "structure",
                   "members": {
                     "AllocationStrategy": {
+                      "shape": "S4x",
                       "locationName": "allocationStrategy"
                     }
                   }
@@ -3841,9 +3976,11 @@
                   "locationName": "resourceId"
                 },
                 "TrafficType": {
+                  "shape": "S5d",
                   "locationName": "trafficType"
                 },
                 "LogDestinationType": {
+                  "shape": "S5e",
                   "locationName": "logDestinationType"
                 },
                 "LogDestination": {
@@ -3870,7 +4007,9 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {}
+          "Attribute": {
+            "shape": "Sfe"
+          }
         }
       },
       "output": {
@@ -3905,9 +4044,11 @@
             "shape": "Scs",
             "locationName": "Filter"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sfq"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sfr"
           }
         }
       },
@@ -3951,7 +4092,14 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code"
+                      "locationName": "code",
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "failed",
+                        "available",
+                        "unavailable"
+                      ]
                     },
                     "Message": {
                       "locationName": "message"
@@ -3988,6 +4136,7 @@
             }
           },
           "NextToken": {
+            "shape": "Sfq",
             "locationName": "nextToken"
           }
         }
@@ -4027,6 +4176,7 @@
               "type": "structure",
               "members": {
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Duration": {
@@ -4043,6 +4193,7 @@
                   "locationName": "offeringId"
                 },
                 "PaymentOption": {
+                  "shape": "Sg2",
                   "locationName": "paymentOption"
                 },
                 "UpfrontPrice": {
@@ -4088,6 +4239,7 @@
                   "type": "integer"
                 },
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Duration": {
@@ -4115,6 +4267,7 @@
                   "locationName": "offeringId"
                 },
                 "PaymentOption": {
+                  "shape": "Sg2",
                   "locationName": "paymentOption"
                 },
                 "Start": {
@@ -4122,7 +4275,14 @@
                   "type": "timestamp"
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "payment-pending",
+                    "payment-failed",
+                    "active",
+                    "retired"
+                  ]
                 },
                 "UpfrontPrice": {
                   "locationName": "upfrontPrice"
@@ -4168,6 +4328,7 @@
               "type": "structure",
               "members": {
                 "AutoPlacement": {
+                  "shape": "Sx",
                   "locationName": "autoPlacement"
                 },
                 "AvailabilityZone": {
@@ -4251,7 +4412,15 @@
                   }
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "available",
+                    "under-assessment",
+                    "permanent-failure",
+                    "released",
+                    "released-permanent-failure"
+                  ]
                 },
                 "AllocationTime": {
                   "locationName": "allocationTime",
@@ -4290,9 +4459,11 @@
             "locationName": "Filter"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sfr"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sfq"
+          }
         }
       },
       "output": {
@@ -4307,6 +4478,7 @@
             }
           },
           "NextToken": {
+            "shape": "Sfq",
             "locationName": "nextToken"
           }
         }
@@ -4362,7 +4534,18 @@
           "ImageId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "type": "string",
+            "enum": [
+              "description",
+              "kernel",
+              "ramdisk",
+              "launchPermission",
+              "productCodes",
+              "blockDeviceMapping",
+              "sriovNetSupport"
+            ]
+          },
           "ImageId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -4450,6 +4633,7 @@
               "type": "structure",
               "members": {
                 "Architecture": {
+                  "shape": "Sh6",
                   "locationName": "architecture"
                 },
                 "CreationDate": {
@@ -4462,7 +4646,13 @@
                   "locationName": "imageLocation"
                 },
                 "ImageType": {
-                  "locationName": "imageType"
+                  "locationName": "imageType",
+                  "type": "string",
+                  "enum": [
+                    "machine",
+                    "kernel",
+                    "ramdisk"
+                  ]
                 },
                 "Public": {
                   "locationName": "isPublic",
@@ -4475,6 +4665,7 @@
                   "locationName": "imageOwnerId"
                 },
                 "Platform": {
+                  "shape": "Sdq",
                   "locationName": "platform"
                 },
                 "ProductCodes": {
@@ -4485,7 +4676,17 @@
                   "locationName": "ramdiskId"
                 },
                 "State": {
-                  "locationName": "imageState"
+                  "locationName": "imageState",
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "available",
+                    "invalid",
+                    "deregistered",
+                    "transient",
+                    "failed",
+                    "error"
+                  ]
                 },
                 "BlockDeviceMappings": {
                   "shape": "Sgx",
@@ -4499,6 +4700,7 @@
                   "type": "boolean"
                 },
                 "Hypervisor": {
+                  "shape": "Sh9",
                   "locationName": "hypervisor"
                 },
                 "ImageOwnerAlias": {
@@ -4511,6 +4713,7 @@
                   "locationName": "rootDeviceName"
                 },
                 "RootDeviceType": {
+                  "shape": "Sha",
                   "locationName": "rootDeviceType"
                 },
                 "SriovNetSupport": {
@@ -4525,6 +4728,7 @@
                   "locationName": "tagSet"
                 },
                 "VirtualizationType": {
+                  "shape": "Shc",
                   "locationName": "virtualizationType"
                 }
               }
@@ -4664,6 +4868,7 @@
         ],
         "members": {
           "Attribute": {
+            "shape": "Shr",
             "locationName": "attribute"
           },
           "DryRun": {
@@ -4833,7 +5038,15 @@
                     "type": "structure",
                     "members": {
                       "Code": {
-                        "locationName": "code"
+                        "locationName": "code",
+                        "type": "string",
+                        "enum": [
+                          "instance-reboot",
+                          "system-reboot",
+                          "system-maintenance",
+                          "instance-retirement",
+                          "instance-stop"
+                        ]
                       },
                       "Description": {
                         "locationName": "description"
@@ -4998,7 +5211,9 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {},
+          "LaunchTemplateName": {
+            "shape": "S52"
+          },
           "Versions": {
             "shape": "Sbi",
             "locationName": "LaunchTemplateVersion"
@@ -5047,6 +5262,7 @@
             "locationName": "LaunchTemplateName",
             "type": "list",
             "member": {
+              "shape": "S52",
               "locationName": "item"
             }
           },
@@ -5113,7 +5329,12 @@
               "type": "structure",
               "members": {
                 "MoveStatus": {
-                  "locationName": "moveStatus"
+                  "locationName": "moveStatus",
+                  "type": "string",
+                  "enum": [
+                    "movingToVpc",
+                    "restoringToClassic"
+                  ]
                 },
                 "PublicIp": {
                   "locationName": "publicIp"
@@ -5201,7 +5422,14 @@
         ],
         "members": {
           "Attribute": {
-            "locationName": "attribute"
+            "locationName": "attribute",
+            "type": "string",
+            "enum": [
+              "description",
+              "groupSet",
+              "sourceDestCheck",
+              "attachment"
+            ]
           },
           "DryRun": {
             "locationName": "dryRun",
@@ -5348,9 +5576,17 @@
                   "locationName": "groupName"
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "pending",
+                    "available",
+                    "deleting",
+                    "deleted"
+                  ]
                 },
                 "Strategy": {
+                  "shape": "S8n",
                   "locationName": "strategy"
                 }
               }
@@ -5506,7 +5742,9 @@
             "shape": "Scs",
             "locationName": "Filter"
           },
-          "OfferingClass": {},
+          "OfferingClass": {
+            "shape": "Skl"
+          },
           "ReservedInstancesIds": {
             "shape": "Skm",
             "locationName": "ReservedInstancesId"
@@ -5516,6 +5754,7 @@
             "type": "boolean"
           },
           "OfferingType": {
+            "shape": "Skn",
             "locationName": "offeringType"
           }
         }
@@ -5550,9 +5789,11 @@
                   "type": "integer"
                 },
                 "InstanceType": {
+                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
+                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "ReservedInstancesId": {
@@ -5563,22 +5804,33 @@
                   "type": "timestamp"
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "payment-pending",
+                    "active",
+                    "payment-failed",
+                    "retired"
+                  ]
                 },
                 "UsagePrice": {
                   "locationName": "usagePrice",
                   "type": "float"
                 },
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "InstanceTenancy": {
+                  "shape": "S4a",
                   "locationName": "instanceTenancy"
                 },
                 "OfferingClass": {
+                  "shape": "Skl",
                   "locationName": "offeringClass"
                 },
                 "OfferingType": {
+                  "shape": "Skn",
                   "locationName": "offeringType"
                 },
                 "RecurringCharges": {
@@ -5586,6 +5838,7 @@
                   "locationName": "recurringCharges"
                 },
                 "Scope": {
+                  "shape": "Skx",
                   "locationName": "scope"
                 },
                 "Tags": {
@@ -5729,7 +5982,9 @@
           "IncludeMarketplace": {
             "type": "boolean"
           },
-          "InstanceType": {},
+          "InstanceType": {
+            "shape": "S55"
+          },
           "MaxDuration": {
             "type": "long"
           },
@@ -5739,8 +5994,12 @@
           "MinDuration": {
             "type": "long"
           },
-          "OfferingClass": {},
-          "ProductDescription": {},
+          "OfferingClass": {
+            "shape": "Skl"
+          },
+          "ProductDescription": {
+            "shape": "Sks"
+          },
           "ReservedInstancesOfferingIds": {
             "locationName": "ReservedInstancesOfferingId",
             "type": "list",
@@ -5751,6 +6010,7 @@
             "type": "boolean"
           },
           "InstanceTenancy": {
+            "shape": "S4a",
             "locationName": "instanceTenancy"
           },
           "MaxResults": {
@@ -5761,6 +6021,7 @@
             "locationName": "nextToken"
           },
           "OfferingType": {
+            "shape": "Skn",
             "locationName": "offeringType"
           }
         }
@@ -5787,9 +6048,11 @@
                   "type": "float"
                 },
                 "InstanceType": {
+                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
+                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "ReservedInstancesOfferingId": {
@@ -5800,9 +6063,11 @@
                   "type": "float"
                 },
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "InstanceTenancy": {
+                  "shape": "S4a",
                   "locationName": "instanceTenancy"
                 },
                 "Marketplace": {
@@ -5810,9 +6075,11 @@
                   "type": "boolean"
                 },
                 "OfferingClass": {
+                  "shape": "Skl",
                   "locationName": "offeringClass"
                 },
                 "OfferingType": {
+                  "shape": "Skn",
                   "locationName": "offeringType"
                 },
                 "PricingDetails": {
@@ -5838,6 +6105,7 @@
                   "locationName": "recurringCharges"
                 },
                 "Scope": {
+                  "shape": "Skx",
                   "locationName": "scope"
                 }
               }
@@ -6195,7 +6463,9 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "shape": "Sma"
+          },
           "SnapshotId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -6347,6 +6617,7 @@
             "type": "boolean"
           },
           "EventType": {
+            "shape": "Smo",
             "locationName": "eventType"
           },
           "MaxResults": {
@@ -6391,6 +6662,7 @@
                   "locationName": "eventInformation"
                 },
                 "EventType": {
+                  "shape": "Smo",
                   "locationName": "eventType"
                 },
                 "Timestamp": {
@@ -6461,7 +6733,14 @@
               ],
               "members": {
                 "ActivityStatus": {
-                  "locationName": "activityStatus"
+                  "locationName": "activityStatus",
+                  "type": "string",
+                  "enum": [
+                    "error",
+                    "pending_fulfillment",
+                    "pending_termination",
+                    "fulfilled"
+                  ]
                 },
                 "CreateTime": {
                   "locationName": "createTime",
@@ -6475,6 +6754,7 @@
                   "locationName": "spotFleetRequestId"
                 },
                 "SpotFleetRequestState": {
+                  "shape": "S3e",
                   "locationName": "spotFleetRequestState"
                 }
               }
@@ -6533,7 +6813,9 @@
           "InstanceTypes": {
             "locationName": "InstanceType",
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S55"
+            }
           },
           "MaxResults": {
             "locationName": "maxResults",
@@ -6570,9 +6852,11 @@
                   "locationName": "availabilityZone"
                 },
                 "InstanceType": {
+                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
+                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "SpotPrice": {
@@ -6599,9 +6883,11 @@
             "type": "boolean"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sfr"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sfq"
+          },
           "VpcId": {}
         }
       },
@@ -6723,6 +7009,7 @@
                   "locationName": "resourceId"
                 },
                 "ResourceType": {
+                  "shape": "S10",
                   "locationName": "resourceType"
                 },
                 "Value": {
@@ -6742,7 +7029,13 @@
           "VolumeId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "type": "string",
+            "enum": [
+              "autoEnableIO",
+              "productCodes"
+            ]
+          },
           "VolumeId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -6869,7 +7162,12 @@
                         "type": "structure",
                         "members": {
                           "Name": {
-                            "locationName": "name"
+                            "locationName": "name",
+                            "type": "string",
+                            "enum": [
+                              "io-enabled",
+                              "io-performance"
+                            ]
                           },
                           "Status": {
                             "locationName": "status"
@@ -6878,7 +7176,13 @@
                       }
                     },
                     "Status": {
-                      "locationName": "status"
+                      "locationName": "status",
+                      "type": "string",
+                      "enum": [
+                        "ok",
+                        "impaired",
+                        "insufficient-data"
+                      ]
                     }
                   }
                 }
@@ -6976,7 +7280,13 @@
           "VpcId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "type": "string",
+            "enum": [
+              "enableDnsSupport",
+              "enableDnsHostnames"
+            ]
+          },
           "VpcId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -7051,10 +7361,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "locationName": "maxResults",
-            "type": "integer"
+            "shape": "Sfr",
+            "locationName": "maxResults"
           },
           "NextToken": {
+            "shape": "Sfq",
             "locationName": "nextToken"
           },
           "VpcIds": {
@@ -7066,6 +7377,7 @@
         "type": "structure",
         "members": {
           "NextToken": {
+            "shape": "Sfq",
             "locationName": "nextToken"
           },
           "Vpcs": {
@@ -7160,6 +7472,7 @@
                   "locationName": "vpcEndpointOwner"
                 },
                 "VpcEndpointState": {
+                  "shape": "S9t",
                   "locationName": "vpcEndpointState"
                 },
                 "CreationTimestamp": {
@@ -7245,7 +7558,16 @@
               "type": "structure",
               "members": {
                 "PrincipalType": {
-                  "locationName": "principalType"
+                  "locationName": "principalType",
+                  "type": "string",
+                  "enum": [
+                    "All",
+                    "Service",
+                    "OrganizationUnit",
+                    "Account",
+                    "User",
+                    "Role"
+                  ]
                 },
                 "Principal": {
                   "locationName": "principal"
@@ -7931,6 +8253,7 @@
         "type": "structure",
         "members": {
           "CurrencyCode": {
+            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Purchase": {
@@ -8209,6 +8532,7 @@
                 "locationName": "additionalInfo"
               },
               "Architecture": {
+                "shape": "Sh6",
                 "locationName": "architecture"
               },
               "GroupIds": {
@@ -8220,9 +8544,11 @@
                 "locationName": "GroupName"
               },
               "InstanceInitiatedShutdownBehavior": {
+                "shape": "S6k",
                 "locationName": "instanceInitiatedShutdownBehavior"
               },
               "InstanceType": {
+                "shape": "S55",
                 "locationName": "instanceType"
               },
               "Monitoring": {
@@ -8251,6 +8577,7 @@
             }
           },
           "Platform": {
+            "shape": "Sdq",
             "locationName": "platform"
           }
         }
@@ -8390,7 +8717,9 @@
           "DryRun": {
             "type": "boolean"
           },
-          "ExcessCapacityTerminationPolicy": {},
+          "ExcessCapacityTerminationPolicy": {
+            "shape": "S4y"
+          },
           "FleetId": {},
           "TargetCapacitySpecification": {
             "shape": "S56"
@@ -8418,8 +8747,12 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {},
-          "OperationType": {},
+          "Attribute": {
+            "shape": "Sfe"
+          },
+          "OperationType": {
+            "shape": "Ssf"
+          },
           "UserIds": {
             "shape": "Ssg",
             "locationName": "UserId"
@@ -8466,6 +8799,7 @@
         ],
         "members": {
           "AutoPlacement": {
+            "shape": "Sx",
             "locationName": "autoPlacement"
           },
           "HostIds": {
@@ -8548,7 +8882,9 @@
               }
             }
           },
-          "OperationType": {},
+          "OperationType": {
+            "shape": "Ssf"
+          },
           "ProductCodes": {
             "shape": "Ssi",
             "locationName": "ProductCode"
@@ -8580,6 +8916,7 @@
             "shape": "Shw"
           },
           "Attribute": {
+            "shape": "Shr",
             "locationName": "attribute"
           },
           "BlockDeviceMappings": {
@@ -8729,7 +9066,14 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code"
+                      "locationName": "code",
+                      "type": "string",
+                      "enum": [
+                        "InvalidInstanceID.Malformed",
+                        "InvalidInstanceID.NotFound",
+                        "IncorrectInstanceState",
+                        "InstanceCreditSpecification.NotSupported"
+                      ]
                     },
                     "Message": {
                       "locationName": "message"
@@ -8750,7 +9094,12 @@
         ],
         "members": {
           "Affinity": {
-            "locationName": "affinity"
+            "locationName": "affinity",
+            "type": "string",
+            "enum": [
+              "default",
+              "host"
+            ]
           },
           "GroupName": {},
           "HostId": {
@@ -8760,7 +9109,12 @@
             "locationName": "instanceId"
           },
           "Tenancy": {
-            "locationName": "tenancy"
+            "locationName": "tenancy",
+            "type": "string",
+            "enum": [
+              "dedicated",
+              "host"
+            ]
           }
         }
       },
@@ -8783,7 +9137,9 @@
           },
           "ClientToken": {},
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {},
+          "LaunchTemplateName": {
+            "shape": "S52"
+          },
           "DefaultVersion": {
             "locationName": "SetDefaultVersion"
           }
@@ -8882,7 +9238,9 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "shape": "Sma"
+          },
           "CreateVolumePermission": {
             "type": "structure",
             "members": {
@@ -8898,7 +9256,9 @@
             "shape": "Sm5",
             "locationName": "UserGroup"
           },
-          "OperationType": {},
+          "OperationType": {
+            "shape": "Ssf"
+          },
           "SnapshotId": {},
           "UserIds": {
             "shape": "Ssg",
@@ -8919,6 +9279,7 @@
         ],
         "members": {
           "ExcessCapacityTerminationPolicy": {
+            "shape": "Sn0",
             "locationName": "excessCapacityTerminationPolicy"
           },
           "SpotFleetRequestId": {
@@ -8973,7 +9334,9 @@
           "Size": {
             "type": "integer"
           },
-          "VolumeType": {},
+          "VolumeType": {
+            "shape": "S5n"
+          },
           "Iops": {
             "type": "integer"
           }
@@ -9212,7 +9575,12 @@
         ],
         "members": {
           "VpcId": {},
-          "InstanceTenancy": {},
+          "InstanceTenancy": {
+            "type": "string",
+            "enum": [
+              "default"
+            ]
+          },
           "DryRun": {
             "type": "boolean"
           }
@@ -9278,6 +9646,7 @@
             "locationName": "allocationId"
           },
           "Status": {
+            "shape": "Sue",
             "locationName": "status"
           }
         }
@@ -9292,7 +9661,9 @@
         ],
         "members": {
           "ClientToken": {},
-          "CurrencyCode": {},
+          "CurrencyCode": {
+            "shape": "S36"
+          },
           "HostIdSet": {
             "shape": "Srb"
           },
@@ -9307,6 +9678,7 @@
             "locationName": "clientToken"
           },
           "CurrencyCode": {
+            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Purchase": {
@@ -9347,6 +9719,7 @@
                 "type": "double"
               },
               "CurrencyCode": {
+                "shape": "S36",
                 "locationName": "currencyCode"
               }
             }
@@ -9391,7 +9764,8 @@
                 },
                 "PurchaseToken": {}
               }
-            }
+            },
+            "min": 1
           }
         }
       },
@@ -9436,6 +9810,7 @@
         "members": {
           "ImageLocation": {},
           "Architecture": {
+            "shape": "Sh6",
             "locationName": "architecture"
           },
           "BlockDeviceMappings": {
@@ -9676,6 +10051,7 @@
             "locationName": "protocol"
           },
           "RuleAction": {
+            "shape": "S81",
             "locationName": "ruleAction"
           },
           "RuleNumber": {
@@ -9783,7 +10159,19 @@
             "locationName": "reasonCode",
             "type": "list",
             "member": {
-              "locationName": "item"
+              "locationName": "item",
+              "type": "string",
+              "enum": [
+                "instance-stuck-in-state",
+                "unresponsive",
+                "not-accepting-credentials",
+                "password-not-available",
+                "performance-network",
+                "performance-instance-store",
+                "performance-ebs-volume",
+                "performance-other",
+                "other"
+              ]
             }
           },
           "StartTime": {
@@ -9791,7 +10179,12 @@
             "type": "timestamp"
           },
           "Status": {
-            "locationName": "status"
+            "locationName": "status",
+            "type": "string",
+            "enum": [
+              "ok",
+              "impaired"
+            ]
           }
         }
       }
@@ -9880,6 +10273,7 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
+                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -9915,6 +10309,7 @@
             "locationName": "spotPrice"
           },
           "Type": {
+            "shape": "S6t",
             "locationName": "type"
           },
           "ValidFrom": {
@@ -9925,7 +10320,9 @@
             "locationName": "validUntil",
             "type": "timestamp"
           },
-          "InstanceInterruptionBehavior": {}
+          "InstanceInterruptionBehavior": {
+            "shape": "S6u"
+          }
         }
       },
       "output": {
@@ -9949,7 +10346,12 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {}
+          "Attribute": {
+            "type": "string",
+            "enum": [
+              "loadPermission"
+            ]
+          }
         }
       },
       "output": {
@@ -9970,7 +10372,12 @@
           "ImageId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "type": "string",
+            "enum": [
+              "launchPermission"
+            ]
+          },
           "ImageId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -9988,6 +10395,7 @@
         ],
         "members": {
           "Attribute": {
+            "shape": "Shr",
             "locationName": "attribute"
           },
           "DryRun": {
@@ -10028,7 +10436,9 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {},
+          "Attribute": {
+            "shape": "Sma"
+          },
           "SnapshotId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -10060,6 +10470,7 @@
             "locationName": "publicIp"
           },
           "Status": {
+            "shape": "Sue",
             "locationName": "status"
           }
         }
@@ -10145,7 +10556,9 @@
             "locationName": "BlockDeviceMapping"
           },
           "ImageId": {},
-          "InstanceType": {},
+          "InstanceType": {
+            "shape": "S55"
+          },
           "Ipv6AddressCount": {
             "type": "integer"
           },
@@ -10201,6 +10614,7 @@
             "locationName": "iamInstanceProfile"
           },
           "InstanceInitiatedShutdownBehavior": {
+            "shape": "S6k",
             "locationName": "instanceInitiatedShutdownBehavior"
           },
           "NetworkInterfaces": {
@@ -10232,19 +10646,25 @@
           "InstanceMarketOptions": {
             "type": "structure",
             "members": {
-              "MarketType": {},
+              "MarketType": {
+                "shape": "S6r"
+              },
               "SpotOptions": {
                 "type": "structure",
                 "members": {
                   "MaxPrice": {},
-                  "SpotInstanceType": {},
+                  "SpotInstanceType": {
+                    "shape": "S6t"
+                  },
                   "BlockDurationMinutes": {
                     "type": "integer"
                   },
                   "ValidUntil": {
                     "type": "timestamp"
                   },
-                  "InstanceInterruptionBehavior": {}
+                  "InstanceInterruptionBehavior": {
+                    "shape": "S6u"
+                  }
                 }
               }
             }
@@ -10737,7 +11157,19 @@
           "type": "structure",
           "members": {
             "Code": {
-              "locationName": "code"
+              "locationName": "code",
+              "type": "string",
+              "enum": [
+                "initiating-request",
+                "pending-acceptance",
+                "active",
+                "deleted",
+                "rejected",
+                "failed",
+                "expired",
+                "provisioning",
+                "deleting"
+              ]
             },
             "Message": {
               "locationName": "message"
@@ -10829,6 +11261,20 @@
         }
       }
     },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "vpc",
+        "standard"
+      ]
+    },
+    "Sx": {
+      "type": "string",
+      "enum": [
+        "on",
+        "off"
+      ]
+    },
     "Sy": {
       "type": "list",
       "member": {
@@ -10836,6 +11282,7 @@
         "type": "structure",
         "members": {
           "ResourceType": {
+            "shape": "S10",
             "locationName": "resourceType"
           },
           "Tags": {
@@ -10844,6 +11291,29 @@
           }
         }
       }
+    },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "image",
+        "instance",
+        "internet-gateway",
+        "network-acl",
+        "network-interface",
+        "reserved-instances",
+        "route-table",
+        "snapshot",
+        "spot-instances-request",
+        "subnet",
+        "security-group",
+        "volume",
+        "vpc",
+        "vpn-connection",
+        "vpn-gateway"
+      ]
     },
     "S12": {
       "type": "list",
@@ -10888,7 +11358,14 @@
           "locationName": "iamInstanceProfile"
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "associating",
+            "associated",
+            "disassociating",
+            "disassociated"
+          ]
         },
         "Timestamp": {
           "locationName": "timestamp",
@@ -10921,7 +11398,16 @@
           "type": "structure",
           "members": {
             "State": {
-              "locationName": "state"
+              "locationName": "state",
+              "type": "string",
+              "enum": [
+                "associating",
+                "associated",
+                "disassociating",
+                "disassociated",
+                "failing",
+                "failed"
+              ]
             },
             "StatusMessage": {
               "locationName": "statusMessage"
@@ -10949,7 +11435,16 @@
       "type": "structure",
       "members": {
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "associating",
+            "associated",
+            "disassociating",
+            "disassociated",
+            "failing",
+            "failed"
+          ]
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -10991,7 +11486,15 @@
           "locationName": "instanceId"
         },
         "State": {
-          "locationName": "status"
+          "locationName": "status",
+          "type": "string",
+          "enum": [
+            "attaching",
+            "attached",
+            "detaching",
+            "detached",
+            "busy"
+          ]
         },
         "VolumeId": {
           "locationName": "volumeId"
@@ -11006,12 +11509,22 @@
       "type": "structure",
       "members": {
         "State": {
+          "shape": "S26",
           "locationName": "state"
         },
         "VpcId": {
           "locationName": "vpcId"
         }
       }
+    },
+    "S26": {
+      "type": "string",
+      "enum": [
+        "attaching",
+        "attached",
+        "detaching",
+        "detached"
+      ]
     },
     "S28": {
       "type": "list",
@@ -11168,7 +11681,17 @@
           "type": "timestamp"
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "pending",
+            "waiting-for-shutdown",
+            "bundling",
+            "storing",
+            "cancelling",
+            "complete",
+            "failed"
+          ]
         },
         "Storage": {
           "shape": "S2k",
@@ -11205,7 +11728,14 @@
                   "type": "integer"
                 },
                 "State": {
-                  "locationName": "state"
+                  "locationName": "state",
+                  "type": "string",
+                  "enum": [
+                    "available",
+                    "sold",
+                    "cancelled",
+                    "pending"
+                  ]
                 }
               }
             }
@@ -11222,6 +11752,7 @@
                   "type": "boolean"
                 },
                 "CurrencyCode": {
+                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Price": {
@@ -11242,7 +11773,14 @@
             "locationName": "reservedInstancesListingId"
           },
           "Status": {
-            "locationName": "status"
+            "locationName": "status",
+            "type": "string",
+            "enum": [
+              "active",
+              "pending",
+              "cancelled",
+              "closed"
+            ]
           },
           "StatusMessage": {
             "locationName": "statusMessage"
@@ -11258,11 +11796,35 @@
         }
       }
     },
+    "S36": {
+      "type": "string",
+      "enum": [
+        "USD"
+      ]
+    },
+    "S3e": {
+      "type": "string",
+      "enum": [
+        "submitted",
+        "active",
+        "cancelled",
+        "failed",
+        "cancelled_running",
+        "cancelled_terminating",
+        "modifying"
+      ]
+    },
     "S3k": {
       "type": "list",
       "member": {
         "locationName": "SpotInstanceRequestId"
       }
+    },
+    "S3y": {
+      "type": "string",
+      "enum": [
+        "ipsec.1"
+      ]
     },
     "S40": {
       "type": "structure",
@@ -11310,7 +11872,12 @@
           "type": "boolean"
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "pending",
+            "available"
+          ]
         },
         "SubnetId": {
           "locationName": "subnetId"
@@ -11346,12 +11913,18 @@
           "locationName": "dhcpOptionsId"
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "pending",
+            "available"
+          ]
         },
         "VpcId": {
           "locationName": "vpcId"
         },
         "InstanceTenancy": {
+          "shape": "S4a",
           "locationName": "instanceTenancy"
         },
         "Ipv6CidrBlockAssociationSet": {
@@ -11379,6 +11952,14 @@
           "locationName": "tagSet"
         }
       }
+    },
+    "S4a": {
+      "type": "string",
+      "enum": [
+        "default",
+        "dedicated",
+        "host"
+      ]
     },
     "S4h": {
       "type": "structure",
@@ -11440,6 +12021,7 @@
         "type": "structure",
         "members": {
           "State": {
+            "shape": "S26",
             "locationName": "state"
           },
           "VpcId": {
@@ -11447,6 +12029,196 @@
           }
         }
       }
+    },
+    "S4u": {
+      "type": "string",
+      "enum": [
+        "lowest-price",
+        "diversified"
+      ]
+    },
+    "S4v": {
+      "type": "string",
+      "enum": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "S4x": {
+      "type": "string",
+      "enum": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "S4y": {
+      "type": "string",
+      "enum": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "S52": {
+      "type": "string",
+      "max": 128,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9\\(\\)\\.-/_]+"
+    },
+    "S55": {
+      "type": "string",
+      "enum": [
+        "t1.micro",
+        "t2.nano",
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "t2.xlarge",
+        "t2.2xlarge",
+        "t3.nano",
+        "t3.micro",
+        "t3.small",
+        "t3.medium",
+        "t3.large",
+        "t3.xlarge",
+        "t3.2xlarge",
+        "m1.small",
+        "m1.medium",
+        "m1.large",
+        "m1.xlarge",
+        "m3.medium",
+        "m3.large",
+        "m3.xlarge",
+        "m3.2xlarge",
+        "m4.large",
+        "m4.xlarge",
+        "m4.2xlarge",
+        "m4.4xlarge",
+        "m4.10xlarge",
+        "m4.16xlarge",
+        "m2.xlarge",
+        "m2.2xlarge",
+        "m2.4xlarge",
+        "cr1.8xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
+        "r4.large",
+        "r4.xlarge",
+        "r4.2xlarge",
+        "r4.4xlarge",
+        "r4.8xlarge",
+        "r4.16xlarge",
+        "r5.large",
+        "r5.xlarge",
+        "r5.2xlarge",
+        "r5.4xlarge",
+        "r5.8xlarge",
+        "r5.12xlarge",
+        "r5.16xlarge",
+        "r5.24xlarge",
+        "r5.metal",
+        "r5d.large",
+        "r5d.xlarge",
+        "r5d.2xlarge",
+        "r5d.4xlarge",
+        "r5d.8xlarge",
+        "r5d.12xlarge",
+        "r5d.16xlarge",
+        "r5d.24xlarge",
+        "r5d.metal",
+        "x1.16xlarge",
+        "x1.32xlarge",
+        "x1e.xlarge",
+        "x1e.2xlarge",
+        "x1e.4xlarge",
+        "x1e.8xlarge",
+        "x1e.16xlarge",
+        "x1e.32xlarge",
+        "i2.xlarge",
+        "i2.2xlarge",
+        "i2.4xlarge",
+        "i2.8xlarge",
+        "i3.large",
+        "i3.xlarge",
+        "i3.2xlarge",
+        "i3.4xlarge",
+        "i3.8xlarge",
+        "i3.16xlarge",
+        "i3.metal",
+        "hi1.4xlarge",
+        "hs1.8xlarge",
+        "c1.medium",
+        "c1.xlarge",
+        "c3.large",
+        "c3.xlarge",
+        "c3.2xlarge",
+        "c3.4xlarge",
+        "c3.8xlarge",
+        "c4.large",
+        "c4.xlarge",
+        "c4.2xlarge",
+        "c4.4xlarge",
+        "c4.8xlarge",
+        "c5.large",
+        "c5.xlarge",
+        "c5.2xlarge",
+        "c5.4xlarge",
+        "c5.9xlarge",
+        "c5.18xlarge",
+        "c5d.large",
+        "c5d.xlarge",
+        "c5d.2xlarge",
+        "c5d.4xlarge",
+        "c5d.9xlarge",
+        "c5d.18xlarge",
+        "cc1.4xlarge",
+        "cc2.8xlarge",
+        "g2.2xlarge",
+        "g2.8xlarge",
+        "g3.4xlarge",
+        "g3.8xlarge",
+        "g3.16xlarge",
+        "cg1.4xlarge",
+        "p2.xlarge",
+        "p2.8xlarge",
+        "p2.16xlarge",
+        "p3.2xlarge",
+        "p3.8xlarge",
+        "p3.16xlarge",
+        "d2.xlarge",
+        "d2.2xlarge",
+        "d2.4xlarge",
+        "d2.8xlarge",
+        "f1.2xlarge",
+        "f1.4xlarge",
+        "f1.16xlarge",
+        "m5.large",
+        "m5.xlarge",
+        "m5.2xlarge",
+        "m5.4xlarge",
+        "m5.12xlarge",
+        "m5.24xlarge",
+        "m5d.large",
+        "m5d.xlarge",
+        "m5d.2xlarge",
+        "m5d.4xlarge",
+        "m5d.12xlarge",
+        "m5d.24xlarge",
+        "h1.2xlarge",
+        "h1.4xlarge",
+        "h1.8xlarge",
+        "h1.16xlarge",
+        "z1d.large",
+        "z1d.xlarge",
+        "z1d.2xlarge",
+        "z1d.3xlarge",
+        "z1d.6xlarge",
+        "z1d.12xlarge"
+      ]
     },
     "S56": {
       "type": "structure",
@@ -11463,8 +12235,39 @@
         "SpotTargetCapacity": {
           "type": "integer"
         },
-        "DefaultTargetCapacityType": {}
+        "DefaultTargetCapacityType": {
+          "shape": "S57"
+        }
       }
+    },
+    "S57": {
+      "type": "string",
+      "enum": [
+        "spot",
+        "on-demand"
+      ]
+    },
+    "S58": {
+      "type": "string",
+      "enum": [
+        "request",
+        "maintain"
+      ]
+    },
+    "S5d": {
+      "type": "string",
+      "enum": [
+        "ACCEPT",
+        "REJECT",
+        "ALL"
+      ]
+    },
+    "S5e": {
+      "type": "string",
+      "enum": [
+        "cloud-watch-logs",
+        "s3"
+      ]
     },
     "S5h": {
       "type": "structure",
@@ -11509,6 +12312,7 @@
               "type": "integer"
             },
             "VolumeType": {
+              "shape": "S5n",
               "locationName": "volumeType"
             },
             "Encrypted": {
@@ -11522,6 +12326,38 @@
           "locationName": "noDevice"
         }
       }
+    },
+    "S5n": {
+      "type": "string",
+      "enum": [
+        "standard",
+        "io1",
+        "gp2",
+        "sc1",
+        "st1"
+      ]
+    },
+    "S5r": {
+      "type": "string",
+      "enum": [
+        "ova"
+      ]
+    },
+    "S5s": {
+      "type": "string",
+      "enum": [
+        "VMDK",
+        "RAW",
+        "VHD"
+      ]
+    },
+    "S5t": {
+      "type": "string",
+      "enum": [
+        "citrix",
+        "vmware",
+        "microsoft"
+      ]
     },
     "S5v": {
       "type": "structure",
@@ -11537,9 +12373,11 @@
           "type": "structure",
           "members": {
             "ContainerFormat": {
+              "shape": "S5r",
               "locationName": "containerFormat"
             },
             "DiskImageFormat": {
+              "shape": "S5s",
               "locationName": "diskImageFormat"
             },
             "S3Bucket": {
@@ -11558,12 +12396,20 @@
               "locationName": "instanceId"
             },
             "TargetEnvironment": {
+              "shape": "S5t",
               "locationName": "targetEnvironment"
             }
           }
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "active",
+            "cancelling",
+            "cancelled",
+            "completed"
+          ]
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -11585,6 +12431,10 @@
           "locationName": "tagSet"
         }
       }
+    },
+    "S65": {
+      "type": "string",
+      "max": 255
     },
     "S66": {
       "type": "structure",
@@ -11626,7 +12476,9 @@
                   "VolumeSize": {
                     "type": "integer"
                   },
-                  "VolumeType": {}
+                  "VolumeType": {
+                    "shape": "S5n"
+                  }
                 }
               },
               "NoDevice": {}
@@ -11680,7 +12532,9 @@
           }
         },
         "ImageId": {},
-        "InstanceType": {},
+        "InstanceType": {
+          "shape": "S55"
+        },
         "KeyName": {},
         "Monitoring": {
           "type": "structure",
@@ -11697,7 +12551,9 @@
             "Affinity": {},
             "GroupName": {},
             "HostId": {},
-            "Tenancy": {},
+            "Tenancy": {
+              "shape": "S4a"
+            },
             "SpreadDomain": {}
           }
         },
@@ -11705,7 +12561,9 @@
         "DisableApiTermination": {
           "type": "boolean"
         },
-        "InstanceInitiatedShutdownBehavior": {},
+        "InstanceInitiatedShutdownBehavior": {
+          "shape": "S6k"
+        },
         "UserData": {},
         "TagSpecifications": {
           "locationName": "TagSpecification",
@@ -11714,7 +12572,9 @@
             "locationName": "LaunchTemplateTagSpecificationRequest",
             "type": "structure",
             "members": {
-              "ResourceType": {},
+              "ResourceType": {
+                "shape": "S10"
+              },
               "Tags": {
                 "shape": "Sr",
                 "locationName": "Tag"
@@ -11741,19 +12601,25 @@
         "InstanceMarketOptions": {
           "type": "structure",
           "members": {
-            "MarketType": {},
+            "MarketType": {
+              "shape": "S6r"
+            },
             "SpotOptions": {
               "type": "structure",
               "members": {
                 "MaxPrice": {},
-                "SpotInstanceType": {},
+                "SpotInstanceType": {
+                  "shape": "S6t"
+                },
                 "BlockDurationMinutes": {
                   "type": "integer"
                 },
                 "ValidUntil": {
                   "type": "timestamp"
                 },
-                "InstanceInterruptionBehavior": {}
+                "InstanceInterruptionBehavior": {
+                  "shape": "S6u"
+                }
               }
             }
           }
@@ -11796,6 +12662,13 @@
         }
       }
     },
+    "S6k": {
+      "type": "string",
+      "enum": [
+        "stop",
+        "terminate"
+      ]
+    },
     "S6o": {
       "type": "structure",
       "required": [
@@ -11810,6 +12683,27 @@
       "member": {
         "locationName": "SecurityGroup"
       }
+    },
+    "S6r": {
+      "type": "string",
+      "enum": [
+        "spot"
+      ]
+    },
+    "S6t": {
+      "type": "string",
+      "enum": [
+        "one-time",
+        "persistent"
+      ]
+    },
+    "S6u": {
+      "type": "string",
+      "enum": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
     },
     "S6v": {
       "type": "structure",
@@ -11827,6 +12721,7 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
+          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "CreateTime": {
@@ -11857,6 +12752,7 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
+          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "VersionNumber": {
@@ -11864,6 +12760,7 @@
           "type": "long"
         },
         "VersionDescription": {
+          "shape": "S65",
           "locationName": "versionDescription"
         },
         "CreateTime": {
@@ -11945,6 +12842,7 @@
                     "type": "integer"
                   },
                   "VolumeType": {
+                    "shape": "S5n",
                     "locationName": "volumeType"
                   }
                 }
@@ -12013,6 +12911,7 @@
           "locationName": "imageId"
         },
         "InstanceType": {
+          "shape": "S55",
           "locationName": "instanceType"
         },
         "KeyName": {
@@ -12045,6 +12944,7 @@
               "locationName": "hostId"
             },
             "Tenancy": {
+              "shape": "S4a",
               "locationName": "tenancy"
             },
             "SpreadDomain": {
@@ -12060,6 +12960,7 @@
           "type": "boolean"
         },
         "InstanceInitiatedShutdownBehavior": {
+          "shape": "S6k",
           "locationName": "instanceInitiatedShutdownBehavior"
         },
         "UserData": {
@@ -12073,6 +12974,7 @@
             "type": "structure",
             "members": {
               "ResourceType": {
+                "shape": "S10",
                 "locationName": "resourceType"
               },
               "Tags": {
@@ -12108,6 +13010,7 @@
           "type": "structure",
           "members": {
             "MarketType": {
+              "shape": "S6r",
               "locationName": "marketType"
             },
             "SpotOptions": {
@@ -12118,6 +13021,7 @@
                   "locationName": "maxPrice"
                 },
                 "SpotInstanceType": {
+                  "shape": "S6t",
                   "locationName": "spotInstanceType"
                 },
                 "BlockDurationMinutes": {
@@ -12129,6 +13033,7 @@
                   "type": "timestamp"
                 },
                 "InstanceInterruptionBehavior": {
+                  "shape": "S6u",
                   "locationName": "instanceInterruptionBehavior"
                 }
               }
@@ -12238,7 +13143,15 @@
           }
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "pending",
+            "failed",
+            "available",
+            "deleting",
+            "deleted"
+          ]
         },
         "SubnetId": {
           "locationName": "subnetId"
@@ -12303,6 +13216,7 @@
                 "locationName": "protocol"
               },
               "RuleAction": {
+                "shape": "S81",
                 "locationName": "ruleAction"
               },
               "RuleNumber": {
@@ -12354,6 +13268,13 @@
         }
       }
     },
+    "S81": {
+      "type": "string",
+      "enum": [
+        "allow",
+        "deny"
+      ]
+    },
     "S85": {
       "type": "structure",
       "members": {
@@ -12376,7 +13297,12 @@
           "locationName": "groupSet"
         },
         "InterfaceType": {
-          "locationName": "interfaceType"
+          "locationName": "interfaceType",
+          "type": "string",
+          "enum": [
+            "interface",
+            "natGateway"
+          ]
         },
         "Ipv6Addresses": {
           "locationName": "ipv6AddressesSet",
@@ -12442,6 +13368,7 @@
           "type": "boolean"
         },
         "Status": {
+          "shape": "S8f",
           "locationName": "status"
         },
         "SubnetId": {
@@ -12501,6 +13428,7 @@
           "locationName": "instanceOwnerId"
         },
         "Status": {
+          "shape": "S26",
           "locationName": "status"
         }
       }
@@ -12520,6 +13448,23 @@
         }
       }
     },
+    "S8f": {
+      "type": "string",
+      "enum": [
+        "available",
+        "associated",
+        "attaching",
+        "in-use",
+        "detaching"
+      ]
+    },
+    "S8h": {
+      "type": "string",
+      "enum": [
+        "INSTANCE-ATTACH",
+        "EIP-ASSOCIATE"
+      ]
+    },
     "S8j": {
       "type": "structure",
       "members": {
@@ -12536,6 +13481,7 @@
           "locationName": "awsService"
         },
         "Permission": {
+          "shape": "S8h",
           "locationName": "permission"
         },
         "PermissionState": {
@@ -12543,7 +13489,14 @@
           "type": "structure",
           "members": {
             "State": {
-              "locationName": "state"
+              "locationName": "state",
+              "type": "string",
+              "enum": [
+                "pending",
+                "granted",
+                "revoking",
+                "revoked"
+              ]
             },
             "StatusMessage": {
               "locationName": "statusMessage"
@@ -12551,6 +13504,13 @@
           }
         }
       }
+    },
+    "S8n": {
+      "type": "string",
+      "enum": [
+        "cluster",
+        "spread"
+      ]
     },
     "S8w": {
       "type": "structure",
@@ -12629,10 +13589,21 @@
                 "locationName": "networkInterfaceId"
               },
               "Origin": {
-                "locationName": "origin"
+                "locationName": "origin",
+                "type": "string",
+                "enum": [
+                  "CreateRouteTable",
+                  "CreateRoute",
+                  "EnableVgwRoutePropagation"
+                ]
               },
               "State": {
-                "locationName": "state"
+                "locationName": "state",
+                "type": "string",
+                "enum": [
+                  "active",
+                  "blackhole"
+                ]
               },
               "VpcPeeringConnectionId": {
                 "locationName": "vpcPeeringConnectionId"
@@ -12679,7 +13650,13 @@
           "type": "timestamp"
         },
         "State": {
-          "locationName": "status"
+          "locationName": "status",
+          "type": "string",
+          "enum": [
+            "pending",
+            "completed",
+            "error"
+          ]
         },
         "StateMessage": {
           "locationName": "statusMessage"
@@ -12717,7 +13694,12 @@
           "locationName": "prefix"
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "Active",
+            "Inactive"
+          ]
         }
       }
     },
@@ -12769,7 +13751,16 @@
           "locationName": "snapshotId"
         },
         "State": {
-          "locationName": "status"
+          "locationName": "status",
+          "type": "string",
+          "enum": [
+            "creating",
+            "available",
+            "in-use",
+            "deleting",
+            "deleted",
+            "error"
+          ]
         },
         "VolumeId": {
           "locationName": "volumeId"
@@ -12783,9 +13774,17 @@
           "locationName": "tagSet"
         },
         "VolumeType": {
+          "shape": "S5n",
           "locationName": "volumeType"
         }
       }
+    },
+    "S9q": {
+      "type": "string",
+      "enum": [
+        "Interface",
+        "Gateway"
+      ]
     },
     "S9s": {
       "type": "structure",
@@ -12794,6 +13793,7 @@
           "locationName": "vpcEndpointId"
         },
         "VpcEndpointType": {
+          "shape": "S9q",
           "locationName": "vpcEndpointType"
         },
         "VpcId": {
@@ -12803,6 +13803,7 @@
           "locationName": "serviceName"
         },
         "State": {
+          "shape": "S9t",
           "locationName": "state"
         },
         "PolicyDocument": {
@@ -12862,6 +13863,19 @@
         }
       }
     },
+    "S9t": {
+      "type": "string",
+      "enum": [
+        "PendingAcceptance",
+        "Pending",
+        "Available",
+        "Deleting",
+        "Deleted",
+        "Rejected",
+        "Failed",
+        "Expired"
+      ]
+    },
     "Sa0": {
       "type": "structure",
       "members": {
@@ -12875,7 +13889,11 @@
           "locationName": "vpcEndpointId"
         },
         "ConnectionNotificationType": {
-          "locationName": "connectionNotificationType"
+          "locationName": "connectionNotificationType",
+          "type": "string",
+          "enum": [
+            "Topic"
+          ]
         },
         "ConnectionNotificationArn": {
           "locationName": "connectionNotificationArn"
@@ -12885,7 +13903,12 @@
           "locationName": "connectionEvents"
         },
         "ConnectionNotificationState": {
-          "locationName": "connectionNotificationState"
+          "locationName": "connectionNotificationState",
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ]
         }
       }
     },
@@ -12903,7 +13926,15 @@
           "locationName": "serviceName"
         },
         "ServiceState": {
-          "locationName": "serviceState"
+          "locationName": "serviceState",
+          "type": "string",
+          "enum": [
+            "Pending",
+            "Available",
+            "Deleting",
+            "Deleted",
+            "Failed"
+          ]
         },
         "AvailabilityZones": {
           "shape": "Sa",
@@ -12933,7 +13964,12 @@
         "type": "structure",
         "members": {
           "ServiceType": {
-            "locationName": "serviceType"
+            "locationName": "serviceType",
+            "type": "string",
+            "enum": [
+              "Interface",
+              "Gateway"
+            ]
           }
         }
       }
@@ -12951,9 +13987,11 @@
           "locationName": "category"
         },
         "State": {
+          "shape": "Sai",
           "locationName": "state"
         },
         "Type": {
+          "shape": "S3y",
           "locationName": "type"
         },
         "VpnConnectionId": {
@@ -12983,9 +14021,14 @@
                 "locationName": "destinationCidrBlock"
               },
               "Source": {
-                "locationName": "source"
+                "locationName": "source",
+                "type": "string",
+                "enum": [
+                  "Static"
+                ]
               },
               "State": {
+                "shape": "Sai",
                 "locationName": "state"
               }
             }
@@ -13014,7 +14057,12 @@
                 "locationName": "outsideIpAddress"
               },
               "Status": {
-                "locationName": "status"
+                "locationName": "status",
+                "type": "string",
+                "enum": [
+                  "UP",
+                  "DOWN"
+                ]
               },
               "StatusMessage": {
                 "locationName": "statusMessage"
@@ -13024,6 +14072,15 @@
         }
       }
     },
+    "Sai": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "available",
+        "deleting",
+        "deleted"
+      ]
+    },
     "Sat": {
       "type": "structure",
       "members": {
@@ -13031,9 +14088,11 @@
           "locationName": "availabilityZone"
         },
         "State": {
+          "shape": "Sai",
           "locationName": "state"
         },
         "Type": {
+          "shape": "S3y",
           "locationName": "type"
         },
         "VpcAttachments": {
@@ -13060,6 +14119,18 @@
     "Sb0": {
       "type": "list",
       "member": {}
+    },
+    "Sb4": {
+      "type": "string",
+      "enum": [
+        "submitted",
+        "active",
+        "deleted",
+        "failed",
+        "deleted-running",
+        "deleted-terminating",
+        "modifying"
+      ]
     },
     "Sbi": {
       "type": "list",
@@ -13127,6 +14198,7 @@
               "locationName": "instanceId"
             },
             "Platform": {
+              "shape": "Sdq",
               "locationName": "platform"
             },
             "Volumes": {
@@ -13197,7 +14269,14 @@
           }
         },
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "active",
+            "cancelling",
+            "cancelled",
+            "completed"
+          ]
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -13208,6 +14287,12 @@
         }
       }
     },
+    "Sdq": {
+      "type": "string",
+      "enum": [
+        "Windows"
+      ]
+    },
     "Sdt": {
       "type": "structure",
       "members": {
@@ -13215,6 +14300,7 @@
           "locationName": "checksum"
         },
         "Format": {
+          "shape": "S5s",
           "locationName": "format"
         },
         "ImportManifestUrl": {
@@ -13237,6 +14323,14 @@
           "type": "long"
         }
       }
+    },
+    "Sem": {
+      "type": "string",
+      "enum": [
+        "instance-change",
+        "fleet-change",
+        "service-error"
+      ]
     },
     "Seq": {
       "type": "structure",
@@ -13268,7 +14362,12 @@
             "locationName": "spotInstanceRequestId"
           },
           "InstanceHealth": {
-            "locationName": "instanceHealth"
+            "locationName": "instanceHealth",
+            "type": "string",
+            "enum": [
+              "healthy",
+              "unhealthy"
+            ]
           }
         }
       }
@@ -13280,12 +14379,22 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
+          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "Version": {
           "locationName": "version"
         }
       }
+    },
+    "Sfe": {
+      "type": "string",
+      "enum": [
+        "description",
+        "name",
+        "loadPermission",
+        "productCodes"
+      ]
     },
     "Sfg": {
       "type": "structure",
@@ -13310,6 +14419,7 @@
                 "locationName": "userId"
               },
               "Group": {
+                "shape": "Sfj",
                 "locationName": "group"
               }
             }
@@ -13321,6 +14431,12 @@
         }
       }
     },
+    "Sfj": {
+      "type": "string",
+      "enum": [
+        "all"
+      ]
+    },
     "Sfk": {
       "type": "list",
       "member": {
@@ -13331,7 +14447,12 @@
             "locationName": "productCode"
           },
           "ProductCodeType": {
-            "locationName": "type"
+            "locationName": "type",
+            "type": "string",
+            "enum": [
+              "devpay",
+              "marketplace"
+            ]
           }
         }
       }
@@ -13341,6 +14462,24 @@
       "member": {
         "locationName": "Owner"
       }
+    },
+    "Sfq": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "Sfr": {
+      "type": "integer",
+      "max": 255,
+      "min": 5
+    },
+    "Sg2": {
+      "type": "string",
+      "enum": [
+        "AllUpfront",
+        "PartialUpfront",
+        "NoUpfront"
+      ]
     },
     "Sg8": {
       "type": "list",
@@ -13368,6 +14507,7 @@
         "type": "structure",
         "members": {
           "Group": {
+            "shape": "Sfj",
             "locationName": "group"
           },
           "UserId": {
@@ -13375,6 +14515,27 @@
           }
         }
       }
+    },
+    "Sh6": {
+      "type": "string",
+      "enum": [
+        "i386",
+        "x86_64"
+      ]
+    },
+    "Sh9": {
+      "type": "string",
+      "enum": [
+        "ovm",
+        "xen"
+      ]
+    },
+    "Sha": {
+      "type": "string",
+      "enum": [
+        "ebs",
+        "instance-store"
+      ]
     },
     "Shb": {
       "type": "structure",
@@ -13386,6 +14547,13 @@
           "locationName": "message"
         }
       }
+    },
+    "Shc": {
+      "type": "string",
+      "enum": [
+        "hvm",
+        "paravirtual"
+      ]
     },
     "She": {
       "type": "list",
@@ -13479,6 +14647,25 @@
         }
       }
     },
+    "Shr": {
+      "type": "string",
+      "enum": [
+        "instanceType",
+        "kernel",
+        "ramdisk",
+        "userData",
+        "disableApiTermination",
+        "instanceInitiatedShutdownBehavior",
+        "rootDeviceName",
+        "blockDeviceMapping",
+        "productCodes",
+        "sourceDestCheck",
+        "groupSet",
+        "ebsOptimized",
+        "sriovNetSupport",
+        "enaSupport"
+      ]
+    },
     "Sht": {
       "type": "list",
       "member": {
@@ -13501,6 +14688,7 @@
                 "type": "boolean"
               },
               "Status": {
+                "shape": "S26",
                 "locationName": "status"
               },
               "VolumeId": {
@@ -13528,7 +14716,16 @@
           "type": "integer"
         },
         "Name": {
-          "locationName": "name"
+          "locationName": "name",
+          "type": "string",
+          "enum": [
+            "pending",
+            "running",
+            "shutting-down",
+            "terminated",
+            "stopping",
+            "stopped"
+          ]
         }
       }
     },
@@ -13547,16 +14744,35 @@
                 "type": "timestamp"
               },
               "Name": {
-                "locationName": "name"
+                "locationName": "name",
+                "type": "string",
+                "enum": [
+                  "reachability"
+                ]
               },
               "Status": {
-                "locationName": "status"
+                "locationName": "status",
+                "type": "string",
+                "enum": [
+                  "passed",
+                  "failed",
+                  "insufficient-data",
+                  "initializing"
+                ]
               }
             }
           }
         },
         "Status": {
-          "locationName": "status"
+          "locationName": "status",
+          "type": "string",
+          "enum": [
+            "ok",
+            "impaired",
+            "insufficient-data",
+            "not-applicable",
+            "initializing"
+          ]
         }
       }
     },
@@ -13585,6 +14801,7 @@
                 "locationName": "instanceId"
               },
               "InstanceType": {
+                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -13606,6 +14823,7 @@
                 "locationName": "placement"
               },
               "Platform": {
+                "shape": "Sdq",
                 "locationName": "platform"
               },
               "PrivateDnsName": {
@@ -13641,6 +14859,7 @@
                 "locationName": "vpcId"
               },
               "Architecture": {
+                "shape": "Sh6",
                 "locationName": "architecture"
               },
               "BlockDeviceMappings": {
@@ -13659,6 +14878,7 @@
                 "type": "boolean"
               },
               "Hypervisor": {
+                "shape": "Sh9",
                 "locationName": "hypervisor"
               },
               "IamInstanceProfile": {
@@ -13666,7 +14886,12 @@
                 "locationName": "iamInstanceProfile"
               },
               "InstanceLifecycle": {
-                "locationName": "instanceLifecycle"
+                "locationName": "instanceLifecycle",
+                "type": "string",
+                "enum": [
+                  "spot",
+                  "scheduled"
+                ]
               },
               "ElasticGpuAssociations": {
                 "locationName": "elasticGpuAssociationSet",
@@ -13721,6 +14946,7 @@
                           "type": "integer"
                         },
                         "Status": {
+                          "shape": "S26",
                           "locationName": "status"
                         }
                       }
@@ -13780,6 +15006,7 @@
                       "type": "boolean"
                     },
                     "Status": {
+                      "shape": "S8f",
                       "locationName": "status"
                     },
                     "SubnetId": {
@@ -13795,6 +15022,7 @@
                 "locationName": "rootDeviceName"
               },
               "RootDeviceType": {
+                "shape": "Sha",
                 "locationName": "rootDeviceType"
               },
               "SecurityGroups": {
@@ -13820,6 +15048,7 @@
                 "locationName": "tagSet"
               },
               "VirtualizationType": {
+                "shape": "Shc",
                 "locationName": "virtualizationType"
               },
               "CpuOptions": {
@@ -13854,7 +15083,14 @@
       "type": "structure",
       "members": {
         "State": {
-          "locationName": "state"
+          "locationName": "state",
+          "type": "string",
+          "enum": [
+            "disabled",
+            "disabling",
+            "enabled",
+            "pending"
+          ]
         }
       }
     },
@@ -13874,6 +15110,7 @@
           "locationName": "hostId"
         },
         "Tenancy": {
+          "shape": "S4a",
           "locationName": "tenancy"
         },
         "SpreadDomain": {
@@ -13895,11 +15132,38 @@
         }
       }
     },
+    "Skl": {
+      "type": "string",
+      "enum": [
+        "standard",
+        "convertible"
+      ]
+    },
     "Skm": {
       "type": "list",
       "member": {
         "locationName": "ReservedInstancesId"
       }
+    },
+    "Skn": {
+      "type": "string",
+      "enum": [
+        "Heavy Utilization",
+        "Medium Utilization",
+        "Light Utilization",
+        "No Upfront",
+        "Partial Upfront",
+        "All Upfront"
+      ]
+    },
+    "Sks": {
+      "type": "string",
+      "enum": [
+        "Linux/UNIX",
+        "Linux/UNIX (Amazon VPC)",
+        "Windows",
+        "Windows (Amazon VPC)"
+      ]
     },
     "Sku": {
       "type": "list",
@@ -13912,10 +15176,21 @@
             "type": "double"
           },
           "Frequency": {
-            "locationName": "frequency"
+            "locationName": "frequency",
+            "type": "string",
+            "enum": [
+              "Hourly"
+            ]
           }
         }
       }
+    },
+    "Skx": {
+      "type": "string",
+      "enum": [
+        "Availability Zone",
+        "Region"
+      ]
     },
     "Sl7": {
       "type": "structure",
@@ -13928,12 +15203,14 @@
           "type": "integer"
         },
         "InstanceType": {
+          "shape": "S55",
           "locationName": "instanceType"
         },
         "Platform": {
           "locationName": "platform"
         },
         "Scope": {
+          "shape": "Skx",
           "locationName": "scope"
         }
       }
@@ -14030,6 +15307,13 @@
         "locationName": "GroupName"
       }
     },
+    "Sma": {
+      "type": "string",
+      "enum": [
+        "productCodes",
+        "createVolumePermission"
+      ]
+    },
     "Smc": {
       "type": "list",
       "member": {
@@ -14037,6 +15321,7 @@
         "type": "structure",
         "members": {
           "Group": {
+            "shape": "Sfj",
             "locationName": "group"
           },
           "UserId": {
@@ -14044,6 +15329,14 @@
           }
         }
       }
+    },
+    "Smo": {
+      "type": "string",
+      "enum": [
+        "instanceChange",
+        "fleetRequestChange",
+        "error"
+      ]
     },
     "Smx": {
       "type": "structure",
@@ -14053,15 +15346,26 @@
       ],
       "members": {
         "AllocationStrategy": {
-          "locationName": "allocationStrategy"
+          "locationName": "allocationStrategy",
+          "type": "string",
+          "enum": [
+            "lowestPrice",
+            "diversified"
+          ]
         },
         "OnDemandAllocationStrategy": {
-          "locationName": "onDemandAllocationStrategy"
+          "locationName": "onDemandAllocationStrategy",
+          "type": "string",
+          "enum": [
+            "lowestPrice",
+            "prioritized"
+          ]
         },
         "ClientToken": {
           "locationName": "clientToken"
         },
         "ExcessCapacityTerminationPolicy": {
+          "shape": "Sn0",
           "locationName": "excessCapacityTerminationPolicy"
         },
         "FulfilledCapacity": {
@@ -14105,6 +15409,7 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
+                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -14155,6 +15460,7 @@
                   "type": "structure",
                   "members": {
                     "ResourceType": {
+                      "shape": "S10",
                       "locationName": "resourceType"
                     },
                     "Tags": {
@@ -14186,6 +15492,7 @@
                   "type": "structure",
                   "members": {
                     "InstanceType": {
+                      "shape": "S55",
                       "locationName": "instanceType"
                     },
                     "SpotPrice": {
@@ -14227,6 +15534,7 @@
           "type": "boolean"
         },
         "Type": {
+          "shape": "S58",
           "locationName": "type"
         },
         "ValidFrom": {
@@ -14242,6 +15550,7 @@
           "type": "boolean"
         },
         "InstanceInterruptionBehavior": {
+          "shape": "S6u",
           "locationName": "instanceInterruptionBehavior"
         },
         "LoadBalancersConfig": {
@@ -14269,7 +15578,9 @@
                         "locationName": "name"
                       }
                     }
-                  }
+                  },
+                  "max": 5,
+                  "min": 1
                 }
               }
             },
@@ -14294,7 +15605,9 @@
                         "locationName": "arn"
                       }
                     }
-                  }
+                  },
+                  "max": 5,
+                  "min": 1
                 }
               }
             }
@@ -14305,6 +15618,13 @@
           "type": "integer"
         }
       }
+    },
+    "Sn0": {
+      "type": "string",
+      "enum": [
+        "noTermination",
+        "default"
+      ]
     },
     "Sn4": {
       "type": "list",
@@ -14371,6 +15691,7 @@
           "locationName": "groupName"
         },
         "Tenancy": {
+          "shape": "S4a",
           "locationName": "tenancy"
         }
       }
@@ -14435,6 +15756,7 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
+                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -14467,6 +15789,7 @@
             "locationName": "launchedAvailabilityZone"
           },
           "ProductDescription": {
+            "shape": "Sks",
             "locationName": "productDescription"
           },
           "SpotInstanceRequestId": {
@@ -14476,7 +15799,15 @@
             "locationName": "spotPrice"
           },
           "State": {
-            "locationName": "state"
+            "locationName": "state",
+            "type": "string",
+            "enum": [
+              "open",
+              "active",
+              "closed",
+              "cancelled",
+              "failed"
+            ]
           },
           "Status": {
             "locationName": "status",
@@ -14499,6 +15830,7 @@
             "locationName": "tagSet"
           },
           "Type": {
+            "shape": "S6t",
             "locationName": "type"
           },
           "ValidFrom": {
@@ -14510,6 +15842,7 @@
             "type": "timestamp"
           },
           "InstanceInterruptionBehavior": {
+            "shape": "S6u",
             "locationName": "instanceInterruptionBehavior"
           }
         }
@@ -14582,7 +15915,14 @@
           "locationName": "volumeId"
         },
         "ModificationState": {
-          "locationName": "modificationState"
+          "locationName": "modificationState",
+          "type": "string",
+          "enum": [
+            "modifying",
+            "optimizing",
+            "completed",
+            "failed"
+          ]
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -14596,6 +15936,7 @@
           "type": "integer"
         },
         "TargetVolumeType": {
+          "shape": "S5n",
           "locationName": "targetVolumeType"
         },
         "OriginalSize": {
@@ -14607,6 +15948,7 @@
           "type": "integer"
         },
         "OriginalVolumeType": {
+          "shape": "S5n",
           "locationName": "originalVolumeType"
         },
         "Progress": {
@@ -14642,6 +15984,7 @@
         "type": "structure",
         "members": {
           "CurrencyCode": {
+            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Duration": {
@@ -14662,6 +16005,7 @@
             "locationName": "instanceFamily"
           },
           "PaymentOption": {
+            "shape": "Sg2",
             "locationName": "paymentOption"
           },
           "UpfrontPrice": {
@@ -14719,6 +16063,7 @@
           "type": "long"
         },
         "Format": {
+          "shape": "S5s",
           "locationName": "format"
         },
         "ImportManifestUrl": {
@@ -14737,6 +16082,13 @@
           "type": "long"
         }
       }
+    },
+    "Ssf": {
+      "type": "string",
+      "enum": [
+        "add",
+        "remove"
+      ]
     },
     "Ssg": {
       "type": "list",
@@ -14762,7 +16114,9 @@
         "locationName": "item",
         "type": "structure",
         "members": {
-          "Group": {},
+          "Group": {
+            "shape": "Sfj"
+          },
           "UserId": {}
         }
       }
@@ -14820,6 +16174,14 @@
           }
         }
       }
+    },
+    "Sue": {
+      "type": "string",
+      "enum": [
+        "MoveInProgress",
+        "InVpc",
+        "InClassic"
+      ]
     },
     "Sw8": {
       "type": "list",

--- a/apis/ecr-2015-09-21.min.json
+++ b/apis/ecr-2015-09-21.min.json
@@ -21,11 +21,19 @@
           "layerDigests"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "layerDigests": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            },
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -37,8 +45,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "layerDigest": {},
-                "layerAvailability": {},
+                "layerDigest": {
+                  "shape": "S9"
+                },
+                "layerAvailability": {
+                  "type": "string",
+                  "enum": [
+                    "AVAILABLE",
+                    "UNAVAILABLE"
+                  ]
+                },
                 "layerSize": {
                   "type": "long"
                 },
@@ -51,8 +67,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "layerDigest": {},
-                "failureCode": {},
+                "layerDigest": {
+                  "shape": "S5"
+                },
+                "failureCode": {
+                  "type": "string",
+                  "enum": [
+                    "InvalidLayerDigest",
+                    "MissingLayerDigest"
+                  ]
+                },
                 "failureReason": {}
               }
             }
@@ -68,8 +92,12 @@
           "imageIds"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "imageIds": {
             "shape": "Si"
           }
@@ -95,14 +123,20 @@
           "imageIds"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "imageIds": {
             "shape": "Si"
           },
           "acceptedMediaTypes": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -130,22 +164,40 @@
           "layerDigests"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "uploadId": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "uploadId": {
+            "shape": "Sy"
+          },
           "layerDigests": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S9"
+            },
+            "max": 100,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "uploadId": {},
-          "layerDigest": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "uploadId": {
+            "shape": "Sy"
+          },
+          "layerDigest": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -156,7 +208,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {}
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -175,16 +229,26 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          },
           "lastEvaluatedAt": {
             "type": "timestamp"
           }
@@ -198,8 +262,12 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "force": {
             "type": "boolean"
           }
@@ -221,16 +289,26 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "policyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "policyText": {
+            "shape": "S1g"
+          }
         }
       }
     },
@@ -241,19 +319,25 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "imageIds": {
             "shape": "Si"
           },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "S1j"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {}
+              "tagStatus": {
+                "shape": "S1l"
+              }
             }
           }
         }
@@ -266,8 +350,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "registryId": {},
-                "repositoryName": {},
+                "registryId": {
+                  "shape": "S2"
+                },
+                "repositoryName": {
+                  "shape": "S3"
+                },
                 "imageDigest": {},
                 "imageTags": {
                   "shape": "S1p"
@@ -289,14 +377,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "registryId": {},
+          "registryId": {
+            "shape": "S2"
+          },
           "repositoryNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "max": 100,
+            "min": 1
           },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -319,7 +413,11 @@
         "members": {
           "registryIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            },
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -331,7 +429,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "authorizationToken": {},
+                "authorizationToken": {
+                  "type": "string",
+                  "pattern": "^\\S+$"
+                },
                 "expiresAt": {
                   "type": "timestamp"
                 },
@@ -350,16 +451,24 @@
           "layerDigest"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "layerDigest": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "layerDigest": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "downloadUrl": {},
-          "layerDigest": {}
+          "layerDigest": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -370,16 +479,26 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          },
           "lastEvaluatedAt": {
             "type": "timestamp"
           }
@@ -393,19 +512,25 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "imageIds": {
             "shape": "Si"
           },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "S1j"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {}
+              "tagStatus": {
+                "shape": "S1l"
+              }
             }
           }
         }
@@ -413,10 +538,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {},
-          "status": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          },
+          "status": {
+            "shape": "S2b"
+          },
           "nextToken": {},
           "previewResults": {
             "type": "list",
@@ -433,11 +566,17 @@
                 "action": {
                   "type": "structure",
                   "members": {
-                    "type": {}
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "EXPIRE"
+                      ]
+                    }
                   }
                 },
                 "appliedRulePriority": {
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1
                 }
               }
             }
@@ -446,7 +585,8 @@
             "type": "structure",
             "members": {
               "expiringImageTotalCount": {
-                "type": "integer"
+                "type": "integer",
+                "min": 0
               }
             }
           }
@@ -460,16 +600,26 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "policyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "policyText": {
+            "shape": "S1g"
+          }
         }
       }
     },
@@ -480,16 +630,22 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "uploadId": {},
+          "uploadId": {
+            "shape": "Sy"
+          },
           "partSize": {
-            "type": "long"
+            "shape": "S2n"
           }
         }
       }
@@ -501,16 +657,22 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "S1j"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {}
+              "tagStatus": {
+                "shape": "S1l"
+              }
             }
           }
         }
@@ -533,8 +695,12 @@
           "imageManifest"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
           "imageManifest": {},
           "imageTag": {}
         }
@@ -556,17 +722,29 @@
           "lifecyclePolicyText"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          }
         }
       }
     },
@@ -578,9 +756,15 @@
           "policyText"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "policyText": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "policyText": {
+            "shape": "S1g"
+          },
           "force": {
             "type": "boolean"
           }
@@ -589,9 +773,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "policyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "policyText": {
+            "shape": "S1g"
+          }
         }
       }
     },
@@ -602,18 +792,32 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "lifecyclePolicyText": {},
-          "status": {}
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "lifecyclePolicyText": {
+            "shape": "S19"
+          },
+          "status": {
+            "shape": "S2b"
+          }
         }
       }
     },
@@ -628,14 +832,20 @@
           "layerPartBlob"
         ],
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "uploadId": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "uploadId": {
+            "shape": "Sy"
+          },
           "partFirstByte": {
-            "type": "long"
+            "shape": "S2n"
           },
           "partLastByte": {
-            "type": "long"
+            "shape": "S2n"
           },
           "layerPartBlob": {
             "type": "blob"
@@ -645,22 +855,49 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {},
-          "repositoryName": {},
-          "uploadId": {},
+          "registryId": {
+            "shape": "S2"
+          },
+          "repositoryName": {
+            "shape": "S3"
+          },
+          "uploadId": {
+            "shape": "Sy"
+          },
           "lastByteReceived": {
-            "type": "long"
+            "shape": "S2n"
           }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "[0-9]{12}"
+    },
+    "S3": {
+      "type": "string",
+      "max": 256,
+      "min": 2,
+      "pattern": "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*"
+    },
+    "S5": {
+      "type": "string",
+      "max": 1000,
+      "min": 0
+    },
+    "S9": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+"
+    },
     "Si": {
       "type": "list",
       "member": {
         "shape": "Sj"
-      }
+      },
+      "max": 100,
+      "min": 1
     },
     "Sj": {
       "type": "structure",
@@ -677,7 +914,16 @@
           "imageId": {
             "shape": "Sj"
           },
-          "failureCode": {},
+          "failureCode": {
+            "type": "string",
+            "enum": [
+              "InvalidImageDigest",
+              "InvalidImageTag",
+              "ImageTagDoesNotMatchDigest",
+              "ImageNotFound",
+              "MissingDigestAndTag"
+            ]
+          },
           "failureReason": {}
         }
       }
@@ -685,29 +931,76 @@
     "Sv": {
       "type": "structure",
       "members": {
-        "registryId": {},
-        "repositoryName": {},
+        "registryId": {
+          "shape": "S2"
+        },
+        "repositoryName": {
+          "shape": "S3"
+        },
         "imageId": {
           "shape": "Sj"
         },
         "imageManifest": {}
       }
     },
+    "Sy": {
+      "type": "string",
+      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    },
     "S13": {
       "type": "structure",
       "members": {
         "repositoryArn": {},
-        "registryId": {},
-        "repositoryName": {},
+        "registryId": {
+          "shape": "S2"
+        },
+        "repositoryName": {
+          "shape": "S3"
+        },
         "repositoryUri": {},
         "createdAt": {
           "type": "timestamp"
         }
       }
     },
+    "S19": {
+      "type": "string",
+      "max": 10240,
+      "min": 100
+    },
+    "S1g": {
+      "type": "string",
+      "max": 10240,
+      "min": 0
+    },
+    "S1j": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "S1l": {
+      "type": "string",
+      "enum": [
+        "TAGGED",
+        "UNTAGGED"
+      ]
+    },
     "S1p": {
       "type": "list",
       "member": {}
+    },
+    "S2b": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "COMPLETE",
+        "EXPIRED",
+        "FAILED"
+      ]
+    },
+    "S2n": {
+      "type": "long",
+      "min": 0
     }
   }
 }

--- a/apis/ecs-2014-11-13.min.json
+++ b/apis/ecs-2014-11-13.min.json
@@ -50,7 +50,9 @@
             "type": "integer"
           },
           "clientToken": {},
-          "launchType": {},
+          "launchType": {
+            "shape": "Se"
+          },
           "platformVersion": {},
           "role": {},
           "deploymentConfiguration": {
@@ -68,7 +70,9 @@
           "healthCheckGracePeriodSeconds": {
             "type": "integer"
           },
-          "schedulingStrategy": {}
+          "schedulingStrategy": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -195,7 +199,12 @@
           },
           "include": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "STATISTICS"
+              ]
+            }
           }
         }
       },
@@ -335,7 +344,9 @@
         ],
         "members": {
           "cluster": {},
-          "targetType": {},
+          "targetType": {
+            "shape": "S11"
+          },
           "attributeName": {},
           "attributeValue": {},
           "nextToken": {},
@@ -384,7 +395,9 @@
           "maxResults": {
             "type": "integer"
           },
-          "status": {}
+          "status": {
+            "shape": "S3y"
+          }
         }
       },
       "output": {
@@ -406,8 +419,12 @@
           "maxResults": {
             "type": "integer"
           },
-          "launchType": {},
-          "schedulingStrategy": {}
+          "launchType": {
+            "shape": "Se"
+          },
+          "schedulingStrategy": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -425,7 +442,14 @@
         "type": "structure",
         "members": {
           "familyPrefix": {},
-          "status": {},
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE",
+              "ALL"
+            ]
+          },
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -447,8 +471,16 @@
         "type": "structure",
         "members": {
           "familyPrefix": {},
-          "status": {},
-          "sort": {},
+          "status": {
+            "shape": "S2q"
+          },
+          "sort": {
+            "type": "string",
+            "enum": [
+              "ASC",
+              "DESC"
+            ]
+          },
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -478,8 +510,17 @@
           },
           "startedBy": {},
           "serviceName": {},
-          "desiredStatus": {},
-          "launchType": {}
+          "desiredStatus": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "PENDING",
+              "STOPPED"
+            ]
+          },
+          "launchType": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -553,7 +594,9 @@
           "family": {},
           "taskRoleArn": {},
           "executionRoleArn": {},
-          "networkMode": {},
+          "networkMode": {
+            "shape": "S2j"
+          },
           "containerDefinitions": {
             "shape": "S1o"
           },
@@ -602,7 +645,9 @@
           "placementStrategy": {
             "shape": "Sj"
           },
-          "launchType": {},
+          "launchType": {
+            "shape": "Se"
+          },
           "platformVersion": {},
           "networkConfiguration": {
             "shape": "Sm"
@@ -790,7 +835,9 @@
           "containerInstances": {
             "shape": "So"
           },
-          "status": {}
+          "status": {
+            "shape": "S3y"
+          }
         }
       },
       "output": {
@@ -907,6 +954,13 @@
         }
       }
     },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "EC2",
+        "FARGATE"
+      ]
+    },
     "Sf": {
       "type": "structure",
       "members": {
@@ -923,7 +977,13 @@
       "member": {
         "type": "structure",
         "members": {
-          "type": {},
+          "type": {
+            "type": "string",
+            "enum": [
+              "distinctInstance",
+              "memberOf"
+            ]
+          },
           "expression": {}
         }
       }
@@ -933,7 +993,14 @@
       "member": {
         "type": "structure",
         "members": {
-          "type": {},
+          "type": {
+            "type": "string",
+            "enum": [
+              "random",
+              "spread",
+              "binpack"
+            ]
+          },
           "field": {}
         }
       }
@@ -953,7 +1020,13 @@
             "securityGroups": {
               "shape": "So"
             },
-            "assignPublicIp": {}
+            "assignPublicIp": {
+              "type": "string",
+              "enum": [
+                "ENABLED",
+                "DISABLED"
+              ]
+            }
           }
         }
       }
@@ -961,6 +1034,13 @@
     "So": {
       "type": "list",
       "member": {}
+    },
+    "Sq": {
+      "type": "string",
+      "enum": [
+        "REPLICA",
+        "DAEMON"
+      ]
     },
     "Ss": {
       "type": "structure",
@@ -984,7 +1064,9 @@
         "pendingCount": {
           "type": "integer"
         },
-        "launchType": {},
+        "launchType": {
+          "shape": "Se"
+        },
         "platformVersion": {},
         "taskDefinition": {},
         "deploymentConfiguration": {
@@ -1013,7 +1095,9 @@
               "updatedAt": {
                 "type": "timestamp"
               },
-              "launchType": {},
+              "launchType": {
+                "shape": "Se"
+              },
               "platformVersion": {},
               "networkConfiguration": {
                 "shape": "Sm"
@@ -1050,7 +1134,9 @@
         "healthCheckGracePeriodSeconds": {
           "type": "integer"
         },
-        "schedulingStrategy": {}
+        "schedulingStrategy": {
+          "shape": "Sq"
+        }
       }
     },
     "Sz": {
@@ -1067,9 +1153,17 @@
       "members": {
         "name": {},
         "value": {},
-        "targetType": {},
+        "targetType": {
+          "shape": "S11"
+        },
         "targetId": {}
       }
+    },
+    "S11": {
+      "type": "string",
+      "enum": [
+        "container-instance"
+      ]
     },
     "S1a": {
       "type": "structure",
@@ -1098,7 +1192,17 @@
         "pendingTasksCount": {
           "type": "integer"
         },
-        "agentUpdateStatus": {},
+        "agentUpdateStatus": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "STAGING",
+            "STAGED",
+            "UPDATING",
+            "UPDATED",
+            "FAILED"
+          ]
+        },
         "attributes": {
           "shape": "Sz"
         },
@@ -1167,14 +1271,18 @@
         "family": {},
         "taskRoleArn": {},
         "executionRoleArn": {},
-        "networkMode": {},
+        "networkMode": {
+          "shape": "S2j"
+        },
         "revision": {
           "type": "integer"
         },
         "volumes": {
           "shape": "S2k"
         },
-        "status": {},
+        "status": {
+          "shape": "S2q"
+        },
         "requiresAttributes": {
           "type": "list",
           "member": {
@@ -1233,7 +1341,9 @@
                 "hostPort": {
                   "type": "integer"
                 },
-                "protocol": {}
+                "protocol": {
+                  "shape": "S1t"
+                }
               }
             }
           },
@@ -1300,7 +1410,14 @@
                     "containerPath": {},
                     "permissions": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "type": "string",
+                        "enum": [
+                          "read",
+                          "write",
+                          "mknod"
+                        ]
+                      }
                     }
                   }
                 }
@@ -1388,7 +1505,26 @@
                 "hardLimit"
               ],
               "members": {
-                "name": {},
+                "name": {
+                  "type": "string",
+                  "enum": [
+                    "core",
+                    "cpu",
+                    "data",
+                    "fsize",
+                    "locks",
+                    "memlock",
+                    "msgqueue",
+                    "nice",
+                    "nofile",
+                    "nproc",
+                    "rss",
+                    "rtprio",
+                    "rttime",
+                    "sigpending",
+                    "stack"
+                  ]
+                },
                 "softLimit": {
                   "type": "integer"
                 },
@@ -1404,7 +1540,18 @@
               "logDriver"
             ],
             "members": {
-              "logDriver": {},
+              "logDriver": {
+                "type": "string",
+                "enum": [
+                  "json-file",
+                  "syslog",
+                  "journald",
+                  "gelf",
+                  "fluentd",
+                  "awslogs",
+                  "splunk"
+                ]
+              },
               "options": {
                 "type": "map",
                 "key": {},
@@ -1448,11 +1595,27 @@
         }
       }
     },
+    "S1t": {
+      "type": "string",
+      "enum": [
+        "tcp",
+        "udp"
+      ]
+    },
     "S1u": {
       "type": "list",
       "member": {
         "shape": "S7"
       }
+    },
+    "S2j": {
+      "type": "string",
+      "enum": [
+        "bridge",
+        "host",
+        "awsvpc",
+        "none"
+      ]
     },
     "S2k": {
       "type": "list",
@@ -1469,7 +1632,13 @@
           "dockerVolumeConfiguration": {
             "type": "structure",
             "members": {
-              "scope": {},
+              "scope": {
+                "type": "string",
+                "enum": [
+                  "task",
+                  "shared"
+                ]
+              },
               "autoprovision": {
                 "type": "boolean"
               },
@@ -1490,19 +1659,37 @@
       "key": {},
       "value": {}
     },
+    "S2q": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
     "S2s": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "type": {},
+          "type": {
+            "type": "string",
+            "enum": [
+              "memberOf"
+            ]
+          },
           "expression": {}
         }
       }
     },
     "S2v": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "EC2",
+          "FARGATE"
+        ]
+      }
     },
     "S32": {
       "type": "list",
@@ -1567,7 +1754,9 @@
                   }
                 }
               },
-              "healthStatus": {}
+              "healthStatus": {
+                "shape": "S3p"
+              }
             }
           }
         },
@@ -1576,7 +1765,13 @@
           "type": "long"
         },
         "stoppedReason": {},
-        "connectivity": {},
+        "connectivity": {
+          "type": "string",
+          "enum": [
+            "CONNECTED",
+            "DISCONNECTED"
+          ]
+        },
         "connectivityAt": {
           "type": "timestamp"
         },
@@ -1602,12 +1797,16 @@
           "type": "timestamp"
         },
         "group": {},
-        "launchType": {},
+        "launchType": {
+          "shape": "Se"
+        },
         "platformVersion": {},
         "attachments": {
           "shape": "S1i"
         },
-        "healthStatus": {}
+        "healthStatus": {
+          "shape": "S3p"
+        }
       }
     },
     "S3g": {
@@ -1653,9 +1852,26 @@
           "hostPort": {
             "type": "integer"
           },
-          "protocol": {}
+          "protocol": {
+            "shape": "S1t"
+          }
         }
       }
+    },
+    "S3p": {
+      "type": "string",
+      "enum": [
+        "HEALTHY",
+        "UNHEALTHY",
+        "UNKNOWN"
+      ]
+    },
+    "S3y": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DRAINING"
+      ]
     }
   }
 }

--- a/apis/eks-2017-11-01.min.json
+++ b/apis/eks-2017-11-01.min.json
@@ -25,7 +25,12 @@
           "resourcesVpcConfig"
         ],
         "members": {
-          "name": {},
+          "name": {
+            "type": "string",
+            "max": 255,
+            "min": 1,
+            "pattern": "[A-Za-z0-9\\-_]*"
+          },
           "version": {},
           "roleArn": {},
           "resourcesVpcConfig": {
@@ -119,7 +124,9 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           },
           "nextToken": {
             "location": "querystring",
@@ -166,7 +173,15 @@
             "vpcId": {}
           }
         },
-        "status": {},
+        "status": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "ACTIVE",
+            "DELETING",
+            "FAILED"
+          ]
+        },
         "certificateAuthority": {
           "type": "structure",
           "members": {

--- a/apis/elasticache-2015-02-02.min.json
+++ b/apis/elasticache-2015-02-02.min.json
@@ -86,7 +86,9 @@
         "members": {
           "CacheClusterId": {},
           "ReplicationGroupId": {},
-          "AZMode": {},
+          "AZMode": {
+            "shape": "So"
+          },
           "PreferredAvailabilityZone": {},
           "PreferredAvailabilityZones": {
             "shape": "Sp"
@@ -662,7 +664,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S37"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -690,7 +694,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S37"
+                },
                 "Message": {},
                 "Date": {
                   "type": "timestamp"
@@ -917,7 +923,9 @@
           "CacheNodeIdsToRemove": {
             "shape": "Sz"
           },
-          "AZMode": {},
+          "AZMode": {
+            "shape": "So"
+          },
           "NewAvailabilityZones": {
             "shape": "Sp"
           },
@@ -1071,7 +1079,9 @@
               "locationName": "ReshardingConfiguration",
               "type": "structure",
               "members": {
-                "NodeGroupId": {},
+                "NodeGroupId": {
+                  "shape": "Sl"
+                },
                 "PreferredAvailabilityZones": {
                   "shape": "Sm"
                 }
@@ -1081,12 +1091,14 @@
           "NodeGroupsToRemove": {
             "type": "list",
             "member": {
+              "shape": "Sl",
               "locationName": "NodeGroupToRemove"
             }
           },
           "NodeGroupsToRetain": {
             "type": "list",
             "member": {
+              "shape": "Sl",
               "locationName": "NodeGroupToRetain"
             }
           }
@@ -1224,7 +1236,9 @@
         ],
         "members": {
           "ReplicationGroupId": {},
-          "NodeGroupId": {}
+          "NodeGroupId": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -1316,7 +1330,9 @@
         "NumNodeGroups": {
           "type": "integer"
         },
-        "AutomaticFailover": {},
+        "AutomaticFailover": {
+          "shape": "Sh"
+        },
         "NodeSnapshots": {
           "type": "list",
           "member": {
@@ -1343,10 +1359,21 @@
       },
       "wrapper": true
     },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "enabled",
+        "disabled",
+        "enabling",
+        "disabling"
+      ]
+    },
     "Sk": {
       "type": "structure",
       "members": {
-        "NodeGroupId": {},
+        "NodeGroupId": {
+          "shape": "Sl"
+        },
         "Slots": {},
         "ReplicaCount": {
           "type": "integer"
@@ -1357,11 +1384,24 @@
         }
       }
     },
+    "Sl": {
+      "type": "string",
+      "max": 4,
+      "min": 1,
+      "pattern": "\\d+"
+    },
     "Sm": {
       "type": "list",
       "member": {
         "locationName": "AvailabilityZone"
       }
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "single-az",
+        "cross-az"
+      ]
     },
     "Sp": {
       "type": "list",
@@ -1565,7 +1605,13 @@
           "type": "structure",
           "members": {
             "PrimaryClusterId": {},
-            "AutomaticFailoverStatus": {},
+            "AutomaticFailoverStatus": {
+              "type": "string",
+              "enum": [
+                "enabled",
+                "disabled"
+              ]
+            },
             "Resharding": {
               "type": "structure",
               "members": {
@@ -1619,7 +1665,9 @@
           }
         },
         "SnapshottingClusterId": {},
-        "AutomaticFailover": {},
+        "AutomaticFailover": {
+          "shape": "Sh"
+        },
         "ConfigurationEndpoint": {
           "shape": "Sw"
         },
@@ -1653,7 +1701,9 @@
           "NewReplicaCount"
         ],
         "members": {
-          "NodeGroupId": {},
+          "NodeGroupId": {
+            "shape": "Sl"
+          },
           "NewReplicaCount": {
             "type": "integer"
           },
@@ -1679,9 +1729,18 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ChangeType": {}
+          "ChangeType": {
+            "shape": "S2s"
+          }
         }
       }
+    },
+    "S2s": {
+      "type": "string",
+      "enum": [
+        "immediate",
+        "requires-reboot"
+      ]
     },
     "S2t": {
       "type": "list",
@@ -1709,9 +1768,21 @@
               }
             }
           },
-          "ChangeType": {}
+          "ChangeType": {
+            "shape": "S2s"
+          }
         }
       }
+    },
+    "S37": {
+      "type": "string",
+      "enum": [
+        "cache-cluster",
+        "cache-parameter-group",
+        "cache-security-group",
+        "cache-subnet-group",
+        "replication-group"
+      ]
     },
     "S3h": {
       "type": "structure",

--- a/apis/elasticbeanstalk-2010-12-01.min.json
+++ b/apis/elasticbeanstalk-2010-12-01.min.json
@@ -17,7 +17,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -39,7 +41,9 @@
         "members": {
           "ActionId": {},
           "ActionDescription": {},
-          "ActionType": {},
+          "ActionType": {
+            "shape": "S7"
+          },
           "Status": {}
         }
       }
@@ -51,7 +55,9 @@
           "CNAMEPrefix"
         ],
         "members": {
-          "CNAMEPrefix": {}
+          "CNAMEPrefix": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -61,7 +67,9 @@
           "Available": {
             "type": "boolean"
           },
-          "FullyQualifiedCNAME": {}
+          "FullyQualifiedCNAME": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -69,11 +77,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
-          "GroupName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "GroupName": {
+            "shape": "Sf"
+          },
           "VersionLabels": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sh"
+            }
           }
         }
       },
@@ -89,8 +103,12 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
-          "Description": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "Description": {
+            "shape": "So"
+          },
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -109,9 +127,15 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {},
-          "VersionLabel": {},
-          "Description": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "VersionLabel": {
+            "shape": "Sh"
+          },
+          "Description": {
+            "shape": "So"
+          },
           "SourceBuildInformation": {
             "shape": "S1j"
           },
@@ -126,9 +150,20 @@
             ],
             "members": {
               "ArtifactName": {},
-              "CodeBuildServiceRole": {},
-              "ComputeType": {},
-              "Image": {},
+              "CodeBuildServiceRole": {
+                "shape": "S1r"
+              },
+              "ComputeType": {
+                "type": "string",
+                "enum": [
+                  "BUILD_GENERAL1_SMALL",
+                  "BUILD_GENERAL1_MEDIUM",
+                  "BUILD_GENERAL1_LARGE"
+                ]
+              },
+              "Image": {
+                "shape": "S1r"
+              },
               "TimeoutInMinutes": {
                 "type": "integer"
               }
@@ -155,19 +190,29 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
           "SolutionStackName": {},
           "PlatformArn": {},
           "SourceConfiguration": {
             "type": "structure",
             "members": {
-              "ApplicationName": {},
-              "TemplateName": {}
+              "ApplicationName": {
+                "shape": "Se"
+              },
+              "TemplateName": {
+                "shape": "Sn"
+              }
             }
           },
           "EnvironmentId": {},
-          "Description": {},
+          "Description": {
+            "shape": "So"
+          },
           "OptionSettings": {
             "shape": "S21"
           }
@@ -185,11 +230,21 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
-          "EnvironmentName": {},
-          "GroupName": {},
-          "Description": {},
-          "CNAMEPrefix": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "EnvironmentName": {
+            "shape": "S3"
+          },
+          "GroupName": {
+            "shape": "Sf"
+          },
+          "Description": {
+            "shape": "So"
+          },
+          "CNAMEPrefix": {
+            "shape": "S9"
+          },
           "Tier": {
             "shape": "S11"
           },
@@ -199,8 +254,12 @@
               "shape": "S2b"
             }
           },
-          "VersionLabel": {},
-          "TemplateName": {},
+          "VersionLabel": {
+            "shape": "Sh"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
           "SolutionStackName": {},
           "PlatformArn": {},
           "OptionSettings": {
@@ -230,7 +289,9 @@
           "PlatformDefinitionBundle": {
             "shape": "S1n"
           },
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "OptionSettings": {
             "shape": "S21"
           }
@@ -257,7 +318,9 @@
         "resultWrapper": "CreateStorageLocationResult",
         "type": "structure",
         "members": {
-          "S3Bucket": {}
+          "S3Bucket": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -268,7 +331,9 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
           "TerminateEnvByForce": {
             "type": "boolean"
           }
@@ -283,8 +348,12 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {},
-          "VersionLabel": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "VersionLabel": {
+            "shape": "Sh"
+          },
           "DeleteSourceBundle": {
             "type": "boolean"
           }
@@ -299,8 +368,12 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {}
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -312,8 +385,12 @@
           "EnvironmentName"
         ],
         "members": {
-          "ApplicationName": {},
-          "EnvironmentName": {}
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -366,12 +443,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
           "VersionLabels": {
             "shape": "S1g"
           },
           "MaxRecords": {
-            "type": "integer"
+            "shape": "S39"
           },
           "NextToken": {}
         }
@@ -396,7 +475,9 @@
         "members": {
           "ApplicationNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Se"
+            }
           }
         }
       },
@@ -417,9 +498,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {},
-          "EnvironmentName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "SolutionStackName": {},
           "PlatformArn": {},
           "Options": {
@@ -445,7 +532,13 @@
                 "UserDefined": {
                   "type": "boolean"
                 },
-                "ValueType": {},
+                "ValueType": {
+                  "type": "string",
+                  "enum": [
+                    "Scalar",
+                    "List"
+                  ]
+                },
                 "ValueOptions": {
                   "type": "list",
                   "member": {}
@@ -479,9 +572,15 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {},
-          "EnvironmentName": {}
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -501,11 +600,25 @@
       "input": {
         "type": "structure",
         "members": {
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "EnvironmentId": {},
           "AttributeNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "Status",
+                "Color",
+                "Causes",
+                "ApplicationMetrics",
+                "InstancesHealth",
+                "All",
+                "HealthStatus",
+                "RefreshedAt"
+              ]
+            }
           }
         }
       },
@@ -513,9 +626,13 @@
         "resultWrapper": "DescribeEnvironmentHealthResult",
         "type": "structure",
         "members": {
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "HealthStatus": {},
-          "Status": {},
+          "Status": {
+            "shape": "Su"
+          },
           "Color": {},
           "Causes": {
             "shape": "S43"
@@ -563,7 +680,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxItems": {
             "type": "integer"
@@ -580,10 +699,30 @@
               "type": "structure",
               "members": {
                 "ActionId": {},
-                "ActionType": {},
+                "ActionType": {
+                  "shape": "S7"
+                },
                 "ActionDescription": {},
-                "FailureType": {},
-                "Status": {},
+                "FailureType": {
+                  "type": "string",
+                  "enum": [
+                    "UpdateCancelled",
+                    "CancellationFailed",
+                    "RollbackFailed",
+                    "RollbackSuccessful",
+                    "InternalFailure",
+                    "InvalidEnvironmentState",
+                    "PermissionsError"
+                  ]
+                },
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Completed",
+                    "Failed",
+                    "Unknown"
+                  ]
+                },
                 "FailureDescription": {},
                 "ExecutedTime": {
                   "type": "timestamp"
@@ -592,7 +731,9 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "NextToken": {}
         }
@@ -604,7 +745,9 @@
         "members": {
           "EnvironmentName": {},
           "EnvironmentId": {},
-          "Status": {}
+          "Status": {
+            "shape": "S4l"
+          }
         }
       },
       "output": {
@@ -618,13 +761,19 @@
               "members": {
                 "ActionId": {},
                 "ActionDescription": {},
-                "ActionType": {},
-                "Status": {},
+                "ActionType": {
+                  "shape": "S7"
+                },
+                "Status": {
+                  "shape": "S4l"
+                },
                 "WindowStartTime": {
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 100,
+            "min": 1
           }
         }
       }
@@ -634,7 +783,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -644,7 +795,9 @@
           "EnvironmentResources": {
             "type": "structure",
             "members": {
-              "EnvironmentName": {},
+              "EnvironmentName": {
+                "shape": "S3"
+              },
               "AutoScalingGroups": {
                 "type": "list",
                 "member": {
@@ -709,15 +862,21 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
-          "VersionLabel": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "VersionLabel": {
+            "shape": "Sh"
+          },
           "EnvironmentIds": {
             "type": "list",
             "member": {}
           },
           "EnvironmentNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           },
           "IncludeDeleted": {
             "type": "boolean"
@@ -726,7 +885,7 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "type": "integer"
+            "shape": "S39"
           },
           "NextToken": {}
         }
@@ -740,14 +899,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
-          "VersionLabel": {},
-          "TemplateName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "VersionLabel": {
+            "shape": "Sh"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
           "EnvironmentId": {},
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "PlatformArn": {},
           "RequestId": {},
-          "Severity": {},
+          "Severity": {
+            "shape": "S5c"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -755,7 +924,7 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "type": "integer"
+            "shape": "S39"
           },
           "NextToken": {}
         }
@@ -773,13 +942,23 @@
                   "type": "timestamp"
                 },
                 "Message": {},
-                "ApplicationName": {},
-                "VersionLabel": {},
-                "TemplateName": {},
-                "EnvironmentName": {},
+                "ApplicationName": {
+                  "shape": "Se"
+                },
+                "VersionLabel": {
+                  "shape": "Sh"
+                },
+                "TemplateName": {
+                  "shape": "Sn"
+                },
+                "EnvironmentName": {
+                  "shape": "S3"
+                },
                 "PlatformArn": {},
                 "RequestId": {},
-                "Severity": {}
+                "Severity": {
+                  "shape": "S5c"
+                }
               }
             }
           },
@@ -791,13 +970,32 @@
       "input": {
         "type": "structure",
         "members": {
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "EnvironmentId": {},
           "AttributeNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "HealthStatus",
+                "Color",
+                "Causes",
+                "ApplicationMetrics",
+                "RefreshedAt",
+                "LaunchedAt",
+                "System",
+                "Deployment",
+                "AvailabilityZone",
+                "InstanceType",
+                "All"
+              ]
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5n"
+          }
         }
       },
       "output": {
@@ -809,7 +1007,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "InstanceId": {},
+                "InstanceId": {
+                  "type": "string",
+                  "max": 255,
+                  "min": 1
+                },
                 "HealthStatus": {},
                 "Color": {},
                 "Causes": {
@@ -882,7 +1084,9 @@
           "RefreshedAt": {
             "type": "timestamp"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5n"
+          }
         }
       }
     },
@@ -905,7 +1109,9 @@
               "PlatformName": {},
               "PlatformVersion": {},
               "SolutionStackName": {},
-              "PlatformStatus": {},
+              "PlatformStatus": {
+                "shape": "S2m"
+              },
               "DateCreated": {
                 "type": "timestamp"
               },
@@ -913,7 +1119,9 @@
                 "type": "timestamp"
               },
               "PlatformCategory": {},
-              "Description": {},
+              "Description": {
+                "shape": "So"
+              },
               "Maintainer": {},
               "OperatingSystemName": {},
               "OperatingSystemVersion": {},
@@ -975,7 +1183,11 @@
                 "SolutionStackName": {},
                 "PermittedFileTypes": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 100,
+                    "min": 1
+                  }
                 }
               }
             }
@@ -1002,7 +1214,8 @@
             }
           },
           "MaxRecords": {
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           },
           "NextToken": {}
         }
@@ -1047,7 +1260,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1059,8 +1274,12 @@
         ],
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {},
-          "InfoType": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          },
+          "InfoType": {
+            "shape": "S6y"
+          }
         }
       }
     },
@@ -1069,7 +1288,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1081,8 +1302,12 @@
         ],
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {},
-          "InfoType": {}
+          "EnvironmentName": {
+            "shape": "S3"
+          },
+          "InfoType": {
+            "shape": "S6y"
+          }
         }
       },
       "output": {
@@ -1094,7 +1319,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "InfoType": {},
+                "InfoType": {
+                  "shape": "S6y"
+                },
                 "Ec2InstanceId": {},
                 "SampleTimestamp": {
                   "type": "timestamp"
@@ -1111,9 +1338,13 @@
         "type": "structure",
         "members": {
           "SourceEnvironmentId": {},
-          "SourceEnvironmentName": {},
+          "SourceEnvironmentName": {
+            "shape": "S3"
+          },
           "DestinationEnvironmentId": {},
-          "DestinationEnvironmentName": {}
+          "DestinationEnvironmentName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1122,7 +1353,9 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "TerminateResources": {
             "type": "boolean"
           },
@@ -1143,8 +1376,12 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
-          "Description": {}
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "Description": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -1160,7 +1397,9 @@
           "ResourceLifecycleConfig"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -1170,7 +1409,9 @@
         "resultWrapper": "UpdateApplicationResourceLifecycleResult",
         "type": "structure",
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -1185,9 +1426,15 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {},
-          "VersionLabel": {},
-          "Description": {}
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "VersionLabel": {
+            "shape": "Sh"
+          },
+          "Description": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -1203,9 +1450,15 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {},
-          "Description": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
+          "Description": {
+            "shape": "So"
+          },
           "OptionSettings": {
             "shape": "S21"
           },
@@ -1223,16 +1476,28 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
           "EnvironmentId": {},
-          "EnvironmentName": {},
-          "GroupName": {},
-          "Description": {},
+          "EnvironmentName": {
+            "shape": "S3"
+          },
+          "GroupName": {
+            "shape": "Sf"
+          },
+          "Description": {
+            "shape": "So"
+          },
           "Tier": {
             "shape": "S11"
           },
-          "VersionLabel": {},
-          "TemplateName": {},
+          "VersionLabel": {
+            "shape": "Sh"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
           "SolutionStackName": {},
           "PlatformArn": {},
           "OptionSettings": {
@@ -1261,7 +1526,9 @@
           },
           "TagsToRemove": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2c"
+            }
           }
         }
       }
@@ -1274,9 +1541,15 @@
           "OptionSettings"
         ],
         "members": {
-          "ApplicationName": {},
-          "TemplateName": {},
-          "EnvironmentName": {},
+          "ApplicationName": {
+            "shape": "Se"
+          },
+          "TemplateName": {
+            "shape": "Sn"
+          },
+          "EnvironmentName": {
+            "shape": "S3"
+          },
           "OptionSettings": {
             "shape": "S21"
           }
@@ -1292,7 +1565,13 @@
               "type": "structure",
               "members": {
                 "Message": {},
-                "Severity": {},
+                "Severity": {
+                  "type": "string",
+                  "enum": [
+                    "error",
+                    "warning"
+                  ]
+                },
                 "Namespace": {},
                 "OptionName": {}
               }
@@ -1303,6 +1582,44 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 40,
+      "min": 4
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "InstanceRefresh",
+        "PlatformUpdate",
+        "Unknown"
+      ]
+    },
+    "S9": {
+      "type": "string",
+      "max": 63,
+      "min": 4
+    },
+    "Sc": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "Se": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "Sf": {
+      "type": "string",
+      "max": 19,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
     "Si": {
       "type": "structure",
       "members": {
@@ -1318,28 +1635,64 @@
     "Sk": {
       "type": "structure",
       "members": {
-        "EnvironmentName": {},
+        "EnvironmentName": {
+          "shape": "S3"
+        },
         "EnvironmentId": {},
-        "ApplicationName": {},
-        "VersionLabel": {},
+        "ApplicationName": {
+          "shape": "Se"
+        },
+        "VersionLabel": {
+          "shape": "Sh"
+        },
         "SolutionStackName": {},
         "PlatformArn": {},
-        "TemplateName": {},
-        "Description": {},
+        "TemplateName": {
+          "shape": "Sn"
+        },
+        "Description": {
+          "shape": "So"
+        },
         "EndpointURL": {},
-        "CNAME": {},
+        "CNAME": {
+          "shape": "Sc"
+        },
         "DateCreated": {
           "type": "timestamp"
         },
         "DateUpdated": {
           "type": "timestamp"
         },
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Launching",
+            "Updating",
+            "Ready",
+            "Terminating",
+            "Terminated"
+          ]
+        },
         "AbortableOperationInProgress": {
           "type": "boolean"
         },
-        "Health": {},
-        "HealthStatus": {},
+        "Health": {
+          "shape": "Su"
+        },
+        "HealthStatus": {
+          "type": "string",
+          "enum": [
+            "NoData",
+            "Unknown",
+            "Pending",
+            "Ok",
+            "Info",
+            "Warning",
+            "Degraded",
+            "Severe",
+            "Suspended"
+          ]
+        },
         "Resources": {
           "type": "structure",
           "members": {
@@ -1379,6 +1732,24 @@
         },
         "EnvironmentArn": {}
       }
+    },
+    "Sn": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "So": {
+      "type": "string",
+      "max": 200
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "Green",
+        "Yellow",
+        "Red",
+        "Grey"
+      ]
     },
     "S11": {
       "type": "structure",
@@ -1445,8 +1816,12 @@
       "type": "structure",
       "members": {
         "ApplicationArn": {},
-        "ApplicationName": {},
-        "Description": {},
+        "ApplicationName": {
+          "shape": "Se"
+        },
+        "Description": {
+          "shape": "So"
+        },
         "DateCreated": {
           "type": "timestamp"
         },
@@ -1458,7 +1833,9 @@
         },
         "ConfigurationTemplates": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "Sn"
+          }
         },
         "ResourceLifecycleConfig": {
           "shape": "S17"
@@ -1467,7 +1844,9 @@
     },
     "S1g": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sh"
+      }
     },
     "S1j": {
       "type": "structure",
@@ -1477,17 +1856,47 @@
         "SourceLocation"
       ],
       "members": {
-        "SourceType": {},
-        "SourceRepository": {},
-        "SourceLocation": {}
+        "SourceType": {
+          "type": "string",
+          "enum": [
+            "Git",
+            "Zip"
+          ]
+        },
+        "SourceRepository": {
+          "type": "string",
+          "enum": [
+            "CodeCommit",
+            "S3"
+          ]
+        },
+        "SourceLocation": {
+          "type": "string",
+          "max": 255,
+          "min": 3,
+          "pattern": ".+/.+"
+        }
       }
     },
     "S1n": {
       "type": "structure",
       "members": {
-        "S3Bucket": {},
-        "S3Key": {}
+        "S3Bucket": {
+          "shape": "S1o"
+        },
+        "S3Key": {
+          "type": "string",
+          "max": 1024
+        }
       }
+    },
+    "S1o": {
+      "type": "string",
+      "max": 255
+    },
+    "S1r": {
+      "type": "string",
+      "pattern": ".*\\S.*"
     },
     "S1v": {
       "type": "structure",
@@ -1501,9 +1910,15 @@
       "type": "structure",
       "members": {
         "ApplicationVersionArn": {},
-        "ApplicationName": {},
-        "Description": {},
-        "VersionLabel": {},
+        "ApplicationName": {
+          "shape": "Se"
+        },
+        "Description": {
+          "shape": "So"
+        },
+        "VersionLabel": {
+          "shape": "Sh"
+        },
         "SourceBuildInformation": {
           "shape": "S1j"
         },
@@ -1517,7 +1932,16 @@
         "DateUpdated": {
           "type": "timestamp"
         },
-        "Status": {}
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Processed",
+            "Unprocessed",
+            "Failed",
+            "Processing",
+            "Building"
+          ]
+        }
       }
     },
     "S21": {
@@ -1525,23 +1949,45 @@
       "member": {
         "type": "structure",
         "members": {
-          "ResourceName": {},
+          "ResourceName": {
+            "shape": "S23"
+          },
           "Namespace": {},
           "OptionName": {},
           "Value": {}
         }
       }
     },
+    "S23": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
     "S27": {
       "type": "structure",
       "members": {
         "SolutionStackName": {},
         "PlatformArn": {},
-        "ApplicationName": {},
-        "TemplateName": {},
-        "Description": {},
-        "EnvironmentName": {},
-        "DeploymentStatus": {},
+        "ApplicationName": {
+          "shape": "Se"
+        },
+        "TemplateName": {
+          "shape": "Sn"
+        },
+        "Description": {
+          "shape": "So"
+        },
+        "EnvironmentName": {
+          "shape": "S3"
+        },
+        "DeploymentStatus": {
+          "type": "string",
+          "enum": [
+            "deployed",
+            "pending",
+            "failed"
+          ]
+        },
         "DateCreated": {
           "type": "timestamp"
         },
@@ -1556,16 +2002,29 @@
     "S2b": {
       "type": "structure",
       "members": {
-        "Key": {},
-        "Value": {}
+        "Key": {
+          "shape": "S2c"
+        },
+        "Value": {
+          "type": "string",
+          "max": 256,
+          "min": 1
+        }
       }
+    },
+    "S2c": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S2e": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceName": {},
+          "ResourceName": {
+            "shape": "S23"
+          },
           "Namespace": {},
           "OptionName": {}
         }
@@ -1576,7 +2035,9 @@
       "members": {
         "PlatformArn": {},
         "PlatformOwner": {},
-        "PlatformStatus": {},
+        "PlatformStatus": {
+          "shape": "S2m"
+        },
         "PlatformCategory": {},
         "OperatingSystemName": {},
         "OperatingSystemVersion": {},
@@ -1587,6 +2048,16 @@
           "shape": "S2s"
         }
       }
+    },
+    "S2m": {
+      "type": "string",
+      "enum": [
+        "Creating",
+        "Failed",
+        "Ready",
+        "Deleting",
+        "Deleted"
+      ]
     },
     "S2q": {
       "type": "list",
@@ -1604,9 +2075,18 @@
         }
       }
     },
+    "S39": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
     "S43": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      }
     },
     "S45": {
       "type": "structure",
@@ -1665,11 +2145,43 @@
         }
       }
     },
+    "S4l": {
+      "type": "string",
+      "enum": [
+        "Scheduled",
+        "Pending",
+        "Running",
+        "Unknown"
+      ]
+    },
+    "S5c": {
+      "type": "string",
+      "enum": [
+        "TRACE",
+        "DEBUG",
+        "INFO",
+        "WARN",
+        "ERROR",
+        "FATAL"
+      ]
+    },
+    "S5n": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
     "S6v": {
       "type": "list",
       "member": {
         "shape": "S2b"
       }
+    },
+    "S6y": {
+      "type": "string",
+      "enum": [
+        "tail",
+        "bundle"
+      ]
     }
   }
 }

--- a/apis/elasticfilesystem-2015-02-01.min.json
+++ b/apis/elasticfilesystem-2015-02-01.min.json
@@ -22,15 +22,23 @@
           "CreationToken"
         ],
         "members": {
-          "CreationToken": {},
-          "PerformanceMode": {},
+          "CreationToken": {
+            "shape": "S2"
+          },
+          "PerformanceMode": {
+            "shape": "S3"
+          },
           "Encrypted": {
             "type": "boolean"
           },
-          "KmsKeyId": {},
-          "ThroughputMode": {},
+          "KmsKeyId": {
+            "shape": "S5"
+          },
+          "ThroughputMode": {
+            "shape": "S6"
+          },
           "ProvisionedThroughputInMibps": {
-            "type": "double"
+            "shape": "S7"
           }
         }
       },
@@ -140,7 +148,9 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Ss"
+            }
           }
         }
       }
@@ -155,15 +165,16 @@
         "type": "structure",
         "members": {
           "MaxItems": {
+            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           },
           "Marker": {
             "location": "querystring",
             "locationName": "Marker"
           },
           "CreationToken": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "CreationToken"
           },
@@ -227,9 +238,9 @@
         "type": "structure",
         "members": {
           "MaxItems": {
+            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           },
           "Marker": {
             "location": "querystring",
@@ -272,9 +283,9 @@
         ],
         "members": {
           "MaxItems": {
+            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           },
           "Marker": {
             "location": "querystring",
@@ -338,9 +349,11 @@
             "location": "uri",
             "locationName": "FileSystemId"
           },
-          "ThroughputMode": {},
+          "ThroughputMode": {
+            "shape": "S6"
+          },
           "ProvisionedThroughputInMibps": {
-            "type": "double"
+            "shape": "S7"
           }
         }
       },
@@ -350,6 +363,34 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "enum": [
+        "generalPurpose",
+        "maxIO"
+      ]
+    },
+    "S5": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "enum": [
+        "bursting",
+        "provisioned"
+      ]
+    },
+    "S7": {
+      "type": "double",
+      "min": 0
+    },
     "S8": {
       "type": "structure",
       "required": [
@@ -364,15 +405,22 @@
       ],
       "members": {
         "OwnerId": {},
-        "CreationToken": {},
+        "CreationToken": {
+          "shape": "S2"
+        },
         "FileSystemId": {},
         "CreationTime": {
           "type": "timestamp"
         },
-        "LifeCycleState": {},
-        "Name": {},
+        "LifeCycleState": {
+          "shape": "Sc"
+        },
+        "Name": {
+          "shape": "Sd"
+        },
         "NumberOfMountTargets": {
-          "type": "integer"
+          "type": "integer",
+          "min": 0
         },
         "SizeInBytes": {
           "type": "structure",
@@ -381,27 +429,49 @@
           ],
           "members": {
             "Value": {
-              "type": "long"
+              "type": "long",
+              "min": 0
             },
             "Timestamp": {
               "type": "timestamp"
             }
           }
         },
-        "PerformanceMode": {},
+        "PerformanceMode": {
+          "shape": "S3"
+        },
         "Encrypted": {
           "type": "boolean"
         },
-        "KmsKeyId": {},
-        "ThroughputMode": {},
+        "KmsKeyId": {
+          "shape": "S5"
+        },
+        "ThroughputMode": {
+          "shape": "S6"
+        },
         "ProvisionedThroughputInMibps": {
-          "type": "double"
+          "shape": "S7"
         }
       }
     },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "creating",
+        "available",
+        "updating",
+        "deleting",
+        "deleted"
+      ]
+    },
+    "Sd": {
+      "type": "string",
+      "max": 256
+    },
     "Sk": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 5
     },
     "Sm": {
       "type": "structure",
@@ -416,7 +486,9 @@
         "MountTargetId": {},
         "FileSystemId": {},
         "SubnetId": {},
-        "LifeCycleState": {},
+        "LifeCycleState": {
+          "shape": "Sc"
+        },
         "IpAddress": {},
         "NetworkInterfaceId": {}
       }
@@ -430,10 +502,23 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Ss"
+          },
+          "Value": {
+            "shape": "Sd"
+          }
         }
       }
+    },
+    "Ss": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Sy": {
+      "type": "integer",
+      "min": 1
     }
   }
 }

--- a/apis/elasticloadbalancing-2012-06-01.min.json
+++ b/apis/elasticloadbalancing-2012-06-01.min.json
@@ -318,7 +318,7 @@
         "members": {
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S1v"
           }
         }
       },
@@ -478,7 +478,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S1v"
           }
         }
       },
@@ -545,7 +545,7 @@
                     "type": "structure",
                     "members": {
                       "InstancePort": {
-                        "type": "integer"
+                        "shape": "S11"
                       },
                       "PolicyNames": {
                         "shape": "S2s"
@@ -596,7 +596,9 @@
         "members": {
           "LoadBalancerNames": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 20,
+            "min": 1
           }
         }
       },
@@ -756,9 +758,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {}
+                "Key": {
+                  "shape": "S6"
+                }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
@@ -852,10 +857,24 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S6"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "Sa": {
       "type": "list",
@@ -877,16 +896,24 @@
       "members": {
         "Target": {},
         "Interval": {
-          "type": "integer"
+          "type": "integer",
+          "max": 300,
+          "min": 5
         },
         "Timeout": {
-          "type": "integer"
+          "type": "integer",
+          "max": 60,
+          "min": 2
         },
         "UnhealthyThreshold": {
-          "type": "integer"
+          "type": "integer",
+          "max": 10,
+          "min": 2
         },
         "HealthyThreshold": {
-          "type": "integer"
+          "type": "integer",
+          "max": 10,
+          "min": 2
         }
       }
     },
@@ -910,10 +937,15 @@
         },
         "InstanceProtocol": {},
         "InstancePort": {
-          "type": "integer"
+          "shape": "S11"
         },
         "SSLCertificateId": {}
       }
+    },
+    "S11": {
+      "type": "integer",
+      "max": 65535,
+      "min": 1
     },
     "S13": {
       "type": "list",
@@ -927,6 +959,11 @@
           "InstanceId": {}
         }
       }
+    },
+    "S1v": {
+      "type": "integer",
+      "max": 400,
+      "min": 1
     },
     "S2a": {
       "type": "structure",
@@ -979,7 +1016,9 @@
           ],
           "members": {
             "IdleTimeout": {
-              "type": "integer"
+              "type": "integer",
+              "max": 3600,
+              "min": 1
             }
           }
         },
@@ -988,10 +1027,19 @@
           "member": {
             "type": "structure",
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "type": "string",
+                "max": 256,
+                "pattern": "^[a-zA-Z0-9.]+$"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "pattern": "^[a-zA-Z0-9.]+$"
+              }
             }
-          }
+          },
+          "max": 10
         }
       }
     },

--- a/apis/elasticloadbalancingv2-2015-12-01.min.json
+++ b/apis/elasticloadbalancingv2-2015-12-01.min.json
@@ -69,9 +69,11 @@
         ],
         "members": {
           "LoadBalancerArn": {},
-          "Protocol": {},
+          "Protocol": {
+            "shape": "Si"
+          },
           "Port": {
-            "type": "integer"
+            "shape": "Sj"
           },
           "SslPolicy": {},
           "Certificates": {
@@ -109,12 +111,18 @@
           "SecurityGroups": {
             "shape": "S20"
           },
-          "Scheme": {},
+          "Scheme": {
+            "shape": "S22"
+          },
           "Tags": {
             "shape": "Sb"
           },
-          "Type": {},
-          "IpAddressType": {}
+          "Type": {
+            "shape": "S23"
+          },
+          "IpAddressType": {
+            "shape": "S24"
+          }
         }
       },
       "output": {
@@ -142,7 +150,7 @@
             "shape": "S2m"
           },
           "Priority": {
-            "type": "integer"
+            "shape": "S2r"
           },
           "Actions": {
             "shape": "Sl"
@@ -170,30 +178,38 @@
         ],
         "members": {
           "Name": {},
-          "Protocol": {},
+          "Protocol": {
+            "shape": "Si"
+          },
           "Port": {
-            "type": "integer"
+            "shape": "Sj"
           },
           "VpcId": {},
-          "HealthCheckProtocol": {},
+          "HealthCheckProtocol": {
+            "shape": "Si"
+          },
           "HealthCheckPort": {},
-          "HealthCheckPath": {},
+          "HealthCheckPath": {
+            "shape": "S31"
+          },
           "HealthCheckIntervalSeconds": {
-            "type": "integer"
+            "shape": "S32"
           },
           "HealthCheckTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S33"
           },
           "HealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
           "UnhealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
           "Matcher": {
             "shape": "S35"
           },
-          "TargetType": {}
+          "TargetType": {
+            "shape": "S37"
+          }
         }
       },
       "output": {
@@ -296,7 +312,7 @@
         "members": {
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -328,7 +344,7 @@
           "ListenerArn": {},
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -354,7 +370,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -402,7 +418,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -428,7 +444,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -453,7 +469,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -556,7 +572,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3r"
           }
         }
       },
@@ -600,8 +616,33 @@
                 "TargetHealth": {
                   "type": "structure",
                   "members": {
-                    "State": {},
-                    "Reason": {},
+                    "State": {
+                      "type": "string",
+                      "enum": [
+                        "initial",
+                        "healthy",
+                        "unhealthy",
+                        "unused",
+                        "draining",
+                        "unavailable"
+                      ]
+                    },
+                    "Reason": {
+                      "type": "string",
+                      "enum": [
+                        "Elb.RegistrationInProgress",
+                        "Elb.InitialHealthChecking",
+                        "Target.ResponseCodeMismatch",
+                        "Target.Timeout",
+                        "Target.FailedHealthChecks",
+                        "Target.NotRegistered",
+                        "Target.NotInUse",
+                        "Target.DeregistrationInProgress",
+                        "Target.InvalidState",
+                        "Target.IpUnusable",
+                        "Elb.InternalError"
+                      ]
+                    },
                     "Description": {}
                   }
                 }
@@ -620,9 +661,11 @@
         "members": {
           "ListenerArn": {},
           "Port": {
-            "type": "integer"
+            "shape": "Sj"
           },
-          "Protocol": {},
+          "Protocol": {
+            "shape": "Si"
+          },
           "SslPolicy": {},
           "Certificates": {
             "shape": "S3"
@@ -700,20 +743,24 @@
         ],
         "members": {
           "TargetGroupArn": {},
-          "HealthCheckProtocol": {},
+          "HealthCheckProtocol": {
+            "shape": "Si"
+          },
           "HealthCheckPort": {},
-          "HealthCheckPath": {},
+          "HealthCheckPath": {
+            "shape": "S31"
+          },
           "HealthCheckIntervalSeconds": {
-            "type": "integer"
+            "shape": "S32"
           },
           "HealthCheckTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S33"
           },
           "HealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
           "UnhealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
           "Matcher": {
             "shape": "S35"
@@ -807,7 +854,9 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sd"
+            }
           }
         }
       },
@@ -826,14 +875,18 @@
         ],
         "members": {
           "LoadBalancerArn": {},
-          "IpAddressType": {}
+          "IpAddressType": {
+            "shape": "S24"
+          }
         }
       },
       "output": {
         "resultWrapper": "SetIpAddressTypeResult",
         "type": "structure",
         "members": {
-          "IpAddressType": {}
+          "IpAddressType": {
+            "shape": "S24"
+          }
         }
       }
     },
@@ -851,7 +904,7 @@
               "members": {
                 "RuleArn": {},
                 "Priority": {
-                  "type": "integer"
+                  "shape": "S2r"
                 }
               }
             }
@@ -944,10 +997,37 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Sd"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "Si": {
+      "type": "string",
+      "enum": [
+        "HTTP",
+        "HTTPS",
+        "TCP"
+      ]
+    },
+    "Sj": {
+      "type": "integer",
+      "max": 65535,
+      "min": 1
     },
     "Sl": {
       "type": "list",
@@ -957,7 +1037,16 @@
           "Type"
         ],
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "forward",
+              "authenticate-oidc",
+              "authenticate-cognito",
+              "redirect",
+              "fixed-response"
+            ]
+          },
           "TargetGroupArn": {},
           "AuthenticateOidcConfig": {
             "type": "structure",
@@ -986,7 +1075,14 @@
                 "key": {},
                 "value": {}
               },
-              "OnUnauthenticatedRequest": {}
+              "OnUnauthenticatedRequest": {
+                "type": "string",
+                "enum": [
+                  "deny",
+                  "allow",
+                  "authenticate"
+                ]
+              }
             }
           },
           "AuthenticateCognitoConfig": {
@@ -1010,11 +1106,20 @@
                 "key": {},
                 "value": {}
               },
-              "OnUnauthenticatedRequest": {}
+              "OnUnauthenticatedRequest": {
+                "type": "string",
+                "enum": [
+                  "deny",
+                  "allow",
+                  "authenticate"
+                ]
+              }
             }
           },
           "Order": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50000,
+            "min": 1
           },
           "RedirectConfig": {
             "type": "structure",
@@ -1022,12 +1127,33 @@
               "StatusCode"
             ],
             "members": {
-              "Protocol": {},
+              "Protocol": {
+                "type": "string",
+                "pattern": "^(HTTPS?|#\\{protocol\\})$"
+              },
               "Port": {},
-              "Host": {},
-              "Path": {},
-              "Query": {},
-              "StatusCode": {}
+              "Host": {
+                "type": "string",
+                "max": 128,
+                "min": 1
+              },
+              "Path": {
+                "type": "string",
+                "max": 128,
+                "min": 1
+              },
+              "Query": {
+                "type": "string",
+                "max": 128,
+                "min": 0
+              },
+              "StatusCode": {
+                "type": "string",
+                "enum": [
+                  "HTTP_301",
+                  "HTTP_302"
+                ]
+              }
             }
           },
           "FixedResponseConfig": {
@@ -1036,9 +1162,20 @@
               "StatusCode"
             ],
             "members": {
-              "MessageBody": {},
-              "StatusCode": {},
-              "ContentType": {}
+              "MessageBody": {
+                "type": "string",
+                "max": 1024,
+                "min": 0
+              },
+              "StatusCode": {
+                "type": "string",
+                "pattern": "^(2|4|5)\\d\\d$"
+              },
+              "ContentType": {
+                "type": "string",
+                "max": 32,
+                "min": 0
+              }
             }
           }
         }
@@ -1052,9 +1189,11 @@
           "ListenerArn": {},
           "LoadBalancerArn": {},
           "Port": {
-            "type": "integer"
+            "shape": "Sj"
           },
-          "Protocol": {},
+          "Protocol": {
+            "shape": "Si"
+          },
           "Certificates": {
             "shape": "S3"
           },
@@ -1083,6 +1222,27 @@
       "type": "list",
       "member": {}
     },
+    "S22": {
+      "type": "string",
+      "enum": [
+        "internet-facing",
+        "internal"
+      ]
+    },
+    "S23": {
+      "type": "string",
+      "enum": [
+        "application",
+        "network"
+      ]
+    },
+    "S24": {
+      "type": "string",
+      "enum": [
+        "ipv4",
+        "dualstack"
+      ]
+    },
     "S26": {
       "type": "list",
       "member": {
@@ -1095,23 +1255,37 @@
             "type": "timestamp"
           },
           "LoadBalancerName": {},
-          "Scheme": {},
+          "Scheme": {
+            "shape": "S22"
+          },
           "VpcId": {},
           "State": {
             "type": "structure",
             "members": {
-              "Code": {},
+              "Code": {
+                "type": "string",
+                "enum": [
+                  "active",
+                  "provisioning",
+                  "active_impaired",
+                  "failed"
+                ]
+              },
               "Reason": {}
             }
           },
-          "Type": {},
+          "Type": {
+            "shape": "S23"
+          },
           "AvailabilityZones": {
             "shape": "S2f"
           },
           "SecurityGroups": {
             "shape": "S20"
           },
-          "IpAddressType": {}
+          "IpAddressType": {
+            "shape": "S24"
+          }
         }
       }
     },
@@ -1140,13 +1314,21 @@
       "member": {
         "type": "structure",
         "members": {
-          "Field": {},
+          "Field": {
+            "type": "string",
+            "max": 64
+          },
           "Values": {
             "type": "list",
             "member": {}
           }
         }
       }
+    },
+    "S2r": {
+      "type": "integer",
+      "max": 50000,
+      "min": 1
     },
     "S2t": {
       "type": "list",
@@ -1167,6 +1349,26 @@
         }
       }
     },
+    "S31": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S32": {
+      "type": "integer",
+      "max": 300,
+      "min": 5
+    },
+    "S33": {
+      "type": "integer",
+      "max": 60,
+      "min": 2
+    },
+    "S34": {
+      "type": "integer",
+      "max": 10,
+      "min": 2
+    },
     "S35": {
       "type": "structure",
       "required": [
@@ -1176,6 +1378,13 @@
         "HttpCode": {}
       }
     },
+    "S37": {
+      "type": "string",
+      "enum": [
+        "instance",
+        "ip"
+      ]
+    },
     "S39": {
       "type": "list",
       "member": {
@@ -1183,33 +1392,41 @@
         "members": {
           "TargetGroupArn": {},
           "TargetGroupName": {},
-          "Protocol": {},
+          "Protocol": {
+            "shape": "Si"
+          },
           "Port": {
-            "type": "integer"
+            "shape": "Sj"
           },
           "VpcId": {},
-          "HealthCheckProtocol": {},
+          "HealthCheckProtocol": {
+            "shape": "Si"
+          },
           "HealthCheckPort": {},
           "HealthCheckIntervalSeconds": {
-            "type": "integer"
+            "shape": "S32"
           },
           "HealthCheckTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S33"
           },
           "HealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
           "UnhealthyThresholdCount": {
-            "type": "integer"
+            "shape": "S34"
           },
-          "HealthCheckPath": {},
+          "HealthCheckPath": {
+            "shape": "S31"
+          },
           "Matcher": {
             "shape": "S35"
           },
           "LoadBalancerArns": {
             "shape": "S3b"
           },
-          "TargetType": {}
+          "TargetType": {
+            "shape": "S37"
+          }
         }
       }
     },
@@ -1231,27 +1448,44 @@
       "members": {
         "Id": {},
         "Port": {
-          "type": "integer"
+          "shape": "Sj"
         },
         "AvailabilityZone": {}
       }
+    },
+    "S3r": {
+      "type": "integer",
+      "max": 400,
+      "min": 1
     },
     "S44": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 256,
+            "pattern": "^[a-zA-Z0-9._]+$"
+          },
+          "Value": {
+            "type": "string",
+            "max": 1024
+          }
         }
-      }
+      },
+      "max": 20
     },
     "S4v": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 256,
+            "pattern": "^[a-zA-Z0-9._]+$"
+          },
           "Value": {}
         }
       }

--- a/apis/elasticmapreduce-2009-03-31.min.json
+++ b/apis/elasticmapreduce-2009-03-31.min.json
@@ -22,7 +22,9 @@
           "InstanceFleet"
         ],
         "members": {
-          "ClusterId": {},
+          "ClusterId": {
+            "shape": "S2"
+          },
           "InstanceFleet": {
             "shape": "S3"
           }
@@ -31,7 +33,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ClusterId": {},
+          "ClusterId": {
+            "shape": "S2"
+          },
           "InstanceFleetId": {}
         }
       }
@@ -47,16 +51,22 @@
           "InstanceGroups": {
             "shape": "Sq"
           },
-          "JobFlowId": {}
+          "JobFlowId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobFlowId": {},
+          "JobFlowId": {
+            "shape": "S2"
+          },
           "InstanceGroupIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           }
         }
       }
@@ -69,7 +79,9 @@
           "Steps"
         ],
         "members": {
-          "JobFlowId": {},
+          "JobFlowId": {
+            "shape": "S2"
+          },
           "Steps": {
             "shape": "S1b"
           }
@@ -107,7 +119,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ClusterId": {},
+          "ClusterId": {
+            "shape": "S2"
+          },
           "StepIds": {
             "shape": "S1k"
           }
@@ -122,7 +136,13 @@
               "type": "structure",
               "members": {
                 "StepId": {},
-                "Status": {},
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "SUBMITTED",
+                    "FAILED"
+                  ]
+                },
                 "Reason": {}
               }
             }
@@ -138,7 +158,9 @@
           "SecurityConfiguration"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S1h"
+          },
           "SecurityConfiguration": {}
         }
       },
@@ -149,7 +171,9 @@
           "CreationDateTime"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S1h"
+          },
           "CreationDateTime": {
             "type": "timestamp"
           }
@@ -163,7 +187,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S1h"
+          }
         }
       },
       "output": {
@@ -216,7 +242,13 @@
                   }
                 }
               },
-              "InstanceCollectionType": {},
+              "InstanceCollectionType": {
+                "type": "string",
+                "enum": [
+                  "INSTANCE_FLEET",
+                  "INSTANCE_GROUP"
+                ]
+              },
               "LogUri": {},
               "RequestedAmiVersion": {},
               "RunningAmiVersion": {},
@@ -244,14 +276,24 @@
               "Configurations": {
                 "shape": "Sh"
               },
-              "SecurityConfiguration": {},
-              "AutoScalingRole": {},
-              "ScaleDownBehavior": {},
-              "CustomAmiId": {},
+              "SecurityConfiguration": {
+                "shape": "S1h"
+              },
+              "AutoScalingRole": {
+                "shape": "S1h"
+              },
+              "ScaleDownBehavior": {
+                "shape": "S2h"
+              },
+              "CustomAmiId": {
+                "shape": "S2"
+              },
               "EbsRootVolumeSize": {
                 "type": "integer"
               },
-              "RepoUpgradeOnBoot": {},
+              "RepoUpgradeOnBoot": {
+                "shape": "S2i"
+              },
               "KerberosAttributes": {
                 "shape": "S2j"
               }
@@ -275,7 +317,9 @@
           },
           "JobFlowStates": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2m"
+            }
           }
         }
       },
@@ -293,10 +337,18 @@
                 "Instances"
               ],
               "members": {
-                "JobFlowId": {},
-                "Name": {},
-                "LogUri": {},
-                "AmiVersion": {},
+                "JobFlowId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S2"
+                },
+                "LogUri": {
+                  "shape": "S1h"
+                },
+                "AmiVersion": {
+                  "shape": "S2"
+                },
                 "ExecutionStatusDetail": {
                   "type": "structure",
                   "required": [
@@ -304,7 +356,9 @@
                     "CreationDateTime"
                   ],
                   "members": {
-                    "State": {},
+                    "State": {
+                      "shape": "S2m"
+                    },
                     "CreationDateTime": {
                       "type": "timestamp"
                     },
@@ -317,7 +371,9 @@
                     "EndDateTime": {
                       "type": "timestamp"
                     },
-                    "LastStateChangeReason": {}
+                    "LastStateChangeReason": {
+                      "shape": "S1h"
+                    }
                   }
                 },
                 "Instances": {
@@ -328,10 +384,18 @@
                     "InstanceCount"
                   ],
                   "members": {
-                    "MasterInstanceType": {},
-                    "MasterPublicDnsName": {},
-                    "MasterInstanceId": {},
-                    "SlaveInstanceType": {},
+                    "MasterInstanceType": {
+                      "shape": "S8"
+                    },
+                    "MasterPublicDnsName": {
+                      "shape": "S1h"
+                    },
+                    "MasterInstanceId": {
+                      "shape": "S1h"
+                    },
+                    "SlaveInstanceType": {
+                      "shape": "S8"
+                    },
                     "InstanceCount": {
                       "type": "integer"
                     },
@@ -349,20 +413,36 @@
                           "CreationDateTime"
                         ],
                         "members": {
-                          "InstanceGroupId": {},
-                          "Name": {},
-                          "Market": {},
-                          "InstanceRole": {},
-                          "BidPrice": {},
-                          "InstanceType": {},
+                          "InstanceGroupId": {
+                            "shape": "S2"
+                          },
+                          "Name": {
+                            "shape": "S2"
+                          },
+                          "Market": {
+                            "shape": "Ss"
+                          },
+                          "InstanceRole": {
+                            "shape": "St"
+                          },
+                          "BidPrice": {
+                            "shape": "S2"
+                          },
+                          "InstanceType": {
+                            "shape": "S8"
+                          },
                           "InstanceRequestCount": {
                             "type": "integer"
                           },
                           "InstanceRunningCount": {
                             "type": "integer"
                           },
-                          "State": {},
-                          "LastStateChangeReason": {},
+                          "State": {
+                            "shape": "S2u"
+                          },
+                          "LastStateChangeReason": {
+                            "shape": "S1h"
+                          },
                           "CreationDateTime": {
                             "type": "timestamp"
                           },
@@ -381,8 +461,12 @@
                     "NormalizedInstanceHours": {
                       "type": "integer"
                     },
-                    "Ec2KeyName": {},
-                    "Ec2SubnetId": {},
+                    "Ec2KeyName": {
+                      "shape": "S2"
+                    },
+                    "Ec2SubnetId": {
+                      "shape": "S2"
+                    },
                     "Placement": {
                       "shape": "S2v"
                     },
@@ -392,7 +476,9 @@
                     "TerminationProtected": {
                       "type": "boolean"
                     },
-                    "HadoopVersion": {}
+                    "HadoopVersion": {
+                      "shape": "S2"
+                    }
                   }
                 },
                 "Steps": {
@@ -414,7 +500,18 @@
                           "CreationDateTime"
                         ],
                         "members": {
-                          "State": {},
+                          "State": {
+                            "type": "string",
+                            "enum": [
+                              "PENDING",
+                              "RUNNING",
+                              "CONTINUE",
+                              "COMPLETED",
+                              "CANCELLED",
+                              "FAILED",
+                              "INTERRUPTED"
+                            ]
+                          },
                           "CreationDateTime": {
                             "type": "timestamp"
                           },
@@ -424,7 +521,9 @@
                           "EndDateTime": {
                             "type": "timestamp"
                           },
-                          "LastStateChangeReason": {}
+                          "LastStateChangeReason": {
+                            "shape": "S1h"
+                          }
                         }
                       }
                     }
@@ -447,10 +546,18 @@
                 "VisibleToAllUsers": {
                   "type": "boolean"
                 },
-                "JobFlowRole": {},
-                "ServiceRole": {},
-                "AutoScalingRole": {},
-                "ScaleDownBehavior": {}
+                "JobFlowRole": {
+                  "shape": "S1h"
+                },
+                "ServiceRole": {
+                  "shape": "S1h"
+                },
+                "AutoScalingRole": {
+                  "shape": "S1h"
+                },
+                "ScaleDownBehavior": {
+                  "shape": "S2h"
+                }
               }
             }
           }
@@ -465,13 +572,17 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S1h"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S1h"
+          },
           "SecurityConfiguration": {},
           "CreationDateTime": {
             "type": "timestamp"
@@ -502,7 +613,9 @@
               "Config": {
                 "shape": "S3a"
               },
-              "ActionOnFailure": {},
+              "ActionOnFailure": {
+                "shape": "S1d"
+              },
               "Status": {
                 "shape": "S3b"
               }
@@ -554,7 +667,9 @@
           },
           "ClusterStates": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S26"
+            }
           },
           "Marker": {}
         }
@@ -602,15 +717,36 @@
               "type": "structure",
               "members": {
                 "Id": {},
-                "Name": {},
+                "Name": {
+                  "shape": "S2"
+                },
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {},
+                    "State": {
+                      "type": "string",
+                      "enum": [
+                        "PROVISIONING",
+                        "BOOTSTRAPPING",
+                        "RUNNING",
+                        "RESIZING",
+                        "SUSPENDED",
+                        "TERMINATING",
+                        "TERMINATED"
+                      ]
+                    },
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {},
+                        "Code": {
+                          "type": "string",
+                          "enum": [
+                            "INTERNAL_ERROR",
+                            "VALIDATION_ERROR",
+                            "INSTANCE_FAILURE",
+                            "CLUSTER_TERMINATED"
+                          ]
+                        },
                         "Message": {}
                       }
                     },
@@ -630,31 +766,37 @@
                     }
                   }
                 },
-                "InstanceFleetType": {},
+                "InstanceFleetType": {
+                  "shape": "S4"
+                },
                 "TargetOnDemandCapacity": {
-                  "type": "integer"
+                  "shape": "S5"
                 },
                 "TargetSpotCapacity": {
-                  "type": "integer"
+                  "shape": "S5"
                 },
                 "ProvisionedOnDemandCapacity": {
-                  "type": "integer"
+                  "shape": "S5"
                 },
                 "ProvisionedSpotCapacity": {
-                  "type": "integer"
+                  "shape": "S5"
                 },
                 "InstanceTypeSpecifications": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "InstanceType": {},
-                      "WeightedCapacity": {
-                        "type": "integer"
+                      "InstanceType": {
+                        "shape": "S8"
                       },
-                      "BidPrice": {},
+                      "WeightedCapacity": {
+                        "shape": "S5"
+                      },
+                      "BidPrice": {
+                        "shape": "S2"
+                      },
                       "BidPriceAsPercentageOfOnDemandPrice": {
-                        "type": "double"
+                        "shape": "S9"
                       },
                       "Configurations": {
                         "shape": "Sh"
@@ -699,10 +841,16 @@
               "members": {
                 "Id": {},
                 "Name": {},
-                "Market": {},
-                "InstanceGroupType": {},
+                "Market": {
+                  "shape": "Ss"
+                },
+                "InstanceGroupType": {
+                  "shape": "S49"
+                },
                 "BidPrice": {},
-                "InstanceType": {},
+                "InstanceType": {
+                  "shape": "S8"
+                },
                 "RequestedInstanceCount": {
                   "type": "integer"
                 },
@@ -712,11 +860,21 @@
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {},
+                    "State": {
+                      "shape": "S2u"
+                    },
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {},
+                        "Code": {
+                          "type": "string",
+                          "enum": [
+                            "INTERNAL_ERROR",
+                            "VALIDATION_ERROR",
+                            "INSTANCE_FAILURE",
+                            "CLUSTER_TERMINATED"
+                          ]
+                        },
                         "Message": {}
                       }
                     },
@@ -769,13 +927,19 @@
           "InstanceGroupId": {},
           "InstanceGroupTypes": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S49"
+            }
           },
           "InstanceFleetId": {},
-          "InstanceFleetType": {},
+          "InstanceFleetType": {
+            "shape": "S4"
+          },
           "InstanceStates": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4q"
+            }
           },
           "Marker": {}
         }
@@ -797,11 +961,22 @@
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {},
+                    "State": {
+                      "shape": "S4q"
+                    },
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {},
+                        "Code": {
+                          "type": "string",
+                          "enum": [
+                            "INTERNAL_ERROR",
+                            "VALIDATION_ERROR",
+                            "INSTANCE_FAILURE",
+                            "BOOTSTRAP_FAILURE",
+                            "CLUSTER_TERMINATED"
+                          ]
+                        },
                         "Message": {}
                       }
                     },
@@ -823,8 +998,12 @@
                 },
                 "InstanceGroupId": {},
                 "InstanceFleetId": {},
-                "Market": {},
-                "InstanceType": {},
+                "Market": {
+                  "shape": "Ss"
+                },
+                "InstanceType": {
+                  "shape": "S8"
+                },
                 "EbsVolumes": {
                   "type": "list",
                   "member": {
@@ -857,7 +1036,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
+                "Name": {
+                  "shape": "S1h"
+                },
                 "CreationDateTime": {
                   "type": "timestamp"
                 }
@@ -878,7 +1059,9 @@
           "ClusterId": {},
           "StepStates": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3c"
+            }
           },
           "StepIds": {
             "shape": "S1i"
@@ -899,7 +1082,9 @@
                 "Config": {
                   "shape": "S3a"
                 },
-                "ActionOnFailure": {},
+                "ActionOnFailure": {
+                  "shape": "S1d"
+                },
                 "Status": {
                   "shape": "S3b"
                 }
@@ -927,10 +1112,10 @@
             "members": {
               "InstanceFleetId": {},
               "TargetOnDemandCapacity": {
-                "type": "integer"
+                "shape": "S5"
               },
               "TargetSpotCapacity": {
-                "type": "integer"
+                "shape": "S5"
               }
             }
           }
@@ -950,7 +1135,9 @@
                 "InstanceGroupId"
               ],
               "members": {
-                "InstanceGroupId": {},
+                "InstanceGroupId": {
+                  "shape": "S2"
+                },
                 "InstanceCount": {
                   "type": "integer"
                 },
@@ -1038,16 +1225,30 @@
           "Instances"
         ],
         "members": {
-          "Name": {},
-          "LogUri": {},
-          "AdditionalInfo": {},
-          "AmiVersion": {},
-          "ReleaseLabel": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "LogUri": {
+            "shape": "S1h"
+          },
+          "AdditionalInfo": {
+            "shape": "S1h"
+          },
+          "AmiVersion": {
+            "shape": "S2"
+          },
+          "ReleaseLabel": {
+            "shape": "S2"
+          },
           "Instances": {
             "type": "structure",
             "members": {
-              "MasterInstanceType": {},
-              "SlaveInstanceType": {},
+              "MasterInstanceType": {
+                "shape": "S8"
+              },
+              "SlaveInstanceType": {
+                "shape": "S8"
+              },
               "InstanceCount": {
                 "type": "integer"
               },
@@ -1060,7 +1261,9 @@
                   "shape": "S3"
                 }
               },
-              "Ec2KeyName": {},
+              "Ec2KeyName": {
+                "shape": "S2"
+              },
               "Placement": {
                 "shape": "S2v"
               },
@@ -1070,14 +1273,24 @@
               "TerminationProtected": {
                 "type": "boolean"
               },
-              "HadoopVersion": {},
-              "Ec2SubnetId": {},
+              "HadoopVersion": {
+                "shape": "S2"
+              },
+              "Ec2SubnetId": {
+                "shape": "S2"
+              },
               "Ec2SubnetIds": {
                 "shape": "S2b"
               },
-              "EmrManagedMasterSecurityGroup": {},
-              "EmrManagedSlaveSecurityGroup": {},
-              "ServiceAccessSecurityGroup": {},
+              "EmrManagedMasterSecurityGroup": {
+                "shape": "S2"
+              },
+              "EmrManagedSlaveSecurityGroup": {
+                "shape": "S2"
+              },
+              "ServiceAccessSecurityGroup": {
+                "shape": "S2"
+              },
               "AdditionalMasterSecurityGroups": {
                 "shape": "S5o"
               },
@@ -1103,7 +1316,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
+                "Name": {
+                  "shape": "S2"
+                },
                 "Args": {
                   "shape": "S1i"
                 }
@@ -1119,19 +1334,33 @@
           "VisibleToAllUsers": {
             "type": "boolean"
           },
-          "JobFlowRole": {},
-          "ServiceRole": {},
+          "JobFlowRole": {
+            "shape": "S1h"
+          },
+          "ServiceRole": {
+            "shape": "S1h"
+          },
           "Tags": {
             "shape": "S1n"
           },
-          "SecurityConfiguration": {},
-          "AutoScalingRole": {},
-          "ScaleDownBehavior": {},
-          "CustomAmiId": {},
+          "SecurityConfiguration": {
+            "shape": "S1h"
+          },
+          "AutoScalingRole": {
+            "shape": "S1h"
+          },
+          "ScaleDownBehavior": {
+            "shape": "S2h"
+          },
+          "CustomAmiId": {
+            "shape": "S2"
+          },
           "EbsRootVolumeSize": {
             "type": "integer"
           },
-          "RepoUpgradeOnBoot": {},
+          "RepoUpgradeOnBoot": {
+            "shape": "S2i"
+          },
           "KerberosAttributes": {
             "shape": "S2j"
           }
@@ -1140,7 +1369,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobFlowId": {}
+          "JobFlowId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -1193,19 +1424,29 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 256,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S3": {
       "type": "structure",
       "required": [
         "InstanceFleetType"
       ],
       "members": {
-        "Name": {},
-        "InstanceFleetType": {},
+        "Name": {
+          "shape": "S2"
+        },
+        "InstanceFleetType": {
+          "shape": "S4"
+        },
         "TargetOnDemandCapacity": {
-          "type": "integer"
+          "shape": "S5"
         },
         "TargetSpotCapacity": {
-          "type": "integer"
+          "shape": "S5"
         },
         "InstanceTypeConfigs": {
           "type": "list",
@@ -1215,13 +1456,17 @@
               "InstanceType"
             ],
             "members": {
-              "InstanceType": {},
-              "WeightedCapacity": {
-                "type": "integer"
+              "InstanceType": {
+                "shape": "S8"
               },
-              "BidPrice": {},
+              "WeightedCapacity": {
+                "shape": "S5"
+              },
+              "BidPrice": {
+                "shape": "S2"
+              },
               "BidPriceAsPercentageOfOnDemandPrice": {
-                "type": "double"
+                "shape": "S9"
               },
               "EbsConfiguration": {
                 "shape": "Sa"
@@ -1236,6 +1481,28 @@
           "shape": "Sk"
         }
       }
+    },
+    "S4": {
+      "type": "string",
+      "enum": [
+        "MASTER",
+        "CORE",
+        "TASK"
+      ]
+    },
+    "S5": {
+      "type": "integer",
+      "min": 0
+    },
+    "S8": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S9": {
+      "type": "double",
+      "min": 0
     },
     "Sa": {
       "type": "structure",
@@ -1312,11 +1579,17 @@
           ],
           "members": {
             "TimeoutDurationMinutes": {
-              "type": "integer"
+              "shape": "S5"
             },
-            "TimeoutAction": {},
+            "TimeoutAction": {
+              "type": "string",
+              "enum": [
+                "SWITCH_TO_ON_DEMAND",
+                "TERMINATE_CLUSTER"
+              ]
+            },
             "BlockDurationMinutes": {
-              "type": "integer"
+              "shape": "S5"
             }
           }
         }
@@ -1332,11 +1605,21 @@
           "InstanceCount"
         ],
         "members": {
-          "Name": {},
-          "Market": {},
-          "InstanceRole": {},
-          "BidPrice": {},
-          "InstanceType": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "Market": {
+            "shape": "Ss"
+          },
+          "InstanceRole": {
+            "shape": "St"
+          },
+          "BidPrice": {
+            "shape": "S2"
+          },
+          "InstanceType": {
+            "shape": "S8"
+          },
           "InstanceCount": {
             "type": "integer"
           },
@@ -1351,6 +1634,21 @@
           }
         }
       }
+    },
+    "Ss": {
+      "type": "string",
+      "enum": [
+        "ON_DEMAND",
+        "SPOT"
+      ]
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "MASTER",
+        "CORE",
+        "TASK"
+      ]
     },
     "Su": {
       "type": "structure",
@@ -1400,14 +1698,23 @@
               "SimpleScalingPolicyConfiguration"
             ],
             "members": {
-              "Market": {},
+              "Market": {
+                "shape": "Ss"
+              },
               "SimpleScalingPolicyConfiguration": {
                 "type": "structure",
                 "required": [
                   "ScalingAdjustment"
                 ],
                 "members": {
-                  "AdjustmentType": {},
+                  "AdjustmentType": {
+                    "type": "string",
+                    "enum": [
+                      "CHANGE_IN_CAPACITY",
+                      "PERCENT_CHANGE_IN_CAPACITY",
+                      "EXACT_CAPACITY"
+                    ]
+                  },
                   "ScalingAdjustment": {
                     "type": "integer"
                   },
@@ -1433,7 +1740,15 @@
                   "Threshold"
                 ],
                 "members": {
-                  "ComparisonOperator": {},
+                  "ComparisonOperator": {
+                    "type": "string",
+                    "enum": [
+                      "GREATER_THAN_OR_EQUAL",
+                      "GREATER_THAN",
+                      "LESS_THAN",
+                      "LESS_THAN_OR_EQUAL"
+                    ]
+                  },
                   "EvaluationPeriods": {
                     "type": "integer"
                   },
@@ -1442,11 +1757,51 @@
                   "Period": {
                     "type": "integer"
                   },
-                  "Statistic": {},
-                  "Threshold": {
-                    "type": "double"
+                  "Statistic": {
+                    "type": "string",
+                    "enum": [
+                      "SAMPLE_COUNT",
+                      "AVERAGE",
+                      "SUM",
+                      "MINIMUM",
+                      "MAXIMUM"
+                    ]
                   },
-                  "Unit": {},
+                  "Threshold": {
+                    "shape": "S9"
+                  },
+                  "Unit": {
+                    "type": "string",
+                    "enum": [
+                      "NONE",
+                      "SECONDS",
+                      "MICRO_SECONDS",
+                      "MILLI_SECONDS",
+                      "BYTES",
+                      "KILO_BYTES",
+                      "MEGA_BYTES",
+                      "GIGA_BYTES",
+                      "TERA_BYTES",
+                      "BITS",
+                      "KILO_BITS",
+                      "MEGA_BITS",
+                      "GIGA_BITS",
+                      "TERA_BITS",
+                      "PERCENT",
+                      "COUNT",
+                      "BYTES_PER_SECOND",
+                      "KILO_BYTES_PER_SECOND",
+                      "MEGA_BYTES_PER_SECOND",
+                      "GIGA_BYTES_PER_SECOND",
+                      "TERA_BYTES_PER_SECOND",
+                      "BITS_PER_SECOND",
+                      "KILO_BITS_PER_SECOND",
+                      "MEGA_BITS_PER_SECOND",
+                      "GIGA_BITS_PER_SECOND",
+                      "TERA_BITS_PER_SECOND",
+                      "COUNT_PER_SECOND"
+                    ]
+                  },
                   "Dimensions": {
                     "type": "list",
                     "member": {
@@ -1477,8 +1832,12 @@
         "HadoopJarStep"
       ],
       "members": {
-        "Name": {},
-        "ActionOnFailure": {},
+        "Name": {
+          "shape": "S2"
+        },
+        "ActionOnFailure": {
+          "shape": "S1d"
+        },
         "HadoopJarStep": {
           "type": "structure",
           "required": [
@@ -1490,13 +1849,21 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "Key": {},
-                  "Value": {}
+                  "Key": {
+                    "shape": "S1h"
+                  },
+                  "Value": {
+                    "shape": "S1h"
+                  }
                 }
               }
             },
-            "Jar": {},
-            "MainClass": {},
+            "Jar": {
+              "shape": "S1h"
+            },
+            "MainClass": {
+              "shape": "S1h"
+            },
             "Args": {
               "shape": "S1i"
             }
@@ -1504,13 +1871,32 @@
         }
       }
     },
+    "S1d": {
+      "type": "string",
+      "enum": [
+        "TERMINATE_JOB_FLOW",
+        "TERMINATE_CLUSTER",
+        "CANCEL_AND_WAIT",
+        "CONTINUE"
+      ]
+    },
+    "S1h": {
+      "type": "string",
+      "max": 10280,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S1i": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1h"
+      }
     },
     "S1k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "S1n": {
       "type": "list",
@@ -1525,11 +1911,25 @@
     "S25": {
       "type": "structure",
       "members": {
-        "State": {},
+        "State": {
+          "shape": "S26"
+        },
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {},
+            "Code": {
+              "type": "string",
+              "enum": [
+                "INTERNAL_ERROR",
+                "VALIDATION_ERROR",
+                "INSTANCE_FAILURE",
+                "INSTANCE_FLEET_TIMEOUT",
+                "BOOTSTRAP_FAILURE",
+                "USER_REQUEST",
+                "STEP_FAILURE",
+                "ALL_STEPS_COMPLETED"
+              ]
+            },
             "Message": {}
           }
         },
@@ -1549,9 +1949,23 @@
         }
       }
     },
+    "S26": {
+      "type": "string",
+      "enum": [
+        "STARTING",
+        "BOOTSTRAPPING",
+        "RUNNING",
+        "WAITING",
+        "TERMINATING",
+        "TERMINATED",
+        "TERMINATED_WITH_ERRORS"
+      ]
+    },
     "S2b": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "S2c": {
       "type": "list",
@@ -1573,6 +1987,20 @@
         }
       }
     },
+    "S2h": {
+      "type": "string",
+      "enum": [
+        "TERMINATE_AT_INSTANCE_HOUR",
+        "TERMINATE_AT_TASK_COMPLETION"
+      ]
+    },
+    "S2i": {
+      "type": "string",
+      "enum": [
+        "SECURITY",
+        "NONE"
+      ]
+    },
     "S2j": {
       "type": "structure",
       "required": [
@@ -1580,17 +2008,57 @@
         "KdcAdminPassword"
       ],
       "members": {
-        "Realm": {},
-        "KdcAdminPassword": {},
-        "CrossRealmTrustPrincipalPassword": {},
-        "ADDomainJoinUser": {},
-        "ADDomainJoinPassword": {}
+        "Realm": {
+          "shape": "S2"
+        },
+        "KdcAdminPassword": {
+          "shape": "S2"
+        },
+        "CrossRealmTrustPrincipalPassword": {
+          "shape": "S2"
+        },
+        "ADDomainJoinUser": {
+          "shape": "S2"
+        },
+        "ADDomainJoinPassword": {
+          "shape": "S2"
+        }
       }
+    },
+    "S2m": {
+      "type": "string",
+      "enum": [
+        "STARTING",
+        "BOOTSTRAPPING",
+        "RUNNING",
+        "WAITING",
+        "SHUTTING_DOWN",
+        "TERMINATED",
+        "COMPLETED",
+        "FAILED"
+      ]
+    },
+    "S2u": {
+      "type": "string",
+      "enum": [
+        "PROVISIONING",
+        "BOOTSTRAPPING",
+        "RUNNING",
+        "RESIZING",
+        "SUSPENDED",
+        "TERMINATING",
+        "TERMINATED",
+        "ARRESTED",
+        "SHUTTING_DOWN",
+        "ENDED"
+      ]
     },
     "S2v": {
       "type": "structure",
       "members": {
-        "AvailabilityZone": {},
+        "AvailabilityZone": {
+          "shape": "S1h"
+        },
         "AvailabilityZones": {
           "shape": "S2b"
         }
@@ -1603,14 +2071,18 @@
         "ScriptBootstrapAction"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S2"
+        },
         "ScriptBootstrapAction": {
           "type": "structure",
           "required": [
             "Path"
           ],
           "members": {
-            "Path": {},
+            "Path": {
+              "shape": "S1h"
+            },
             "Args": {
               "shape": "S1i"
             }
@@ -1620,7 +2092,9 @@
     },
     "S34": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "S3a": {
       "type": "structure",
@@ -1638,11 +2112,18 @@
     "S3b": {
       "type": "structure",
       "members": {
-        "State": {},
+        "State": {
+          "shape": "S3c"
+        },
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {},
+            "Code": {
+              "type": "string",
+              "enum": [
+                "NONE"
+              ]
+            },
             "Message": {}
           }
         },
@@ -1670,6 +2151,18 @@
         }
       }
     },
+    "S3c": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "CANCEL_PENDING",
+        "RUNNING",
+        "COMPLETED",
+        "CANCELLED",
+        "FAILED",
+        "INTERRUPTED"
+      ]
+    },
     "S42": {
       "type": "list",
       "member": {
@@ -1681,6 +2174,14 @@
           "Device": {}
         }
       }
+    },
+    "S49": {
+      "type": "string",
+      "enum": [
+        "MASTER",
+        "CORE",
+        "TASK"
+      ]
     },
     "S4e": {
       "type": "structure",
@@ -1714,11 +2215,28 @@
         "Status": {
           "type": "structure",
           "members": {
-            "State": {},
+            "State": {
+              "type": "string",
+              "enum": [
+                "PENDING",
+                "ATTACHING",
+                "ATTACHED",
+                "DETACHING",
+                "DETACHED",
+                "FAILED"
+              ]
+            },
             "StateChangeReason": {
               "type": "structure",
               "members": {
-                "Code": {},
+                "Code": {
+                  "type": "string",
+                  "enum": [
+                    "USER_REQUEST",
+                    "PROVISION_FAILURE",
+                    "CLEANUP_FAILURE"
+                  ]
+                },
                 "Message": {}
               }
             }
@@ -1732,9 +2250,21 @@
         }
       }
     },
+    "S4q": {
+      "type": "string",
+      "enum": [
+        "AWAITING_FULFILLMENT",
+        "PROVISIONING",
+        "BOOTSTRAPPING",
+        "RUNNING",
+        "TERMINATED"
+      ]
+    },
     "S5o": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     }
   }
 }

--- a/apis/elastictranscoder-2012-09-25.min.json
+++ b/apis/elastictranscoder-2012-09-25.min.json
@@ -23,6 +23,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -44,7 +45,9 @@
           "PipelineId"
         ],
         "members": {
-          "PipelineId": {},
+          "PipelineId": {
+            "shape": "S2"
+          },
           "Input": {
             "shape": "S5"
           },
@@ -58,16 +61,23 @@
             "type": "list",
             "member": {
               "shape": "Su"
-            }
+            },
+            "max": 30
           },
-          "OutputKeyPrefix": {},
+          "OutputKeyPrefix": {
+            "shape": "Sm"
+          },
           "Playlists": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Format": {},
+                "Name": {
+                  "shape": "S1j"
+                },
+                "Format": {
+                  "shape": "S1k"
+                },
                 "OutputKeys": {
                   "shape": "S1l"
                 },
@@ -78,7 +88,8 @@
                   "shape": "S1q"
                 }
               }
-            }
+            },
+            "max": 30
           },
           "UserMetadata": {
             "shape": "S1v"
@@ -107,11 +118,21 @@
           "Role"
         ],
         "members": {
-          "Name": {},
-          "InputBucket": {},
-          "OutputBucket": {},
-          "Role": {},
-          "AwsKmsKeyArn": {},
+          "Name": {
+            "shape": "So"
+          },
+          "InputBucket": {
+            "shape": "S27"
+          },
+          "OutputBucket": {
+            "shape": "S27"
+          },
+          "Role": {
+            "shape": "S28"
+          },
+          "AwsKmsKeyArn": {
+            "shape": "S29"
+          },
           "Notifications": {
             "shape": "S2a"
           },
@@ -147,9 +168,15 @@
           "Container"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
-          "Container": {},
+          "Name": {
+            "shape": "So"
+          },
+          "Description": {
+            "shape": "S21"
+          },
+          "Container": {
+            "shape": "S2q"
+          },
           "Video": {
             "shape": "S2r"
           },
@@ -184,6 +211,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -207,6 +235,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -229,14 +258,17 @@
         ],
         "members": {
           "PipelineId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "PipelineId"
           },
           "Ascending": {
+            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -248,7 +280,9 @@
           "Jobs": {
             "shape": "S3v"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -264,14 +298,17 @@
         ],
         "members": {
           "Status": {
+            "shape": "S20",
             "location": "uri",
             "locationName": "Status"
           },
           "Ascending": {
+            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -283,7 +320,9 @@
           "Jobs": {
             "shape": "S3v"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -296,10 +335,12 @@
         "type": "structure",
         "members": {
           "Ascending": {
+            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -314,7 +355,9 @@
               "shape": "S2l"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -327,10 +370,12 @@
         "type": "structure",
         "members": {
           "Ascending": {
+            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -345,7 +390,9 @@
               "shape": "S3m"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -361,6 +408,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -387,6 +435,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -416,6 +465,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -444,12 +494,21 @@
           "Topics"
         ],
         "members": {
-          "Role": {},
-          "InputBucket": {},
-          "OutputBucket": {},
+          "Role": {
+            "shape": "S28"
+          },
+          "InputBucket": {
+            "shape": "S27"
+          },
+          "OutputBucket": {
+            "shape": "S27"
+          },
           "Topics": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2b"
+            },
+            "max": 30
           }
         },
         "deprecated": true
@@ -457,7 +516,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "Success": {},
+          "Success": {
+            "type": "string",
+            "pattern": "(^true$)|(^false$)"
+          },
           "Messages": {
             "type": "list",
             "member": {}
@@ -480,13 +542,22 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Name": {},
-          "InputBucket": {},
-          "Role": {},
-          "AwsKmsKeyArn": {},
+          "Name": {
+            "shape": "So"
+          },
+          "InputBucket": {
+            "shape": "S27"
+          },
+          "Role": {
+            "shape": "S28"
+          },
+          "AwsKmsKeyArn": {
+            "shape": "S29"
+          },
           "Notifications": {
             "shape": "S2a"
           },
@@ -522,6 +593,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -551,10 +623,13 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Status": {}
+          "Status": {
+            "shape": "S2m"
+          }
         }
       },
       "output": {
@@ -568,15 +643,33 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "^\\d{13}-\\w{6}$"
+    },
     "S5": {
       "type": "structure",
       "members": {
-        "Key": {},
-        "FrameRate": {},
-        "Resolution": {},
-        "AspectRatio": {},
-        "Interlaced": {},
-        "Container": {},
+        "Key": {
+          "shape": "S6"
+        },
+        "FrameRate": {
+          "shape": "S7"
+        },
+        "Resolution": {
+          "shape": "S8"
+        },
+        "AspectRatio": {
+          "shape": "S9"
+        },
+        "Interlaced": {
+          "type": "string",
+          "pattern": "(^auto$)|(^true$)|(^false$)"
+        },
+        "Container": {
+          "type": "string",
+          "pattern": "(^auto$)|(^3gp$)|(^asf$)|(^avi$)|(^divx$)|(^flv$)|(^mkv$)|(^mov$)|(^mp4$)|(^mpeg$)|(^mpeg-ps$)|(^mpeg-ts$)|(^mxf$)|(^ogg$)|(^ts$)|(^vob$)|(^wav$)|(^webm$)|(^mp3$)|(^m4a$)|(^aac$)"
+        },
         "Encryption": {
           "shape": "Sc"
         },
@@ -586,7 +679,9 @@
         "InputCaptions": {
           "type": "structure",
           "members": {
-            "MergePolicy": {},
+            "MergePolicy": {
+              "shape": "Sj"
+            },
             "CaptionSources": {
               "shape": "Sk"
             }
@@ -601,7 +696,9 @@
             "Height": {
               "type": "integer"
             },
-            "FrameRate": {},
+            "FrameRate": {
+              "shape": "Sr"
+            },
             "FileSize": {
               "type": "long"
             },
@@ -612,54 +709,136 @@
         }
       }
     },
+    "S6": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "pattern": "(^auto$)|(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
+    },
+    "S8": {
+      "type": "string",
+      "pattern": "(^auto$)|(^\\d{1,5}x\\d{1,5}$)"
+    },
+    "S9": {
+      "type": "string",
+      "pattern": "(^auto$)|(^1:1$)|(^4:3$)|(^3:2$)|(^16:9$)"
+    },
     "Sc": {
       "type": "structure",
       "members": {
-        "Mode": {},
-        "Key": {},
-        "KeyMd5": {},
-        "InitializationVector": {}
+        "Mode": {
+          "type": "string",
+          "pattern": "(^s3$)|(^s3-aws-kms$)|(^aes-cbc-pkcs7$)|(^aes-ctr$)|(^aes-gcm$)"
+        },
+        "Key": {
+          "shape": "Se"
+        },
+        "KeyMd5": {
+          "shape": "Se"
+        },
+        "InitializationVector": {
+          "shape": "Sf"
+        }
       }
+    },
+    "Se": {
+      "type": "string",
+      "pattern": "^$|(^(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}==|[A-Za-z0-9\\+/]{3}=)?$)"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 255,
+      "min": 0
     },
     "Sg": {
       "type": "structure",
       "members": {
-        "StartTime": {},
-        "Duration": {}
+        "StartTime": {
+          "shape": "Sh"
+        },
+        "Duration": {
+          "shape": "Sh"
+        }
       }
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "(^\\d{1,5}(\\.\\d{0,3})?$)|(^([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\\.\\d{0,3})?$)"
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "(^MergeOverride$)|(^MergeRetain$)|(^Override$)"
     },
     "Sk": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Language": {},
-          "TimeOffset": {},
-          "Label": {},
+          "Key": {
+            "shape": "S6"
+          },
+          "Language": {
+            "shape": "Sm"
+          },
+          "TimeOffset": {
+            "type": "string",
+            "pattern": "(^[+-]?\\d{1,5}(\\.\\d{0,3})?$)|(^[+-]?([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\\.\\d{0,3})?$)"
+          },
+          "Label": {
+            "shape": "So"
+          },
           "Encryption": {
             "shape": "Sc"
           }
         }
-      }
+      },
+      "max": 20
+    },
+    "Sm": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "So": {
+      "type": "string",
+      "max": 40,
+      "min": 1
+    },
+    "Sr": {
+      "type": "string",
+      "pattern": "^\\d{1,5}(\\.\\d{0,5})?$"
     },
     "St": {
       "type": "list",
       "member": {
         "shape": "S5"
-      }
+      },
+      "max": 200
     },
     "Su": {
       "type": "structure",
       "members": {
-        "Key": {},
-        "ThumbnailPattern": {},
+        "Key": {
+          "shape": "Sm"
+        },
+        "ThumbnailPattern": {
+          "shape": "Sv"
+        },
         "ThumbnailEncryption": {
           "shape": "Sc"
         },
-        "Rotate": {},
-        "PresetId": {},
-        "SegmentDuration": {},
+        "Rotate": {
+          "shape": "Sw"
+        },
+        "PresetId": {
+          "shape": "S2"
+        },
+        "SegmentDuration": {
+          "shape": "Sr"
+        },
         "Watermarks": {
           "shape": "Sx"
         },
@@ -678,34 +857,72 @@
         }
       }
     },
+    "Sv": {
+      "type": "string",
+      "pattern": "(^$)|(^.*\\{count\\}.*$)"
+    },
+    "Sw": {
+      "type": "string",
+      "pattern": "(^auto$)|(^0$)|(^90$)|(^180$)|(^270$)"
+    },
     "Sx": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "PresetWatermarkId": {},
-          "InputKey": {},
+          "PresetWatermarkId": {
+            "shape": "Sz"
+          },
+          "InputKey": {
+            "shape": "S10"
+          },
           "Encryption": {
             "shape": "Sc"
           }
         }
       }
     },
+    "Sz": {
+      "type": "string",
+      "max": 40,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "(^.{1,1020}.jpg$)|(^.{1,1019}.jpeg$)|(^.{1,1020}.png$)"
+    },
     "S11": {
       "type": "structure",
       "members": {
-        "MergePolicy": {},
+        "MergePolicy": {
+          "type": "string",
+          "pattern": "(^Replace$)|(^Prepend$)|(^Append$)|(^Fallback$)"
+        },
         "Artwork": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "InputKey": {},
-              "MaxWidth": {},
-              "MaxHeight": {},
-              "SizingPolicy": {},
-              "PaddingPolicy": {},
-              "AlbumArtFormat": {},
+              "InputKey": {
+                "shape": "S10"
+              },
+              "MaxWidth": {
+                "shape": "S15"
+              },
+              "MaxHeight": {
+                "shape": "S15"
+              },
+              "SizingPolicy": {
+                "shape": "S16"
+              },
+              "PaddingPolicy": {
+                "shape": "S17"
+              },
+              "AlbumArtFormat": {
+                "shape": "S18"
+              },
               "Encryption": {
                 "shape": "Sc"
               }
@@ -713,6 +930,22 @@
           }
         }
       }
+    },
+    "S15": {
+      "type": "string",
+      "pattern": "(^auto$)|(^\\d{2,4}$)"
+    },
+    "S16": {
+      "type": "string",
+      "pattern": "(^Fit$)|(^Fill$)|(^Stretch$)|(^Keep$)|(^ShrinkToFit$)|(^ShrinkToFill$)"
+    },
+    "S17": {
+      "type": "string",
+      "pattern": "(^Pad$)|(^NoPad$)"
+    },
+    "S18": {
+      "type": "string",
+      "pattern": "(^jpg$)|(^png$)"
     },
     "S19": {
       "type": "list",
@@ -731,6 +964,7 @@
       "type": "structure",
       "members": {
         "MergePolicy": {
+          "shape": "Sj",
           "deprecated": true
         },
         "CaptionSources": {
@@ -742,41 +976,96 @@
           "member": {
             "type": "structure",
             "members": {
-              "Format": {},
-              "Pattern": {},
+              "Format": {
+                "type": "string",
+                "pattern": "(^mov-text$)|(^srt$)|(^scc$)|(^webvtt$)|(^dfxp$)|(^cea-708$)"
+              },
+              "Pattern": {
+                "type": "string",
+                "pattern": "(^$)|(^.*\\{language\\}.*$)"
+              },
               "Encryption": {
                 "shape": "Sc"
               }
             }
-          }
+          },
+          "max": 4
         }
       }
     },
+    "S1j": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S1k": {
+      "type": "string",
+      "pattern": "(^HLSv3$)|(^HLSv4$)|(^Smooth$)|(^MPEG-DASH$)"
+    },
     "S1l": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sm"
+      },
+      "max": 30
     },
     "S1m": {
       "type": "structure",
       "members": {
-        "Method": {},
-        "Key": {},
-        "KeyMd5": {},
-        "InitializationVector": {},
-        "LicenseAcquisitionUrl": {},
-        "KeyStoragePolicy": {}
+        "Method": {
+          "type": "string",
+          "pattern": "(^aes-128$)"
+        },
+        "Key": {
+          "shape": "Se"
+        },
+        "KeyMd5": {
+          "shape": "Se"
+        },
+        "InitializationVector": {
+          "shape": "Sf"
+        },
+        "LicenseAcquisitionUrl": {
+          "type": "string",
+          "max": 512,
+          "min": 0
+        },
+        "KeyStoragePolicy": {
+          "type": "string",
+          "pattern": "(^NoStore$)|(^WithVariantPlaylists$)"
+        }
       }
     },
     "S1q": {
       "type": "structure",
       "members": {
-        "Format": {},
-        "Key": {},
-        "KeyMd5": {},
-        "KeyId": {},
-        "InitializationVector": {},
-        "LicenseAcquisitionUrl": {}
+        "Format": {
+          "type": "string",
+          "pattern": "(^microsoft$)|(^discretix-3.0$)"
+        },
+        "Key": {
+          "shape": "S1s"
+        },
+        "KeyMd5": {
+          "shape": "S1s"
+        },
+        "KeyId": {
+          "type": "string",
+          "pattern": "(^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$)|(^[0-9A-Fa-f]{32}$)"
+        },
+        "InitializationVector": {
+          "shape": "Sf"
+        },
+        "LicenseAcquisitionUrl": {
+          "type": "string",
+          "max": 512,
+          "min": 1
+        }
       }
+    },
+    "S1s": {
+      "type": "string",
+      "pattern": "(^(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}==|[A-Za-z0-9\\+/]{3}=)?$)"
     },
     "S1v": {
       "type": "map",
@@ -786,9 +1075,13 @@
     "S1y": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S2"
+        },
         "Arn": {},
-        "PipelineId": {},
+        "PipelineId": {
+          "shape": "S2"
+        },
         "Input": {
           "shape": "S5"
         },
@@ -804,14 +1097,20 @@
             "shape": "S1z"
           }
         },
-        "OutputKeyPrefix": {},
+        "OutputKeyPrefix": {
+          "shape": "Sm"
+        },
         "Playlists": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "Format": {},
+              "Name": {
+                "shape": "S1j"
+              },
+              "Format": {
+                "shape": "S1k"
+              },
               "OutputKeys": {
                 "shape": "S1l"
               },
@@ -821,12 +1120,18 @@
               "PlayReadyDrm": {
                 "shape": "S1q"
               },
-              "Status": {},
-              "StatusDetail": {}
+              "Status": {
+                "shape": "S20"
+              },
+              "StatusDetail": {
+                "shape": "S21"
+              }
             }
           }
         },
-        "Status": {},
+        "Status": {
+          "shape": "S20"
+        },
         "UserMetadata": {
           "shape": "S1v"
         },
@@ -850,16 +1155,30 @@
       "type": "structure",
       "members": {
         "Id": {},
-        "Key": {},
-        "ThumbnailPattern": {},
+        "Key": {
+          "shape": "Sm"
+        },
+        "ThumbnailPattern": {
+          "shape": "Sv"
+        },
         "ThumbnailEncryption": {
           "shape": "Sc"
         },
-        "Rotate": {},
-        "PresetId": {},
-        "SegmentDuration": {},
-        "Status": {},
-        "StatusDetail": {},
+        "Rotate": {
+          "shape": "Sw"
+        },
+        "PresetId": {
+          "shape": "S2"
+        },
+        "SegmentDuration": {
+          "shape": "Sr"
+        },
+        "Status": {
+          "shape": "S20"
+        },
+        "StatusDetail": {
+          "shape": "S21"
+        },
         "Duration": {
           "type": "long"
         },
@@ -869,7 +1188,9 @@
         "Height": {
           "type": "integer"
         },
-        "FrameRate": {},
+        "FrameRate": {
+          "shape": "Sr"
+        },
         "FileSize": {
           "type": "long"
         },
@@ -895,47 +1216,112 @@
         "AppliedColorSpaceConversion": {}
       }
     },
+    "S20": {
+      "type": "string",
+      "pattern": "(^Submitted$)|(^Progressing$)|(^Complete$)|(^Canceled$)|(^Error$)"
+    },
+    "S21": {
+      "type": "string",
+      "max": 255,
+      "min": 0
+    },
+    "S27": {
+      "type": "string",
+      "pattern": "^(\\w|\\.|-){1,255}$"
+    },
+    "S28": {
+      "type": "string",
+      "pattern": "^arn:aws:iam::\\w{12}:role/.+$"
+    },
+    "S29": {
+      "type": "string",
+      "max": 255,
+      "min": 0
+    },
     "S2a": {
       "type": "structure",
       "members": {
-        "Progressing": {},
-        "Completed": {},
-        "Warning": {},
-        "Error": {}
+        "Progressing": {
+          "shape": "S2b"
+        },
+        "Completed": {
+          "shape": "S2b"
+        },
+        "Warning": {
+          "shape": "S2b"
+        },
+        "Error": {
+          "shape": "S2b"
+        }
       }
+    },
+    "S2b": {
+      "type": "string",
+      "pattern": "(^$)|(^arn:aws:sns:.*:\\w{12}:.+$)"
     },
     "S2c": {
       "type": "structure",
       "members": {
-        "Bucket": {},
-        "StorageClass": {},
+        "Bucket": {
+          "shape": "S27"
+        },
+        "StorageClass": {
+          "type": "string",
+          "pattern": "(^ReducedRedundancy$)|(^Standard$)"
+        },
         "Permissions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "GranteeType": {},
-              "Grantee": {},
+              "GranteeType": {
+                "type": "string",
+                "pattern": "(^Canonical$)|(^Email$)|(^Group$)"
+              },
+              "Grantee": {
+                "type": "string",
+                "max": 255,
+                "min": 1
+              },
               "Access": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "type": "string",
+                  "pattern": "(^FullControl$)|(^Read$)|(^ReadAcp$)|(^WriteAcp$)"
+                },
+                "max": 30
               }
             }
-          }
+          },
+          "max": 30
         }
       }
     },
     "S2l": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S2"
+        },
         "Arn": {},
-        "Name": {},
-        "Status": {},
-        "InputBucket": {},
-        "OutputBucket": {},
-        "Role": {},
-        "AwsKmsKeyArn": {},
+        "Name": {
+          "shape": "So"
+        },
+        "Status": {
+          "shape": "S2m"
+        },
+        "InputBucket": {
+          "shape": "S27"
+        },
+        "OutputBucket": {
+          "shape": "S27"
+        },
+        "Role": {
+          "shape": "S28"
+        },
+        "AwsKmsKeyArn": {
+          "shape": "S29"
+        },
         "Notifications": {
           "shape": "S2a"
         },
@@ -947,6 +1333,10 @@
         }
       }
     },
+    "S2m": {
+      "type": "string",
+      "pattern": "(^Active$)|(^Paused$)"
+    },
     "S2n": {
       "type": "list",
       "member": {
@@ -957,62 +1347,163 @@
         }
       }
     },
+    "S2q": {
+      "type": "string",
+      "pattern": "(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)|(^wav$)|(^mp2$)"
+    },
     "S2r": {
       "type": "structure",
       "members": {
-        "Codec": {},
+        "Codec": {
+          "type": "string",
+          "pattern": "(^H\\.264$)|(^vp8$)|(^vp9$)|(^mpeg2$)|(^gif$)"
+        },
         "CodecOptions": {
           "type": "map",
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "S2u"
+          },
+          "value": {
+            "shape": "S2u"
+          },
+          "max": 30
         },
-        "KeyframesMaxDist": {},
-        "FixedGOP": {},
-        "BitRate": {},
-        "FrameRate": {},
-        "MaxFrameRate": {},
-        "Resolution": {},
-        "AspectRatio": {},
-        "MaxWidth": {},
-        "MaxHeight": {},
-        "DisplayAspectRatio": {},
-        "SizingPolicy": {},
-        "PaddingPolicy": {},
+        "KeyframesMaxDist": {
+          "type": "string",
+          "pattern": "^\\d{1,6}$"
+        },
+        "FixedGOP": {
+          "type": "string",
+          "pattern": "(^true$)|(^false$)"
+        },
+        "BitRate": {
+          "type": "string",
+          "pattern": "(^\\d{2,5}$)|(^auto$)"
+        },
+        "FrameRate": {
+          "shape": "S7"
+        },
+        "MaxFrameRate": {
+          "type": "string",
+          "pattern": "(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
+        },
+        "Resolution": {
+          "shape": "S8"
+        },
+        "AspectRatio": {
+          "shape": "S9"
+        },
+        "MaxWidth": {
+          "shape": "S15"
+        },
+        "MaxHeight": {
+          "shape": "S15"
+        },
+        "DisplayAspectRatio": {
+          "shape": "S9"
+        },
+        "SizingPolicy": {
+          "shape": "S16"
+        },
+        "PaddingPolicy": {
+          "shape": "S17"
+        },
         "Watermarks": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Id": {},
-              "MaxWidth": {},
-              "MaxHeight": {},
-              "SizingPolicy": {},
-              "HorizontalAlign": {},
-              "HorizontalOffset": {},
-              "VerticalAlign": {},
-              "VerticalOffset": {},
-              "Opacity": {},
-              "Target": {}
+              "Id": {
+                "shape": "Sz"
+              },
+              "MaxWidth": {
+                "shape": "S31"
+              },
+              "MaxHeight": {
+                "shape": "S31"
+              },
+              "SizingPolicy": {
+                "type": "string",
+                "pattern": "(^Fit$)|(^Stretch$)|(^ShrinkToFit$)"
+              },
+              "HorizontalAlign": {
+                "type": "string",
+                "pattern": "(^Left$)|(^Right$)|(^Center$)"
+              },
+              "HorizontalOffset": {
+                "shape": "S31"
+              },
+              "VerticalAlign": {
+                "type": "string",
+                "pattern": "(^Top$)|(^Bottom$)|(^Center$)"
+              },
+              "VerticalOffset": {
+                "shape": "S31"
+              },
+              "Opacity": {
+                "type": "string",
+                "pattern": "^\\d{1,3}(\\.\\d{0,20})?$"
+              },
+              "Target": {
+                "type": "string",
+                "pattern": "(^Content$)|(^Frame$)"
+              }
             }
           }
         }
       }
     },
+    "S2u": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S31": {
+      "type": "string",
+      "pattern": "(^\\d{1,3}(\\.\\d{0,5})?%$)|(^\\d{1,4}?px$)"
+    },
     "S37": {
       "type": "structure",
       "members": {
-        "Codec": {},
-        "SampleRate": {},
-        "BitRate": {},
-        "Channels": {},
-        "AudioPackingMode": {},
+        "Codec": {
+          "type": "string",
+          "pattern": "(^AAC$)|(^vorbis$)|(^mp3$)|(^mp2$)|(^pcm$)|(^flac$)"
+        },
+        "SampleRate": {
+          "type": "string",
+          "pattern": "(^auto$)|(^22050$)|(^32000$)|(^44100$)|(^48000$)|(^96000$)|(^192000$)"
+        },
+        "BitRate": {
+          "type": "string",
+          "pattern": "^\\d{1,3}$"
+        },
+        "Channels": {
+          "type": "string",
+          "pattern": "(^auto$)|(^0$)|(^1$)|(^2$)"
+        },
+        "AudioPackingMode": {
+          "type": "string",
+          "pattern": "(^SingleTrack$)|(^OneChannelPerTrack$)|(^OneChannelPerTrackWithMosTo8Tracks$)"
+        },
         "CodecOptions": {
           "type": "structure",
           "members": {
-            "Profile": {},
-            "BitDepth": {},
-            "BitOrder": {},
-            "Signed": {}
+            "Profile": {
+              "type": "string",
+              "pattern": "(^auto$)|(^AAC-LC$)|(^HE-AAC$)|(^HE-AACv2$)"
+            },
+            "BitDepth": {
+              "type": "string",
+              "pattern": "(^8$)|(^16$)|(^24$)|(^32$)"
+            },
+            "BitOrder": {
+              "type": "string",
+              "pattern": "(^LittleEndian$)"
+            },
+            "Signed": {
+              "type": "string",
+              "pattern": "(^Unsigned$)|(^Signed$)"
+            }
           }
         }
       }
@@ -1020,24 +1511,50 @@
     "S3i": {
       "type": "structure",
       "members": {
-        "Format": {},
-        "Interval": {},
-        "Resolution": {},
-        "AspectRatio": {},
-        "MaxWidth": {},
-        "MaxHeight": {},
-        "SizingPolicy": {},
-        "PaddingPolicy": {}
+        "Format": {
+          "shape": "S18"
+        },
+        "Interval": {
+          "type": "string",
+          "pattern": "^\\d{1,5}$"
+        },
+        "Resolution": {
+          "type": "string",
+          "pattern": "^\\d{1,5}x\\d{1,5}$"
+        },
+        "AspectRatio": {
+          "shape": "S9"
+        },
+        "MaxWidth": {
+          "shape": "S15"
+        },
+        "MaxHeight": {
+          "shape": "S15"
+        },
+        "SizingPolicy": {
+          "shape": "S16"
+        },
+        "PaddingPolicy": {
+          "shape": "S17"
+        }
       }
     },
     "S3m": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S2"
+        },
         "Arn": {},
-        "Name": {},
-        "Description": {},
-        "Container": {},
+        "Name": {
+          "shape": "So"
+        },
+        "Description": {
+          "shape": "S21"
+        },
+        "Container": {
+          "shape": "S2q"
+        },
         "Audio": {
           "shape": "S37"
         },
@@ -1047,8 +1564,15 @@
         "Thumbnails": {
           "shape": "S3i"
         },
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "pattern": "(^System$)|(^Custom$)"
+        }
       }
+    },
+    "S3t": {
+      "type": "string",
+      "pattern": "(^true$)|(^false$)"
     },
     "S3v": {
       "type": "list",

--- a/apis/email-2010-12-01.min.json
+++ b/apis/email-2010-12-01.min.json
@@ -269,7 +269,9 @@
         ],
         "members": {
           "Identity": {},
-          "PolicyName": {}
+          "PolicyName": {
+            "shape": "S2g"
+          }
         }
       },
       "output": {
@@ -383,7 +385,14 @@
           "ConfigurationSetName": {},
           "ConfigurationSetAttributeNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "eventDestinations",
+                "trackingOptions",
+                "reputationOptions"
+              ]
+            }
           }
         }
       },
@@ -531,7 +540,9 @@
                 "DkimEnabled": {
                   "type": "boolean"
                 },
-                "DkimVerificationStatus": {},
+                "DkimVerificationStatus": {
+                  "shape": "S3f"
+                },
                 "DkimTokens": {
                   "shape": "S3g"
                 }
@@ -572,8 +583,18 @@
               ],
               "members": {
                 "MailFromDomain": {},
-                "MailFromDomainStatus": {},
-                "BehaviorOnMXFailure": {}
+                "MailFromDomainStatus": {
+                  "type": "string",
+                  "enum": [
+                    "Pending",
+                    "Success",
+                    "Failed",
+                    "TemporaryFailure"
+                  ]
+                },
+                "BehaviorOnMXFailure": {
+                  "shape": "S3o"
+                }
               }
             }
           }
@@ -655,8 +676,12 @@
         "members": {
           "Policies": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S2g"
+            },
+            "value": {
+              "shape": "S3y"
+            }
           }
         }
       }
@@ -689,7 +714,9 @@
                 "VerificationStatus"
               ],
               "members": {
-                "VerificationStatus": {},
+                "VerificationStatus": {
+                  "shape": "S3f"
+                },
                 "VerificationToken": {}
               }
             }
@@ -795,7 +822,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -824,7 +853,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "IdentityType": {},
+          "IdentityType": {
+            "type": "string",
+            "enum": [
+              "EmailAddress",
+              "Domain"
+            ]
+          },
           "NextToken": {},
           "MaxItems": {
             "type": "integer"
@@ -958,8 +993,12 @@
         ],
         "members": {
           "Identity": {},
-          "PolicyName": {},
-          "Policy": {}
+          "PolicyName": {
+            "shape": "S2g"
+          },
+          "Policy": {
+            "shape": "S3y"
+          }
         }
       },
       "output": {
@@ -1026,7 +1065,17 @@
               "members": {
                 "Recipient": {},
                 "RecipientArn": {},
-                "BounceType": {},
+                "BounceType": {
+                  "type": "string",
+                  "enum": [
+                    "DoesNotExist",
+                    "MessageTooLarge",
+                    "ExceededQuota",
+                    "ContentRejected",
+                    "Undefined",
+                    "TemporaryFailure"
+                  ]
+                },
                 "RecipientDsnFields": {
                   "type": "structure",
                   "required": [
@@ -1035,7 +1084,16 @@
                   ],
                   "members": {
                     "FinalRecipient": {},
-                    "Action": {},
+                    "Action": {
+                      "type": "string",
+                      "enum": [
+                        "failed",
+                        "delayed",
+                        "delivered",
+                        "relayed",
+                        "expanded"
+                      ]
+                    },
                     "RemoteMta": {},
                     "Status": {},
                     "DiagnosticCode": {},
@@ -1083,7 +1141,9 @@
           },
           "Template": {},
           "TemplateArn": {},
-          "DefaultTemplateData": {},
+          "DefaultTemplateData": {
+            "shape": "S5y"
+          },
           "Destinations": {
             "type": "list",
             "member": {
@@ -1098,7 +1158,9 @@
                 "ReplacementTags": {
                   "shape": "S5u"
                 },
-                "ReplacementTemplateData": {}
+                "ReplacementTemplateData": {
+                  "shape": "S5y"
+                }
               }
             }
           }
@@ -1116,7 +1178,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "Status": {},
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Success",
+                    "MessageRejected",
+                    "MailFromDomainNotVerified",
+                    "ConfigurationSetDoesNotExist",
+                    "TemplateDoesNotExist",
+                    "AccountSuspended",
+                    "AccountThrottled",
+                    "AccountDailyQuotaExceeded",
+                    "InvalidSendingPoolName",
+                    "AccountSendingPaused",
+                    "ConfigurationSetSendingPaused",
+                    "InvalidParameterValue",
+                    "TransientFailure",
+                    "Failed"
+                  ]
+                },
                 "Error": {},
                 "MessageId": {}
               }
@@ -1273,7 +1353,9 @@
           "ConfigurationSetName": {},
           "Template": {},
           "TemplateArn": {},
-          "TemplateData": {}
+          "TemplateData": {
+            "shape": "S5y"
+          }
         }
       },
       "output": {
@@ -1350,7 +1432,9 @@
         ],
         "members": {
           "Identity": {},
-          "NotificationType": {},
+          "NotificationType": {
+            "shape": "S6t"
+          },
           "Enabled": {
             "type": "boolean"
           }
@@ -1371,7 +1455,9 @@
         "members": {
           "Identity": {},
           "MailFromDomain": {},
-          "BehaviorOnMXFailure": {}
+          "BehaviorOnMXFailure": {
+            "shape": "S3o"
+          }
         }
       },
       "output": {
@@ -1389,7 +1475,9 @@
         ],
         "members": {
           "Identity": {},
-          "NotificationType": {},
+          "NotificationType": {
+            "shape": "S6t"
+          },
           "SnsTopic": {}
         }
       },
@@ -1427,7 +1515,9 @@
         ],
         "members": {
           "TemplateName": {},
-          "TemplateData": {}
+          "TemplateData": {
+            "shape": "S5y"
+          }
         }
       },
       "output": {
@@ -1667,7 +1757,19 @@
         },
         "MatchingEventTypes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "send",
+              "reject",
+              "bounce",
+              "complaint",
+              "delivery",
+              "open",
+              "click",
+              "renderingFailure"
+            ]
+          }
         },
         "KinesisFirehoseDestination": {
           "type": "structure",
@@ -1697,7 +1799,14 @@
                 ],
                 "members": {
                   "DimensionName": {},
-                  "DimensionValueSource": {},
+                  "DimensionValueSource": {
+                    "type": "string",
+                    "enum": [
+                      "messageTag",
+                      "emailHeader",
+                      "linkTag"
+                    ]
+                  },
                   "DefaultDimensionValue": {}
                 }
               }
@@ -1736,7 +1845,13 @@
             "Cidr"
           ],
           "members": {
-            "Policy": {},
+            "Policy": {
+              "type": "string",
+              "enum": [
+                "Block",
+                "Allow"
+              ]
+            },
             "Cidr": {}
           }
         }
@@ -1752,7 +1867,13 @@
         "Enabled": {
           "type": "boolean"
         },
-        "TlsPolicy": {},
+        "TlsPolicy": {
+          "type": "string",
+          "enum": [
+            "Require",
+            "Optional"
+          ]
+        },
         "Recipients": {
           "type": "list",
           "member": {}
@@ -1807,7 +1928,13 @@
                 "members": {
                   "TopicArn": {},
                   "FunctionArn": {},
-                  "InvocationType": {}
+                  "InvocationType": {
+                    "type": "string",
+                    "enum": [
+                      "Event",
+                      "RequestResponse"
+                    ]
+                  }
                 }
               },
               "StopAction": {
@@ -1816,7 +1943,12 @@
                   "Scope"
                 ],
                 "members": {
-                  "Scope": {},
+                  "Scope": {
+                    "type": "string",
+                    "enum": [
+                      "RuleSet"
+                    ]
+                  },
                   "TopicArn": {}
                 }
               },
@@ -1838,7 +1970,13 @@
                 ],
                 "members": {
                   "TopicArn": {},
-                  "Encoding": {}
+                  "Encoding": {
+                    "type": "string",
+                    "enum": [
+                      "UTF-8",
+                      "Base64"
+                    ]
+                  }
                 }
               }
             }
@@ -1861,6 +1999,11 @@
         "HtmlPart": {}
       }
     },
+    "S2g": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
     "S2t": {
       "type": "structure",
       "members": {
@@ -1880,13 +2023,36 @@
       "type": "list",
       "member": {}
     },
+    "S3f": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "Success",
+        "Failed",
+        "TemporaryFailure",
+        "NotStarted"
+      ]
+    },
     "S3g": {
       "type": "list",
       "member": {}
     },
+    "S3o": {
+      "type": "string",
+      "enum": [
+        "UseDefaultValue",
+        "RejectMessage"
+      ]
+    },
     "S3v": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2g"
+      }
+    },
+    "S3y": {
+      "type": "string",
+      "min": 1
     },
     "S53": {
       "type": "list",
@@ -1920,6 +2086,10 @@
         }
       }
     },
+    "S5y": {
+      "type": "string",
+      "max": 262144
+    },
     "S61": {
       "type": "structure",
       "members": {
@@ -1943,6 +2113,14 @@
         "Data": {},
         "Charset": {}
       }
+    },
+    "S6t": {
+      "type": "string",
+      "enum": [
+        "Bounce",
+        "Complaint",
+        "Delivery"
+      ]
     }
   }
 }

--- a/apis/entitlement.marketplace-2017-01-11.min.json
+++ b/apis/entitlement.marketplace-2017-01-11.min.json
@@ -20,16 +20,27 @@
           "ProductCode"
         ],
         "members": {
-          "ProductCode": {},
+          "ProductCode": {
+            "shape": "S2"
+          },
           "Filter": {
             "type": "map",
-            "key": {},
+            "key": {
+              "type": "string",
+              "enum": [
+                "CUSTOMER_IDENTIFIER",
+                "DIMENSION"
+              ]
+            },
             "value": {
               "type": "list",
-              "member": {}
+              "member": {},
+              "min": 1
             }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S7"
+          },
           "MaxResults": {
             "type": "integer"
           }
@@ -43,9 +54,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProductCode": {},
-                "Dimension": {},
-                "CustomerIdentifier": {},
+                "ProductCode": {
+                  "shape": "S2"
+                },
+                "Dimension": {
+                  "shape": "S7"
+                },
+                "CustomerIdentifier": {
+                  "shape": "S7"
+                },
                 "Value": {
                   "type": "structure",
                   "members": {
@@ -65,12 +82,25 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "min": 0
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S7"
+          }
         }
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "pattern": "\\S+"
+    }
+  }
 }

--- a/apis/es-2015-01-01.min.json
+++ b/apis/es-2015-01-01.min.json
@@ -38,7 +38,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S8"
+          },
           "ElasticsearchVersion": {},
           "ElasticsearchClusterConfig": {
             "shape": "Sa"
@@ -91,6 +93,7 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -123,6 +126,7 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -152,6 +156,7 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -181,7 +186,9 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S8"
+            }
           }
         }
       },
@@ -213,10 +220,12 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           },
           "InstanceType": {
+            "shape": "Sb",
             "location": "uri",
             "locationName": "InstanceType"
           },
@@ -300,13 +309,14 @@
         "type": "structure",
         "members": {
           "ReservedElasticsearchInstanceOfferingId": {
+            "shape": "S2e",
             "location": "querystring",
             "locationName": "offeringId"
           },
           "MaxResults": {
+            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -323,8 +333,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "ReservedElasticsearchInstanceOfferingId": {},
-                "ElasticsearchInstanceType": {},
+                "ReservedElasticsearchInstanceOfferingId": {
+                  "shape": "S2e"
+                },
+                "ElasticsearchInstanceType": {
+                  "shape": "Sb"
+                },
                 "Duration": {
                   "type": "integer"
                 },
@@ -335,7 +349,9 @@
                   "type": "double"
                 },
                 "CurrencyCode": {},
-                "PaymentOption": {},
+                "PaymentOption": {
+                  "shape": "S2m"
+                },
                 "RecurringCharges": {
                   "shape": "S2n"
                 }
@@ -354,13 +370,14 @@
         "type": "structure",
         "members": {
           "ReservedElasticsearchInstanceId": {
+            "shape": "S2e",
             "location": "querystring",
             "locationName": "reservationId"
           },
           "MaxResults": {
+            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -377,10 +394,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "ReservationName": {},
-                "ReservedElasticsearchInstanceId": {},
+                "ReservationName": {
+                  "shape": "S2t"
+                },
+                "ReservedElasticsearchInstanceId": {
+                  "shape": "S2e"
+                },
                 "ReservedElasticsearchInstanceOfferingId": {},
-                "ElasticsearchInstanceType": {},
+                "ElasticsearchInstanceType": {
+                  "shape": "Sb"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -398,7 +421,9 @@
                   "type": "integer"
                 },
                 "State": {},
-                "PaymentOption": {},
+                "PaymentOption": {
+                  "shape": "S2m"
+                },
                 "RecurringCharges": {
                   "shape": "S2n"
                 }
@@ -417,6 +442,7 @@
         "type": "structure",
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           }
@@ -452,13 +478,14 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           },
           "MaxResults": {
+            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -478,14 +505,20 @@
                 "StartTimestamp": {
                   "type": "timestamp"
                 },
-                "UpgradeStatus": {},
+                "UpgradeStatus": {
+                  "shape": "S35"
+                },
                 "StepsList": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "UpgradeStep": {},
-                      "UpgradeStepStatus": {},
+                      "UpgradeStep": {
+                        "shape": "S38"
+                      },
+                      "UpgradeStepStatus": {
+                        "shape": "S35"
+                      },
                       "Issues": {
                         "type": "list",
                         "member": {}
@@ -515,6 +548,7 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -523,8 +557,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "UpgradeStep": {},
-          "StepStatus": {},
+          "UpgradeStep": {
+            "shape": "S38"
+          },
+          "StepStatus": {
+            "shape": "S35"
+          },
           "UpgradeName": {}
         }
       }
@@ -542,7 +580,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {}
+                "DomainName": {
+                  "shape": "S8"
+                }
               }
             }
           }
@@ -565,13 +605,14 @@
             "locationName": "ElasticsearchVersion"
           },
           "DomainName": {
+            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           },
           "MaxResults": {
+            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -584,7 +625,9 @@
         "members": {
           "ElasticsearchInstanceTypes": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sb"
+            }
           },
           "NextToken": {}
         }
@@ -599,9 +642,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -656,18 +699,27 @@
           "ReservationName"
         ],
         "members": {
-          "ReservedElasticsearchInstanceOfferingId": {},
-          "ReservationName": {},
+          "ReservedElasticsearchInstanceOfferingId": {
+            "shape": "S2e"
+          },
+          "ReservationName": {
+            "shape": "S2t"
+          },
           "InstanceCount": {
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ReservedElasticsearchInstanceId": {},
-          "ReservationName": {}
+          "ReservedElasticsearchInstanceId": {
+            "shape": "S2e"
+          },
+          "ReservationName": {
+            "shape": "S2t"
+          }
         }
       }
     },
@@ -700,6 +752,7 @@
         ],
         "members": {
           "DomainName": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           },
@@ -750,7 +803,9 @@
           "TargetVersion"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S8"
+          },
           "TargetVersion": {},
           "PerformCheckOnly": {
             "type": "boolean"
@@ -760,7 +815,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S8"
+          },
           "TargetVersion": {},
           "PerformCheckOnly": {
             "type": "boolean"
@@ -779,15 +836,31 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+          }
         }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 28,
+      "min": 3,
+      "pattern": "[a-z][a-z0-9\\-]+"
     },
     "Sa": {
       "type": "structure",
       "members": {
-        "InstanceType": {},
+        "InstanceType": {
+          "shape": "Sb"
+        },
         "InstanceCount": {
           "type": "integer"
         },
@@ -797,11 +870,58 @@
         "ZoneAwarenessEnabled": {
           "type": "boolean"
         },
-        "DedicatedMasterType": {},
+        "DedicatedMasterType": {
+          "shape": "Sb"
+        },
         "DedicatedMasterCount": {
           "type": "integer"
         }
       }
+    },
+    "Sb": {
+      "type": "string",
+      "enum": [
+        "m3.medium.elasticsearch",
+        "m3.large.elasticsearch",
+        "m3.xlarge.elasticsearch",
+        "m3.2xlarge.elasticsearch",
+        "m4.large.elasticsearch",
+        "m4.xlarge.elasticsearch",
+        "m4.2xlarge.elasticsearch",
+        "m4.4xlarge.elasticsearch",
+        "m4.10xlarge.elasticsearch",
+        "t2.micro.elasticsearch",
+        "t2.small.elasticsearch",
+        "t2.medium.elasticsearch",
+        "r3.large.elasticsearch",
+        "r3.xlarge.elasticsearch",
+        "r3.2xlarge.elasticsearch",
+        "r3.4xlarge.elasticsearch",
+        "r3.8xlarge.elasticsearch",
+        "i2.xlarge.elasticsearch",
+        "i2.2xlarge.elasticsearch",
+        "d2.xlarge.elasticsearch",
+        "d2.2xlarge.elasticsearch",
+        "d2.4xlarge.elasticsearch",
+        "d2.8xlarge.elasticsearch",
+        "c4.large.elasticsearch",
+        "c4.xlarge.elasticsearch",
+        "c4.2xlarge.elasticsearch",
+        "c4.4xlarge.elasticsearch",
+        "c4.8xlarge.elasticsearch",
+        "r4.large.elasticsearch",
+        "r4.xlarge.elasticsearch",
+        "r4.2xlarge.elasticsearch",
+        "r4.4xlarge.elasticsearch",
+        "r4.8xlarge.elasticsearch",
+        "r4.16xlarge.elasticsearch",
+        "i3.large.elasticsearch",
+        "i3.xlarge.elasticsearch",
+        "i3.2xlarge.elasticsearch",
+        "i3.4xlarge.elasticsearch",
+        "i3.8xlarge.elasticsearch",
+        "i3.16xlarge.elasticsearch"
+      ]
     },
     "Se": {
       "type": "structure",
@@ -809,7 +929,14 @@
         "EBSEnabled": {
           "type": "boolean"
         },
-        "VolumeType": {},
+        "VolumeType": {
+          "type": "string",
+          "enum": [
+            "standard",
+            "gp2",
+            "io1"
+          ]
+        },
         "VolumeSize": {
           "type": "integer"
         },
@@ -847,9 +974,23 @@
         "Enabled": {
           "type": "boolean"
         },
-        "UserPoolId": {},
-        "IdentityPoolId": {},
-        "RoleArn": {}
+        "UserPoolId": {
+          "type": "string",
+          "max": 55,
+          "min": 1,
+          "pattern": "[\\w-]+_[0-9a-zA-Z]+"
+        },
+        "IdentityPoolId": {
+          "type": "string",
+          "max": 55,
+          "min": 1,
+          "pattern": "[\\w-]+:[0-9a-f-]+"
+        },
+        "RoleArn": {
+          "type": "string",
+          "max": 2048,
+          "min": 20
+        }
       }
     },
     "Sp": {
@@ -858,7 +999,11 @@
         "Enabled": {
           "type": "boolean"
         },
-        "KmsKeyId": {}
+        "KmsKeyId": {
+          "type": "string",
+          "max": 500,
+          "min": 1
+        }
       }
     },
     "Sr": {
@@ -876,7 +1021,14 @@
     },
     "St": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "INDEX_SLOW_LOGS",
+          "SEARCH_SLOW_LOGS",
+          "ES_APPLICATION_LOGS"
+        ]
+      },
       "value": {
         "type": "structure",
         "members": {
@@ -896,8 +1048,14 @@
         "ElasticsearchClusterConfig"
       ],
       "members": {
-        "DomainId": {},
-        "DomainName": {},
+        "DomainId": {
+          "type": "string",
+          "max": 64,
+          "min": 1
+        },
+        "DomainName": {
+          "shape": "S8"
+        },
         "ARN": {},
         "Created": {
           "type": "boolean"
@@ -1140,9 +1298,17 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "type": "integer"
+          "type": "integer",
+          "min": 0
         },
-        "State": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "RequiresIndexDocuments",
+            "Processing",
+            "Active"
+          ]
+        },
         "PendingDeletion": {
           "type": "boolean"
         }
@@ -1151,6 +1317,22 @@
     "S25": {
       "type": "list",
       "member": {}
+    },
+    "S2e": {
+      "type": "string",
+      "pattern": "\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}"
+    },
+    "S2f": {
+      "type": "integer",
+      "max": 100
+    },
+    "S2m": {
+      "type": "string",
+      "enum": [
+        "ALL_UPFRONT",
+        "PARTIAL_UPFRONT",
+        "NO_UPFRONT"
+      ]
     },
     "S2n": {
       "type": "list",
@@ -1164,9 +1346,31 @@
         }
       }
     },
+    "S2t": {
+      "type": "string",
+      "max": 64,
+      "min": 5
+    },
     "S2y": {
       "type": "list",
       "member": {}
+    },
+    "S35": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "SUCCEEDED",
+        "SUCCEEDED_WITH_ISSUES",
+        "FAILED"
+      ]
+    },
+    "S38": {
+      "type": "string",
+      "enum": [
+        "PRE_UPGRADE_CHECK",
+        "SNAPSHOT",
+        "UPGRADE"
+      ]
     }
   }
 }

--- a/apis/events-2015-10-07.min.json
+++ b/apis/events-2015-10-07.min.json
@@ -19,7 +19,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -44,19 +46,33 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "Arn": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "Arn": {
+            "shape": "S8"
+          },
           "EventPattern": {},
-          "ScheduleExpression": {},
-          "State": {},
-          "Description": {},
-          "RoleArn": {}
+          "ScheduleExpression": {
+            "shape": "Sa"
+          },
+          "State": {
+            "shape": "Sb"
+          },
+          "Description": {
+            "shape": "Sc"
+          },
+          "RoleArn": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -67,7 +83,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -78,7 +96,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -89,10 +109,14 @@
           "TargetArn"
         ],
         "members": {
-          "TargetArn": {},
-          "NextToken": {},
+          "TargetArn": {
+            "shape": "Sh"
+          },
+          "NextToken": {
+            "shape": "Si"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "Sj"
           }
         }
       },
@@ -101,9 +125,13 @@
         "members": {
           "RuleNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -111,10 +139,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "NamePrefix": {},
-          "NextToken": {},
+          "NamePrefix": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "Si"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "Sj"
           }
         }
       },
@@ -126,17 +158,31 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Arn": {},
+                "Name": {
+                  "shape": "S2"
+                },
+                "Arn": {
+                  "shape": "S8"
+                },
                 "EventPattern": {},
-                "State": {},
-                "Description": {},
-                "ScheduleExpression": {},
-                "RoleArn": {}
+                "State": {
+                  "shape": "Sb"
+                },
+                "Description": {
+                  "shape": "Sc"
+                },
+                "ScheduleExpression": {
+                  "shape": "Sa"
+                },
+                "RoleArn": {
+                  "shape": "Sd"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -147,10 +193,14 @@
           "Rule"
         ],
         "members": {
-          "Rule": {},
-          "NextToken": {},
+          "Rule": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "Si"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "Sj"
           }
         }
       },
@@ -160,7 +210,9 @@
           "Targets": {
             "shape": "Ss"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -187,7 +239,9 @@
                 "DetailType": {},
                 "Detail": {}
               }
-            }
+            },
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -220,9 +274,21 @@
           "StatementId"
         ],
         "members": {
-          "Action": {},
-          "Principal": {},
-          "StatementId": {}
+          "Action": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "events:[a-zA-Z]+"
+          },
+          "Principal": {
+            "type": "string",
+            "max": 12,
+            "min": 1,
+            "pattern": "(\\d{12}|\\*)"
+          },
+          "StatementId": {
+            "shape": "S22"
+          }
         }
       }
     },
@@ -233,18 +299,30 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "ScheduleExpression": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "ScheduleExpression": {
+            "shape": "Sa"
+          },
           "EventPattern": {},
-          "State": {},
-          "Description": {},
-          "RoleArn": {}
+          "State": {
+            "shape": "Sb"
+          },
+          "Description": {
+            "shape": "Sc"
+          },
+          "RoleArn": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "RuleArn": {}
+          "RuleArn": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -256,7 +334,9 @@
           "Targets"
         ],
         "members": {
-          "Rule": {},
+          "Rule": {
+            "shape": "S2"
+          },
           "Targets": {
             "shape": "Ss"
           }
@@ -273,7 +353,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {},
+                "TargetId": {
+                  "shape": "Su"
+                },
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
@@ -289,7 +371,9 @@
           "StatementId"
         ],
         "members": {
-          "StatementId": {}
+          "StatementId": {
+            "shape": "S22"
+          }
         }
       }
     },
@@ -301,10 +385,16 @@
           "Ids"
         ],
         "members": {
-          "Rule": {},
+          "Rule": {
+            "shape": "S2"
+          },
           "Ids": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Su"
+            },
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -319,7 +409,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {},
+                "TargetId": {
+                  "shape": "Su"
+                },
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
@@ -351,6 +443,52 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\.\\-_A-Za-z0-9]+"
+    },
+    "S8": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "Sa": {
+      "type": "string",
+      "max": 256
+    },
+    "Sb": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
+    "Sc": {
+      "type": "string",
+      "max": 512
+    },
+    "Sd": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "Si": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "Sj": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
     "Ss": {
       "type": "list",
       "member": {
@@ -360,11 +498,22 @@
           "Arn"
         ],
         "members": {
-          "Id": {},
-          "Arn": {},
-          "RoleArn": {},
-          "Input": {},
-          "InputPath": {},
+          "Id": {
+            "shape": "Su"
+          },
+          "Arn": {
+            "shape": "Sh"
+          },
+          "RoleArn": {
+            "shape": "Sd"
+          },
+          "Input": {
+            "type": "string",
+            "max": 8192
+          },
+          "InputPath": {
+            "shape": "Sw"
+          },
           "InputTransformer": {
             "type": "structure",
             "required": [
@@ -373,10 +522,22 @@
             "members": {
               "InputPathsMap": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1,
+                  "pattern": "[A-Za-z0-9\\_\\-]+"
+                },
+                "value": {
+                  "shape": "Sw"
+                },
+                "max": 10
               },
-              "InputTemplate": {}
+              "InputTemplate": {
+                "type": "string",
+                "max": 8192,
+                "min": 1
+              }
             }
           },
           "KinesisParameters": {
@@ -385,7 +546,10 @@
               "PartitionKeyPath"
             ],
             "members": {
-              "PartitionKeyPath": {}
+              "PartitionKeyPath": {
+                "type": "string",
+                "max": 256
+              }
             }
           },
           "RunCommandParameters": {
@@ -403,13 +567,26 @@
                     "Values"
                   ],
                   "members": {
-                    "Key": {},
+                    "Key": {
+                      "type": "string",
+                      "max": 128,
+                      "min": 1,
+                      "pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$"
+                    },
                     "Values": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "type": "string",
+                        "max": 256,
+                        "min": 1
+                      },
+                      "max": 50,
+                      "min": 1
                     }
                   }
-                }
+                },
+                "max": 5,
+                "min": 1
               }
             }
           },
@@ -419,11 +596,22 @@
               "TaskDefinitionArn"
             ],
             "members": {
-              "TaskDefinitionArn": {},
-              "TaskCount": {
-                "type": "integer"
+              "TaskDefinitionArn": {
+                "type": "string",
+                "max": 1600,
+                "min": 1
               },
-              "LaunchType": {},
+              "TaskCount": {
+                "type": "integer",
+                "min": 1
+              },
+              "LaunchType": {
+                "type": "string",
+                "enum": [
+                  "EC2",
+                  "FARGATE"
+                ]
+              },
               "NetworkConfiguration": {
                 "type": "structure",
                 "members": {
@@ -439,7 +627,13 @@
                       "SecurityGroups": {
                         "shape": "S1f"
                       },
-                      "AssignPublicIp": {}
+                      "AssignPublicIp": {
+                        "type": "string",
+                        "enum": [
+                          "ENABLED",
+                          "DISABLED"
+                        ]
+                      }
                     }
                   }
                 }
@@ -482,11 +676,29 @@
             }
           }
         }
-      }
+      },
+      "max": 100,
+      "min": 1
+    },
+    "Su": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\.\\-_A-Za-z0-9]+"
+    },
+    "Sw": {
+      "type": "string",
+      "max": 256
     },
     "S1f": {
       "type": "list",
       "member": {}
+    },
+    "S22": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9-_]+"
     }
   }
 }

--- a/apis/firehose-2015-08-04.min.json
+++ b/apis/firehose-2015-08-04.min.json
@@ -20,8 +20,12 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {},
-          "DeliveryStreamType": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
+          "DeliveryStreamType": {
+            "shape": "S3"
+          },
           "KinesisStreamSourceConfiguration": {
             "type": "structure",
             "required": [
@@ -29,8 +33,12 @@
               "RoleARN"
             ],
             "members": {
-              "KinesisStreamARN": {},
-              "RoleARN": {}
+              "KinesisStreamARN": {
+                "shape": "S5"
+              },
+              "RoleARN": {
+                "shape": "S6"
+              }
             }
           },
           "S3DestinationConfiguration": {
@@ -44,13 +52,19 @@
               "BucketARN"
             ],
             "members": {
-              "RoleARN": {},
-              "BucketARN": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "BucketARN": {
+                "shape": "S8"
+              },
               "Prefix": {},
               "BufferingHints": {
                 "shape": "Sa"
               },
-              "CompressionFormat": {},
+              "CompressionFormat": {
+                "shape": "Sd"
+              },
               "EncryptionConfiguration": {
                 "shape": "Se"
               },
@@ -60,7 +74,9 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "Sv"
+              },
               "S3BackupConfiguration": {
                 "shape": "S7"
               },
@@ -80,8 +96,12 @@
               "S3Configuration"
             ],
             "members": {
-              "RoleARN": {},
-              "ClusterJDBCURL": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "ClusterJDBCURL": {
+                "shape": "S1m"
+              },
               "CopyCommand": {
                 "shape": "S1n"
               },
@@ -100,7 +120,9 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "S1v"
+              },
               "S3BackupConfiguration": {
                 "shape": "S7"
               },
@@ -119,18 +141,30 @@
               "S3Configuration"
             ],
             "members": {
-              "RoleARN": {},
-              "DomainARN": {},
-              "IndexName": {},
-              "TypeName": {},
-              "IndexRotationPeriod": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "DomainARN": {
+                "shape": "S1x"
+              },
+              "IndexName": {
+                "shape": "S1y"
+              },
+              "TypeName": {
+                "shape": "S1z"
+              },
+              "IndexRotationPeriod": {
+                "shape": "S20"
+              },
               "BufferingHints": {
                 "shape": "S21"
               },
               "RetryOptions": {
                 "shape": "S24"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "S26"
+              },
               "S3Configuration": {
                 "shape": "S7"
               },
@@ -152,15 +186,19 @@
             ],
             "members": {
               "HECEndpoint": {},
-              "HECEndpointType": {},
+              "HECEndpointType": {
+                "shape": "S29"
+              },
               "HECToken": {},
               "HECAcknowledgmentTimeoutInSeconds": {
-                "type": "integer"
+                "shape": "S2b"
               },
               "RetryOptions": {
                 "shape": "S2c"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "S2e"
+              },
               "S3Configuration": {
                 "shape": "S7"
               },
@@ -177,7 +215,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DeliveryStreamARN": {}
+          "DeliveryStreamARN": {
+            "shape": "S2g"
+          }
         }
       }
     },
@@ -188,7 +228,9 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {}
+          "DeliveryStreamName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -203,11 +245,17 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {},
-          "Limit": {
-            "type": "integer"
+          "DeliveryStreamName": {
+            "shape": "S2"
           },
-          "ExclusiveStartDestinationId": {}
+          "Limit": {
+            "type": "integer",
+            "max": 10000,
+            "min": 1
+          },
+          "ExclusiveStartDestinationId": {
+            "shape": "S2l"
+          }
         }
       },
       "output": {
@@ -228,11 +276,26 @@
               "HasMoreDestinations"
             ],
             "members": {
-              "DeliveryStreamName": {},
-              "DeliveryStreamARN": {},
-              "DeliveryStreamStatus": {},
-              "DeliveryStreamType": {},
-              "VersionId": {},
+              "DeliveryStreamName": {
+                "shape": "S2"
+              },
+              "DeliveryStreamARN": {
+                "shape": "S2g"
+              },
+              "DeliveryStreamStatus": {
+                "type": "string",
+                "enum": [
+                  "CREATING",
+                  "DELETING",
+                  "ACTIVE"
+                ]
+              },
+              "DeliveryStreamType": {
+                "shape": "S3"
+              },
+              "VersionId": {
+                "shape": "S2p"
+              },
               "CreateTimestamp": {
                 "type": "timestamp"
               },
@@ -245,8 +308,12 @@
                   "KinesisStreamSourceDescription": {
                     "type": "structure",
                     "members": {
-                      "KinesisStreamARN": {},
-                      "RoleARN": {},
+                      "KinesisStreamARN": {
+                        "shape": "S5"
+                      },
+                      "RoleARN": {
+                        "shape": "S6"
+                      },
                       "DeliveryStartTimestamp": {
                         "type": "timestamp"
                       }
@@ -262,7 +329,9 @@
                     "DestinationId"
                   ],
                   "members": {
-                    "DestinationId": {},
+                    "DestinationId": {
+                      "shape": "S2l"
+                    },
                     "S3DestinationDescription": {
                       "shape": "S2w"
                     },
@@ -276,13 +345,19 @@
                         "EncryptionConfiguration"
                       ],
                       "members": {
-                        "RoleARN": {},
-                        "BucketARN": {},
+                        "RoleARN": {
+                          "shape": "S6"
+                        },
+                        "BucketARN": {
+                          "shape": "S8"
+                        },
                         "Prefix": {},
                         "BufferingHints": {
                           "shape": "Sa"
                         },
-                        "CompressionFormat": {},
+                        "CompressionFormat": {
+                          "shape": "Sd"
+                        },
                         "EncryptionConfiguration": {
                           "shape": "Se"
                         },
@@ -292,7 +367,9 @@
                         "ProcessingConfiguration": {
                           "shape": "Sn"
                         },
-                        "S3BackupMode": {},
+                        "S3BackupMode": {
+                          "shape": "Sv"
+                        },
                         "S3BackupDescription": {
                           "shape": "S2w"
                         },
@@ -311,8 +388,12 @@
                         "S3DestinationDescription"
                       ],
                       "members": {
-                        "RoleARN": {},
-                        "ClusterJDBCURL": {},
+                        "RoleARN": {
+                          "shape": "S6"
+                        },
+                        "ClusterJDBCURL": {
+                          "shape": "S1m"
+                        },
                         "CopyCommand": {
                           "shape": "S1n"
                         },
@@ -328,7 +409,9 @@
                         "ProcessingConfiguration": {
                           "shape": "Sn"
                         },
-                        "S3BackupMode": {},
+                        "S3BackupMode": {
+                          "shape": "S1v"
+                        },
                         "S3BackupDescription": {
                           "shape": "S2w"
                         },
@@ -340,18 +423,30 @@
                     "ElasticsearchDestinationDescription": {
                       "type": "structure",
                       "members": {
-                        "RoleARN": {},
-                        "DomainARN": {},
-                        "IndexName": {},
-                        "TypeName": {},
-                        "IndexRotationPeriod": {},
+                        "RoleARN": {
+                          "shape": "S6"
+                        },
+                        "DomainARN": {
+                          "shape": "S1x"
+                        },
+                        "IndexName": {
+                          "shape": "S1y"
+                        },
+                        "TypeName": {
+                          "shape": "S1z"
+                        },
+                        "IndexRotationPeriod": {
+                          "shape": "S20"
+                        },
                         "BufferingHints": {
                           "shape": "S21"
                         },
                         "RetryOptions": {
                           "shape": "S24"
                         },
-                        "S3BackupMode": {},
+                        "S3BackupMode": {
+                          "shape": "S26"
+                        },
                         "S3DestinationDescription": {
                           "shape": "S2w"
                         },
@@ -367,15 +462,19 @@
                       "type": "structure",
                       "members": {
                         "HECEndpoint": {},
-                        "HECEndpointType": {},
+                        "HECEndpointType": {
+                          "shape": "S29"
+                        },
                         "HECToken": {},
                         "HECAcknowledgmentTimeoutInSeconds": {
-                          "type": "integer"
+                          "shape": "S2b"
                         },
                         "RetryOptions": {
                           "shape": "S2c"
                         },
-                        "S3BackupMode": {},
+                        "S3BackupMode": {
+                          "shape": "S2e"
+                        },
                         "S3DestinationDescription": {
                           "shape": "S2w"
                         },
@@ -403,10 +502,16 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
-          "DeliveryStreamType": {},
-          "ExclusiveStartDeliveryStreamName": {}
+          "DeliveryStreamType": {
+            "shape": "S3"
+          },
+          "ExclusiveStartDeliveryStreamName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -418,7 +523,9 @@
         "members": {
           "DeliveryStreamNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           },
           "HasMoreDeliveryStreams": {
             "type": "boolean"
@@ -433,10 +540,16 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {},
-          "ExclusiveStartTagKey": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
+          "ExclusiveStartTagKey": {
+            "shape": "S36"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -451,7 +564,9 @@
             "type": "list",
             "member": {
               "shape": "S3a"
-            }
+            },
+            "max": 50,
+            "min": 0
           },
           "HasMoreTags": {
             "type": "boolean"
@@ -467,7 +582,9 @@
           "Record"
         ],
         "members": {
-          "DeliveryStreamName": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
           "Record": {
             "shape": "S3d"
           }
@@ -479,7 +596,9 @@
           "RecordId"
         ],
         "members": {
-          "RecordId": {}
+          "RecordId": {
+            "shape": "S3g"
+          }
         }
       }
     },
@@ -491,12 +610,16 @@
           "Records"
         ],
         "members": {
-          "DeliveryStreamName": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
           "Records": {
             "type": "list",
             "member": {
               "shape": "S3d"
-            }
+            },
+            "max": 500,
+            "min": 1
           }
         }
       },
@@ -508,18 +631,22 @@
         ],
         "members": {
           "FailedPutCount": {
-            "type": "integer"
+            "shape": "S1c"
           },
           "RequestResponses": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "RecordId": {},
+                "RecordId": {
+                  "shape": "S3g"
+                },
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
-            }
+            },
+            "max": 500,
+            "min": 1
           }
         }
       }
@@ -532,12 +659,16 @@
           "Tags"
         ],
         "members": {
-          "DeliveryStreamName": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
           "Tags": {
             "type": "list",
             "member": {
               "shape": "S3a"
-            }
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -554,10 +685,16 @@
           "TagKeys"
         ],
         "members": {
-          "DeliveryStreamName": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S36"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -575,9 +712,15 @@
           "DestinationId"
         ],
         "members": {
-          "DeliveryStreamName": {},
-          "CurrentDeliveryStreamVersionId": {},
-          "DestinationId": {},
+          "DeliveryStreamName": {
+            "shape": "S2"
+          },
+          "CurrentDeliveryStreamVersionId": {
+            "shape": "S2p"
+          },
+          "DestinationId": {
+            "shape": "S2l"
+          },
           "S3DestinationUpdate": {
             "shape": "S3v",
             "deprecated": true
@@ -585,13 +728,19 @@
           "ExtendedS3DestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {},
-              "BucketARN": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "BucketARN": {
+                "shape": "S8"
+              },
               "Prefix": {},
               "BufferingHints": {
                 "shape": "Sa"
               },
-              "CompressionFormat": {},
+              "CompressionFormat": {
+                "shape": "Sd"
+              },
               "EncryptionConfiguration": {
                 "shape": "Se"
               },
@@ -601,7 +750,9 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "Sv"
+              },
               "S3BackupUpdate": {
                 "shape": "S3v"
               },
@@ -613,8 +764,12 @@
           "RedshiftDestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {},
-              "ClusterJDBCURL": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "ClusterJDBCURL": {
+                "shape": "S1m"
+              },
               "CopyCommand": {
                 "shape": "S1n"
               },
@@ -633,7 +788,9 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "S1v"
+              },
               "S3BackupUpdate": {
                 "shape": "S3v"
               },
@@ -645,11 +802,21 @@
           "ElasticsearchDestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {},
-              "DomainARN": {},
-              "IndexName": {},
-              "TypeName": {},
-              "IndexRotationPeriod": {},
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "DomainARN": {
+                "shape": "S1x"
+              },
+              "IndexName": {
+                "shape": "S1y"
+              },
+              "TypeName": {
+                "shape": "S1z"
+              },
+              "IndexRotationPeriod": {
+                "shape": "S20"
+              },
               "BufferingHints": {
                 "shape": "S21"
               },
@@ -671,15 +838,19 @@
             "type": "structure",
             "members": {
               "HECEndpoint": {},
-              "HECEndpointType": {},
+              "HECEndpointType": {
+                "shape": "S29"
+              },
               "HECToken": {},
               "HECAcknowledgmentTimeoutInSeconds": {
-                "type": "integer"
+                "shape": "S2b"
               },
               "RetryOptions": {
                 "shape": "S2c"
               },
-              "S3BackupMode": {},
+              "S3BackupMode": {
+                "shape": "S2e"
+              },
               "S3Update": {
                 "shape": "S3v"
               },
@@ -700,6 +871,31 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S3": {
+      "type": "string",
+      "enum": [
+        "DirectPut",
+        "KinesisStreamAsSource"
+      ]
+    },
+    "S5": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
+    "S6": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
     "S7": {
       "type": "structure",
       "required": [
@@ -707,13 +903,19 @@
         "BucketARN"
       ],
       "members": {
-        "RoleARN": {},
-        "BucketARN": {},
+        "RoleARN": {
+          "shape": "S6"
+        },
+        "BucketARN": {
+          "shape": "S8"
+        },
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {},
+        "CompressionFormat": {
+          "shape": "Sd"
+        },
         "EncryptionConfiguration": {
           "shape": "Se"
         },
@@ -722,28 +924,57 @@
         }
       }
     },
+    "S8": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
     "Sa": {
       "type": "structure",
       "members": {
         "SizeInMBs": {
-          "type": "integer"
+          "type": "integer",
+          "max": 128,
+          "min": 1
         },
         "IntervalInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 900,
+          "min": 60
         }
       }
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "UNCOMPRESSED",
+        "GZIP",
+        "ZIP",
+        "Snappy"
+      ]
     },
     "Se": {
       "type": "structure",
       "members": {
-        "NoEncryptionConfig": {},
+        "NoEncryptionConfig": {
+          "type": "string",
+          "enum": [
+            "NoEncryption"
+          ]
+        },
         "KMSEncryptionConfig": {
           "type": "structure",
           "required": [
             "AWSKMSKeyARN"
           ],
           "members": {
-            "AWSKMSKeyARN": {}
+            "AWSKMSKeyARN": {
+              "type": "string",
+              "max": 512,
+              "min": 1,
+              "pattern": "arn:.*"
+            }
           }
         }
       }
@@ -772,7 +1003,12 @@
               "Type"
             ],
             "members": {
-              "Type": {},
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "Lambda"
+                ]
+              },
               "Parameters": {
                 "type": "list",
                 "member": {
@@ -782,8 +1018,21 @@
                     "ParameterValue"
                   ],
                   "members": {
-                    "ParameterName": {},
-                    "ParameterValue": {}
+                    "ParameterName": {
+                      "type": "string",
+                      "enum": [
+                        "LambdaArn",
+                        "NumberOfRetries",
+                        "RoleArn",
+                        "BufferSizeInMBs",
+                        "BufferIntervalInSeconds"
+                      ]
+                    },
+                    "ParameterValue": {
+                      "type": "string",
+                      "max": 512,
+                      "min": 1
+                    }
                   }
                 }
               }
@@ -792,18 +1041,37 @@
         }
       }
     },
+    "Sv": {
+      "type": "string",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ]
+    },
     "Sw": {
       "type": "structure",
       "members": {
         "SchemaConfiguration": {
           "type": "structure",
           "members": {
-            "RoleARN": {},
-            "CatalogId": {},
-            "DatabaseName": {},
-            "TableName": {},
-            "Region": {},
-            "VersionId": {}
+            "RoleARN": {
+              "shape": "Sy"
+            },
+            "CatalogId": {
+              "shape": "Sy"
+            },
+            "DatabaseName": {
+              "shape": "Sy"
+            },
+            "TableName": {
+              "shape": "Sy"
+            },
+            "Region": {
+              "shape": "Sy"
+            },
+            "VersionId": {
+              "shape": "Sy"
+            }
           }
         },
         "InputFormatConfiguration": {
@@ -823,8 +1091,12 @@
                     },
                     "ColumnToJsonKeyMappings": {
                       "type": "map",
-                      "key": {},
-                      "value": {}
+                      "key": {
+                        "shape": "Sy"
+                      },
+                      "value": {
+                        "shape": "S13"
+                      }
                     }
                   }
                 },
@@ -833,7 +1105,9 @@
                   "members": {
                     "TimestampFormats": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "S13"
+                      }
                     }
                   }
                 }
@@ -851,51 +1125,82 @@
                   "type": "structure",
                   "members": {
                     "BlockSizeBytes": {
-                      "type": "integer"
+                      "shape": "S19"
                     },
                     "PageSizeBytes": {
-                      "type": "integer"
+                      "type": "integer",
+                      "min": 65536
                     },
-                    "Compression": {},
+                    "Compression": {
+                      "type": "string",
+                      "enum": [
+                        "UNCOMPRESSED",
+                        "GZIP",
+                        "SNAPPY"
+                      ]
+                    },
                     "EnableDictionaryCompression": {
                       "type": "boolean"
                     },
                     "MaxPaddingBytes": {
-                      "type": "integer"
+                      "shape": "S1c"
                     },
-                    "WriterVersion": {}
+                    "WriterVersion": {
+                      "type": "string",
+                      "enum": [
+                        "V1",
+                        "V2"
+                      ]
+                    }
                   }
                 },
                 "OrcSerDe": {
                   "type": "structure",
                   "members": {
                     "StripeSizeBytes": {
-                      "type": "integer"
+                      "type": "integer",
+                      "min": 8388608
                     },
                     "BlockSizeBytes": {
-                      "type": "integer"
+                      "shape": "S19"
                     },
                     "RowIndexStride": {
-                      "type": "integer"
+                      "type": "integer",
+                      "min": 1000
                     },
                     "EnablePadding": {
                       "type": "boolean"
                     },
                     "PaddingTolerance": {
-                      "type": "double"
+                      "shape": "S1h"
                     },
-                    "Compression": {},
+                    "Compression": {
+                      "type": "string",
+                      "enum": [
+                        "NONE",
+                        "ZLIB",
+                        "SNAPPY"
+                      ]
+                    },
                     "BloomFilterColumns": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "Sy"
+                      }
                     },
                     "BloomFilterFalsePositiveProbability": {
-                      "type": "double"
+                      "shape": "S1h"
                     },
                     "DictionaryKeyThreshold": {
-                      "type": "double"
+                      "shape": "S1h"
                     },
-                    "FormatVersion": {}
+                    "FormatVersion": {
+                      "type": "string",
+                      "enum": [
+                        "V0_11",
+                        "V0_12"
+                      ]
+                    }
                   }
                 }
               }
@@ -907,41 +1212,111 @@
         }
       }
     },
+    "Sy": {
+      "type": "string",
+      "pattern": "^\\S+$"
+    },
+    "S13": {
+      "type": "string",
+      "pattern": "^(?!\\s*$).+"
+    },
+    "S19": {
+      "type": "integer",
+      "min": 67108864
+    },
+    "S1c": {
+      "type": "integer",
+      "min": 0
+    },
+    "S1h": {
+      "type": "double",
+      "max": 1,
+      "min": 0
+    },
+    "S1m": {
+      "type": "string",
+      "min": 1,
+      "pattern": "jdbc:(redshift|postgresql)://((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+redshift\\.amazonaws\\.com:\\d{1,5}/[a-zA-Z0-9_$]+"
+    },
     "S1n": {
       "type": "structure",
       "required": [
         "DataTableName"
       ],
       "members": {
-        "DataTableName": {},
+        "DataTableName": {
+          "type": "string",
+          "min": 1
+        },
         "DataTableColumns": {},
         "CopyOptions": {}
       }
     },
     "S1r": {
       "type": "string",
+      "min": 1,
       "sensitive": true
     },
     "S1s": {
       "type": "string",
+      "min": 6,
       "sensitive": true
     },
     "S1t": {
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 7200,
+          "min": 0
         }
       }
+    },
+    "S1v": {
+      "type": "string",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ]
+    },
+    "S1x": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
+    "S1y": {
+      "type": "string",
+      "max": 80,
+      "min": 1
+    },
+    "S1z": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S20": {
+      "type": "string",
+      "enum": [
+        "NoRotation",
+        "OneHour",
+        "OneDay",
+        "OneWeek",
+        "OneMonth"
+      ]
     },
     "S21": {
       "type": "structure",
       "members": {
         "IntervalInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 900,
+          "min": 60
         },
         "SizeInMBs": {
-          "type": "integer"
+          "type": "integer",
+          "max": 100,
+          "min": 1
         }
       }
     },
@@ -949,17 +1324,64 @@
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 7200,
+          "min": 0
         }
       }
+    },
+    "S26": {
+      "type": "string",
+      "enum": [
+        "FailedDocumentsOnly",
+        "AllDocuments"
+      ]
+    },
+    "S29": {
+      "type": "string",
+      "enum": [
+        "Raw",
+        "Event"
+      ]
+    },
+    "S2b": {
+      "type": "integer",
+      "max": 600,
+      "min": 180
     },
     "S2c": {
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 7200,
+          "min": 0
         }
       }
+    },
+    "S2e": {
+      "type": "string",
+      "enum": [
+        "FailedEventsOnly",
+        "AllEvents"
+      ]
+    },
+    "S2g": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
+    "S2l": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S2p": {
+      "type": "string",
+      "max": 50,
+      "min": 1,
+      "pattern": "[0-9]+"
     },
     "S2w": {
       "type": "structure",
@@ -971,13 +1393,19 @@
         "EncryptionConfiguration"
       ],
       "members": {
-        "RoleARN": {},
-        "BucketARN": {},
+        "RoleARN": {
+          "shape": "S6"
+        },
+        "BucketARN": {
+          "shape": "S8"
+        },
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {},
+        "CompressionFormat": {
+          "shape": "Sd"
+        },
         "EncryptionConfiguration": {
           "shape": "Se"
         },
@@ -986,14 +1414,25 @@
         }
       }
     },
+    "S36": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
     "S3a": {
       "type": "structure",
       "required": [
         "Key"
       ],
       "members": {
-        "Key": {},
-        "Value": {}
+        "Key": {
+          "shape": "S36"
+        },
+        "Value": {
+          "type": "string",
+          "max": 256,
+          "min": 0
+        }
       }
     },
     "S3d": {
@@ -1003,20 +1442,32 @@
       ],
       "members": {
         "Data": {
-          "type": "blob"
+          "type": "blob",
+          "max": 1024000,
+          "min": 0
         }
       }
+    },
+    "S3g": {
+      "type": "string",
+      "min": 1
     },
     "S3v": {
       "type": "structure",
       "members": {
-        "RoleARN": {},
-        "BucketARN": {},
+        "RoleARN": {
+          "shape": "S6"
+        },
+        "BucketARN": {
+          "shape": "S8"
+        },
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {},
+        "CompressionFormat": {
+          "shape": "Sd"
+        },
         "EncryptionConfiguration": {
           "shape": "Se"
         },

--- a/apis/fms-2018-01-01.min.json
+++ b/apis/fms-2018-01-01.min.json
@@ -20,7 +20,9 @@
           "AdminAccount"
         ],
         "members": {
-          "AdminAccount": {}
+          "AdminAccount": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -37,7 +39,9 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {}
+          "PolicyId": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -55,8 +59,19 @@
       "output": {
         "type": "structure",
         "members": {
-          "AdminAccount": {},
-          "RoleStatus": {}
+          "AdminAccount": {
+            "shape": "S2"
+          },
+          "RoleStatus": {
+            "type": "string",
+            "enum": [
+              "READY",
+              "CREATING",
+              "PENDING_DELETION",
+              "DELETING",
+              "DELETED"
+            ]
+          }
         }
       }
     },
@@ -68,8 +83,12 @@
           "MemberAccount"
         ],
         "members": {
-          "PolicyId": {},
-          "MemberAccount": {}
+          "PolicyId": {
+            "shape": "S5"
+          },
+          "MemberAccount": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -78,17 +97,36 @@
           "PolicyComplianceDetail": {
             "type": "structure",
             "members": {
-              "PolicyOwner": {},
-              "PolicyId": {},
-              "MemberAccount": {},
+              "PolicyOwner": {
+                "shape": "S2"
+              },
+              "PolicyId": {
+                "shape": "S5"
+              },
+              "MemberAccount": {
+                "shape": "S2"
+              },
               "Violators": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "ResourceId": {},
-                    "ViolationReason": {},
-                    "ResourceType": {}
+                    "ResourceId": {
+                      "type": "string",
+                      "max": 1024,
+                      "min": 1
+                    },
+                    "ViolationReason": {
+                      "type": "string",
+                      "enum": [
+                        "WEB_ACL_MISSING_RULE_GROUP",
+                        "RESOURCE_MISSING_WEB_ACL",
+                        "RESOURCE_INCORRECT_WEB_ACL"
+                      ]
+                    },
+                    "ResourceType": {
+                      "shape": "Sh"
+                    }
                   }
                 }
               },
@@ -114,8 +152,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "SnsTopicArn": {},
-          "SnsRoleName": {}
+          "SnsTopicArn": {
+            "shape": "Sp"
+          },
+          "SnsRoleName": {
+            "shape": "Sp"
+          }
         }
       }
     },
@@ -126,7 +168,9 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {}
+          "PolicyId": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -135,7 +179,9 @@
           "Policy": {
             "shape": "Ss"
           },
-          "PolicyArn": {}
+          "PolicyArn": {
+            "shape": "Sp"
+          }
         }
       }
     },
@@ -146,10 +192,14 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {},
-          "NextToken": {},
+          "PolicyId": {
+            "shape": "S5"
+          },
+          "NextToken": {
+            "shape": "S17"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S18"
           }
         }
       },
@@ -161,18 +211,33 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyOwner": {},
-                "PolicyId": {},
-                "PolicyName": {},
-                "MemberAccount": {},
+                "PolicyOwner": {
+                  "shape": "S2"
+                },
+                "PolicyId": {
+                  "shape": "S5"
+                },
+                "PolicyName": {
+                  "shape": "St"
+                },
+                "MemberAccount": {
+                  "shape": "S2"
+                },
                 "EvaluationResults": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ComplianceStatus": {},
+                      "ComplianceStatus": {
+                        "type": "string",
+                        "enum": [
+                          "COMPLIANT",
+                          "NON_COMPLIANT"
+                        ]
+                      },
                       "ViolatorCount": {
-                        "type": "long"
+                        "type": "long",
+                        "min": 0
                       },
                       "EvaluationLimitExceeded": {
                         "type": "boolean"
@@ -189,7 +254,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S17"
+          }
         }
       }
     },
@@ -197,9 +264,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S17"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S18"
           }
         }
       },
@@ -208,9 +277,13 @@
         "members": {
           "MemberAccounts": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S17"
+          }
         }
       }
     },
@@ -218,9 +291,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S17"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S18"
           }
         }
       },
@@ -232,18 +307,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyArn": {},
-                "PolicyId": {},
-                "PolicyName": {},
-                "ResourceType": {},
-                "SecurityServiceType": {},
+                "PolicyArn": {
+                  "shape": "Sp"
+                },
+                "PolicyId": {
+                  "shape": "S5"
+                },
+                "PolicyName": {
+                  "shape": "St"
+                },
+                "ResourceType": {
+                  "shape": "Sh"
+                },
+                "SecurityServiceType": {
+                  "shape": "Sw"
+                },
                 "RemediationEnabled": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S17"
+          }
         }
       }
     },
@@ -255,8 +342,12 @@
           "SnsRoleName"
         ],
         "members": {
-          "SnsTopicArn": {},
-          "SnsRoleName": {}
+          "SnsTopicArn": {
+            "shape": "Sp"
+          },
+          "SnsRoleName": {
+            "shape": "Sp"
+          }
         }
       }
     },
@@ -278,16 +369,48 @@
           "Policy": {
             "shape": "Ss"
           },
-          "PolicyArn": {}
+          "PolicyArn": {
+            "shape": "Sp"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "max": 36,
+      "min": 36
+    },
+    "Sh": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
     "Sk": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "enum": [
+          "AWSCONFIG",
+          "AWSWAF"
+        ]
+      },
+      "value": {
+        "type": "string",
+        "max": 1024,
+        "min": 1
+      }
+    },
+    "Sp": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
     },
     "Ss": {
       "type": "structure",
@@ -299,20 +422,36 @@
         "RemediationEnabled"
       ],
       "members": {
-        "PolicyId": {},
-        "PolicyName": {},
-        "PolicyUpdateToken": {},
+        "PolicyId": {
+          "shape": "S5"
+        },
+        "PolicyName": {
+          "shape": "St"
+        },
+        "PolicyUpdateToken": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        },
         "SecurityServicePolicyData": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {},
-            "ManagedServiceData": {}
+            "Type": {
+              "shape": "Sw"
+            },
+            "ManagedServiceData": {
+              "type": "string",
+              "max": 1024,
+              "min": 1
+            }
           }
         },
-        "ResourceType": {},
+        "ResourceType": {
+          "shape": "Sh"
+        },
         "ResourceTags": {
           "type": "list",
           "member": {
@@ -321,10 +460,21 @@
               "Key"
             ],
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "type": "string",
+                "max": 128,
+                "min": 1,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+              }
             }
-          }
+          },
+          "max": 8,
+          "min": 0
         },
         "ExcludeResourceTags": {
           "type": "boolean"
@@ -340,13 +490,42 @@
         }
       }
     },
+    "St": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Sw": {
+      "type": "string",
+      "enum": [
+        "WAF"
+      ]
+    },
     "S12": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "ACCOUNT"
+        ]
+      },
       "value": {
         "type": "list",
-        "member": {}
+        "member": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        }
       }
+    },
+    "S17": {
+      "type": "string",
+      "min": 1
+    },
+    "S18": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     }
   }
 }

--- a/apis/gamelift-2015-10-01.min.json
+++ b/apis/gamelift-2015-10-01.min.json
@@ -21,11 +21,19 @@
           "AcceptanceType"
         ],
         "members": {
-          "TicketId": {},
+          "TicketId": {
+            "shape": "S2"
+          },
           "PlayerIds": {
             "shape": "S3"
           },
-          "AcceptanceType": {}
+          "AcceptanceType": {
+            "type": "string",
+            "enum": [
+              "ACCEPT",
+              "REJECT"
+            ]
+          }
         }
       },
       "output": {
@@ -41,8 +49,12 @@
           "RoutingStrategy"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S8"
+          },
+          "Description": {
+            "shape": "S4"
+          },
           "RoutingStrategy": {
             "shape": "S9"
           }
@@ -61,12 +73,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "Version": {},
+          "Name": {
+            "shape": "S4"
+          },
+          "Version": {
+            "shape": "S4"
+          },
           "StorageLocation": {
             "shape": "Sj"
           },
-          "OperatingSystem": {}
+          "OperatingSystem": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -93,19 +111,33 @@
           "EC2InstanceType"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
-          "BuildId": {},
-          "ServerLaunchPath": {},
-          "ServerLaunchParameters": {},
+          "Name": {
+            "shape": "S4"
+          },
+          "Description": {
+            "shape": "S4"
+          },
+          "BuildId": {
+            "shape": "So"
+          },
+          "ServerLaunchPath": {
+            "shape": "S4"
+          },
+          "ServerLaunchParameters": {
+            "shape": "S4"
+          },
           "LogPaths": {
             "shape": "S3"
           },
-          "EC2InstanceType": {},
+          "EC2InstanceType": {
+            "shape": "St"
+          },
           "EC2InboundPermissions": {
             "shape": "Su"
           },
-          "NewGameSessionProtectionPolicy": {},
+          "NewGameSessionProtectionPolicy": {
+            "shape": "Sz"
+          },
           "RuntimeConfiguration": {
             "shape": "S10"
           },
@@ -115,9 +147,15 @@
           "MetricGroups": {
             "shape": "S18"
           },
-          "PeerVpcAwsAccountId": {},
-          "PeerVpcId": {},
-          "FleetType": {}
+          "PeerVpcAwsAccountId": {
+            "shape": "S4"
+          },
+          "PeerVpcId": {
+            "shape": "S4"
+          },
+          "FleetType": {
+            "shape": "S1a"
+          }
         }
       },
       "output": {
@@ -136,19 +174,33 @@
           "MaximumPlayerSessionCount"
         ],
         "members": {
-          "FleetId": {},
-          "AliasId": {},
-          "MaximumPlayerSessionCount": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "Name": {},
+          "AliasId": {
+            "shape": "Sf"
+          },
+          "MaximumPlayerSessionCount": {
+            "shape": "S17"
+          },
+          "Name": {
+            "shape": "S4"
+          },
           "GameProperties": {
             "shape": "S1h"
           },
-          "CreatorId": {},
-          "GameSessionId": {},
-          "IdempotencyToken": {},
-          "GameSessionData": {}
+          "CreatorId": {
+            "shape": "S4"
+          },
+          "GameSessionId": {
+            "shape": "S1l"
+          },
+          "IdempotencyToken": {
+            "shape": "S1l"
+          },
+          "GameSessionData": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -167,9 +219,11 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S1v"
+          },
           "TimeoutInSeconds": {
-            "type": "integer"
+            "shape": "S17"
           },
           "PlayerLatencyPolicies": {
             "shape": "S1w"
@@ -199,30 +253,42 @@
           "RuleSetName"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S4"
+          },
           "GameSessionQueueArns": {
             "shape": "S23"
           },
           "RequestTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S24"
           },
           "AcceptanceTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S25"
           },
           "AcceptanceRequired": {
             "type": "boolean"
           },
-          "RuleSetName": {},
-          "NotificationTarget": {},
-          "AdditionalPlayerCount": {
-            "type": "integer"
+          "RuleSetName": {
+            "shape": "S2"
           },
-          "CustomEventData": {},
+          "NotificationTarget": {
+            "shape": "S27"
+          },
+          "AdditionalPlayerCount": {
+            "shape": "S17"
+          },
+          "CustomEventData": {
+            "shape": "S28"
+          },
           "GameProperties": {
             "shape": "S1h"
           },
-          "GameSessionData": {}
+          "GameSessionData": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -242,8 +308,12 @@
           "RuleSetBody"
         ],
         "members": {
-          "Name": {},
-          "RuleSetBody": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "RuleSetBody": {
+            "shape": "S2c"
+          }
         }
       },
       "output": {
@@ -266,9 +336,15 @@
           "PlayerId"
         ],
         "members": {
-          "GameSessionId": {},
-          "PlayerId": {},
-          "PlayerData": {}
+          "GameSessionId": {
+            "shape": "Sg"
+          },
+          "PlayerId": {
+            "shape": "S4"
+          },
+          "PlayerData": {
+            "shape": "S2g"
+          }
         }
       },
       "output": {
@@ -288,15 +364,25 @@
           "PlayerIds"
         ],
         "members": {
-          "GameSessionId": {},
+          "GameSessionId": {
+            "shape": "Sg"
+          },
           "PlayerIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            },
+            "max": 25,
+            "min": 1
           },
           "PlayerDataMap": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S4"
+            },
+            "value": {
+              "shape": "S2g"
+            }
           }
         }
       },
@@ -317,8 +403,12 @@
           "PeerVpcId"
         ],
         "members": {
-          "GameLiftAwsAccountId": {},
-          "PeerVpcId": {}
+          "GameLiftAwsAccountId": {
+            "shape": "S4"
+          },
+          "PeerVpcId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -339,9 +429,15 @@
           "PeerVpcId"
         ],
         "members": {
-          "FleetId": {},
-          "PeerVpcAwsAccountId": {},
-          "PeerVpcId": {}
+          "FleetId": {
+            "shape": "Sb"
+          },
+          "PeerVpcAwsAccountId": {
+            "shape": "S4"
+          },
+          "PeerVpcId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -356,7 +452,9 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {}
+          "AliasId": {
+            "shape": "Sf"
+          }
         }
       }
     },
@@ -367,7 +465,9 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {}
+          "BuildId": {
+            "shape": "So"
+          }
         }
       }
     },
@@ -378,7 +478,9 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -389,7 +491,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S1v"
+          }
         }
       },
       "output": {
@@ -404,7 +508,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -420,8 +526,12 @@
           "FleetId"
         ],
         "members": {
-          "Name": {},
-          "FleetId": {}
+          "Name": {
+            "shape": "S4"
+          },
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -433,8 +543,12 @@
           "PeerVpcId"
         ],
         "members": {
-          "GameLiftAwsAccountId": {},
-          "PeerVpcId": {}
+          "GameLiftAwsAccountId": {
+            "shape": "S4"
+          },
+          "PeerVpcId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -450,8 +564,12 @@
           "VpcPeeringConnectionId"
         ],
         "members": {
-          "FleetId": {},
-          "VpcPeeringConnectionId": {}
+          "FleetId": {
+            "shape": "Sb"
+          },
+          "VpcPeeringConnectionId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -466,7 +584,9 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {}
+          "AliasId": {
+            "shape": "Sf"
+          }
         }
       },
       "output": {
@@ -485,7 +605,9 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {}
+          "BuildId": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -501,7 +623,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "EC2InstanceType": {}
+          "EC2InstanceType": {
+            "shape": "St"
+          }
         }
       },
       "output": {
@@ -512,12 +636,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "EC2InstanceType": {},
+                "EC2InstanceType": {
+                  "shape": "St"
+                },
                 "CurrentInstances": {
-                  "type": "integer"
+                  "shape": "S17"
                 },
                 "InstanceLimit": {
-                  "type": "integer"
+                  "shape": "S17"
                 }
               }
             }
@@ -533,9 +659,11 @@
             "shape": "S3g"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S13"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -547,7 +675,9 @@
               "shape": "S1c"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -559,9 +689,11 @@
             "shape": "S3g"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S13"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -572,38 +704,44 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {},
-                "InstanceType": {},
+                "FleetId": {
+                  "shape": "Sb"
+                },
+                "InstanceType": {
+                  "shape": "St"
+                },
                 "InstanceCounts": {
                   "type": "structure",
                   "members": {
                     "DESIRED": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "MINIMUM": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "MAXIMUM": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "PENDING": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "ACTIVE": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "IDLE": {
-                      "type": "integer"
+                      "shape": "S17"
                     },
                     "TERMINATING": {
-                      "type": "integer"
+                      "shape": "S17"
                     }
                   }
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -614,7 +752,9 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -622,9 +762,11 @@
             "type": "timestamp"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S13"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -635,18 +777,65 @@
             "member": {
               "type": "structure",
               "members": {
-                "EventId": {},
-                "ResourceId": {},
-                "EventCode": {},
-                "Message": {},
+                "EventId": {
+                  "shape": "S4"
+                },
+                "ResourceId": {
+                  "shape": "S4"
+                },
+                "EventCode": {
+                  "type": "string",
+                  "enum": [
+                    "GENERIC_EVENT",
+                    "FLEET_CREATED",
+                    "FLEET_DELETED",
+                    "FLEET_SCALING_EVENT",
+                    "FLEET_STATE_DOWNLOADING",
+                    "FLEET_STATE_VALIDATING",
+                    "FLEET_STATE_BUILDING",
+                    "FLEET_STATE_ACTIVATING",
+                    "FLEET_STATE_ACTIVE",
+                    "FLEET_STATE_ERROR",
+                    "FLEET_INITIALIZATION_FAILED",
+                    "FLEET_BINARY_DOWNLOAD_FAILED",
+                    "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND",
+                    "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE",
+                    "FLEET_VALIDATION_TIMED_OUT",
+                    "FLEET_ACTIVATION_FAILED",
+                    "FLEET_ACTIVATION_FAILED_NO_INSTANCES",
+                    "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED",
+                    "SERVER_PROCESS_INVALID_PATH",
+                    "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT",
+                    "SERVER_PROCESS_PROCESS_READY_TIMEOUT",
+                    "SERVER_PROCESS_CRASHED",
+                    "SERVER_PROCESS_TERMINATED_UNHEALTHY",
+                    "SERVER_PROCESS_FORCE_TERMINATED",
+                    "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT",
+                    "GAME_SESSION_ACTIVATION_TIMEOUT",
+                    "FLEET_CREATION_EXTRACTING_BUILD",
+                    "FLEET_CREATION_RUNNING_INSTALLER",
+                    "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG",
+                    "FLEET_VPC_PEERING_SUCCEEDED",
+                    "FLEET_VPC_PEERING_FAILED",
+                    "FLEET_VPC_PEERING_DELETED",
+                    "INSTANCE_INTERRUPTED"
+                  ]
+                },
+                "Message": {
+                  "shape": "Sk"
+                },
                 "EventTime": {
                   "type": "timestamp"
                 },
-                "PreSignedLogUrl": {}
+                "PreSignedLogUrl": {
+                  "shape": "S4"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -657,7 +846,9 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -677,9 +868,11 @@
             "shape": "S3g"
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S13"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -690,23 +883,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {},
+                "FleetId": {
+                  "shape": "Sb"
+                },
                 "ActiveServerProcessCount": {
-                  "type": "integer"
+                  "shape": "S17"
                 },
                 "ActiveGameSessionCount": {
-                  "type": "integer"
+                  "shape": "S17"
                 },
                 "CurrentPlayerSessionCount": {
-                  "type": "integer"
+                  "shape": "S17"
                 },
                 "MaximumPlayerSessionCount": {
-                  "type": "integer"
+                  "shape": "S17"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -714,14 +911,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {},
-          "GameSessionId": {},
-          "AliasId": {},
-          "StatusFilter": {},
-          "Limit": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "GameSessionId": {
+            "shape": "Sg"
+          },
+          "AliasId": {
+            "shape": "Sf"
+          },
+          "StatusFilter": {
+            "shape": "S4"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -735,11 +942,15 @@
                 "GameSession": {
                   "shape": "S1o"
                 },
-                "ProtectionPolicy": {}
+                "ProtectionPolicy": {
+                  "shape": "Sz"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -750,7 +961,9 @@
           "PlacementId"
         ],
         "members": {
-          "PlacementId": {}
+          "PlacementId": {
+            "shape": "S1l"
+          }
         }
       },
       "output": {
@@ -768,12 +981,16 @@
         "members": {
           "Names": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1v"
+            }
           },
           "Limit": {
-            "type": "integer"
+            "shape": "S13"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -785,7 +1002,9 @@
               "shape": "S21"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -793,14 +1012,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {},
-          "GameSessionId": {},
-          "AliasId": {},
-          "StatusFilter": {},
-          "Limit": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "GameSessionId": {
+            "shape": "Sg"
+          },
+          "AliasId": {
+            "shape": "Sf"
+          },
+          "StatusFilter": {
+            "shape": "S4"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -809,7 +1038,9 @@
           "GameSessions": {
             "shape": "S4i"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -820,12 +1051,18 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
-          "InstanceId": {},
-          "Limit": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "InstanceId": {
+            "shape": "S4k"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -836,19 +1073,36 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {},
-                "InstanceId": {},
+                "FleetId": {
+                  "shape": "Sb"
+                },
+                "InstanceId": {
+                  "shape": "S4k"
+                },
                 "IpAddress": {},
-                "OperatingSystem": {},
-                "Type": {},
-                "Status": {},
+                "OperatingSystem": {
+                  "shape": "Sl"
+                },
+                "Type": {
+                  "shape": "St"
+                },
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "PENDING",
+                    "ACTIVE",
+                    "TERMINATING"
+                  ]
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -883,11 +1137,15 @@
           "Names": {
             "shape": "S4q"
           },
-          "RuleSetName": {},
-          "Limit": {
-            "type": "integer"
+          "RuleSetName": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -899,7 +1157,9 @@
               "shape": "S2a"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -909,12 +1169,20 @@
         "members": {
           "Names": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            },
+            "max": 10,
+            "min": 1
           },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -929,7 +1197,9 @@
               "shape": "S2e"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -937,14 +1207,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "GameSessionId": {},
-          "PlayerId": {},
-          "PlayerSessionId": {},
-          "PlayerSessionStatusFilter": {},
-          "Limit": {
-            "type": "integer"
+          "GameSessionId": {
+            "shape": "Sg"
           },
-          "NextToken": {}
+          "PlayerId": {
+            "shape": "S4"
+          },
+          "PlayerSessionId": {
+            "shape": "S2j"
+          },
+          "PlayerSessionStatusFilter": {
+            "shape": "S4"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -953,7 +1233,9 @@
           "PlayerSessions": {
             "shape": "S2p"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -964,7 +1246,9 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -983,12 +1267,18 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
-          "StatusFilter": {},
-          "Limit": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "StatusFilter": {
+            "shape": "S5j"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -999,29 +1289,45 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {},
-                "Name": {},
-                "Status": {},
+                "FleetId": {
+                  "shape": "Sb"
+                },
+                "Name": {
+                  "shape": "S4"
+                },
+                "Status": {
+                  "shape": "S5j"
+                },
                 "ScalingAdjustment": {
                   "type": "integer"
                 },
-                "ScalingAdjustmentType": {},
-                "ComparisonOperator": {},
+                "ScalingAdjustmentType": {
+                  "shape": "S5o"
+                },
+                "ComparisonOperator": {
+                  "shape": "S5p"
+                },
                 "Threshold": {
                   "type": "double"
                 },
                 "EvaluationPeriods": {
-                  "type": "integer"
+                  "shape": "S13"
                 },
-                "MetricName": {},
-                "PolicyType": {},
+                "MetricName": {
+                  "shape": "S5r"
+                },
+                "PolicyType": {
+                  "shape": "S5s"
+                },
                 "TargetConfiguration": {
                   "shape": "S5t"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1046,7 +1352,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -1057,18 +1365,32 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {},
-                "IpV4CidrBlock": {},
-                "VpcPeeringConnectionId": {},
+                "FleetId": {
+                  "shape": "Sb"
+                },
+                "IpV4CidrBlock": {
+                  "shape": "S4"
+                },
+                "VpcPeeringConnectionId": {
+                  "shape": "S4"
+                },
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "Code": {},
-                    "Message": {}
+                    "Code": {
+                      "shape": "S4"
+                    },
+                    "Message": {
+                      "shape": "S4"
+                    }
                   }
                 },
-                "PeerVpcId": {},
-                "GameLiftVpcId": {}
+                "PeerVpcId": {
+                  "shape": "S4"
+                },
+                "GameLiftVpcId": {
+                  "shape": "S4"
+                }
               }
             }
           }
@@ -1082,13 +1404,17 @@
           "GameSessionId"
         ],
         "members": {
-          "GameSessionId": {}
+          "GameSessionId": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PreSignedUrl": {}
+          "PreSignedUrl": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1100,8 +1426,12 @@
           "InstanceId"
         ],
         "members": {
-          "FleetId": {},
-          "InstanceId": {}
+          "FleetId": {
+            "shape": "Sb"
+          },
+          "InstanceId": {
+            "shape": "S4k"
+          }
         }
       },
       "output": {
@@ -1110,15 +1440,25 @@
           "InstanceAccess": {
             "type": "structure",
             "members": {
-              "FleetId": {},
-              "InstanceId": {},
+              "FleetId": {
+                "shape": "Sb"
+              },
+              "InstanceId": {
+                "shape": "S4k"
+              },
               "IpAddress": {},
-              "OperatingSystem": {},
+              "OperatingSystem": {
+                "shape": "Sl"
+              },
               "Credentials": {
                 "type": "structure",
                 "members": {
-                  "UserName": {},
-                  "Secret": {}
+                  "UserName": {
+                    "shape": "Sk"
+                  },
+                  "Secret": {
+                    "shape": "Sk"
+                  }
                 },
                 "sensitive": true
               }
@@ -1131,12 +1471,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoutingStrategyType": {},
-          "Name": {},
-          "Limit": {
-            "type": "integer"
+          "RoutingStrategyType": {
+            "shape": "Sa"
           },
-          "NextToken": {}
+          "Name": {
+            "shape": "Sk"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -1148,7 +1494,9 @@
               "shape": "Se"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -1156,11 +1504,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "Status": {},
-          "Limit": {
-            "type": "integer"
+          "Status": {
+            "shape": "Sp"
           },
-          "NextToken": {}
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "Sk"
+          }
         }
       },
       "output": {
@@ -1172,7 +1524,9 @@
               "shape": "Sn"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -1180,11 +1534,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "BuildId": {},
-          "Limit": {
-            "type": "integer"
+          "BuildId": {
+            "shape": "So"
           },
-          "NextToken": {}
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1193,7 +1551,9 @@
           "FleetIds": {
             "shape": "S3g"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1206,21 +1566,33 @@
           "MetricName"
         ],
         "members": {
-          "Name": {},
-          "FleetId": {},
+          "Name": {
+            "shape": "S4"
+          },
+          "FleetId": {
+            "shape": "Sb"
+          },
           "ScalingAdjustment": {
             "type": "integer"
           },
-          "ScalingAdjustmentType": {},
+          "ScalingAdjustmentType": {
+            "shape": "S5o"
+          },
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {},
-          "EvaluationPeriods": {
-            "type": "integer"
+          "ComparisonOperator": {
+            "shape": "S5p"
           },
-          "MetricName": {},
-          "PolicyType": {},
+          "EvaluationPeriods": {
+            "shape": "S13"
+          },
+          "MetricName": {
+            "shape": "S5r"
+          },
+          "PolicyType": {
+            "shape": "S5s"
+          },
           "TargetConfiguration": {
             "shape": "S5t"
           }
@@ -1229,7 +1601,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1240,7 +1614,9 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {}
+          "BuildId": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -1262,13 +1638,17 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {}
+          "AliasId": {
+            "shape": "Sf"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -1276,14 +1656,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {},
-          "AliasId": {},
-          "FilterExpression": {},
-          "SortExpression": {},
-          "Limit": {
-            "type": "integer"
+          "FleetId": {
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "AliasId": {
+            "shape": "Sf"
+          },
+          "FilterExpression": {
+            "shape": "S4"
+          },
+          "SortExpression": {
+            "shape": "S4"
+          },
+          "Limit": {
+            "shape": "S13"
+          },
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1292,7 +1682,9 @@
           "GameSessions": {
             "shape": "S4i"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -1304,7 +1696,9 @@
           "Actions"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "Actions": {
             "shape": "S1e"
           }
@@ -1324,15 +1718,21 @@
           "MaximumPlayerSessionCount"
         ],
         "members": {
-          "PlacementId": {},
-          "GameSessionQueueName": {},
+          "PlacementId": {
+            "shape": "S1l"
+          },
+          "GameSessionQueueName": {
+            "shape": "S1v"
+          },
           "GameProperties": {
             "shape": "S1h"
           },
           "MaximumPlayerSessionCount": {
-            "type": "integer"
+            "shape": "S17"
           },
-          "GameSessionName": {},
+          "GameSessionName": {
+            "shape": "S4"
+          },
           "PlayerLatencies": {
             "shape": "S47"
           },
@@ -1341,12 +1741,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "PlayerId": {},
-                "PlayerData": {}
+                "PlayerId": {
+                  "shape": "S4"
+                },
+                "PlayerData": {
+                  "shape": "S2g"
+                }
               }
             }
           },
-          "GameSessionData": {}
+          "GameSessionData": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -1367,9 +1773,15 @@
           "Players"
         ],
         "members": {
-          "TicketId": {},
-          "ConfigurationName": {},
-          "GameSessionArn": {},
+          "TicketId": {
+            "shape": "S2"
+          },
+          "ConfigurationName": {
+            "shape": "S2"
+          },
+          "GameSessionArn": {
+            "shape": "Sg"
+          },
           "Players": {
             "shape": "S4w"
           }
@@ -1392,8 +1804,12 @@
           "Players"
         ],
         "members": {
-          "TicketId": {},
-          "ConfigurationName": {},
+          "TicketId": {
+            "shape": "S2"
+          },
+          "ConfigurationName": {
+            "shape": "S2"
+          },
           "Players": {
             "shape": "S4w"
           }
@@ -1416,7 +1832,9 @@
           "Actions"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "Actions": {
             "shape": "S1e"
           }
@@ -1434,7 +1852,9 @@
           "PlacementId"
         ],
         "members": {
-          "PlacementId": {}
+          "PlacementId": {
+            "shape": "S1l"
+          }
         }
       },
       "output": {
@@ -1453,7 +1873,9 @@
           "TicketId"
         ],
         "members": {
-          "TicketId": {}
+          "TicketId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1468,9 +1890,15 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {},
-          "Name": {},
-          "Description": {},
+          "AliasId": {
+            "shape": "Sf"
+          },
+          "Name": {
+            "shape": "S8"
+          },
+          "Description": {
+            "shape": "S4"
+          },
           "RoutingStrategy": {
             "shape": "S9"
           }
@@ -1492,9 +1920,15 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {},
-          "Name": {},
-          "Version": {}
+          "BuildId": {
+            "shape": "So"
+          },
+          "Name": {
+            "shape": "S4"
+          },
+          "Version": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -1513,10 +1947,18 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
-          "Name": {},
-          "Description": {},
-          "NewGameSessionProtectionPolicy": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
+          "Name": {
+            "shape": "S4"
+          },
+          "Description": {
+            "shape": "S4"
+          },
+          "NewGameSessionProtectionPolicy": {
+            "shape": "Sz"
+          },
           "ResourceCreationLimitPolicy": {
             "shape": "S16"
           },
@@ -1528,7 +1970,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -1539,22 +1983,26 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "DesiredInstances": {
-            "type": "integer"
+            "shape": "S17"
           },
           "MinSize": {
-            "type": "integer"
+            "shape": "S17"
           },
           "MaxSize": {
-            "type": "integer"
+            "shape": "S17"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -1565,7 +2013,9 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "InboundPermissionAuthorizations": {
             "shape": "Su"
           },
@@ -1577,7 +2027,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {}
+          "FleetId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -1588,13 +2040,21 @@
           "GameSessionId"
         ],
         "members": {
-          "GameSessionId": {},
-          "MaximumPlayerSessionCount": {
-            "type": "integer"
+          "GameSessionId": {
+            "shape": "Sg"
           },
-          "Name": {},
-          "PlayerSessionCreationPolicy": {},
-          "ProtectionPolicy": {}
+          "MaximumPlayerSessionCount": {
+            "shape": "S17"
+          },
+          "Name": {
+            "shape": "S4"
+          },
+          "PlayerSessionCreationPolicy": {
+            "shape": "S1s"
+          },
+          "ProtectionPolicy": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -1613,9 +2073,11 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S1v"
+          },
           "TimeoutInSeconds": {
-            "type": "integer"
+            "shape": "S17"
           },
           "PlayerLatencyPolicies": {
             "shape": "S1w"
@@ -1641,30 +2103,42 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S4"
+          },
           "GameSessionQueueArns": {
             "shape": "S23"
           },
           "RequestTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S24"
           },
           "AcceptanceTimeoutSeconds": {
-            "type": "integer"
+            "shape": "S25"
           },
           "AcceptanceRequired": {
             "type": "boolean"
           },
-          "RuleSetName": {},
-          "NotificationTarget": {},
-          "AdditionalPlayerCount": {
-            "type": "integer"
+          "RuleSetName": {
+            "shape": "S2"
           },
-          "CustomEventData": {},
+          "NotificationTarget": {
+            "shape": "S27"
+          },
+          "AdditionalPlayerCount": {
+            "shape": "S17"
+          },
+          "CustomEventData": {
+            "shape": "S28"
+          },
           "GameProperties": {
             "shape": "S1h"
           },
-          "GameSessionData": {}
+          "GameSessionData": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -1684,7 +2158,9 @@
           "RuntimeConfiguration"
         ],
         "members": {
-          "FleetId": {},
+          "FleetId": {
+            "shape": "Sb"
+          },
           "RuntimeConfiguration": {
             "shape": "S10"
           }
@@ -1706,7 +2182,9 @@
           "RuleSetBody"
         ],
         "members": {
-          "RuleSetBody": {}
+          "RuleSetBody": {
+            "shape": "S2c"
+          }
         }
       },
       "output": {
@@ -1720,24 +2198,64 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9-\\.]+"
+    },
     "S3": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4"
+      }
+    },
+    "S4": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S8": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": ".*\\S.*"
     },
     "S9": {
       "type": "structure",
       "members": {
-        "Type": {},
-        "FleetId": {},
+        "Type": {
+          "shape": "Sa"
+        },
+        "FleetId": {
+          "shape": "Sb"
+        },
         "Message": {}
       }
+    },
+    "Sa": {
+      "type": "string",
+      "enum": [
+        "SIMPLE",
+        "TERMINAL"
+      ]
+    },
+    "Sb": {
+      "type": "string",
+      "pattern": "^fleet-\\S+"
     },
     "Se": {
       "type": "structure",
       "members": {
-        "AliasId": {},
-        "Name": {},
-        "AliasArn": {},
+        "AliasId": {
+          "shape": "Sf"
+        },
+        "Name": {
+          "shape": "S8"
+        },
+        "AliasArn": {
+          "shape": "Sg"
+        },
         "Description": {},
         "RoutingStrategy": {
           "shape": "S9"
@@ -1750,38 +2268,129 @@
         }
       }
     },
+    "Sf": {
+      "type": "string",
+      "pattern": "^alias-\\S+"
+    },
+    "Sg": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:/-]+"
+    },
     "Sj": {
       "type": "structure",
       "members": {
-        "Bucket": {},
-        "Key": {},
-        "RoleArn": {}
+        "Bucket": {
+          "shape": "Sk"
+        },
+        "Key": {
+          "shape": "Sk"
+        },
+        "RoleArn": {
+          "shape": "Sk"
+        }
       }
+    },
+    "Sk": {
+      "type": "string",
+      "min": 1
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "WINDOWS_2012",
+        "AMAZON_LINUX"
+      ]
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "BuildId": {},
+        "BuildId": {
+          "shape": "So"
+        },
         "Name": {},
         "Version": {},
-        "Status": {},
-        "SizeOnDisk": {
-          "type": "long"
+        "Status": {
+          "shape": "Sp"
         },
-        "OperatingSystem": {},
+        "SizeOnDisk": {
+          "type": "long",
+          "min": 1
+        },
+        "OperatingSystem": {
+          "shape": "Sl"
+        },
         "CreationTime": {
           "type": "timestamp"
         }
       }
     },
+    "So": {
+      "type": "string",
+      "pattern": "^build-\\S+"
+    },
+    "Sp": {
+      "type": "string",
+      "enum": [
+        "INITIALIZED",
+        "READY",
+        "FAILED"
+      ]
+    },
     "Sr": {
       "type": "structure",
       "members": {
-        "AccessKeyId": {},
-        "SecretAccessKey": {},
-        "SessionToken": {}
+        "AccessKeyId": {
+          "shape": "Sk"
+        },
+        "SecretAccessKey": {
+          "shape": "Sk"
+        },
+        "SessionToken": {
+          "shape": "Sk"
+        }
       },
       "sensitive": true
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "c3.large",
+        "c3.xlarge",
+        "c3.2xlarge",
+        "c3.4xlarge",
+        "c3.8xlarge",
+        "c4.large",
+        "c4.xlarge",
+        "c4.2xlarge",
+        "c4.4xlarge",
+        "c4.8xlarge",
+        "r3.large",
+        "r3.xlarge",
+        "r3.2xlarge",
+        "r3.4xlarge",
+        "r3.8xlarge",
+        "r4.large",
+        "r4.xlarge",
+        "r4.2xlarge",
+        "r4.4xlarge",
+        "r4.8xlarge",
+        "r4.16xlarge",
+        "m3.medium",
+        "m3.large",
+        "m3.xlarge",
+        "m3.2xlarge",
+        "m4.large",
+        "m4.xlarge",
+        "m4.2xlarge",
+        "m4.4xlarge",
+        "m4.10xlarge"
+      ]
     },
     "Su": {
       "type": "list",
@@ -1795,15 +2404,37 @@
         ],
         "members": {
           "FromPort": {
-            "type": "integer"
+            "shape": "Sw"
           },
           "ToPort": {
-            "type": "integer"
+            "shape": "Sw"
           },
-          "IpRange": {},
-          "Protocol": {}
+          "IpRange": {
+            "type": "string",
+            "pattern": "[^\\s]+"
+          },
+          "Protocol": {
+            "type": "string",
+            "enum": [
+              "TCP",
+              "UDP"
+            ]
+          }
         }
-      }
+      },
+      "max": 50
+    },
+    "Sw": {
+      "type": "integer",
+      "max": 60000,
+      "min": 1
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "NoProtection",
+        "FullProtection"
+      ]
     },
     "S10": {
       "type": "structure",
@@ -1817,61 +2448,126 @@
               "ConcurrentExecutions"
             ],
             "members": {
-              "LaunchPath": {},
-              "Parameters": {},
+              "LaunchPath": {
+                "shape": "S4"
+              },
+              "Parameters": {
+                "shape": "S4"
+              },
               "ConcurrentExecutions": {
-                "type": "integer"
+                "shape": "S13"
               }
             }
-          }
+          },
+          "max": 50,
+          "min": 1
         },
         "MaxConcurrentGameSessionActivations": {
-          "type": "integer"
+          "type": "integer",
+          "max": 2147483647,
+          "min": 1
         },
         "GameSessionActivationTimeoutSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "max": 600,
+          "min": 1
         }
       }
+    },
+    "S13": {
+      "type": "integer",
+      "min": 1
     },
     "S16": {
       "type": "structure",
       "members": {
         "NewGameSessionsPerCreator": {
-          "type": "integer"
+          "shape": "S17"
         },
         "PolicyPeriodInMinutes": {
-          "type": "integer"
+          "shape": "S17"
         }
       }
     },
+    "S17": {
+      "type": "integer",
+      "min": 0
+    },
     "S18": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      },
+      "max": 1
+    },
+    "S1a": {
+      "type": "string",
+      "enum": [
+        "ON_DEMAND",
+        "SPOT"
+      ]
     },
     "S1c": {
       "type": "structure",
       "members": {
-        "FleetId": {},
-        "FleetArn": {},
-        "FleetType": {},
-        "InstanceType": {},
-        "Description": {},
-        "Name": {},
+        "FleetId": {
+          "shape": "Sb"
+        },
+        "FleetArn": {
+          "shape": "Sg"
+        },
+        "FleetType": {
+          "shape": "S1a"
+        },
+        "InstanceType": {
+          "shape": "St"
+        },
+        "Description": {
+          "shape": "S4"
+        },
+        "Name": {
+          "shape": "S4"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
         "TerminationTime": {
           "type": "timestamp"
         },
-        "Status": {},
-        "BuildId": {},
-        "ServerLaunchPath": {},
-        "ServerLaunchParameters": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "NEW",
+            "DOWNLOADING",
+            "VALIDATING",
+            "BUILDING",
+            "ACTIVATING",
+            "ACTIVE",
+            "DELETING",
+            "ERROR",
+            "TERMINATED"
+          ]
+        },
+        "BuildId": {
+          "shape": "So"
+        },
+        "ServerLaunchPath": {
+          "shape": "S4"
+        },
+        "ServerLaunchParameters": {
+          "shape": "S4"
+        },
         "LogPaths": {
           "shape": "S3"
         },
-        "NewGameSessionProtectionPolicy": {},
-        "OperatingSystem": {},
+        "NewGameSessionProtectionPolicy": {
+          "shape": "Sz"
+        },
+        "OperatingSystem": {
+          "shape": "Sl"
+        },
         "ResourceCreationLimitPolicy": {
           "shape": "S16"
         },
@@ -1885,7 +2581,14 @@
     },
     "S1e": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "AUTO_SCALING"
+        ]
+      },
+      "max": 1,
+      "min": 1
     },
     "S1h": {
       "type": "list",
@@ -1896,17 +2599,41 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 32
+          },
+          "Value": {
+            "type": "string",
+            "max": 96
+          }
         }
-      }
+      },
+      "max": 16
+    },
+    "S1l": {
+      "type": "string",
+      "max": 48,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9-]+"
+    },
+    "S1m": {
+      "type": "string",
+      "max": 4096,
+      "min": 1
     },
     "S1o": {
       "type": "structure",
       "members": {
-        "GameSessionId": {},
-        "Name": {},
-        "FleetId": {},
+        "GameSessionId": {
+          "shape": "S4"
+        },
+        "Name": {
+          "shape": "S4"
+        },
+        "FleetId": {
+          "shape": "Sb"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
@@ -1914,25 +2641,65 @@
           "type": "timestamp"
         },
         "CurrentPlayerSessionCount": {
-          "type": "integer"
+          "shape": "S17"
         },
         "MaximumPlayerSessionCount": {
-          "type": "integer"
+          "shape": "S17"
         },
-        "Status": {},
-        "StatusReason": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "ACTIVE",
+            "ACTIVATING",
+            "TERMINATED",
+            "TERMINATING",
+            "ERROR"
+          ]
+        },
+        "StatusReason": {
+          "type": "string",
+          "enum": [
+            "INTERRUPTED"
+          ]
+        },
         "GameProperties": {
           "shape": "S1h"
         },
         "IpAddress": {},
         "Port": {
-          "type": "integer"
+          "shape": "Sw"
         },
-        "PlayerSessionCreationPolicy": {},
-        "CreatorId": {},
-        "GameSessionData": {},
-        "MatchmakerData": {}
+        "PlayerSessionCreationPolicy": {
+          "shape": "S1s"
+        },
+        "CreatorId": {
+          "shape": "S4"
+        },
+        "GameSessionData": {
+          "shape": "S1m"
+        },
+        "MatchmakerData": {
+          "shape": "S1t"
+        }
       }
+    },
+    "S1s": {
+      "type": "string",
+      "enum": [
+        "ACCEPT_ALL",
+        "DENY_ALL"
+      ]
+    },
+    "S1t": {
+      "type": "string",
+      "max": 390000,
+      "min": 1
+    },
+    "S1v": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9-]+"
     },
     "S1w": {
       "type": "list",
@@ -1940,10 +2707,10 @@
         "type": "structure",
         "members": {
           "MaximumIndividualPlayerLatencyMilliseconds": {
-            "type": "integer"
+            "shape": "S17"
           },
           "PolicyDurationSeconds": {
-            "type": "integer"
+            "shape": "S17"
           }
         }
       }
@@ -1953,17 +2720,23 @@
       "member": {
         "type": "structure",
         "members": {
-          "DestinationArn": {}
+          "DestinationArn": {
+            "shape": "Sg"
+          }
         }
       }
     },
     "S21": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "GameSessionQueueArn": {},
+        "Name": {
+          "shape": "S1v"
+        },
+        "GameSessionQueueArn": {
+          "shape": "Sg"
+        },
         "TimeoutInSeconds": {
-          "type": "integer"
+          "shape": "S17"
         },
         "PlayerLatencyPolicies": {
           "shape": "S1w"
@@ -1975,39 +2748,79 @@
     },
     "S23": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sg"
+      }
+    },
+    "S24": {
+      "type": "integer",
+      "max": 43200,
+      "min": 1
+    },
+    "S25": {
+      "type": "integer",
+      "max": 600,
+      "min": 1
+    },
+    "S27": {
+      "type": "string",
+      "max": 300,
+      "min": 0,
+      "pattern": "[a-zA-Z0-9:_/-]*"
+    },
+    "S28": {
+      "type": "string",
+      "max": 256,
+      "min": 0
     },
     "S2a": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Description": {},
+        "Name": {
+          "shape": "S2"
+        },
+        "Description": {
+          "shape": "S4"
+        },
         "GameSessionQueueArns": {
           "shape": "S23"
         },
         "RequestTimeoutSeconds": {
-          "type": "integer"
+          "shape": "S24"
         },
         "AcceptanceTimeoutSeconds": {
-          "type": "integer"
+          "shape": "S25"
         },
         "AcceptanceRequired": {
           "type": "boolean"
         },
-        "RuleSetName": {},
-        "NotificationTarget": {},
-        "AdditionalPlayerCount": {
-          "type": "integer"
+        "RuleSetName": {
+          "shape": "S2"
         },
-        "CustomEventData": {},
+        "NotificationTarget": {
+          "shape": "S27"
+        },
+        "AdditionalPlayerCount": {
+          "shape": "S17"
+        },
+        "CustomEventData": {
+          "shape": "S28"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
         "GameProperties": {
           "shape": "S1h"
         },
-        "GameSessionData": {}
+        "GameSessionData": {
+          "shape": "S1m"
+        }
       }
+    },
+    "S2c": {
+      "type": "string",
+      "max": 65535,
+      "min": 1
     },
     "S2e": {
       "type": "structure",
@@ -2015,33 +2828,64 @@
         "RuleSetBody"
       ],
       "members": {
-        "RuleSetName": {},
-        "RuleSetBody": {},
+        "RuleSetName": {
+          "shape": "S2"
+        },
+        "RuleSetBody": {
+          "shape": "S2c"
+        },
         "CreationTime": {
           "type": "timestamp"
         }
       }
     },
+    "S2g": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
     "S2i": {
       "type": "structure",
       "members": {
-        "PlayerSessionId": {},
-        "PlayerId": {},
-        "GameSessionId": {},
-        "FleetId": {},
+        "PlayerSessionId": {
+          "shape": "S2j"
+        },
+        "PlayerId": {
+          "shape": "S4"
+        },
+        "GameSessionId": {
+          "shape": "S4"
+        },
+        "FleetId": {
+          "shape": "Sb"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
         "TerminationTime": {
           "type": "timestamp"
         },
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "RESERVED",
+            "ACTIVE",
+            "COMPLETED",
+            "TIMEDOUT"
+          ]
+        },
         "IpAddress": {},
         "Port": {
-          "type": "integer"
+          "shape": "Sw"
         },
-        "PlayerData": {}
+        "PlayerData": {
+          "shape": "S2g"
+        }
       }
+    },
+    "S2j": {
+      "type": "string",
+      "pattern": "^psess-\\S+"
     },
     "S2p": {
       "type": "list",
@@ -2052,9 +2896,15 @@
     "S2s": {
       "type": "structure",
       "members": {
-        "GameLiftAwsAccountId": {},
-        "PeerVpcAwsAccountId": {},
-        "PeerVpcId": {},
+        "GameLiftAwsAccountId": {
+          "shape": "S4"
+        },
+        "PeerVpcAwsAccountId": {
+          "shape": "S4"
+        },
+        "PeerVpcId": {
+          "shape": "S4"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2065,24 +2915,47 @@
     },
     "S3g": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      },
+      "min": 1
     },
     "S45": {
       "type": "structure",
       "members": {
-        "PlacementId": {},
-        "GameSessionQueueName": {},
-        "Status": {},
+        "PlacementId": {
+          "shape": "S1l"
+        },
+        "GameSessionQueueName": {
+          "shape": "S1v"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "FULFILLED",
+            "CANCELLED",
+            "TIMED_OUT"
+          ]
+        },
         "GameProperties": {
           "shape": "S1h"
         },
         "MaximumPlayerSessionCount": {
-          "type": "integer"
+          "shape": "S17"
         },
-        "GameSessionName": {},
-        "GameSessionId": {},
-        "GameSessionArn": {},
-        "GameSessionRegion": {},
+        "GameSessionName": {
+          "shape": "S4"
+        },
+        "GameSessionId": {
+          "shape": "S4"
+        },
+        "GameSessionArn": {
+          "shape": "S4"
+        },
+        "GameSessionRegion": {
+          "shape": "S4"
+        },
         "PlayerLatencies": {
           "shape": "S47"
         },
@@ -2094,20 +2967,28 @@
         },
         "IpAddress": {},
         "Port": {
-          "type": "integer"
+          "shape": "Sw"
         },
         "PlacedPlayerSessions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "PlayerId": {},
-              "PlayerSessionId": {}
+              "PlayerId": {
+                "shape": "S4"
+              },
+              "PlayerSessionId": {
+                "shape": "S2j"
+              }
             }
           }
         },
-        "GameSessionData": {},
-        "MatchmakerData": {}
+        "GameSessionData": {
+          "shape": "S1m"
+        },
+        "MatchmakerData": {
+          "shape": "S1t"
+        }
       }
     },
     "S47": {
@@ -2115,8 +2996,12 @@
       "member": {
         "type": "structure",
         "members": {
-          "PlayerId": {},
-          "RegionIdentifier": {},
+          "PlayerId": {
+            "shape": "S4"
+          },
+          "RegionIdentifier": {
+            "shape": "S4"
+          },
           "LatencyInMilliseconds": {
             "type": "float"
           }
@@ -2129,16 +3014,38 @@
         "shape": "S1o"
       }
     },
+    "S4k": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9\\.-]+"
+    },
     "S4q": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "S4t": {
       "type": "structure",
       "members": {
-        "TicketId": {},
-        "ConfigurationName": {},
-        "Status": {},
+        "TicketId": {
+          "shape": "S2"
+        },
+        "ConfigurationName": {
+          "shape": "S2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "CANCELLED",
+            "COMPLETED",
+            "FAILED",
+            "PLACING",
+            "QUEUED",
+            "REQUIRES_ACCEPTANCE",
+            "SEARCHING",
+            "TIMED_OUT"
+          ]
+        },
         "StatusReason": {},
         "StatusMessage": {},
         "StartTime": {
@@ -2153,25 +3060,31 @@
         "GameSessionConnectionInfo": {
           "type": "structure",
           "members": {
-            "GameSessionArn": {},
+            "GameSessionArn": {
+              "shape": "Sg"
+            },
             "IpAddress": {},
             "Port": {
-              "type": "integer"
+              "shape": "S13"
             },
             "MatchedPlayerSessions": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "PlayerId": {},
-                  "PlayerSessionId": {}
+                  "PlayerId": {
+                    "shape": "S4"
+                  },
+                  "PlayerSessionId": {
+                    "shape": "S2j"
+                  }
                 }
               }
             }
           }
         },
         "EstimatedWaitTime": {
-          "type": "integer"
+          "shape": "S17"
         }
       }
     },
@@ -2180,14 +3093,20 @@
       "member": {
         "type": "structure",
         "members": {
-          "PlayerId": {},
+          "PlayerId": {
+            "shape": "S4"
+          },
           "PlayerAttributes": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S4"
+            },
             "value": {
               "type": "structure",
               "members": {
-                "S": {},
+                "S": {
+                  "shape": "S4"
+                },
                 "N": {
                   "type": "double"
                 },
@@ -2196,7 +3115,9 @@
                 },
                 "SDM": {
                   "type": "map",
-                  "key": {},
+                  "key": {
+                    "shape": "S4"
+                  },
                   "value": {
                     "type": "double"
                   }
@@ -2204,16 +3125,72 @@
               }
             }
           },
-          "Team": {},
+          "Team": {
+            "shape": "S4"
+          },
           "LatencyInMs": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "Sk"
+            },
             "value": {
-              "type": "integer"
+              "shape": "S13"
             }
           }
         }
       }
+    },
+    "S5j": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "UPDATE_REQUESTED",
+        "UPDATING",
+        "DELETE_REQUESTED",
+        "DELETING",
+        "DELETED",
+        "ERROR"
+      ]
+    },
+    "S5o": {
+      "type": "string",
+      "enum": [
+        "ChangeInCapacity",
+        "ExactCapacity",
+        "PercentChangeInCapacity"
+      ]
+    },
+    "S5p": {
+      "type": "string",
+      "enum": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanThreshold",
+        "LessThanOrEqualToThreshold"
+      ]
+    },
+    "S5r": {
+      "type": "string",
+      "enum": [
+        "ActivatingGameSessions",
+        "ActiveGameSessions",
+        "ActiveInstances",
+        "AvailableGameSessions",
+        "AvailablePlayerSessions",
+        "CurrentPlayerSessions",
+        "IdleInstances",
+        "PercentAvailableGameSessions",
+        "PercentIdleInstances",
+        "QueueDepth",
+        "WaitTime"
+      ]
+    },
+    "S5s": {
+      "type": "string",
+      "enum": [
+        "RuleBased",
+        "TargetBased"
+      ]
     },
     "S5t": {
       "type": "structure",

--- a/apis/glacier-2012-06-01.min.json
+++ b/apis/glacier-2012-06-01.min.json
@@ -1200,14 +1200,28 @@
       "members": {
         "JobId": {},
         "JobDescription": {},
-        "Action": {},
+        "Action": {
+          "type": "string",
+          "enum": [
+            "ArchiveRetrieval",
+            "InventoryRetrieval",
+            "Select"
+          ]
+        },
         "ArchiveId": {},
         "VaultARN": {},
         "CreationDate": {},
         "Completed": {
           "type": "boolean"
         },
-        "StatusCode": {},
+        "StatusCode": {
+          "type": "string",
+          "enum": [
+            "InProgress",
+            "Succeeded",
+            "Failed"
+          ]
+        },
         "StatusMessage": {},
         "ArchiveSizeInBytes": {
           "type": "long"
@@ -1249,7 +1263,14 @@
             "csv": {
               "type": "structure",
               "members": {
-                "FileHeaderInfo": {},
+                "FileHeaderInfo": {
+                  "type": "string",
+                  "enum": [
+                    "USE",
+                    "IGNORE",
+                    "NONE"
+                  ]
+                },
                 "Comments": {},
                 "QuoteEscapeCharacter": {},
                 "RecordDelimiter": {},
@@ -1259,7 +1280,12 @@
             }
           }
         },
-        "ExpressionType": {},
+        "ExpressionType": {
+          "type": "string",
+          "enum": [
+            "SQL"
+          ]
+        },
         "Expression": {},
         "OutputSerialization": {
           "type": "structure",
@@ -1267,7 +1293,13 @@
             "csv": {
               "type": "structure",
               "members": {
-                "QuoteFields": {},
+                "QuoteFields": {
+                  "type": "string",
+                  "enum": [
+                    "ALWAYS",
+                    "ASNEEDED"
+                  ]
+                },
                 "QuoteEscapeCharacter": {},
                 "RecordDelimiter": {},
                 "FieldDelimiter": {},
@@ -1289,12 +1321,29 @@
             "Encryption": {
               "type": "structure",
               "members": {
-                "EncryptionType": {},
+                "EncryptionType": {
+                  "type": "string",
+                  "enum": [
+                    "aws:kms",
+                    "AES256"
+                  ]
+                },
                 "KMSKeyId": {},
                 "KMSContext": {}
               }
             },
-            "CannedACL": {},
+            "CannedACL": {
+              "type": "string",
+              "enum": [
+                "private",
+                "public-read",
+                "public-read-write",
+                "aws-exec-read",
+                "authenticated-read",
+                "bucket-owner-read",
+                "bucket-owner-full-control"
+              ]
+            },
             "AccessControlList": {
               "type": "list",
               "member": {
@@ -1306,14 +1355,30 @@
                       "Type"
                     ],
                     "members": {
-                      "Type": {},
+                      "Type": {
+                        "type": "string",
+                        "enum": [
+                          "AmazonCustomerByEmail",
+                          "CanonicalUser",
+                          "Group"
+                        ]
+                      },
                       "DisplayName": {},
                       "URI": {},
                       "ID": {},
                       "EmailAddress": {}
                     }
                   },
-                  "Permission": {}
+                  "Permission": {
+                    "type": "string",
+                    "enum": [
+                      "FULL_CONTROL",
+                      "WRITE",
+                      "WRITE_ACP",
+                      "READ",
+                      "READ_ACP"
+                    ]
+                  }
                 }
               }
             },
@@ -1323,7 +1388,14 @@
             "UserMetadata": {
               "shape": "S17"
             },
-            "StorageClass": {}
+            "StorageClass": {
+              "type": "string",
+              "enum": [
+                "STANDARD",
+                "REDUCED_REDUNDANCY",
+                "STANDARD_IA"
+              ]
+            }
           }
         }
       }

--- a/apis/glue-2017-03-31.min.json
+++ b/apis/glue-2017-03-31.min.json
@@ -21,14 +21,22 @@
           "PartitionInputList"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionInputList": {
             "type": "list",
             "member": {
               "shape": "S5"
-            }
+            },
+            "max": 100,
+            "min": 0
           }
         }
       },
@@ -48,10 +56,16 @@
           "ConnectionNameList"
         ],
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "ConnectionNameList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "max": 25,
+            "min": 0
           }
         }
       },
@@ -63,7 +77,9 @@
           },
           "Errors": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "shape": "Sx"
             }
@@ -80,14 +96,22 @@
           "PartitionsToDelete"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionsToDelete": {
             "type": "list",
             "member": {
               "shape": "S15"
-            }
+            },
+            "max": 25,
+            "min": 0
           }
         }
       },
@@ -108,11 +132,19 @@
           "TablesToDelete"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
           "TablesToDelete": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "max": 100,
+            "min": 0
           }
         }
       },
@@ -124,7 +156,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {},
+                "TableName": {
+                  "shape": "S3"
+                },
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -143,12 +177,22 @@
           "VersionIds"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "VersionIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1e"
+            },
+            "max": 100,
+            "min": 0
           }
         }
       },
@@ -160,8 +204,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {},
-                "VersionId": {},
+                "TableName": {
+                  "shape": "S3"
+                },
+                "VersionId": {
+                  "shape": "S1e"
+                },
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -180,9 +228,15 @@
           "PartitionsToGet"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionsToGet": {
             "shape": "S1j"
           }
@@ -208,10 +262,16 @@
           "JobRunIds"
         ],
         "members": {
-          "JobName": {},
+          "JobName": {
+            "shape": "S3"
+          },
           "JobRunIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1p"
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -223,8 +283,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "JobName": {},
-                "JobRunId": {}
+                "JobName": {
+                  "shape": "S3"
+                },
+                "JobRunId": {
+                  "shape": "S1p"
+                }
               }
             }
           },
@@ -233,8 +297,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "JobName": {},
-                "JobRunId": {},
+                "JobName": {
+                  "shape": "S3"
+                },
+                "JobRunId": {
+                  "shape": "S1p"
+                },
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -257,9 +325,15 @@
             ],
             "members": {
               "Classification": {},
-              "Name": {},
-              "GrokPattern": {},
-              "CustomPatterns": {}
+              "Name": {
+                "shape": "S3"
+              },
+              "GrokPattern": {
+                "shape": "S1y"
+              },
+              "CustomPatterns": {
+                "shape": "S1z"
+              }
             }
           },
           "XMLClassifier": {
@@ -270,7 +344,9 @@
             ],
             "members": {
               "Classification": {},
-              "Name": {},
+              "Name": {
+                "shape": "S3"
+              },
               "RowTag": {}
             }
           },
@@ -281,7 +357,9 @@
               "JsonPath"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "S3"
+              },
               "JsonPath": {}
             }
           }
@@ -299,7 +377,9 @@
           "ConnectionInput"
         ],
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "ConnectionInput": {
             "shape": "S26"
           }
@@ -320,10 +400,14 @@
           "Targets"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3"
+          },
           "Role": {},
           "DatabaseName": {},
-          "Description": {},
+          "Description": {
+            "shape": "Sy"
+          },
           "Targets": {
             "shape": "S2h"
           },
@@ -331,12 +415,16 @@
           "Classifiers": {
             "shape": "S2s"
           },
-          "TablePrefix": {},
+          "TablePrefix": {
+            "shape": "S2t"
+          },
           "SchemaChangePolicy": {
             "shape": "S2u"
           },
           "Configuration": {},
-          "CrawlerSecurityConfiguration": {}
+          "CrawlerSecurityConfiguration": {
+            "shape": "S2y"
+          }
         }
       },
       "output": {
@@ -351,7 +439,9 @@
           "DatabaseInput"
         ],
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "DatabaseInput": {
             "shape": "S31"
           }
@@ -371,7 +461,9 @@
         ],
         "members": {
           "EndpointName": {},
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S36"
+          },
           "SecurityGroupIds": {
             "shape": "S37"
           },
@@ -385,7 +477,9 @@
           },
           "ExtraPythonLibsS3Path": {},
           "ExtraJarsS3Path": {},
-          "SecurityConfiguration": {}
+          "SecurityConfiguration": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -397,7 +491,9 @@
             "shape": "S37"
           },
           "SubnetId": {},
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S36"
+          },
           "YarnEndpointAddress": {},
           "ZeppelinRemoteSparkInterpreterPort": {
             "type": "integer"
@@ -410,7 +506,9 @@
           "ExtraPythonLibsS3Path": {},
           "ExtraJarsS3Path": {},
           "FailureReason": {},
-          "SecurityConfiguration": {},
+          "SecurityConfiguration": {
+            "shape": "S3"
+          },
           "CreatedTimestamp": {
             "type": "timestamp"
           }
@@ -426,8 +524,12 @@
           "Command"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S3"
+          },
+          "Description": {
+            "shape": "Sy"
+          },
           "LogUri": {},
           "Role": {},
           "ExecutionProperty": {
@@ -449,18 +551,22 @@
             "type": "integer"
           },
           "Timeout": {
-            "type": "integer"
+            "shape": "S3m"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {}
+          "SecurityConfiguration": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -473,9 +579,15 @@
           "PartitionInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionInput": {
             "shape": "S5"
           }
@@ -496,7 +608,9 @@
           "DagEdges": {
             "shape": "S41"
           },
-          "Language": {}
+          "Language": {
+            "shape": "S43"
+          }
         }
       },
       "output": {
@@ -515,7 +629,9 @@
           "EncryptionConfiguration"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3"
+          },
           "EncryptionConfiguration": {
             "shape": "S48"
           }
@@ -524,7 +640,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3"
+          },
           "CreatedTimestamp": {
             "type": "timestamp"
           }
@@ -539,8 +657,12 @@
           "TableInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
           "TableInput": {
             "shape": "S4j"
           }
@@ -560,8 +682,12 @@
           "Actions"
         ],
         "members": {
-          "Name": {},
-          "Type": {},
+          "Name": {
+            "shape": "S3"
+          },
+          "Type": {
+            "shape": "S4p"
+          },
           "Schedule": {},
           "Predicate": {
             "shape": "S4q"
@@ -569,7 +695,9 @@
           "Actions": {
             "shape": "S4w"
           },
-          "Description": {},
+          "Description": {
+            "shape": "Sy"
+          },
           "StartOnCreation": {
             "type": "boolean"
           }
@@ -578,7 +706,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -590,8 +720,12 @@
           "FunctionInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
           "FunctionInput": {
             "shape": "S51"
           }
@@ -609,7 +743,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -624,8 +760,12 @@
           "ConnectionName"
         ],
         "members": {
-          "CatalogId": {},
-          "ConnectionName": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "ConnectionName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -640,7 +780,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -655,8 +797,12 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {},
-          "Name": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -686,13 +832,17 @@
           "JobName"
         ],
         "members": {
-          "JobName": {}
+          "JobName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobName": {}
+          "JobName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -705,9 +855,15 @@
           "PartitionValues"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionValues": {
             "shape": "S6"
           }
@@ -725,7 +881,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -741,9 +899,15 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "Name": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -760,10 +924,18 @@
           "VersionId"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
-          "VersionId": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
+          "VersionId": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
@@ -778,13 +950,17 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -796,9 +972,15 @@
           "FunctionName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "FunctionName": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "FunctionName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -810,7 +992,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {}
+          "CatalogId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -825,7 +1009,9 @@
               "ImportTime": {
                 "type": "timestamp"
               },
-              "ImportedBy": {}
+              "ImportedBy": {
+                "shape": "S3"
+              }
             }
           }
         }
@@ -838,7 +1024,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -855,7 +1043,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           },
           "NextToken": {}
         }
@@ -880,8 +1068,12 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {},
-          "Name": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -897,19 +1089,23 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "Filter": {
             "type": "structure",
             "members": {
               "MatchCriteria": {
                 "shape": "S28"
               },
-              "ConnectionType": {}
+              "ConnectionType": {
+                "shape": "S27"
+              }
             }
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -933,7 +1129,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -951,10 +1149,14 @@
         "members": {
           "CrawlerNameList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "max": 100,
+            "min": 0
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           },
           "NextToken": {}
         }
@@ -967,27 +1169,29 @@
             "member": {
               "type": "structure",
               "members": {
-                "CrawlerName": {},
+                "CrawlerName": {
+                  "shape": "S3"
+                },
                 "TimeLeftSeconds": {
-                  "type": "double"
+                  "shape": "S6y"
                 },
                 "StillEstimating": {
                   "type": "boolean"
                 },
                 "LastRuntimeSeconds": {
-                  "type": "double"
+                  "shape": "S6y"
                 },
                 "MedianRuntimeSeconds": {
-                  "type": "double"
+                  "shape": "S6y"
                 },
                 "TablesCreated": {
-                  "type": "integer"
+                  "shape": "S4k"
                 },
                 "TablesUpdated": {
-                  "type": "integer"
+                  "shape": "S4k"
                 },
                 "TablesDeleted": {
-                  "type": "integer"
+                  "shape": "S4k"
                 }
               }
             }
@@ -1001,7 +1205,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           },
           "NextToken": {}
         }
@@ -1026,8 +1230,12 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {},
-          "Name": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1043,10 +1251,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1109,7 +1319,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           },
           "NextToken": {}
         }
@@ -1134,7 +1344,9 @@
           "JobName"
         ],
         "members": {
-          "JobName": {}
+          "JobName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1154,8 +1366,12 @@
           "RunId"
         ],
         "members": {
-          "JobName": {},
-          "RunId": {},
+          "JobName": {
+            "shape": "S3"
+          },
+          "RunId": {
+            "shape": "S1p"
+          },
           "PredecessorsIncluded": {
             "type": "boolean"
           }
@@ -1177,10 +1393,12 @@
           "JobName"
         ],
         "members": {
-          "JobName": {},
+          "JobName": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1203,7 +1421,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1259,9 +1477,15 @@
           "PartitionValues"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionValues": {
             "shape": "S6"
           }
@@ -1284,10 +1508,21 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
-          "Expression": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
+          "Expression": {
+            "type": "string",
+            "max": 2048,
+            "min": 0,
+            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+          },
           "NextToken": {},
           "Segment": {
             "type": "structure",
@@ -1297,15 +1532,17 @@
             ],
             "members": {
               "SegmentNumber": {
-                "type": "integer"
+                "shape": "S4k"
               },
               "TotalSegments": {
-                "type": "integer"
+                "type": "integer",
+                "max": 10,
+                "min": 1
               }
             }
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1339,7 +1576,9 @@
           "Location": {
             "shape": "S80"
           },
-          "Language": {}
+          "Language": {
+            "shape": "S43"
+          }
         }
       },
       "output": {
@@ -1357,7 +1596,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1374,7 +1615,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           },
           "NextToken": {}
         }
@@ -1400,9 +1641,15 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "Name": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1422,10 +1669,18 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
-          "VersionId": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
+          "VersionId": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
@@ -1445,12 +1700,18 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1474,12 +1735,21 @@
           "DatabaseName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "Expression": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "Expression": {
+            "type": "string",
+            "max": 2048,
+            "min": 0,
+            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1503,7 +1773,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1520,9 +1792,11 @@
         "type": "structure",
         "members": {
           "NextToken": {},
-          "DependentJobName": {},
+          "DependentJobName": {
+            "shape": "S3"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1547,9 +1821,15 @@
           "FunctionName"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "FunctionName": {}
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "FunctionName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1569,12 +1849,18 @@
           "Pattern"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "Pattern": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "Pattern": {
+            "shape": "S3"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S66"
           }
         }
       },
@@ -1595,7 +1881,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {}
+          "CatalogId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1610,7 +1898,9 @@
           "DataCatalogEncryptionSettings"
         ],
         "members": {
-          "CatalogId": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
           "DataCatalogEncryptionSettings": {
             "type": "structure",
             "members": {
@@ -1620,8 +1910,16 @@
                   "CatalogEncryptionMode"
                 ],
                 "members": {
-                  "CatalogEncryptionMode": {},
-                  "SseAwsKmsKeyId": {}
+                  "CatalogEncryptionMode": {
+                    "type": "string",
+                    "enum": [
+                      "DISABLED",
+                      "SSE-KMS"
+                    ]
+                  },
+                  "SseAwsKmsKeyId": {
+                    "shape": "S3"
+                  }
                 }
               }
             }
@@ -1672,7 +1970,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1687,7 +1987,9 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {}
+          "CrawlerName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1702,8 +2004,12 @@
           "JobName"
         ],
         "members": {
-          "JobName": {},
-          "JobRunId": {},
+          "JobName": {
+            "shape": "S3"
+          },
+          "JobRunId": {
+            "shape": "S1p"
+          },
           "Arguments": {
             "shape": "S3j"
           },
@@ -1711,18 +2017,22 @@
             "type": "integer"
           },
           "Timeout": {
-            "type": "integer"
+            "shape": "S3m"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {}
+          "SecurityConfiguration": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobRunId": {}
+          "JobRunId": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -1733,13 +2043,17 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1750,7 +2064,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1765,7 +2081,9 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {}
+          "CrawlerName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1780,13 +2098,17 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1800,10 +2122,16 @@
               "Name"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "S3"
+              },
               "Classification": {},
-              "GrokPattern": {},
-              "CustomPatterns": {}
+              "GrokPattern": {
+                "shape": "S1y"
+              },
+              "CustomPatterns": {
+                "shape": "S1z"
+              }
             }
           },
           "XMLClassifier": {
@@ -1812,7 +2140,9 @@
               "Name"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "S3"
+              },
               "Classification": {},
               "RowTag": {}
             }
@@ -1823,7 +2153,9 @@
               "Name"
             ],
             "members": {
-              "Name": {},
+              "Name": {
+                "shape": "S3"
+              },
               "JsonPath": {}
             }
           }
@@ -1842,8 +2174,12 @@
           "ConnectionInput"
         ],
         "members": {
-          "CatalogId": {},
-          "Name": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S3"
+          },
           "ConnectionInput": {
             "shape": "S26"
           }
@@ -1861,10 +2197,17 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3"
+          },
           "Role": {},
           "DatabaseName": {},
-          "Description": {},
+          "Description": {
+            "type": "string",
+            "max": 2048,
+            "min": 0,
+            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+          },
           "Targets": {
             "shape": "S2h"
           },
@@ -1872,12 +2215,16 @@
           "Classifiers": {
             "shape": "S2s"
           },
-          "TablePrefix": {},
+          "TablePrefix": {
+            "shape": "S2t"
+          },
           "SchemaChangePolicy": {
             "shape": "S2u"
           },
           "Configuration": {},
-          "CrawlerSecurityConfiguration": {}
+          "CrawlerSecurityConfiguration": {
+            "shape": "S2y"
+          }
         }
       },
       "output": {
@@ -1892,7 +2239,9 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {},
+          "CrawlerName": {
+            "shape": "S3"
+          },
           "Schedule": {}
         }
       },
@@ -1909,8 +2258,12 @@
           "DatabaseInput"
         ],
         "members": {
-          "CatalogId": {},
-          "Name": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S3"
+          },
           "DatabaseInput": {
             "shape": "S31"
           }
@@ -1961,11 +2314,15 @@
           "JobUpdate"
         ],
         "members": {
-          "JobName": {},
+          "JobName": {
+            "shape": "S3"
+          },
           "JobUpdate": {
             "type": "structure",
             "members": {
-              "Description": {},
+              "Description": {
+                "shape": "Sy"
+              },
               "LogUri": {},
               "Role": {},
               "ExecutionProperty": {
@@ -1987,12 +2344,14 @@
                 "type": "integer"
               },
               "Timeout": {
-                "type": "integer"
+                "shape": "S3m"
               },
               "NotificationProperty": {
                 "shape": "S3n"
               },
-              "SecurityConfiguration": {}
+              "SecurityConfiguration": {
+                "shape": "S3"
+              }
             }
           }
         }
@@ -2000,7 +2359,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobName": {}
+          "JobName": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -2014,12 +2375,22 @@
           "PartitionInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "TableName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "TableName": {
+            "shape": "S3"
+          },
           "PartitionValueList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S7"
+            },
+            "max": 100,
+            "min": 0
           },
           "PartitionInput": {
             "shape": "S5"
@@ -2039,8 +2410,12 @@
           "TableInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
           "TableInput": {
             "shape": "S4j"
           },
@@ -2062,12 +2437,18 @@
           "TriggerUpdate"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S3"
+          },
           "TriggerUpdate": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "Description": {},
+              "Name": {
+                "shape": "S3"
+              },
+              "Description": {
+                "shape": "Sy"
+              },
               "Schedule": {},
               "Actions": {
                 "shape": "S4w"
@@ -2097,9 +2478,15 @@
           "FunctionInput"
         ],
         "members": {
-          "CatalogId": {},
-          "DatabaseName": {},
-          "FunctionName": {},
+          "CatalogId": {
+            "shape": "S2"
+          },
+          "DatabaseName": {
+            "shape": "S3"
+          },
+          "FunctionName": {
+            "shape": "S3"
+          },
           "FunctionInput": {
             "shape": "S51"
           }
@@ -2112,6 +2499,18 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+    },
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+    },
     "S5": {
       "type": "structure",
       "members": {
@@ -2134,7 +2533,13 @@
     },
     "S6": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S7"
+      }
+    },
+    "S7": {
+      "type": "string",
+      "max": 1024
     },
     "S9": {
       "type": "structure",
@@ -2142,9 +2547,17 @@
         "Columns": {
           "shape": "Sa"
         },
-        "Location": {},
-        "InputFormat": {},
-        "OutputFormat": {},
+        "Location": {
+          "type": "string",
+          "max": 2056,
+          "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+        },
+        "InputFormat": {
+          "shape": "Sf"
+        },
+        "OutputFormat": {
+          "shape": "Sf"
+        },
         "Compressed": {
           "type": "boolean"
         },
@@ -2154,8 +2567,12 @@
         "SerdeInfo": {
           "type": "structure",
           "members": {
-            "Name": {},
-            "SerializationLibrary": {},
+            "Name": {
+              "shape": "S3"
+            },
+            "SerializationLibrary": {
+              "shape": "S3"
+            },
             "Parameters": {
               "shape": "Sj"
             }
@@ -2173,9 +2590,13 @@
               "SortOrder"
             ],
             "members": {
-              "Column": {},
+              "Column": {
+                "shape": "S3"
+              },
               "SortOrder": {
-                "type": "integer"
+                "type": "integer",
+                "max": 1,
+                "min": 0
               }
             }
           }
@@ -2213,20 +2634,47 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "Type": {},
-          "Comment": {}
+          "Name": {
+            "shape": "S3"
+          },
+          "Type": {
+            "type": "string",
+            "max": 131072,
+            "min": 0,
+            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+          },
+          "Comment": {
+            "type": "string",
+            "max": 255,
+            "min": 0,
+            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+          }
         }
       }
     },
+    "Sf": {
+      "type": "string",
+      "max": 128,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+    },
     "Sj": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 255,
+        "min": 1,
+        "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+      },
+      "value": {
+        "type": "string",
+        "max": 512000
+      }
     },
     "Sm": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
     },
     "Sv": {
       "type": "list",
@@ -2245,9 +2693,19 @@
     "Sx": {
       "type": "structure",
       "members": {
-        "ErrorCode": {},
-        "ErrorMessage": {}
+        "ErrorCode": {
+          "shape": "S3"
+        },
+        "ErrorMessage": {
+          "shape": "Sy"
+        }
       }
+    },
+    "Sy": {
+      "type": "string",
+      "max": 2048,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S15": {
       "type": "structure",
@@ -2260,11 +2718,19 @@
         }
       }
     },
+    "S1e": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+    },
     "S1j": {
       "type": "list",
       "member": {
         "shape": "S15"
-      }
+      },
+      "max": 1000,
+      "min": 0
     },
     "S1l": {
       "type": "list",
@@ -2278,8 +2744,12 @@
         "Values": {
           "shape": "S6"
         },
-        "DatabaseName": {},
-        "TableName": {},
+        "DatabaseName": {
+          "shape": "S3"
+        },
+        "TableName": {
+          "shape": "S3"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2297,6 +2767,24 @@
         }
       }
     },
+    "S1p": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+    },
+    "S1y": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\t]*"
+    },
+    "S1z": {
+      "type": "string",
+      "max": 16000,
+      "min": 0,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
     "S26": {
       "type": "structure",
       "required": [
@@ -2305,9 +2793,15 @@
         "ConnectionProperties"
       ],
       "members": {
-        "Name": {},
-        "Description": {},
-        "ConnectionType": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "ConnectionType": {
+          "shape": "S27"
+        },
         "MatchCriteria": {
           "shape": "S28"
         },
@@ -2319,24 +2813,63 @@
         }
       }
     },
+    "S27": {
+      "type": "string",
+      "enum": [
+        "JDBC",
+        "SFTP"
+      ]
+    },
     "S28": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 10,
+      "min": 0
     },
     "S29": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "enum": [
+          "HOST",
+          "PORT",
+          "USERNAME",
+          "PASSWORD",
+          "JDBC_DRIVER_JAR_URI",
+          "JDBC_DRIVER_CLASS_NAME",
+          "JDBC_ENGINE",
+          "JDBC_ENGINE_VERSION",
+          "CONFIG_FILES",
+          "INSTANCE_ID",
+          "JDBC_CONNECTION_URL",
+          "JDBC_ENFORCE_SSL"
+        ]
+      },
+      "value": {
+        "shape": "S7"
+      },
+      "max": 100,
+      "min": 0
     },
     "S2b": {
       "type": "structure",
       "members": {
-        "SubnetId": {},
+        "SubnetId": {
+          "shape": "S3"
+        },
         "SecurityGroupIdList": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S3"
+          },
+          "max": 50,
+          "min": 0
         },
-        "AvailabilityZone": {}
+        "AvailabilityZone": {
+          "shape": "S3"
+        }
       }
     },
     "S2h": {
@@ -2384,14 +2917,39 @@
     },
     "S2s": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
+    },
+    "S2t": {
+      "type": "string",
+      "max": 128,
+      "min": 0
     },
     "S2u": {
       "type": "structure",
       "members": {
-        "UpdateBehavior": {},
-        "DeleteBehavior": {}
+        "UpdateBehavior": {
+          "type": "string",
+          "enum": [
+            "LOG",
+            "UPDATE_IN_DATABASE"
+          ]
+        },
+        "DeleteBehavior": {
+          "type": "string",
+          "enum": [
+            "LOG",
+            "DELETE_FROM_DATABASE",
+            "DEPRECATE_IN_DATABASE"
+          ]
+        }
       }
+    },
+    "S2y": {
+      "type": "string",
+      "max": 128,
+      "min": 0
     },
     "S31": {
       "type": "structure",
@@ -2399,13 +2957,29 @@
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Description": {},
-        "LocationUri": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "LocationUri": {
+          "shape": "S32"
+        },
         "Parameters": {
           "shape": "Sj"
         }
       }
+    },
+    "S32": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+    },
+    "S36": {
+      "type": "string",
+      "pattern": "arn:aws:iam::\\d{12}:role/.*"
     },
     "S37": {
       "type": "list",
@@ -2413,7 +2987,8 @@
     },
     "S38": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 5
     },
     "S3f": {
       "type": "structure",
@@ -2443,11 +3018,16 @@
         }
       }
     },
+    "S3m": {
+      "type": "integer",
+      "min": 1
+    },
     "S3n": {
       "type": "structure",
       "members": {
         "NotifyDelayAfter": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         }
       }
     },
@@ -2461,7 +3041,9 @@
           "Args"
         ],
         "members": {
-          "Id": {},
+          "Id": {
+            "shape": "S3v"
+          },
           "NodeType": {},
           "Args": {
             "shape": "S3x"
@@ -2471,6 +3053,12 @@
           }
         }
       }
+    },
+    "S3v": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[A-Za-z_][A-Za-z0-9_]*"
     },
     "S3x": {
       "type": "list",
@@ -2487,7 +3075,9 @@
             "type": "boolean"
           }
         }
-      }
+      },
+      "max": 50,
+      "min": 0
     },
     "S41": {
       "type": "list",
@@ -2498,11 +3088,22 @@
           "Target"
         ],
         "members": {
-          "Source": {},
-          "Target": {},
+          "Source": {
+            "shape": "S3v"
+          },
+          "Target": {
+            "shape": "S3v"
+          },
           "TargetParameter": {}
         }
       }
+    },
+    "S43": {
+      "type": "string",
+      "enum": [
+        "PYTHON",
+        "SCALA"
+      ]
     },
     "S48": {
       "type": "structure",
@@ -2512,26 +3113,55 @@
           "member": {
             "type": "structure",
             "members": {
-              "S3EncryptionMode": {},
-              "KmsKeyArn": {}
+              "S3EncryptionMode": {
+                "type": "string",
+                "enum": [
+                  "DISABLED",
+                  "SSE-KMS",
+                  "SSE-S3"
+                ]
+              },
+              "KmsKeyArn": {
+                "shape": "S4c"
+              }
             }
           }
         },
         "CloudWatchEncryption": {
           "type": "structure",
           "members": {
-            "CloudWatchEncryptionMode": {},
-            "KmsKeyArn": {}
+            "CloudWatchEncryptionMode": {
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "SSE-KMS"
+              ]
+            },
+            "KmsKeyArn": {
+              "shape": "S4c"
+            }
           }
         },
         "JobBookmarksEncryption": {
           "type": "structure",
           "members": {
-            "JobBookmarksEncryptionMode": {},
-            "KmsKeyArn": {}
+            "JobBookmarksEncryptionMode": {
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "CSE-KMS"
+              ]
+            },
+            "KmsKeyArn": {
+              "shape": "S4c"
+            }
           }
         }
       }
+    },
+    "S4c": {
+      "type": "string",
+      "pattern": "arn:aws:kms:.*"
     },
     "S4j": {
       "type": "structure",
@@ -2539,9 +3169,15 @@
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Description": {},
-        "Owner": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "Owner": {
+          "shape": "S3"
+        },
         "LastAccessTime": {
           "type": "timestamp"
         },
@@ -2549,7 +3185,7 @@
           "type": "timestamp"
         },
         "Retention": {
-          "type": "integer"
+          "shape": "S4k"
         },
         "StorageDescriptor": {
           "shape": "S9"
@@ -2557,71 +3193,155 @@
         "PartitionKeys": {
           "shape": "Sa"
         },
-        "ViewOriginalText": {},
-        "ViewExpandedText": {},
-        "TableType": {},
+        "ViewOriginalText": {
+          "shape": "S4l"
+        },
+        "ViewExpandedText": {
+          "shape": "S4l"
+        },
+        "TableType": {
+          "shape": "S4m"
+        },
         "Parameters": {
           "shape": "Sj"
         }
       }
     },
+    "S4k": {
+      "type": "integer",
+      "min": 0
+    },
+    "S4l": {
+      "type": "string",
+      "max": 409600
+    },
+    "S4m": {
+      "type": "string",
+      "max": 255
+    },
+    "S4p": {
+      "type": "string",
+      "enum": [
+        "SCHEDULED",
+        "CONDITIONAL",
+        "ON_DEMAND"
+      ]
+    },
     "S4q": {
       "type": "structure",
       "members": {
-        "Logical": {},
+        "Logical": {
+          "type": "string",
+          "enum": [
+            "AND",
+            "ANY"
+          ]
+        },
         "Conditions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "LogicalOperator": {},
-              "JobName": {},
-              "State": {}
+              "LogicalOperator": {
+                "type": "string",
+                "enum": [
+                  "EQUALS"
+                ]
+              },
+              "JobName": {
+                "shape": "S3"
+              },
+              "State": {
+                "shape": "S4v"
+              }
             }
           }
         }
       }
+    },
+    "S4v": {
+      "type": "string",
+      "enum": [
+        "STARTING",
+        "RUNNING",
+        "STOPPING",
+        "STOPPED",
+        "SUCCEEDED",
+        "FAILED",
+        "TIMEOUT"
+      ]
     },
     "S4w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "JobName": {},
+          "JobName": {
+            "shape": "S3"
+          },
           "Arguments": {
             "shape": "S3j"
           },
           "Timeout": {
-            "type": "integer"
+            "shape": "S3m"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {}
+          "SecurityConfiguration": {
+            "shape": "S3"
+          }
         }
       }
     },
     "S51": {
       "type": "structure",
       "members": {
-        "FunctionName": {},
-        "ClassName": {},
-        "OwnerName": {},
-        "OwnerType": {},
+        "FunctionName": {
+          "shape": "S3"
+        },
+        "ClassName": {
+          "shape": "S3"
+        },
+        "OwnerName": {
+          "shape": "S3"
+        },
+        "OwnerType": {
+          "shape": "S52"
+        },
         "ResourceUris": {
           "shape": "S53"
         }
       }
+    },
+    "S52": {
+      "type": "string",
+      "enum": [
+        "USER",
+        "ROLE",
+        "GROUP"
+      ]
     },
     "S53": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceType": {},
-          "Uri": {}
+          "ResourceType": {
+            "type": "string",
+            "enum": [
+              "JAR",
+              "FILE",
+              "ARCHIVE"
+            ]
+          },
+          "Uri": {
+            "shape": "S32"
+          }
         }
-      }
+      },
+      "max": 1000,
+      "min": 0
     },
     "S60": {
       "type": "structure",
@@ -2634,7 +3354,9 @@
             "GrokPattern"
           ],
           "members": {
-            "Name": {},
+            "Name": {
+              "shape": "S3"
+            },
             "Classification": {},
             "CreationTime": {
               "type": "timestamp"
@@ -2645,8 +3367,12 @@
             "Version": {
               "type": "long"
             },
-            "GrokPattern": {},
-            "CustomPatterns": {}
+            "GrokPattern": {
+              "shape": "S1y"
+            },
+            "CustomPatterns": {
+              "shape": "S1z"
+            }
           }
         },
         "XMLClassifier": {
@@ -2656,7 +3382,9 @@
             "Classification"
           ],
           "members": {
-            "Name": {},
+            "Name": {
+              "shape": "S3"
+            },
             "Classification": {},
             "CreationTime": {
               "type": "timestamp"
@@ -2677,7 +3405,9 @@
             "JsonPath"
           ],
           "members": {
-            "Name": {},
+            "Name": {
+              "shape": "S3"
+            },
             "CreationTime": {
               "type": "timestamp"
             },
@@ -2692,12 +3422,23 @@
         }
       }
     },
+    "S66": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
     "S6c": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Description": {},
-        "ConnectionType": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "ConnectionType": {
+          "shape": "S27"
+        },
         "MatchCriteria": {
           "shape": "S28"
         },
@@ -2713,32 +3454,54 @@
         "LastUpdatedTime": {
           "type": "timestamp"
         },
-        "LastUpdatedBy": {}
+        "LastUpdatedBy": {
+          "shape": "S3"
+        }
       }
     },
     "S6j": {
       "type": "structure",
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S3"
+        },
         "Role": {},
         "Targets": {
           "shape": "S2h"
         },
         "DatabaseName": {},
-        "Description": {},
+        "Description": {
+          "shape": "Sy"
+        },
         "Classifiers": {
           "shape": "S2s"
         },
         "SchemaChangePolicy": {
           "shape": "S2u"
         },
-        "State": {},
-        "TablePrefix": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "READY",
+            "RUNNING",
+            "STOPPING"
+          ]
+        },
+        "TablePrefix": {
+          "shape": "S2t"
+        },
         "Schedule": {
           "type": "structure",
           "members": {
             "ScheduleExpression": {},
-            "State": {}
+            "State": {
+              "type": "string",
+              "enum": [
+                "SCHEDULED",
+                "NOT_SCHEDULED",
+                "TRANSITIONING"
+              ]
+            }
           }
         },
         "CrawlElapsedTime": {
@@ -2753,11 +3516,35 @@
         "LastCrawl": {
           "type": "structure",
           "members": {
-            "Status": {},
-            "ErrorMessage": {},
-            "LogGroup": {},
-            "LogStream": {},
-            "MessagePrefix": {},
+            "Status": {
+              "type": "string",
+              "enum": [
+                "SUCCEEDED",
+                "CANCELLED",
+                "FAILED"
+              ]
+            },
+            "ErrorMessage": {
+              "shape": "Sy"
+            },
+            "LogGroup": {
+              "type": "string",
+              "max": 512,
+              "min": 1,
+              "pattern": "[\\.\\-_/#A-Za-z0-9]+"
+            },
+            "LogStream": {
+              "type": "string",
+              "max": 512,
+              "min": 1,
+              "pattern": "[^:*]*"
+            },
+            "MessagePrefix": {
+              "type": "string",
+              "max": 255,
+              "min": 1,
+              "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
+            },
             "StartTime": {
               "type": "timestamp"
             }
@@ -2767,8 +3554,14 @@
           "type": "long"
         },
         "Configuration": {},
-        "CrawlerSecurityConfiguration": {}
+        "CrawlerSecurityConfiguration": {
+          "shape": "S2y"
+        }
       }
+    },
+    "S6y": {
+      "type": "double",
+      "min": 0
     },
     "S74": {
       "type": "structure",
@@ -2776,9 +3569,15 @@
         "Name"
       ],
       "members": {
-        "Name": {},
-        "Description": {},
-        "LocationUri": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "LocationUri": {
+          "shape": "S32"
+        },
         "Parameters": {
           "shape": "Sj"
         },
@@ -2791,7 +3590,9 @@
       "type": "structure",
       "members": {
         "EndpointName": {},
-        "RoleArn": {},
+        "RoleArn": {
+          "shape": "S36"
+        },
         "SecurityGroupIds": {
           "shape": "S37"
         },
@@ -2822,14 +3623,20 @@
         "PublicKeys": {
           "shape": "S38"
         },
-        "SecurityConfiguration": {}
+        "SecurityConfiguration": {
+          "shape": "S3"
+        }
       }
     },
     "S7i": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Description": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
         "LogUri": {},
         "Role": {},
         "CreatedOn": {
@@ -2857,24 +3664,34 @@
           "type": "integer"
         },
         "Timeout": {
-          "type": "integer"
+          "shape": "S3m"
         },
         "NotificationProperty": {
           "shape": "S3n"
         },
-        "SecurityConfiguration": {}
+        "SecurityConfiguration": {
+          "shape": "S3"
+        }
       }
     },
     "S7l": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S1p"
+        },
         "Attempt": {
           "type": "integer"
         },
-        "PreviousRunId": {},
-        "TriggerName": {},
-        "JobName": {},
+        "PreviousRunId": {
+          "shape": "S1p"
+        },
+        "TriggerName": {
+          "shape": "S3"
+        },
+        "JobName": {
+          "shape": "S3"
+        },
         "StartedOn": {
           "type": "timestamp"
         },
@@ -2884,7 +3701,9 @@
         "CompletedOn": {
           "type": "timestamp"
         },
-        "JobRunState": {},
+        "JobRunState": {
+          "shape": "S4v"
+        },
         "Arguments": {
           "shape": "S3j"
         },
@@ -2894,8 +3713,12 @@
           "member": {
             "type": "structure",
             "members": {
-              "JobName": {},
-              "RunId": {}
+              "JobName": {
+                "shape": "S3"
+              },
+              "RunId": {
+                "shape": "S1p"
+              }
             }
           }
         },
@@ -2906,12 +3729,14 @@
           "type": "integer"
         },
         "Timeout": {
-          "type": "integer"
+          "shape": "S3m"
         },
         "NotificationProperty": {
           "shape": "S3n"
         },
-        "SecurityConfiguration": {},
+        "SecurityConfiguration": {
+          "shape": "S3"
+        },
         "LogGroupName": {}
       }
     },
@@ -2922,8 +3747,12 @@
         "TableName"
       ],
       "members": {
-        "DatabaseName": {},
-        "TableName": {}
+        "DatabaseName": {
+          "shape": "S3"
+        },
+        "TableName": {
+          "shape": "S3"
+        }
       }
     },
     "S7z": {
@@ -2963,7 +3792,9 @@
     "S8i": {
       "type": "structure",
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "S3"
+        },
         "CreatedTimeStamp": {
           "type": "timestamp"
         },
@@ -2978,10 +3809,18 @@
         "Name"
       ],
       "members": {
-        "Name": {},
-        "DatabaseName": {},
-        "Description": {},
-        "Owner": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "DatabaseName": {
+          "shape": "S3"
+        },
+        "Description": {
+          "shape": "Sy"
+        },
+        "Owner": {
+          "shape": "S3"
+        },
         "CreateTime": {
           "type": "timestamp"
         },
@@ -2995,7 +3834,7 @@
           "type": "timestamp"
         },
         "Retention": {
-          "type": "integer"
+          "shape": "S4k"
         },
         "StorageDescriptor": {
           "shape": "S9"
@@ -3003,13 +3842,21 @@
         "PartitionKeys": {
           "shape": "Sa"
         },
-        "ViewOriginalText": {},
-        "ViewExpandedText": {},
-        "TableType": {},
+        "ViewOriginalText": {
+          "shape": "S4l"
+        },
+        "ViewExpandedText": {
+          "shape": "S4l"
+        },
+        "TableType": {
+          "shape": "S4m"
+        },
         "Parameters": {
           "shape": "Sj"
         },
-        "CreatedBy": {}
+        "CreatedBy": {
+          "shape": "S3"
+        }
       }
     },
     "S8r": {
@@ -3018,17 +3865,39 @@
         "Table": {
           "shape": "S8o"
         },
-        "VersionId": {}
+        "VersionId": {
+          "shape": "S1e"
+        }
       }
     },
     "S91": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Id": {},
-        "Type": {},
-        "State": {},
-        "Description": {},
+        "Name": {
+          "shape": "S3"
+        },
+        "Id": {
+          "shape": "S1p"
+        },
+        "Type": {
+          "shape": "S4p"
+        },
+        "State": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "CREATED",
+            "ACTIVATING",
+            "ACTIVATED",
+            "DEACTIVATING",
+            "DEACTIVATED",
+            "DELETING",
+            "UPDATING"
+          ]
+        },
+        "Description": {
+          "shape": "Sy"
+        },
         "Schedule": {},
         "Actions": {
           "shape": "S4w"
@@ -3041,10 +3910,18 @@
     "S98": {
       "type": "structure",
       "members": {
-        "FunctionName": {},
-        "ClassName": {},
-        "OwnerName": {},
-        "OwnerType": {},
+        "FunctionName": {
+          "shape": "S3"
+        },
+        "ClassName": {
+          "shape": "S3"
+        },
+        "OwnerName": {
+          "shape": "S3"
+        },
+        "OwnerType": {
+          "shape": "S52"
+        },
         "CreateTime": {
           "type": "timestamp"
         },

--- a/apis/greengrass-2017-06-07.min.json
+++ b/apis/greengrass-2017-06-07.min.json
@@ -133,7 +133,9 @@
             "locationName": "X-Amzn-Client-Token"
           },
           "DeploymentId": {},
-          "DeploymentType": {},
+          "DeploymentType": {
+            "shape": "Sf"
+          },
           "GroupId": {
             "location": "uri",
             "locationName": "GroupId"
@@ -521,14 +523,46 @@
             "locationName": "X-Amzn-Client-Token"
           },
           "S3UrlSignerRole": {},
-          "SoftwareToUpdate": {},
-          "UpdateAgentLogLevel": {},
+          "SoftwareToUpdate": {
+            "type": "string",
+            "enum": [
+              "core",
+              "ota_agent"
+            ]
+          },
+          "UpdateAgentLogLevel": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "TRACE",
+              "DEBUG",
+              "VERBOSE",
+              "INFO",
+              "WARN",
+              "ERROR",
+              "FATAL"
+            ]
+          },
           "UpdateTargets": {
             "type": "list",
             "member": {}
           },
-          "UpdateTargetsArchitecture": {},
-          "UpdateTargetsOperatingSystem": {}
+          "UpdateTargetsArchitecture": {
+            "type": "string",
+            "enum": [
+              "armv7l",
+              "x86_64",
+              "aarch64"
+            ]
+          },
+          "UpdateTargetsOperatingSystem": {
+            "type": "string",
+            "enum": [
+              "ubuntu",
+              "raspbian",
+              "amazon_linux"
+            ]
+          }
         }
       },
       "output": {
@@ -957,7 +991,9 @@
         "type": "structure",
         "members": {
           "DeploymentStatus": {},
-          "DeploymentType": {},
+          "DeploymentType": {
+            "shape": "Sf"
+          },
           "ErrorDetails": {
             "type": "list",
             "member": {
@@ -1554,7 +1590,9 @@
                 "CreatedAt": {},
                 "DeploymentArn": {},
                 "DeploymentId": {},
-                "DeploymentType": {},
+                "DeploymentType": {
+                  "shape": "Sf"
+                },
                 "GroupArn": {}
               }
             }
@@ -2283,6 +2321,15 @@
         "required": []
       }
     },
+    "Sf": {
+      "type": "string",
+      "enum": [
+        "NewDeployment",
+        "Redeployment",
+        "ResetDeployment",
+        "ForceResetDeployment"
+      ]
+    },
     "Si": {
       "type": "structure",
       "members": {
@@ -2323,7 +2370,13 @@
           "FunctionConfiguration": {
             "type": "structure",
             "members": {
-              "EncodingType": {},
+              "EncodingType": {
+                "type": "string",
+                "enum": [
+                  "binary",
+                  "json"
+                ]
+              },
               "Environment": {
                 "type": "structure",
                 "members": {
@@ -2335,7 +2388,13 @@
                     "member": {
                       "type": "structure",
                       "members": {
-                        "Permission": {},
+                        "Permission": {
+                          "type": "string",
+                          "enum": [
+                            "ro",
+                            "rw"
+                          ]
+                        },
                         "ResourceId": {}
                       },
                       "required": []
@@ -2390,13 +2449,34 @@
       "member": {
         "type": "structure",
         "members": {
-          "Component": {},
+          "Component": {
+            "type": "string",
+            "enum": [
+              "GreengrassSystem",
+              "Lambda"
+            ]
+          },
           "Id": {},
-          "Level": {},
+          "Level": {
+            "type": "string",
+            "enum": [
+              "DEBUG",
+              "INFO",
+              "WARN",
+              "ERROR",
+              "FATAL"
+            ]
+          },
           "Space": {
             "type": "integer"
           },
-          "Type": {}
+          "Type": {
+            "type": "string",
+            "enum": [
+              "FileSystem",
+              "AWSCloudWatch"
+            ]
+          }
         },
         "required": []
       }

--- a/apis/guardduty-2017-11-28.min.json
+++ b/apis/guardduty-2017-11-28.min.json
@@ -97,11 +97,15 @@
         "type": "structure",
         "members": {
           "Action": {
+            "shape": "Sf",
             "locationName": "action"
           },
           "ClientToken": {
             "locationName": "clientToken",
-            "idempotencyToken": true
+            "idempotencyToken": true,
+            "type": "string",
+            "min": 0,
+            "max": 64
           },
           "Description": {
             "locationName": "description"
@@ -152,6 +156,7 @@
             "locationName": "detectorId"
           },
           "Format": {
+            "shape": "St",
             "locationName": "format"
           },
           "Location": {
@@ -264,6 +269,7 @@
             "locationName": "detectorId"
           },
           "Format": {
+            "shape": "S1b",
             "locationName": "format"
           },
           "Location": {
@@ -553,7 +559,12 @@
             "locationName": "serviceRole"
           },
           "Status": {
-            "locationName": "status"
+            "locationName": "status",
+            "type": "string",
+            "enum": [
+              "ENABLED",
+              "DISABLED"
+            ]
           },
           "UpdatedAt": {
             "locationName": "updatedAt"
@@ -588,6 +599,7 @@
         "type": "structure",
         "members": {
           "Action": {
+            "shape": "Sf",
             "locationName": "action"
           },
           "Description": {
@@ -1021,7 +1033,12 @@
           "FindingStatisticTypes": {
             "locationName": "findingStatisticTypes",
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "COUNT_BY_SEVERITY"
+              ]
+            }
           }
         },
         "required": [
@@ -1075,6 +1092,7 @@
         "type": "structure",
         "members": {
           "Format": {
+            "shape": "St",
             "locationName": "format"
           },
           "Location": {
@@ -1084,7 +1102,17 @@
             "locationName": "name"
           },
           "Status": {
-            "locationName": "status"
+            "locationName": "status",
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVATING",
+              "ACTIVE",
+              "DEACTIVATING",
+              "ERROR",
+              "DELETE_PENDING",
+              "DELETED"
+            ]
           }
         }
       }
@@ -1213,6 +1241,7 @@
         "type": "structure",
         "members": {
           "Format": {
+            "shape": "S1b",
             "locationName": "format"
           },
           "Location": {
@@ -1222,7 +1251,17 @@
             "locationName": "name"
           },
           "Status": {
-            "locationName": "status"
+            "locationName": "status",
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVATING",
+              "ACTIVE",
+              "DEACTIVATING",
+              "ERROR",
+              "DELETE_PENDING",
+              "DELETED"
+            ]
           }
         }
       }
@@ -1275,9 +1314,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1313,9 +1352,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1357,8 +1396,8 @@
             "locationName": "findingCriteria"
           },
           "MaxResults": {
-            "locationName": "maxResults",
-            "type": "integer"
+            "shape": "S44",
+            "locationName": "maxResults"
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -1399,9 +1438,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1436,9 +1475,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1490,9 +1529,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1534,9 +1573,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
+            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -1684,6 +1723,7 @@
         "type": "structure",
         "members": {
           "Action": {
+            "shape": "Sf",
             "locationName": "action"
           },
           "Description": {
@@ -1736,7 +1776,12 @@
             "locationName": "detectorId"
           },
           "Feedback": {
-            "locationName": "feedback"
+            "locationName": "feedback",
+            "type": "string",
+            "enum": [
+              "USEFUL",
+              "NOT_USEFUL"
+            ]
           },
           "FindingIds": {
             "shape": "S7",
@@ -1832,6 +1877,13 @@
       "type": "list",
       "member": {}
     },
+    "Sf": {
+      "type": "string",
+      "enum": [
+        "NOOP",
+        "ARCHIVE"
+      ]
+    },
     "Si": {
       "type": "structure",
       "members": {
@@ -1873,6 +1925,17 @@
         }
       }
     },
+    "St": {
+      "type": "string",
+      "enum": [
+        "TXT",
+        "STIX",
+        "OTX_CSV",
+        "ALIEN_VAULT",
+        "PROOF_POINT",
+        "FIRE_EYE"
+      ]
+    },
     "S14": {
       "type": "list",
       "member": {
@@ -1891,6 +1954,17 @@
         ]
       }
     },
+    "S1b": {
+      "type": "string",
+      "enum": [
+        "TXT",
+        "STIX",
+        "OTX_CSV",
+        "ALIEN_VAULT",
+        "PROOF_POINT",
+        "FIRE_EYE"
+      ]
+    },
     "S1f": {
       "type": "list",
       "member": {}
@@ -1902,7 +1976,12 @@
           "locationName": "attributeName"
         },
         "OrderBy": {
-          "locationName": "orderBy"
+          "locationName": "orderBy",
+          "type": "string",
+          "enum": [
+            "ASC",
+            "DESC"
+          ]
         }
       }
     },
@@ -2014,6 +2093,11 @@
           "RelationshipStatus"
         ]
       }
+    },
+    "S44": {
+      "type": "integer",
+      "min": 1,
+      "max": 50
     }
   }
 }

--- a/apis/health-2016-08-04.min.json
+++ b/apis/health-2016-08-04.min.json
@@ -43,14 +43,22 @@
               },
               "statusCodes": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "Sh"
+                },
+                "max": 3,
+                "min": 1
               }
             }
           },
-          "locale": {},
-          "nextToken": {},
+          "locale": {
+            "shape": "Si"
+          },
+          "nextToken": {
+            "shape": "Sj"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sk"
           }
         }
       },
@@ -62,21 +70,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "entityArn": {},
-                "eventArn": {},
-                "entityValue": {},
-                "awsAccountId": {},
+                "entityArn": {
+                  "shape": "S6"
+                },
+                "eventArn": {
+                  "shape": "S4"
+                },
+                "entityValue": {
+                  "shape": "S8"
+                },
+                "awsAccountId": {
+                  "type": "string",
+                  "pattern": "[0-9]{12}"
+                },
                 "lastUpdatedTime": {
                   "type": "timestamp"
                 },
-                "statusCode": {},
+                "statusCode": {
+                  "shape": "Sh"
+                },
                 "tags": {
                   "shape": "Sd"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "idempotent": true
@@ -87,7 +108,11 @@
         "members": {
           "eventArns": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -99,7 +124,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "eventArn": {},
+                "eventArn": {
+                  "shape": "S4"
+                },
                 "count": {
                   "type": "integer"
                 }
@@ -120,11 +147,18 @@
           "filter": {
             "shape": "Sw"
           },
-          "aggregateField": {},
-          "maxResults": {
-            "type": "integer"
+          "aggregateField": {
+            "type": "string",
+            "enum": [
+              "eventTypeCategory"
+            ]
           },
-          "nextToken": {}
+          "maxResults": {
+            "shape": "Sk"
+          },
+          "nextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -142,7 +176,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "idempotent": true
@@ -157,7 +193,9 @@
           "eventArns": {
             "shape": "S3"
           },
-          "locale": {}
+          "locale": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -180,7 +218,10 @@
                 "eventMetadata": {
                   "type": "map",
                   "key": {},
-                  "value": {}
+                  "value": {
+                    "type": "string",
+                    "max": 10240
+                  }
                 }
               }
             }
@@ -190,7 +231,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "eventArn": {},
+                "eventArn": {
+                  "shape": "S4"
+                },
                 "errorName": {},
                 "errorMessage": {}
               }
@@ -209,21 +252,33 @@
             "members": {
               "eventTypeCodes": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S1j"
+                },
+                "max": 10,
+                "min": 1
               },
               "services": {
                 "shape": "Sz"
               },
               "eventTypeCategories": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S16"
+                },
+                "max": 10,
+                "min": 1
               }
             }
           },
-          "locale": {},
-          "nextToken": {},
+          "locale": {
+            "shape": "Si"
+          },
+          "nextToken": {
+            "shape": "Sj"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sk"
           }
         }
       },
@@ -235,13 +290,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "service": {},
-                "code": {},
-                "category": {}
+                "service": {
+                  "shape": "S10"
+                },
+                "code": {
+                  "shape": "S1j"
+                },
+                "category": {
+                  "shape": "S16"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "idempotent": true
@@ -253,11 +316,15 @@
           "filter": {
             "shape": "Sw"
           },
-          "nextToken": {},
-          "maxResults": {
-            "type": "integer"
+          "nextToken": {
+            "shape": "Sj"
           },
-          "locale": {}
+          "maxResults": {
+            "shape": "Sk"
+          },
+          "locale": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -269,7 +336,9 @@
               "shape": "S1i"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sj"
+          }
         }
       },
       "idempotent": true
@@ -278,15 +347,40 @@
   "shapes": {
     "S3": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S4": {
+      "type": "string",
+      "max": 1600,
+      "pattern": "arn:aws:health:[^:]*:[^:]*:event(?:/[\\w-]+){1}((?:/[\\w-]+){2})?"
     },
     "S5": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S6"
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 1600
     },
     "S7": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8"
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S8": {
+      "type": "string",
+      "max": 256
     },
     "S9": {
       "type": "list",
@@ -300,18 +394,50 @@
             "type": "timestamp"
           }
         }
-      }
+      },
+      "max": 10,
+      "min": 1
     },
     "Sc": {
       "type": "list",
       "member": {
         "shape": "Sd"
-      }
+      },
+      "max": 50
     },
     "Sd": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 127
+      },
+      "value": {
+        "type": "string",
+        "max": 255
+      },
+      "max": 50
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "IMPAIRED",
+        "UNIMPAIRED",
+        "UNKNOWN"
+      ]
+    },
+    "Si": {
+      "type": "string",
+      "max": 256,
+      "min": 2
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9=/+_.-]{4,512}"
+    },
+    "Sk": {
+      "type": "integer",
+      "max": 100,
+      "min": 10
     },
     "Sw": {
       "type": "structure",
@@ -321,18 +447,30 @@
         },
         "eventTypeCodes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "max": 100,
+            "min": 3
+          },
+          "max": 10,
+          "min": 1
         },
         "services": {
           "shape": "Sz"
         },
         "regions": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S12"
+          },
+          "max": 10,
+          "min": 1
         },
         "availabilityZones": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S14"
+          }
         },
         "startTimes": {
           "shape": "S9"
@@ -351,30 +489,85 @@
         },
         "eventTypeCategories": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S16"
+          },
+          "max": 10,
+          "min": 1
         },
         "tags": {
           "shape": "Sc"
         },
         "eventStatusCodes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S18"
+          },
+          "max": 6,
+          "min": 1
         }
       }
     },
     "Sz": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S10"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "max": 30,
+      "min": 2
+    },
+    "S12": {
+      "type": "string",
+      "pattern": "[^:/]{2,25}"
+    },
+    "S14": {
+      "type": "string",
+      "pattern": "[a-z]{2}\\-[0-9a-z\\-]{4,16}"
+    },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "issue",
+        "accountNotification",
+        "scheduledChange"
+      ],
+      "max": 255,
+      "min": 3
+    },
+    "S18": {
+      "type": "string",
+      "enum": [
+        "open",
+        "closed",
+        "upcoming"
+      ]
     },
     "S1i": {
       "type": "structure",
       "members": {
-        "arn": {},
-        "service": {},
-        "eventTypeCode": {},
-        "eventTypeCategory": {},
-        "region": {},
-        "availabilityZone": {},
+        "arn": {
+          "shape": "S4"
+        },
+        "service": {
+          "shape": "S10"
+        },
+        "eventTypeCode": {
+          "shape": "S1j"
+        },
+        "eventTypeCategory": {
+          "shape": "S16"
+        },
+        "region": {
+          "shape": "S12"
+        },
+        "availabilityZone": {
+          "shape": "S14"
+        },
         "startTime": {
           "type": "timestamp"
         },
@@ -384,8 +577,15 @@
         "lastUpdatedTime": {
           "type": "timestamp"
         },
-        "statusCode": {}
+        "statusCode": {
+          "shape": "S18"
+        }
       }
+    },
+    "S1j": {
+      "type": "string",
+      "max": 100,
+      "min": 3
     }
   }
 }

--- a/apis/iam-2010-05-08.min.json
+++ b/apis/iam-2010-05-08.min.json
@@ -21,8 +21,12 @@
           "ClientID"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {},
-          "ClientID": {}
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          },
+          "ClientID": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -34,8 +38,12 @@
           "RoleName"
         ],
         "members": {
-          "InstanceProfileName": {},
-          "RoleName": {}
+          "InstanceProfileName": {
+            "shape": "S5"
+          },
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -47,8 +55,12 @@
           "UserName"
         ],
         "members": {
-          "GroupName": {},
-          "UserName": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "UserName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -60,8 +72,12 @@
           "PolicyArn"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyArn": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -73,8 +89,12 @@
           "PolicyArn"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyArn": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -86,8 +106,12 @@
           "PolicyArn"
         ],
         "members": {
-          "UserName": {},
-          "PolicyArn": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -112,7 +136,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -131,9 +157,15 @@
               "SecretAccessKey"
             ],
             "members": {
-              "UserName": {},
-              "AccessKeyId": {},
-              "Status": {},
+              "UserName": {
+                "shape": "Sd"
+              },
+              "AccessKeyId": {
+                "shape": "Sj"
+              },
+              "Status": {
+                "shape": "Sk"
+              },
               "SecretAccessKey": {
                 "type": "string",
                 "sensitive": true
@@ -153,7 +185,9 @@
           "AccountAlias"
         ],
         "members": {
-          "AccountAlias": {}
+          "AccountAlias": {
+            "shape": "So"
+          }
         }
       }
     },
@@ -164,8 +198,12 @@
           "GroupName"
         ],
         "members": {
-          "Path": {},
-          "GroupName": {}
+          "Path": {
+            "shape": "Sq"
+          },
+          "GroupName": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -188,8 +226,12 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {},
-          "Path": {}
+          "InstanceProfileName": {
+            "shape": "S5"
+          },
+          "Path": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -213,7 +255,9 @@
           "Password"
         ],
         "members": {
-          "UserName": {},
+          "UserName": {
+            "shape": "Sd"
+          },
           "Password": {
             "shape": "Sf"
           },
@@ -243,7 +287,9 @@
           "ThumbprintList"
         ],
         "members": {
-          "Url": {},
+          "Url": {
+            "shape": "S19"
+          },
           "ClientIDList": {
             "shape": "S1a"
           },
@@ -256,7 +302,9 @@
         "resultWrapper": "CreateOpenIDConnectProviderResult",
         "type": "structure",
         "members": {
-          "OpenIDConnectProviderArn": {}
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -268,10 +316,18 @@
           "PolicyDocument"
         ],
         "members": {
-          "PolicyName": {},
-          "Path": {},
-          "PolicyDocument": {},
-          "Description": {}
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "Path": {
+            "shape": "S1g"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          },
+          "Description": {
+            "shape": "S1h"
+          }
         }
       },
       "output": {
@@ -292,8 +348,12 @@
           "PolicyDocument"
         ],
         "members": {
-          "PolicyArn": {},
-          "PolicyDocument": {},
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          },
           "SetAsDefault": {
             "type": "boolean"
           }
@@ -317,14 +377,24 @@
           "AssumeRolePolicyDocument"
         ],
         "members": {
-          "Path": {},
-          "RoleName": {},
-          "AssumeRolePolicyDocument": {},
-          "Description": {},
-          "MaxSessionDuration": {
-            "type": "integer"
+          "Path": {
+            "shape": "Sq"
           },
-          "PermissionsBoundary": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "AssumeRolePolicyDocument": {
+            "shape": "Sz"
+          },
+          "Description": {
+            "shape": "S10"
+          },
+          "MaxSessionDuration": {
+            "shape": "S11"
+          },
+          "PermissionsBoundary": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -348,15 +418,24 @@
           "Name"
         ],
         "members": {
-          "SAMLMetadataDocument": {},
-          "Name": {}
+          "SAMLMetadataDocument": {
+            "shape": "S1s"
+          },
+          "Name": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[\\w._-]+"
+          }
         }
       },
       "output": {
         "resultWrapper": "CreateSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLProviderArn": {}
+          "SAMLProviderArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -367,9 +446,18 @@
           "AWSServiceName"
         ],
         "members": {
-          "AWSServiceName": {},
-          "Description": {},
-          "CustomSuffix": {}
+          "AWSServiceName": {
+            "shape": "S8"
+          },
+          "Description": {
+            "shape": "S10"
+          },
+          "CustomSuffix": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "[\\w+=,.@-]+"
+          }
         }
       },
       "output": {
@@ -390,7 +478,9 @@
           "ServiceName"
         ],
         "members": {
-          "UserName": {},
+          "UserName": {
+            "shape": "Sd"
+          },
           "ServiceName": {}
         }
       },
@@ -411,9 +501,15 @@
           "UserName"
         ],
         "members": {
-          "Path": {},
-          "UserName": {},
-          "PermissionsBoundary": {}
+          "Path": {
+            "shape": "Sq"
+          },
+          "UserName": {
+            "shape": "Sd"
+          },
+          "PermissionsBoundary": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -433,8 +529,14 @@
           "VirtualMFADeviceName"
         ],
         "members": {
-          "Path": {},
-          "VirtualMFADeviceName": {}
+          "Path": {
+            "shape": "Sq"
+          },
+          "VirtualMFADeviceName": {
+            "type": "string",
+            "min": 1,
+            "pattern": "[\\w+=,.@-]+"
+          }
         }
       },
       "output": {
@@ -458,8 +560,12 @@
           "SerialNumber"
         ],
         "members": {
-          "UserName": {},
-          "SerialNumber": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "SerialNumber": {
+            "shape": "S2c"
+          }
         }
       }
     },
@@ -470,8 +576,12 @@
           "AccessKeyId"
         ],
         "members": {
-          "UserName": {},
-          "AccessKeyId": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "AccessKeyId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -482,7 +592,9 @@
           "AccountAlias"
         ],
         "members": {
-          "AccountAlias": {}
+          "AccountAlias": {
+            "shape": "So"
+          }
         }
       }
     },
@@ -494,7 +606,9 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {}
+          "GroupName": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -506,8 +620,12 @@
           "PolicyName"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyName": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       }
     },
@@ -518,7 +636,9 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {}
+          "InstanceProfileName": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -529,7 +649,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -540,7 +662,9 @@
           "OpenIDConnectProviderArn"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {}
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -551,7 +675,9 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {}
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -563,8 +689,12 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {},
-          "VersionId": {}
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "VersionId": {
+            "shape": "S1k"
+          }
         }
       }
     },
@@ -575,7 +705,9 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {}
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -586,7 +718,9 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {}
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -598,8 +732,12 @@
           "PolicyName"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyName": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       }
     },
@@ -610,7 +748,9 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLProviderArn": {}
+          "SAMLProviderArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -622,8 +762,12 @@
           "SSHPublicKeyId"
         ],
         "members": {
-          "UserName": {},
-          "SSHPublicKeyId": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "SSHPublicKeyId": {
+            "shape": "S2t"
+          }
         }
       }
     },
@@ -634,7 +778,9 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {}
+          "ServerCertificateName": {
+            "shape": "S2v"
+          }
         }
       }
     },
@@ -645,7 +791,9 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {}
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -655,7 +803,9 @@
           "DeletionTaskId"
         ],
         "members": {
-          "DeletionTaskId": {}
+          "DeletionTaskId": {
+            "shape": "S2y"
+          }
         }
       }
     },
@@ -666,8 +816,12 @@
           "ServiceSpecificCredentialId"
         ],
         "members": {
-          "UserName": {},
-          "ServiceSpecificCredentialId": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "ServiceSpecificCredentialId": {
+            "shape": "S24"
+          }
         }
       }
     },
@@ -678,8 +832,12 @@
           "CertificateId"
         ],
         "members": {
-          "UserName": {},
-          "CertificateId": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "CertificateId": {
+            "shape": "S31"
+          }
         }
       }
     },
@@ -690,7 +848,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -701,7 +861,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -713,8 +875,12 @@
           "PolicyName"
         ],
         "members": {
-          "UserName": {},
-          "PolicyName": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       }
     },
@@ -725,7 +891,9 @@
           "SerialNumber"
         ],
         "members": {
-          "SerialNumber": {}
+          "SerialNumber": {
+            "shape": "S2c"
+          }
         }
       }
     },
@@ -737,8 +905,12 @@
           "PolicyArn"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyArn": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -750,8 +922,12 @@
           "PolicyArn"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyArn": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -763,8 +939,12 @@
           "PolicyArn"
         ],
         "members": {
-          "UserName": {},
-          "PolicyArn": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -778,10 +958,18 @@
           "AuthenticationCode2"
         ],
         "members": {
-          "UserName": {},
-          "SerialNumber": {},
-          "AuthenticationCode1": {},
-          "AuthenticationCode2": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "SerialNumber": {
+            "shape": "S2c"
+          },
+          "AuthenticationCode1": {
+            "shape": "S3a"
+          },
+          "AuthenticationCode2": {
+            "shape": "S3a"
+          }
         }
       }
     },
@@ -790,7 +978,14 @@
         "resultWrapper": "GenerateCredentialReportResult",
         "type": "structure",
         "members": {
-          "State": {},
+          "State": {
+            "type": "string",
+            "enum": [
+              "STARTED",
+              "INPROGRESS",
+              "COMPLETE"
+            ]
+          },
           "Description": {}
         }
       }
@@ -802,14 +997,18 @@
           "AccessKeyId"
         ],
         "members": {
-          "AccessKeyId": {}
+          "AccessKeyId": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
         "resultWrapper": "GetAccessKeyLastUsedResult",
         "type": "structure",
         "members": {
-          "UserName": {},
+          "UserName": {
+            "shape": "S9"
+          },
           "AccessKeyLastUsed": {
             "type": "structure",
             "required": [
@@ -834,12 +1033,16 @@
         "members": {
           "Filter": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3k"
+            }
           },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       },
       "output": {
@@ -851,10 +1054,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {},
-                "UserName": {},
-                "UserId": {},
-                "Arn": {},
+                "Path": {
+                  "shape": "Sq"
+                },
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "UserId": {
+                  "shape": "St"
+                },
+                "Arn": {
+                  "shape": "S2"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -863,7 +1074,9 @@
                 },
                 "GroupList": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S8"
+                  }
                 },
                 "AttachedManagedPolicies": {
                   "shape": "S3t"
@@ -879,10 +1092,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {},
-                "GroupName": {},
-                "GroupId": {},
-                "Arn": {},
+                "Path": {
+                  "shape": "Sq"
+                },
+                "GroupName": {
+                  "shape": "S8"
+                },
+                "GroupId": {
+                  "shape": "St"
+                },
+                "Arn": {
+                  "shape": "S2"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -900,14 +1121,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {},
-                "RoleName": {},
-                "RoleId": {},
-                "Arn": {},
+                "Path": {
+                  "shape": "Sq"
+                },
+                "RoleName": {
+                  "shape": "S6"
+                },
+                "RoleId": {
+                  "shape": "St"
+                },
+                "Arn": {
+                  "shape": "S2"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 },
-                "AssumeRolePolicyDocument": {},
+                "AssumeRolePolicyDocument": {
+                  "shape": "Sz"
+                },
                 "InstanceProfileList": {
                   "shape": "S3z"
                 },
@@ -928,11 +1159,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyName": {},
-                "PolicyId": {},
-                "Arn": {},
-                "Path": {},
-                "DefaultVersionId": {},
+                "PolicyName": {
+                  "shape": "S1f"
+                },
+                "PolicyId": {
+                  "shape": "St"
+                },
+                "Arn": {
+                  "shape": "S2"
+                },
+                "Path": {
+                  "shape": "S1g"
+                },
+                "DefaultVersionId": {
+                  "shape": "S1k"
+                },
                 "AttachmentCount": {
                   "type": "integer"
                 },
@@ -942,7 +1183,9 @@
                 "IsAttachable": {
                   "type": "boolean"
                 },
-                "Description": {},
+                "Description": {
+                  "shape": "S1h"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -958,7 +1201,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -974,7 +1219,7 @@
             "type": "structure",
             "members": {
               "MinimumPasswordLength": {
-                "type": "integer"
+                "shape": "S45"
               },
               "RequireSymbols": {
                 "type": "boolean"
@@ -995,10 +1240,10 @@
                 "type": "boolean"
               },
               "MaxPasswordAge": {
-                "type": "integer"
+                "shape": "S46"
               },
               "PasswordReusePrevention": {
-                "type": "integer"
+                "shape": "S47"
               },
               "HardExpiry": {
                 "type": "boolean"
@@ -1015,7 +1260,36 @@
         "members": {
           "SummaryMap": {
             "type": "map",
-            "key": {},
+            "key": {
+              "type": "string",
+              "enum": [
+                "Users",
+                "UsersQuota",
+                "Groups",
+                "GroupsQuota",
+                "ServerCertificates",
+                "ServerCertificatesQuota",
+                "UserPolicySizeQuota",
+                "GroupPolicySizeQuota",
+                "GroupsPerUserQuota",
+                "SigningCertificatesPerUserQuota",
+                "AccessKeysPerUserQuota",
+                "MFADevices",
+                "MFADevicesInUse",
+                "AccountMFAEnabled",
+                "AccountAccessKeysPresent",
+                "AccountSigningCertificatesPresent",
+                "AttachedPoliciesPerGroupQuota",
+                "AttachedPoliciesPerRoleQuota",
+                "AttachedPoliciesPerUserQuota",
+                "Policies",
+                "PoliciesQuota",
+                "PolicySizeQuota",
+                "PolicyVersionsInUse",
+                "PolicyVersionsInUseQuota",
+                "VersionsPerPolicyQuota"
+              ]
+            },
             "value": {
               "type": "integer"
             }
@@ -1047,7 +1321,9 @@
           "PolicySourceArn"
         ],
         "members": {
-          "PolicySourceArn": {},
+          "PolicySourceArn": {
+            "shape": "S2"
+          },
           "PolicyInputList": {
             "shape": "S4e"
           }
@@ -1066,7 +1342,12 @@
           "Content": {
             "type": "blob"
           },
-          "ReportFormat": {},
+          "ReportFormat": {
+            "type": "string",
+            "enum": [
+              "text/csv"
+            ]
+          },
           "GeneratedTime": {
             "type": "timestamp"
           }
@@ -1080,10 +1361,14 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {},
-          "Marker": {},
+          "GroupName": {
+            "shape": "S8"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1104,7 +1389,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1116,8 +1403,12 @@
           "PolicyName"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyName": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       },
       "output": {
@@ -1129,9 +1420,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -1142,7 +1439,9 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {}
+          "InstanceProfileName": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -1165,7 +1464,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -1188,14 +1489,18 @@
           "OpenIDConnectProviderArn"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {}
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "resultWrapper": "GetOpenIDConnectProviderResult",
         "type": "structure",
         "members": {
-          "Url": {},
+          "Url": {
+            "shape": "S19"
+          },
           "ClientIDList": {
             "shape": "S1a"
           },
@@ -1215,7 +1520,9 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {}
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1236,8 +1543,12 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {},
-          "VersionId": {}
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "VersionId": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -1257,7 +1568,9 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {}
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -1281,8 +1594,12 @@
           "PolicyName"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyName": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       },
       "output": {
@@ -1294,9 +1611,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -1307,14 +1630,18 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLProviderArn": {}
+          "SAMLProviderArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "resultWrapper": "GetSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLMetadataDocument": {},
+          "SAMLMetadataDocument": {
+            "shape": "S1s"
+          },
           "CreateDate": {
             "type": "timestamp"
           },
@@ -1333,9 +1660,19 @@
           "Encoding"
         ],
         "members": {
-          "UserName": {},
-          "SSHPublicKeyId": {},
-          "Encoding": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "SSHPublicKeyId": {
+            "shape": "S2t"
+          },
+          "Encoding": {
+            "type": "string",
+            "enum": [
+              "SSH",
+              "PEM"
+            ]
+          }
         }
       },
       "output": {
@@ -1355,7 +1692,9 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {}
+          "ServerCertificateName": {
+            "shape": "S2v"
+          }
         }
       },
       "output": {
@@ -1375,8 +1714,12 @@
               "ServerCertificateMetadata": {
                 "shape": "S5g"
               },
-              "CertificateBody": {},
-              "CertificateChain": {}
+              "CertificateBody": {
+                "shape": "S5h"
+              },
+              "CertificateChain": {
+                "shape": "S5i"
+              }
             }
           }
         }
@@ -1389,7 +1732,9 @@
           "DeletionTaskId"
         ],
         "members": {
-          "DeletionTaskId": {}
+          "DeletionTaskId": {
+            "shape": "S2y"
+          }
         }
       },
       "output": {
@@ -1399,20 +1744,37 @@
           "Status"
         ],
         "members": {
-          "Status": {},
+          "Status": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "IN_PROGRESS",
+              "FAILED",
+              "NOT_STARTED"
+            ]
+          },
           "Reason": {
             "type": "structure",
             "members": {
-              "Reason": {},
+              "Reason": {
+                "type": "string",
+                "max": 1000
+              },
               "RoleUsageList": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Region": {},
+                    "Region": {
+                      "type": "string",
+                      "max": 100,
+                      "min": 1
+                    },
                     "Resources": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "S2"
+                      }
                     }
                   }
                 }
@@ -1426,7 +1788,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {}
+          "UserName": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -1450,8 +1814,12 @@
           "PolicyName"
         ],
         "members": {
-          "UserName": {},
-          "PolicyName": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          }
         }
       },
       "output": {
@@ -1463,9 +1831,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "UserName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -1473,10 +1847,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "S9"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1492,9 +1870,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserName": {},
-                "AccessKeyId": {},
-                "Status": {},
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "AccessKeyId": {
+                  "shape": "Sj"
+                },
+                "Status": {
+                  "shape": "Sk"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 }
@@ -1504,7 +1888,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1512,9 +1898,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {},
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1527,12 +1915,16 @@
         "members": {
           "AccountAliases": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "So"
+            }
           },
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1543,11 +1935,17 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {},
-          "PathPrefix": {},
-          "Marker": {},
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PathPrefix": {
+            "shape": "S1g"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1561,7 +1959,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1572,11 +1972,17 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {},
-          "PathPrefix": {},
-          "Marker": {},
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PathPrefix": {
+            "shape": "S1g"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1590,7 +1996,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1601,11 +2009,17 @@
           "UserName"
         ],
         "members": {
-          "UserName": {},
-          "PathPrefix": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "Sd"
+          },
+          "PathPrefix": {
+            "shape": "S1g"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1619,7 +2033,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1630,13 +2046,23 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {},
-          "EntityFilter": {},
-          "PathPrefix": {},
-          "PolicyUsageFilter": {},
-          "Marker": {},
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "EntityFilter": {
+            "shape": "S3k"
+          },
+          "PathPrefix": {
+            "shape": "Sq"
+          },
+          "PolicyUsageFilter": {
+            "shape": "S6a"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1649,8 +2075,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "GroupName": {},
-                "GroupId": {}
+                "GroupName": {
+                  "shape": "S8"
+                },
+                "GroupId": {
+                  "shape": "St"
+                }
               }
             }
           },
@@ -1659,8 +2089,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserName": {},
-                "UserId": {}
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "UserId": {
+                  "shape": "St"
+                }
               }
             }
           },
@@ -1669,15 +2103,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "RoleName": {},
-                "RoleId": {}
+                "RoleName": {
+                  "shape": "S6"
+                },
+                "RoleId": {
+                  "shape": "St"
+                }
               }
             }
           },
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1688,10 +2128,14 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {},
-          "Marker": {},
+          "GroupName": {
+            "shape": "S8"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1708,7 +2152,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1716,10 +2162,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S6m"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1736,7 +2186,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1747,10 +2199,14 @@
           "UserName"
         ],
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "S9"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1767,7 +2223,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1775,10 +2233,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S6m"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1795,7 +2257,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1806,10 +2270,14 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {},
-          "Marker": {},
+          "RoleName": {
+            "shape": "S6"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1826,7 +2294,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1834,10 +2304,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "S9"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1858,8 +2332,12 @@
                 "EnableDate"
               ],
               "members": {
-                "UserName": {},
-                "SerialNumber": {},
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "SerialNumber": {
+                  "shape": "S2c"
+                },
                 "EnableDate": {
                   "type": "timestamp"
                 }
@@ -1869,7 +2347,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1887,7 +2367,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Arn": {}
+                "Arn": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1898,15 +2380,28 @@
       "input": {
         "type": "structure",
         "members": {
-          "Scope": {},
+          "Scope": {
+            "type": "string",
+            "enum": [
+              "All",
+              "AWS",
+              "Local"
+            ]
+          },
           "OnlyAttached": {
             "type": "boolean"
           },
-          "PathPrefix": {},
-          "PolicyUsageFilter": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S1g"
+          },
+          "PolicyUsageFilter": {
+            "shape": "S6a"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1923,7 +2418,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1934,10 +2431,14 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {},
-          "Marker": {},
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1951,7 +2452,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1962,10 +2465,14 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {},
-          "Marker": {},
+          "RoleName": {
+            "shape": "S6"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -1982,7 +2489,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -1990,10 +2499,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S6m"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2010,7 +2523,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2028,7 +2543,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Arn": {},
+                "Arn": {
+                  "shape": "S2"
+                },
                 "ValidUntil": {
                   "type": "timestamp"
                 },
@@ -2045,10 +2562,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "Sd"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2067,9 +2588,15 @@
                 "UploadDate"
               ],
               "members": {
-                "UserName": {},
-                "SSHPublicKeyId": {},
-                "Status": {},
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "SSHPublicKeyId": {
+                  "shape": "S2t"
+                },
+                "Status": {
+                  "shape": "Sk"
+                },
                 "UploadDate": {
                   "type": "timestamp"
                 }
@@ -2079,7 +2606,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2087,10 +2616,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S6m"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2110,7 +2643,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2118,7 +2653,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {},
+          "UserName": {
+            "shape": "Sd"
+          },
           "ServiceName": {}
         }
       },
@@ -2139,13 +2676,21 @@
                 "ServiceName"
               ],
               "members": {
-                "UserName": {},
-                "Status": {},
-                "ServiceUserName": {},
+                "UserName": {
+                  "shape": "Sd"
+                },
+                "Status": {
+                  "shape": "Sk"
+                },
+                "ServiceUserName": {
+                  "shape": "S22"
+                },
                 "CreateDate": {
                   "type": "timestamp"
                 },
-                "ServiceSpecificCredentialId": {},
+                "ServiceSpecificCredentialId": {
+                  "shape": "S24"
+                },
                 "ServiceName": {}
               }
             }
@@ -2157,10 +2702,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "S9"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2180,7 +2729,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2191,10 +2742,14 @@
           "UserName"
         ],
         "members": {
-          "UserName": {},
-          "Marker": {},
+          "UserName": {
+            "shape": "S9"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2211,7 +2766,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2219,10 +2776,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {},
-          "Marker": {},
+          "PathPrefix": {
+            "shape": "S6m"
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2239,7 +2800,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2247,10 +2810,19 @@
       "input": {
         "type": "structure",
         "members": {
-          "AssignmentStatus": {},
-          "Marker": {},
+          "AssignmentStatus": {
+            "type": "string",
+            "enum": [
+              "Assigned",
+              "Unassigned",
+              "Any"
+            ]
+          },
+          "Marker": {
+            "shape": "S3m"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S3l"
           }
         }
       },
@@ -2270,7 +2842,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -2283,9 +2857,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "GroupName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -2297,8 +2877,12 @@
           "PermissionsBoundary"
         ],
         "members": {
-          "RoleName": {},
-          "PermissionsBoundary": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PermissionsBoundary": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -2311,9 +2895,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -2325,8 +2915,12 @@
           "PermissionsBoundary"
         ],
         "members": {
-          "UserName": {},
-          "PermissionsBoundary": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "PermissionsBoundary": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -2339,9 +2933,15 @@
           "PolicyDocument"
         ],
         "members": {
-          "UserName": {},
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -2353,8 +2953,12 @@
           "ClientID"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {},
-          "ClientID": {}
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          },
+          "ClientID": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -2366,8 +2970,12 @@
           "RoleName"
         ],
         "members": {
-          "InstanceProfileName": {},
-          "RoleName": {}
+          "InstanceProfileName": {
+            "shape": "S5"
+          },
+          "RoleName": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -2379,8 +2987,12 @@
           "UserName"
         ],
         "members": {
-          "GroupName": {},
-          "UserName": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "UserName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -2391,8 +3003,12 @@
           "ServiceSpecificCredentialId"
         ],
         "members": {
-          "UserName": {},
-          "ServiceSpecificCredentialId": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "ServiceSpecificCredentialId": {
+            "shape": "S24"
+          }
         }
       },
       "output": {
@@ -2415,10 +3031,18 @@
           "AuthenticationCode2"
         ],
         "members": {
-          "UserName": {},
-          "SerialNumber": {},
-          "AuthenticationCode1": {},
-          "AuthenticationCode2": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "SerialNumber": {
+            "shape": "S2c"
+          },
+          "AuthenticationCode1": {
+            "shape": "S3a"
+          },
+          "AuthenticationCode2": {
+            "shape": "S3a"
+          }
         }
       }
     },
@@ -2430,8 +3054,12 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {},
-          "VersionId": {}
+          "PolicyArn": {
+            "shape": "S2"
+          },
+          "VersionId": {
+            "shape": "S1k"
+          }
         }
       }
     },
@@ -2452,17 +3080,27 @@
           "ResourceArns": {
             "shape": "S8j"
           },
-          "ResourcePolicy": {},
-          "ResourceOwner": {},
-          "CallerArn": {},
+          "ResourcePolicy": {
+            "shape": "Sz"
+          },
+          "ResourceOwner": {
+            "shape": "S8k"
+          },
+          "CallerArn": {
+            "shape": "S8k"
+          },
           "ContextEntries": {
             "shape": "S8l"
           },
-          "ResourceHandlingOption": {},
-          "MaxItems": {
-            "type": "integer"
+          "ResourceHandlingOption": {
+            "shape": "S8q"
           },
-          "Marker": {}
+          "MaxItems": {
+            "shape": "S3l"
+          },
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       },
       "output": {
@@ -2478,7 +3116,9 @@
           "ActionNames"
         ],
         "members": {
-          "PolicySourceArn": {},
+          "PolicySourceArn": {
+            "shape": "S2"
+          },
           "PolicyInputList": {
             "shape": "S4e"
           },
@@ -2488,17 +3128,27 @@
           "ResourceArns": {
             "shape": "S8j"
           },
-          "ResourcePolicy": {},
-          "ResourceOwner": {},
-          "CallerArn": {},
+          "ResourcePolicy": {
+            "shape": "Sz"
+          },
+          "ResourceOwner": {
+            "shape": "S8k"
+          },
+          "CallerArn": {
+            "shape": "S8k"
+          },
           "ContextEntries": {
             "shape": "S8l"
           },
-          "ResourceHandlingOption": {},
-          "MaxItems": {
-            "type": "integer"
+          "ResourceHandlingOption": {
+            "shape": "S8q"
           },
-          "Marker": {}
+          "MaxItems": {
+            "shape": "S3l"
+          },
+          "Marker": {
+            "shape": "S3m"
+          }
         }
       },
       "output": {
@@ -2514,9 +3164,15 @@
           "Status"
         ],
         "members": {
-          "UserName": {},
-          "AccessKeyId": {},
-          "Status": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "AccessKeyId": {
+            "shape": "Sj"
+          },
+          "Status": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -2525,7 +3181,7 @@
         "type": "structure",
         "members": {
           "MinimumPasswordLength": {
-            "type": "integer"
+            "shape": "S45"
           },
           "RequireSymbols": {
             "type": "boolean"
@@ -2543,10 +3199,10 @@
             "type": "boolean"
           },
           "MaxPasswordAge": {
-            "type": "integer"
+            "shape": "S46"
           },
           "PasswordReusePrevention": {
-            "type": "integer"
+            "shape": "S47"
           },
           "HardExpiry": {
             "type": "boolean"
@@ -2562,8 +3218,12 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {},
-          "PolicyDocument": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -2574,9 +3234,15 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {},
-          "NewPath": {},
-          "NewGroupName": {}
+          "GroupName": {
+            "shape": "S8"
+          },
+          "NewPath": {
+            "shape": "Sq"
+          },
+          "NewGroupName": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -2587,7 +3253,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {},
+          "UserName": {
+            "shape": "Sd"
+          },
           "Password": {
             "shape": "Sf"
           },
@@ -2605,7 +3273,9 @@
           "ThumbprintList"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {},
+          "OpenIDConnectProviderArn": {
+            "shape": "S2"
+          },
           "ThumbprintList": {
             "shape": "S1b"
           }
@@ -2619,10 +3289,14 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {},
-          "Description": {},
+          "RoleName": {
+            "shape": "S6"
+          },
+          "Description": {
+            "shape": "S10"
+          },
           "MaxSessionDuration": {
-            "type": "integer"
+            "shape": "S11"
           }
         }
       },
@@ -2640,8 +3314,12 @@
           "Description"
         ],
         "members": {
-          "RoleName": {},
-          "Description": {}
+          "RoleName": {
+            "shape": "S6"
+          },
+          "Description": {
+            "shape": "S10"
+          }
         }
       },
       "output": {
@@ -2662,15 +3340,21 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLMetadataDocument": {},
-          "SAMLProviderArn": {}
+          "SAMLMetadataDocument": {
+            "shape": "S1s"
+          },
+          "SAMLProviderArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "resultWrapper": "UpdateSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLProviderArn": {}
+          "SAMLProviderArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -2683,9 +3367,15 @@
           "Status"
         ],
         "members": {
-          "UserName": {},
-          "SSHPublicKeyId": {},
-          "Status": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "SSHPublicKeyId": {
+            "shape": "S2t"
+          },
+          "Status": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -2696,9 +3386,15 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {},
-          "NewPath": {},
-          "NewServerCertificateName": {}
+          "ServerCertificateName": {
+            "shape": "S2v"
+          },
+          "NewPath": {
+            "shape": "Sq"
+          },
+          "NewServerCertificateName": {
+            "shape": "S2v"
+          }
         }
       }
     },
@@ -2710,9 +3406,15 @@
           "Status"
         ],
         "members": {
-          "UserName": {},
-          "ServiceSpecificCredentialId": {},
-          "Status": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "ServiceSpecificCredentialId": {
+            "shape": "S24"
+          },
+          "Status": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -2724,9 +3426,15 @@
           "Status"
         ],
         "members": {
-          "UserName": {},
-          "CertificateId": {},
-          "Status": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "CertificateId": {
+            "shape": "S31"
+          },
+          "Status": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -2737,9 +3445,15 @@
           "UserName"
         ],
         "members": {
-          "UserName": {},
-          "NewPath": {},
-          "NewUserName": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "NewPath": {
+            "shape": "Sq"
+          },
+          "NewUserName": {
+            "shape": "Sd"
+          }
         }
       }
     },
@@ -2751,8 +3465,12 @@
           "SSHPublicKeyBody"
         ],
         "members": {
-          "UserName": {},
-          "SSHPublicKeyBody": {}
+          "UserName": {
+            "shape": "Sd"
+          },
+          "SSHPublicKeyBody": {
+            "shape": "S5c"
+          }
         }
       },
       "output": {
@@ -2774,14 +3492,25 @@
           "PrivateKey"
         ],
         "members": {
-          "Path": {},
-          "ServerCertificateName": {},
-          "CertificateBody": {},
+          "Path": {
+            "shape": "Sq"
+          },
+          "ServerCertificateName": {
+            "shape": "S2v"
+          },
+          "CertificateBody": {
+            "shape": "S5h"
+          },
           "PrivateKey": {
             "type": "string",
+            "max": 16384,
+            "min": 1,
+            "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "CertificateChain": {}
+          "CertificateChain": {
+            "shape": "S5i"
+          }
         }
       },
       "output": {
@@ -2801,8 +3530,12 @@
           "CertificateBody"
         ],
         "members": {
-          "UserName": {},
-          "CertificateBody": {}
+          "UserName": {
+            "shape": "S9"
+          },
+          "CertificateBody": {
+            "shape": "S5h"
+          }
         }
       },
       "output": {
@@ -2820,9 +3553,77 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S6": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S8": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S9": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "Sd": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
     "Sf": {
       "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+",
       "sensitive": true
+    },
+    "Sj": {
+      "type": "string",
+      "max": 128,
+      "min": 16,
+      "pattern": "[\\w]+"
+    },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "Active",
+        "Inactive"
+      ]
+    },
+    "So": {
+      "type": "string",
+      "max": 63,
+      "min": 3,
+      "pattern": "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$"
+    },
+    "Sq": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "(\\u002F)|(\\u002F[\\u0021-\\u007F]+\\u002F)"
     },
     "Ss": {
       "type": "structure",
@@ -2834,14 +3635,28 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {},
-        "GroupName": {},
-        "GroupId": {},
-        "Arn": {},
+        "Path": {
+          "shape": "Sq"
+        },
+        "GroupName": {
+          "shape": "S8"
+        },
+        "GroupId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
         "CreateDate": {
           "type": "timestamp"
         }
       }
+    },
+    "St": {
+      "type": "string",
+      "max": 128,
+      "min": 16,
+      "pattern": "[\\w]+"
     },
     "Sw": {
       "type": "structure",
@@ -2854,10 +3669,18 @@
         "Roles"
       ],
       "members": {
-        "Path": {},
-        "InstanceProfileName": {},
-        "InstanceProfileId": {},
-        "Arn": {},
+        "Path": {
+          "shape": "Sq"
+        },
+        "InstanceProfileName": {
+          "shape": "S5"
+        },
+        "InstanceProfileId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
         "CreateDate": {
           "type": "timestamp"
         },
@@ -2882,28 +3705,63 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {},
-        "RoleName": {},
-        "RoleId": {},
-        "Arn": {},
+        "Path": {
+          "shape": "Sq"
+        },
+        "RoleName": {
+          "shape": "S6"
+        },
+        "RoleId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
         "CreateDate": {
           "type": "timestamp"
         },
-        "AssumeRolePolicyDocument": {},
-        "Description": {},
+        "AssumeRolePolicyDocument": {
+          "shape": "Sz"
+        },
+        "Description": {
+          "shape": "S10"
+        },
         "MaxSessionDuration": {
-          "type": "integer"
+          "shape": "S11"
         },
         "PermissionsBoundary": {
           "shape": "S12"
         }
       }
     },
+    "Sz": {
+      "type": "string",
+      "max": 131072,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "S10": {
+      "type": "string",
+      "max": 1000,
+      "pattern": "[\\p{L}\\p{M}\\p{Z}\\p{S}\\p{N}\\p{P}]*"
+    },
+    "S11": {
+      "type": "integer",
+      "max": 43200,
+      "min": 3600
+    },
     "S12": {
       "type": "structure",
       "members": {
-        "PermissionsBoundaryType": {},
-        "PermissionsBoundaryArn": {}
+        "PermissionsBoundaryType": {
+          "type": "string",
+          "enum": [
+            "PermissionsBoundaryPolicy"
+          ]
+        },
+        "PermissionsBoundaryArn": {
+          "shape": "S2"
+        }
       }
     },
     "S17": {
@@ -2913,7 +3771,9 @@
         "CreateDate"
       ],
       "members": {
-        "UserName": {},
+        "UserName": {
+          "shape": "Sd"
+        },
         "CreateDate": {
           "type": "timestamp"
         },
@@ -2922,22 +3782,57 @@
         }
       }
     },
+    "S19": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
     "S1a": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
     },
     "S1b": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 40,
+        "min": 40
+      }
+    },
+    "S1f": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S1g": {
+      "type": "string",
+      "pattern": "((/[A-Za-z0-9\\.,\\+@=_-]+)*)/"
+    },
+    "S1h": {
+      "type": "string",
+      "max": 1000
     },
     "S1j": {
       "type": "structure",
       "members": {
-        "PolicyName": {},
-        "PolicyId": {},
-        "Arn": {},
-        "Path": {},
-        "DefaultVersionId": {},
+        "PolicyName": {
+          "shape": "S1f"
+        },
+        "PolicyId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
+        "Path": {
+          "shape": "S1g"
+        },
+        "DefaultVersionId": {
+          "shape": "S1k"
+        },
         "AttachmentCount": {
           "type": "integer"
         },
@@ -2947,7 +3842,9 @@
         "IsAttachable": {
           "type": "boolean"
         },
-        "Description": {},
+        "Description": {
+          "shape": "S1h"
+        },
         "CreateDate": {
           "type": "timestamp"
         },
@@ -2956,11 +3853,19 @@
         }
       }
     },
+    "S1k": {
+      "type": "string",
+      "pattern": "v[1-9][0-9]*(\\.[A-Za-z0-9-]*)?"
+    },
     "S1o": {
       "type": "structure",
       "members": {
-        "Document": {},
-        "VersionId": {},
+        "Document": {
+          "shape": "Sz"
+        },
+        "VersionId": {
+          "shape": "S1k"
+        },
         "IsDefaultVersion": {
           "type": "boolean"
         },
@@ -2968,6 +3873,11 @@
           "type": "timestamp"
         }
       }
+    },
+    "S1s": {
+      "type": "string",
+      "max": 10000000,
+      "min": 1000
     },
     "S21": {
       "type": "structure",
@@ -2985,15 +3895,35 @@
           "type": "timestamp"
         },
         "ServiceName": {},
-        "ServiceUserName": {},
+        "ServiceUserName": {
+          "shape": "S22"
+        },
         "ServicePassword": {
           "type": "string",
           "sensitive": true
         },
-        "ServiceSpecificCredentialId": {},
-        "UserName": {},
-        "Status": {}
+        "ServiceSpecificCredentialId": {
+          "shape": "S24"
+        },
+        "UserName": {
+          "shape": "Sd"
+        },
+        "Status": {
+          "shape": "Sk"
+        }
       }
+    },
+    "S22": {
+      "type": "string",
+      "max": 200,
+      "min": 17,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S24": {
+      "type": "string",
+      "max": 128,
+      "min": 20,
+      "pattern": "[\\w]+"
     },
     "S27": {
       "type": "structure",
@@ -3005,10 +3935,18 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {},
-        "UserName": {},
-        "UserId": {},
-        "Arn": {},
+        "Path": {
+          "shape": "Sq"
+        },
+        "UserName": {
+          "shape": "Sd"
+        },
+        "UserId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
         "CreateDate": {
           "type": "timestamp"
         },
@@ -3026,7 +3964,9 @@
         "SerialNumber"
       ],
       "members": {
-        "SerialNumber": {},
+        "SerialNumber": {
+          "shape": "S2c"
+        },
         "Base32StringSeed": {
           "shape": "S2d"
         },
@@ -3041,17 +3981,77 @@
         }
       }
     },
+    "S2c": {
+      "type": "string",
+      "max": 256,
+      "min": 9,
+      "pattern": "[\\w+=/:,.@-]+"
+    },
     "S2d": {
       "type": "blob",
       "sensitive": true
+    },
+    "S2t": {
+      "type": "string",
+      "max": 128,
+      "min": 20,
+      "pattern": "[\\w]+"
+    },
+    "S2v": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "S2y": {
+      "type": "string",
+      "max": 1000,
+      "min": 1
+    },
+    "S31": {
+      "type": "string",
+      "max": 128,
+      "min": 24,
+      "pattern": "[\\w]+"
+    },
+    "S3a": {
+      "type": "string",
+      "max": 6,
+      "min": 6,
+      "pattern": "[\\d]+"
+    },
+    "S3k": {
+      "type": "string",
+      "enum": [
+        "User",
+        "Role",
+        "Group",
+        "LocalManagedPolicy",
+        "AWSManagedPolicy"
+      ]
+    },
+    "S3l": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
+    "S3m": {
+      "type": "string",
+      "max": 320,
+      "min": 1,
+      "pattern": "[\\u0020-\\u00FF]+"
     },
     "S3q": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "PolicyName": {},
-          "PolicyDocument": {}
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyDocument": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -3060,8 +4060,12 @@
       "member": {
         "type": "structure",
         "members": {
-          "PolicyName": {},
-          "PolicyArn": {}
+          "PolicyName": {
+            "shape": "S1f"
+          },
+          "PolicyArn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -3077,9 +4081,26 @@
         "shape": "S1o"
       }
     },
+    "S45": {
+      "type": "integer",
+      "max": 128,
+      "min": 6
+    },
+    "S46": {
+      "type": "integer",
+      "max": 1095,
+      "min": 1
+    },
+    "S47": {
+      "type": "integer",
+      "max": 24,
+      "min": 1
+    },
     "S4e": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sz"
+      }
     },
     "S4f": {
       "type": "structure",
@@ -3091,7 +4112,14 @@
     },
     "S4g": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4h"
+      }
+    },
+    "S4h": {
+      "type": "string",
+      "max": 256,
+      "min": 5
     },
     "S4o": {
       "type": "list",
@@ -3109,15 +4137,34 @@
         "Status"
       ],
       "members": {
-        "UserName": {},
-        "SSHPublicKeyId": {},
-        "Fingerprint": {},
-        "SSHPublicKeyBody": {},
-        "Status": {},
+        "UserName": {
+          "shape": "Sd"
+        },
+        "SSHPublicKeyId": {
+          "shape": "S2t"
+        },
+        "Fingerprint": {
+          "type": "string",
+          "max": 48,
+          "min": 48,
+          "pattern": "[:\\w]+"
+        },
+        "SSHPublicKeyBody": {
+          "shape": "S5c"
+        },
+        "Status": {
+          "shape": "Sk"
+        },
         "UploadDate": {
           "type": "timestamp"
         }
       }
+    },
+    "S5c": {
+      "type": "string",
+      "max": 16384,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
     },
     "S5g": {
       "type": "structure",
@@ -3128,10 +4175,18 @@
         "Arn"
       ],
       "members": {
-        "Path": {},
-        "ServerCertificateName": {},
-        "ServerCertificateId": {},
-        "Arn": {},
+        "Path": {
+          "shape": "Sq"
+        },
+        "ServerCertificateName": {
+          "shape": "S2v"
+        },
+        "ServerCertificateId": {
+          "shape": "St"
+        },
+        "Arn": {
+          "shape": "S2"
+        },
         "UploadDate": {
           "type": "timestamp"
         },
@@ -3140,9 +4195,36 @@
         }
       }
     },
+    "S5h": {
+      "type": "string",
+      "max": 16384,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "S5i": {
+      "type": "string",
+      "max": 2097152,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "S6a": {
+      "type": "string",
+      "enum": [
+        "PermissionsPolicy",
+        "PermissionsBoundary"
+      ]
+    },
     "S6k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1f"
+      }
+    },
+    "S6m": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "\\u002F[\\u0021-\\u007F]*"
     },
     "S6o": {
       "type": "list",
@@ -3159,10 +4241,18 @@
         "Status"
       ],
       "members": {
-        "UserName": {},
-        "CertificateId": {},
-        "CertificateBody": {},
-        "Status": {},
+        "UserName": {
+          "shape": "Sd"
+        },
+        "CertificateId": {
+          "shape": "S31"
+        },
+        "CertificateBody": {
+          "shape": "S5h"
+        },
+        "Status": {
+          "shape": "Sk"
+        },
         "UploadDate": {
           "type": "timestamp"
         }
@@ -3170,25 +4260,62 @@
     },
     "S8h": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8i"
+      }
+    },
+    "S8i": {
+      "type": "string",
+      "max": 128,
+      "min": 3
     },
     "S8j": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8k"
+      }
+    },
+    "S8k": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
     },
     "S8l": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ContextKeyName": {},
+          "ContextKeyName": {
+            "shape": "S4h"
+          },
           "ContextKeyValues": {
             "type": "list",
             "member": {}
           },
-          "ContextKeyType": {}
+          "ContextKeyType": {
+            "type": "string",
+            "enum": [
+              "string",
+              "stringList",
+              "numeric",
+              "numericList",
+              "boolean",
+              "booleanList",
+              "ip",
+              "ipList",
+              "binary",
+              "binaryList",
+              "date",
+              "dateList"
+            ]
+          }
         }
       }
+    },
+    "S8q": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "S8r": {
       "type": "structure",
@@ -3202,9 +4329,15 @@
               "EvalDecision"
             ],
             "members": {
-              "EvalActionName": {},
-              "EvalResourceName": {},
-              "EvalDecision": {},
+              "EvalActionName": {
+                "shape": "S8i"
+              },
+              "EvalResourceName": {
+                "shape": "S8k"
+              },
+              "EvalDecision": {
+                "shape": "S8u"
+              },
               "MatchedStatements": {
                 "shape": "S8v"
               },
@@ -3231,8 +4364,12 @@
                     "EvalResourceDecision"
                   ],
                   "members": {
-                    "EvalResourceName": {},
-                    "EvalResourceDecision": {},
+                    "EvalResourceName": {
+                      "shape": "S8k"
+                    },
+                    "EvalResourceDecision": {
+                      "shape": "S8u"
+                    },
                     "MatchedStatements": {
                       "shape": "S8v"
                     },
@@ -3251,8 +4388,18 @@
         "IsTruncated": {
           "type": "boolean"
         },
-        "Marker": {}
+        "Marker": {
+          "shape": "S3m"
+        }
       }
+    },
+    "S8u": {
+      "type": "string",
+      "enum": [
+        "allowed",
+        "explicitDeny",
+        "implicitDeny"
+      ]
     },
     "S8v": {
       "type": "list",
@@ -3260,7 +4407,18 @@
         "type": "structure",
         "members": {
           "SourcePolicyId": {},
-          "SourcePolicyType": {},
+          "SourcePolicyType": {
+            "type": "string",
+            "enum": [
+              "user",
+              "group",
+              "role",
+              "aws-managed",
+              "user-managed",
+              "resource",
+              "none"
+            ]
+          },
           "StartPosition": {
             "shape": "S8z"
           },
@@ -3283,8 +4441,14 @@
     },
     "S93": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 256,
+        "min": 3
+      },
+      "value": {
+        "shape": "S8u"
+      }
     }
   }
 }

--- a/apis/importexport-2010-06-01.min.json
+++ b/apis/importexport-2010-06-01.min.json
@@ -48,7 +48,9 @@
           "ValidateOnly"
         ],
         "members": {
-          "JobType": {},
+          "JobType": {
+            "shape": "S7"
+          },
           "Manifest": {},
           "ManifestAddendum": {},
           "ValidateOnly": {
@@ -62,7 +64,9 @@
         "type": "structure",
         "members": {
           "JobId": {},
-          "JobType": {},
+          "JobType": {
+            "shape": "S7"
+          },
           "Signature": {},
           "SignatureFileContents": {},
           "WarningMessage": {},
@@ -127,7 +131,9 @@
         "type": "structure",
         "members": {
           "JobId": {},
-          "JobType": {},
+          "JobType": {
+            "shape": "S7"
+          },
           "LocationCode": {},
           "LocationMessage": {},
           "ProgressCode": {},
@@ -181,7 +187,9 @@
                 "IsCanceled": {
                   "type": "boolean"
                 },
-                "JobType": {}
+                "JobType": {
+                  "shape": "S7"
+                }
               }
             }
           },
@@ -206,7 +214,9 @@
         "members": {
           "JobId": {},
           "Manifest": {},
-          "JobType": {},
+          "JobType": {
+            "shape": "S7"
+          },
           "ValidateOnly": {
             "type": "boolean"
           },
@@ -229,6 +239,13 @@
     }
   },
   "shapes": {
+    "S7": {
+      "type": "string",
+      "enum": [
+        "Import",
+        "Export"
+      ]
+    },
     "Sf": {
       "type": "list",
       "member": {

--- a/apis/inspector-2016-02-16.min.json
+++ b/apis/inspector-2016-02-16.min.json
@@ -47,8 +47,12 @@
           "assessmentTargetName"
         ],
         "members": {
-          "assessmentTargetName": {},
-          "resourceGroupArn": {}
+          "assessmentTargetName": {
+            "shape": "Se"
+          },
+          "resourceGroupArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -57,7 +61,9 @@
           "assessmentTargetArn"
         ],
         "members": {
-          "assessmentTargetArn": {}
+          "assessmentTargetArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -71,10 +77,14 @@
           "rulesPackageArns"
         ],
         "members": {
-          "assessmentTargetArn": {},
-          "assessmentTemplateName": {},
+          "assessmentTargetArn": {
+            "shape": "S3"
+          },
+          "assessmentTemplateName": {
+            "shape": "Sh"
+          },
           "durationInSeconds": {
-            "type": "integer"
+            "shape": "Si"
           },
           "rulesPackageArns": {
             "shape": "Sj"
@@ -90,7 +100,9 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {}
+          "assessmentTemplateArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -101,7 +113,9 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {}
+          "assessmentTemplateArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -110,7 +124,9 @@
           "previewToken"
         ],
         "members": {
-          "previewToken": {}
+          "previewToken": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -132,7 +148,9 @@
           "resourceGroupArn"
         ],
         "members": {
-          "resourceGroupArn": {}
+          "resourceGroupArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -143,7 +161,9 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {}
+          "assessmentRunArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -154,7 +174,9 @@
           "assessmentTargetArn"
         ],
         "members": {
-          "assessmentTargetArn": {}
+          "assessmentTargetArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -165,7 +187,9 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {}
+          "assessmentTemplateArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -208,16 +232,28 @@
                 "findingCounts"
               ],
               "members": {
-                "arn": {},
-                "name": {},
-                "assessmentTemplateArn": {},
-                "state": {},
+                "arn": {
+                  "shape": "S3"
+                },
+                "name": {
+                  "shape": "S12"
+                },
+                "assessmentTemplateArn": {
+                  "shape": "S3"
+                },
+                "state": {
+                  "shape": "S13"
+                },
                 "durationInSeconds": {
-                  "type": "integer"
+                  "shape": "Si"
                 },
                 "rulesPackageArns": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S3"
+                  },
+                  "max": 50,
+                  "min": 1
                 },
                 "userAttributesForFindings": {
                   "shape": "S4"
@@ -249,9 +285,13 @@
                       "stateChangedAt": {
                         "type": "timestamp"
                       },
-                      "state": {}
+                      "state": {
+                        "shape": "S13"
+                      }
                     }
-                  }
+                  },
+                  "max": 50,
+                  "min": 0
                 },
                 "notifications": {
                   "type": "list",
@@ -266,25 +306,45 @@
                       "date": {
                         "type": "timestamp"
                       },
-                      "event": {},
-                      "message": {},
+                      "event": {
+                        "shape": "S1a"
+                      },
+                      "message": {
+                        "shape": "S1b"
+                      },
                       "error": {
                         "type": "boolean"
                       },
-                      "snsTopicArn": {},
-                      "snsPublishStatusCode": {}
+                      "snsTopicArn": {
+                        "shape": "S3"
+                      },
+                      "snsPublishStatusCode": {
+                        "type": "string",
+                        "enum": [
+                          "SUCCESS",
+                          "TOPIC_DOES_NOT_EXIST",
+                          "ACCESS_DENIED",
+                          "INTERNAL_ERROR"
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "max": 50,
+                  "min": 0
                 },
                 "findingCounts": {
                   "type": "map",
-                  "key": {},
+                  "key": {
+                    "shape": "S1e"
+                  },
                   "value": {
                     "type": "integer"
                   }
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -322,9 +382,15 @@
                 "updatedAt"
               ],
               "members": {
-                "arn": {},
-                "name": {},
-                "resourceGroupArn": {},
+                "arn": {
+                  "shape": "S3"
+                },
+                "name": {
+                  "shape": "Se"
+                },
+                "resourceGroupArn": {
+                  "shape": "S3"
+                },
                 "createdAt": {
                   "type": "timestamp"
                 },
@@ -332,7 +398,9 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -374,11 +442,17 @@
                 "createdAt"
               ],
               "members": {
-                "arn": {},
-                "name": {},
-                "assessmentTargetArn": {},
+                "arn": {
+                  "shape": "S3"
+                },
+                "name": {
+                  "shape": "Sh"
+                },
+                "assessmentTargetArn": {
+                  "shape": "S3"
+                },
                 "durationInSeconds": {
-                  "type": "integer"
+                  "shape": "Si"
                 },
                 "rulesPackageArns": {
                   "shape": "Sj"
@@ -386,7 +460,9 @@
                 "userAttributesForFindings": {
                   "shape": "S4"
                 },
-                "lastAssessmentRunArn": {},
+                "lastAssessmentRunArn": {
+                  "shape": "S3"
+                },
                 "assessmentRunCount": {
                   "type": "integer"
                 },
@@ -394,7 +470,9 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -411,7 +489,9 @@
           "registeredAt"
         ],
         "members": {
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S3"
+          },
           "valid": {
             "type": "boolean"
           },
@@ -430,9 +510,15 @@
         "members": {
           "exclusionArns": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "max": 100,
+            "min": 1
           },
-          "locale": {}
+          "locale": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -444,7 +530,9 @@
         "members": {
           "exclusions": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S3"
+            },
             "value": {
               "type": "structure",
               "required": [
@@ -455,10 +543,18 @@
                 "scopes"
               ],
               "members": {
-                "arn": {},
-                "title": {},
-                "description": {},
-                "recommendation": {},
+                "arn": {
+                  "shape": "S3"
+                },
+                "title": {
+                  "shape": "S1w"
+                },
+                "description": {
+                  "shape": "S1w"
+                },
+                "recommendation": {
+                  "shape": "S1w"
+                },
                 "scopes": {
                   "shape": "S1x"
                 },
@@ -466,7 +562,9 @@
                   "shape": "S21"
                 }
               }
-            }
+            },
+            "max": 100,
+            "min": 1
           },
           "failedItems": {
             "shape": "S9"
@@ -484,7 +582,9 @@
           "findingArns": {
             "shape": "Sy"
           },
-          "locale": {}
+          "locale": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -506,11 +606,17 @@
                 "updatedAt"
               ],
               "members": {
-                "arn": {},
-                "schemaVersion": {
-                  "type": "integer"
+                "arn": {
+                  "shape": "S3"
                 },
-                "service": {},
+                "schemaVersion": {
+                  "shape": "S26"
+                },
+                "service": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 0
+                },
                 "serviceAttributes": {
                   "type": "structure",
                   "required": [
@@ -518,13 +624,22 @@
                   ],
                   "members": {
                     "schemaVersion": {
-                      "type": "integer"
+                      "shape": "S26"
                     },
-                    "assessmentRunArn": {},
-                    "rulesPackageArn": {}
+                    "assessmentRunArn": {
+                      "shape": "S3"
+                    },
+                    "rulesPackageArn": {
+                      "shape": "S3"
+                    }
                   }
                 },
-                "assetType": {},
+                "assetType": {
+                  "type": "string",
+                  "enum": [
+                    "ec2-instance"
+                  ]
+                },
                 "assetAttributes": {
                   "type": "structure",
                   "required": [
@@ -532,28 +647,58 @@
                   ],
                   "members": {
                     "schemaVersion": {
-                      "type": "integer"
+                      "shape": "S26"
                     },
-                    "agentId": {},
-                    "autoScalingGroup": {},
-                    "amiId": {},
-                    "hostname": {},
+                    "agentId": {
+                      "shape": "S2b"
+                    },
+                    "autoScalingGroup": {
+                      "shape": "S2c"
+                    },
+                    "amiId": {
+                      "type": "string",
+                      "max": 256,
+                      "min": 0
+                    },
+                    "hostname": {
+                      "shape": "S2e"
+                    },
                     "ipv4Addresses": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "S2g"
+                      },
+                      "max": 50,
+                      "min": 0
                     }
                   }
                 },
-                "id": {},
-                "title": {},
-                "description": {},
-                "recommendation": {},
-                "severity": {},
+                "id": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 0
+                },
+                "title": {
+                  "shape": "S1w"
+                },
+                "description": {
+                  "shape": "S1w"
+                },
+                "recommendation": {
+                  "shape": "S1w"
+                },
+                "severity": {
+                  "shape": "S1e"
+                },
                 "numericSeverity": {
-                  "type": "double"
+                  "type": "double",
+                  "max": 10,
+                  "min": 0
                 },
                 "confidence": {
-                  "type": "integer"
+                  "type": "integer",
+                  "max": 10,
+                  "min": 0
                 },
                 "indicatorOfCompromise": {
                   "type": "boolean"
@@ -571,7 +716,9 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 100,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -608,7 +755,9 @@
                 "createdAt"
               ],
               "members": {
-                "arn": {},
+                "arn": {
+                  "shape": "S3"
+                },
                 "tags": {
                   "shape": "Sp"
                 },
@@ -616,7 +765,9 @@
                   "type": "timestamp"
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -634,7 +785,9 @@
           "rulesPackageArns": {
             "shape": "Sy"
           },
-          "locale": {}
+          "locale": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -655,13 +808,31 @@
                 "provider"
               ],
               "members": {
-                "arn": {},
-                "name": {},
-                "version": {},
-                "provider": {},
-                "description": {}
+                "arn": {
+                  "shape": "S3"
+                },
+                "name": {
+                  "type": "string",
+                  "max": 1000,
+                  "min": 0
+                },
+                "version": {
+                  "type": "string",
+                  "max": 1000,
+                  "min": 0
+                },
+                "provider": {
+                  "type": "string",
+                  "max": 1000,
+                  "min": 0
+                },
+                "description": {
+                  "shape": "S1w"
+                }
               }
-            }
+            },
+            "max": 10,
+            "min": 0
           },
           "failedItems": {
             "shape": "S9"
@@ -678,9 +849,23 @@
           "reportType"
         ],
         "members": {
-          "assessmentRunArn": {},
-          "reportFileFormat": {},
-          "reportType": {}
+          "assessmentRunArn": {
+            "shape": "S3"
+          },
+          "reportFileFormat": {
+            "type": "string",
+            "enum": [
+              "HTML",
+              "PDF"
+            ]
+          },
+          "reportType": {
+            "type": "string",
+            "enum": [
+              "FINDING",
+              "FULL"
+            ]
+          }
         }
       },
       "output": {
@@ -689,8 +874,18 @@
           "status"
         ],
         "members": {
-          "status": {},
-          "url": {}
+          "status": {
+            "type": "string",
+            "enum": [
+              "WORK_IN_PROGRESS",
+              "FAILED",
+              "COMPLETED"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "max": 2048
+          }
         }
       }
     },
@@ -702,13 +897,21 @@
           "previewToken"
         ],
         "members": {
-          "assessmentTemplateArn": {},
-          "previewToken": {},
-          "nextToken": {},
+          "assessmentTemplateArn": {
+            "shape": "S3"
+          },
+          "previewToken": {
+            "shape": "Sn"
+          },
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           },
-          "locale": {}
+          "locale": {
+            "shape": "S1s"
+          }
         }
       },
       "output": {
@@ -717,7 +920,13 @@
           "previewStatus"
         ],
         "members": {
-          "previewStatus": {},
+          "previewStatus": {
+            "type": "string",
+            "enum": [
+              "WORK_IN_PROGRESS",
+              "COMPLETED"
+            ]
+          },
           "exclusionPreviews": {
             "type": "list",
             "member": {
@@ -729,9 +938,15 @@
                 "scopes"
               ],
               "members": {
-                "title": {},
-                "description": {},
-                "recommendation": {},
+                "title": {
+                  "shape": "S1w"
+                },
+                "description": {
+                  "shape": "S1w"
+                },
+                "recommendation": {
+                  "shape": "S1w"
+                },
                 "scopes": {
                   "shape": "S1x"
                 },
@@ -739,9 +954,13 @@
                   "shape": "S21"
                 }
               }
-            }
+            },
+            "max": 100,
+            "min": 0
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -752,7 +971,9 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {}
+          "assessmentRunArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -774,7 +995,9 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {},
+          "assessmentRunArn": {
+            "shape": "S3"
+          },
           "filter": {
             "type": "structure",
             "required": [
@@ -784,15 +1007,25 @@
             "members": {
               "agentHealths": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S3h"
+                },
+                "max": 10,
+                "min": 0
               },
               "agentHealthCodes": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S3j"
+                },
+                "max": 10,
+                "min": 0
               }
             }
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -816,19 +1049,35 @@
                 "telemetryMetadata"
               ],
               "members": {
-                "agentId": {},
-                "assessmentRunArn": {},
-                "agentHealth": {},
-                "agentHealthCode": {},
-                "agentHealthDetails": {},
-                "autoScalingGroup": {},
+                "agentId": {
+                  "shape": "S2b"
+                },
+                "assessmentRunArn": {
+                  "shape": "S3"
+                },
+                "agentHealth": {
+                  "shape": "S3h"
+                },
+                "agentHealthCode": {
+                  "shape": "S3j"
+                },
+                "agentHealthDetails": {
+                  "shape": "S1b"
+                },
+                "autoScalingGroup": {
+                  "shape": "S2c"
+                },
                 "telemetryMetadata": {
                   "shape": "S3a"
                 }
               }
-            }
+            },
+            "max": 500,
+            "min": 0
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -842,10 +1091,16 @@
           "filter": {
             "type": "structure",
             "members": {
-              "namePattern": {},
+              "namePattern": {
+                "shape": "S3q"
+              },
               "states": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S13"
+                },
+                "max": 50,
+                "min": 0
               },
               "durationRange": {
                 "shape": "S3s"
@@ -864,7 +1119,9 @@
               }
             }
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -879,7 +1136,9 @@
           "assessmentRunArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -890,10 +1149,14 @@
           "filter": {
             "type": "structure",
             "members": {
-              "assessmentTargetNamePattern": {}
+              "assessmentTargetNamePattern": {
+                "shape": "S3q"
+              }
             }
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -908,7 +1171,9 @@
           "assessmentTargetArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -922,7 +1187,9 @@
           "filter": {
             "type": "structure",
             "members": {
-              "namePattern": {},
+              "namePattern": {
+                "shape": "S3q"
+              },
               "durationRange": {
                 "shape": "S3s"
               },
@@ -931,7 +1198,9 @@
               }
             }
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -946,7 +1215,9 @@
           "assessmentTemplateArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -954,8 +1225,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "resourceArn": {},
-          "nextToken": {},
+          "resourceArn": {
+            "shape": "S3"
+          },
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -977,8 +1252,12 @@
                 "eventSubscriptions"
               ],
               "members": {
-                "resourceArn": {},
-                "topicArn": {},
+                "resourceArn": {
+                  "shape": "S3"
+                },
+                "topicArn": {
+                  "shape": "S3"
+                },
                 "eventSubscriptions": {
                   "type": "list",
                   "member": {
@@ -988,17 +1267,25 @@
                       "subscribedAt"
                     ],
                     "members": {
-                      "event": {},
+                      "event": {
+                        "shape": "S1a"
+                      },
                       "subscribedAt": {
                         "type": "timestamp"
                       }
                     }
-                  }
+                  },
+                  "max": 50,
+                  "min": 1
                 }
               }
-            }
+            },
+            "max": 50,
+            "min": 0
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -1009,8 +1296,12 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {},
-          "nextToken": {},
+          "assessmentRunArn": {
+            "shape": "S3"
+          },
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -1025,7 +1316,9 @@
           "exclusionArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -1041,19 +1334,36 @@
             "members": {
               "agentIds": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S2b"
+                },
+                "max": 500,
+                "min": 0
               },
               "autoScalingGroups": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S2c"
+                },
+                "max": 20,
+                "min": 0
               },
               "ruleNames": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "type": "string",
+                  "max": 1000
+                },
+                "max": 50,
+                "min": 0
               },
               "severities": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "shape": "S1e"
+                },
+                "max": 50,
+                "min": 0
               },
               "rulesPackageArns": {
                 "shape": "S3t"
@@ -1069,7 +1379,9 @@
               }
             }
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -1084,7 +1396,9 @@
           "findingArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -1092,7 +1406,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {},
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -1107,7 +1423,9 @@
           "rulesPackageArns": {
             "shape": "S3w"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -1118,7 +1436,9 @@
           "resourceArn"
         ],
         "members": {
-          "resourceArn": {}
+          "resourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1140,8 +1460,12 @@
           "previewAgentsArn"
         ],
         "members": {
-          "previewAgentsArn": {},
-          "nextToken": {},
+          "previewAgentsArn": {
+            "shape": "S3"
+          },
+          "nextToken": {
+            "shape": "S32"
+          },
           "maxResults": {
             "type": "integer"
           }
@@ -1161,18 +1485,44 @@
                 "agentId"
               ],
               "members": {
-                "hostname": {},
-                "agentId": {},
-                "autoScalingGroup": {},
-                "agentHealth": {},
-                "agentVersion": {},
-                "operatingSystem": {},
-                "kernelVersion": {},
-                "ipv4Address": {}
+                "hostname": {
+                  "shape": "S2e"
+                },
+                "agentId": {
+                  "shape": "S2b"
+                },
+                "autoScalingGroup": {
+                  "shape": "S2c"
+                },
+                "agentHealth": {
+                  "shape": "S3h"
+                },
+                "agentVersion": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
+                "operatingSystem": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1
+                },
+                "kernelVersion": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
+                "ipv4Address": {
+                  "shape": "S2g"
+                }
               }
-            }
+            },
+            "max": 100,
+            "min": 0
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -1183,7 +1533,9 @@
           "roleArn"
         ],
         "members": {
-          "roleArn": {}
+          "roleArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1200,7 +1552,11 @@
           },
           "attributeKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S6"
+            },
+            "max": 10,
+            "min": 0
           }
         }
       },
@@ -1223,7 +1579,9 @@
           "resourceArn"
         ],
         "members": {
-          "resourceArn": {},
+          "resourceArn": {
+            "shape": "S3"
+          },
           "tags": {
             "shape": "S4o"
           }
@@ -1237,8 +1595,12 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {},
-          "assessmentRunName": {}
+          "assessmentTemplateArn": {
+            "shape": "S3"
+          },
+          "assessmentRunName": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -1247,7 +1609,9 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {}
+          "assessmentRunArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1258,8 +1622,16 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {},
-          "stopAction": {}
+          "assessmentRunArn": {
+            "shape": "S3"
+          },
+          "stopAction": {
+            "type": "string",
+            "enum": [
+              "START_EVALUATION",
+              "SKIP_EVALUATION"
+            ]
+          }
         }
       }
     },
@@ -1272,9 +1644,15 @@
           "topicArn"
         ],
         "members": {
-          "resourceArn": {},
-          "event": {},
-          "topicArn": {}
+          "resourceArn": {
+            "shape": "S3"
+          },
+          "event": {
+            "shape": "S1a"
+          },
+          "topicArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1287,9 +1665,15 @@
           "topicArn"
         ],
         "members": {
-          "resourceArn": {},
-          "event": {},
-          "topicArn": {}
+          "resourceArn": {
+            "shape": "S3"
+          },
+          "event": {
+            "shape": "S1a"
+          },
+          "topicArn": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1301,9 +1685,15 @@
           "assessmentTargetName"
         ],
         "members": {
-          "assessmentTargetArn": {},
-          "assessmentTargetName": {},
-          "resourceGroupArn": {}
+          "assessmentTargetArn": {
+            "shape": "S3"
+          },
+          "assessmentTargetName": {
+            "shape": "Se"
+          },
+          "resourceGroupArn": {
+            "shape": "S3"
+          }
         }
       }
     }
@@ -1311,13 +1701,24 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "max": 300,
+      "min": 1
     },
     "S4": {
       "type": "list",
       "member": {
         "shape": "S5"
-      }
+      },
+      "max": 10,
+      "min": 0
     },
     "S5": {
       "type": "structure",
@@ -1325,13 +1726,26 @@
         "key"
       ],
       "members": {
-        "key": {},
-        "value": {}
+        "key": {
+          "shape": "S6"
+        },
+        "value": {
+          "type": "string",
+          "max": 256,
+          "min": 1
+        }
       }
+    },
+    "S6": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S9": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S3"
+      },
       "value": {
         "type": "structure",
         "required": [
@@ -1339,16 +1753,49 @@
           "retryable"
         ],
         "members": {
-          "failureCode": {},
+          "failureCode": {
+            "type": "string",
+            "enum": [
+              "INVALID_ARN",
+              "DUPLICATE_ARN",
+              "ITEM_DOES_NOT_EXIST",
+              "ACCESS_DENIED",
+              "LIMIT_EXCEEDED",
+              "INTERNAL_ERROR"
+            ]
+          },
           "retryable": {
             "type": "boolean"
           }
         }
       }
     },
+    "Se": {
+      "type": "string",
+      "max": 140,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 140,
+      "min": 1
+    },
+    "Si": {
+      "type": "integer",
+      "max": 86400,
+      "min": 180
+    },
     "Sj": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 50,
+      "min": 0
+    },
+    "Sn": {
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
     },
     "Sp": {
       "type": "list",
@@ -1358,30 +1805,147 @@
           "key"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "Sr"
+          },
+          "value": {
+            "shape": "Ss"
+          }
         }
-      }
+      },
+      "max": 10,
+      "min": 1
+    },
+    "Sr": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Ss": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     },
     "Sy": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S12": {
+      "type": "string",
+      "max": 140,
+      "min": 1
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "CREATED",
+        "START_DATA_COLLECTION_PENDING",
+        "START_DATA_COLLECTION_IN_PROGRESS",
+        "COLLECTING_DATA",
+        "STOP_DATA_COLLECTION_PENDING",
+        "DATA_COLLECTED",
+        "START_EVALUATING_RULES_PENDING",
+        "EVALUATING_RULES",
+        "FAILED",
+        "ERROR",
+        "COMPLETED",
+        "COMPLETED_WITH_ERRORS",
+        "CANCELED"
+      ]
+    },
+    "S1a": {
+      "type": "string",
+      "enum": [
+        "ASSESSMENT_RUN_STARTED",
+        "ASSESSMENT_RUN_COMPLETED",
+        "ASSESSMENT_RUN_STATE_CHANGED",
+        "FINDING_REPORTED",
+        "OTHER"
+      ]
+    },
+    "S1b": {
+      "type": "string",
+      "max": 1000,
+      "min": 0
+    },
+    "S1e": {
+      "type": "string",
+      "enum": [
+        "Low",
+        "Medium",
+        "High",
+        "Informational",
+        "Undefined"
+      ]
+    },
+    "S1s": {
+      "type": "string",
+      "enum": [
+        "EN_US"
+      ]
+    },
+    "S1w": {
+      "type": "string",
+      "max": 20000,
+      "min": 0
     },
     "S1x": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "key": {},
+          "key": {
+            "type": "string",
+            "enum": [
+              "INSTANCE_ID",
+              "RULES_PACKAGE_ARN"
+            ]
+          },
           "value": {}
         }
-      }
+      },
+      "min": 1
     },
     "S21": {
       "type": "list",
       "member": {
         "shape": "S5"
-      }
+      },
+      "max": 50,
+      "min": 0
+    },
+    "S26": {
+      "type": "integer",
+      "min": 0
+    },
+    "S2b": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S2c": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S2e": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "S2g": {
+      "type": "string",
+      "max": 15,
+      "min": 7
+    },
+    "S32": {
+      "type": "string",
+      "max": 300,
+      "min": 1
     },
     "S3a": {
       "type": "list",
@@ -1392,7 +1956,11 @@
           "count"
         ],
         "members": {
-          "messageType": {},
+          "messageType": {
+            "type": "string",
+            "max": 300,
+            "min": 1
+          },
           "count": {
             "type": "long"
           },
@@ -1400,26 +1968,60 @@
             "type": "long"
           }
         }
-      }
+      },
+      "max": 5000,
+      "min": 0
+    },
+    "S3h": {
+      "type": "string",
+      "enum": [
+        "HEALTHY",
+        "UNHEALTHY",
+        "UNKNOWN"
+      ]
+    },
+    "S3j": {
+      "type": "string",
+      "enum": [
+        "IDLE",
+        "RUNNING",
+        "SHUTDOWN",
+        "UNHEALTHY",
+        "THROTTLED",
+        "UNKNOWN"
+      ]
     },
     "S3o": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 50,
+      "min": 0
+    },
+    "S3q": {
+      "type": "string",
+      "max": 140,
+      "min": 1
     },
     "S3s": {
       "type": "structure",
       "members": {
         "minSeconds": {
-          "type": "integer"
+          "shape": "Si"
         },
         "maxSeconds": {
-          "type": "integer"
+          "shape": "Si"
         }
       }
     },
     "S3t": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 50,
+      "min": 0
     },
     "S3u": {
       "type": "structure",
@@ -1434,7 +2036,11 @@
     },
     "S3w": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 100,
+      "min": 0
     },
     "S4o": {
       "type": "list",
@@ -1444,10 +2050,16 @@
           "key"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "Sr"
+          },
+          "value": {
+            "shape": "Ss"
+          }
         }
-      }
+      },
+      "max": 10,
+      "min": 0
     }
   }
 }

--- a/apis/iot-2015-05-28.min.json
+++ b/apis/iot-2015-05-28.min.json
@@ -23,6 +23,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
@@ -42,9 +43,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingGroupName": {},
+          "thingGroupName": {
+            "shape": "S5"
+          },
           "thingGroupArn": {},
-          "thingName": {},
+          "thingName": {
+            "shape": "S7"
+          },
           "thingArn": {}
         }
       },
@@ -68,18 +73,25 @@
             "shape": "Sb"
           },
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
-          "comment": {}
+          "comment": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {},
-          "description": {}
+          "jobId": {
+            "shape": "Sd"
+          },
+          "description": {
+            "shape": "Sh"
+          }
         }
       }
     },
@@ -96,6 +108,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -116,6 +129,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -140,6 +154,7 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -167,6 +182,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -193,6 +209,7 @@
         ],
         "members": {
           "taskId": {
+            "shape": "Su",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -215,6 +232,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           }
@@ -233,10 +251,13 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
-          "comment": {},
+          "comment": {
+            "shape": "Se"
+          },
           "force": {
             "location": "querystring",
             "locationName": "force",
@@ -248,8 +269,12 @@
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {},
-          "description": {}
+          "jobId": {
+            "shape": "Sd"
+          },
+          "description": {
+            "shape": "Sh"
+          }
         }
       }
     },
@@ -266,10 +291,12 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -315,21 +342,28 @@
         ],
         "members": {
           "authorizerName": {
+            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
           "authorizerFunctionArn": {},
-          "tokenKeyName": {},
+          "tokenKeyName": {
+            "shape": "S1a"
+          },
           "tokenSigningPublicKeys": {
             "shape": "S1b"
           },
-          "status": {}
+          "status": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {},
+          "authorizerName": {
+            "shape": "S18"
+          },
           "authorizerArn": {}
         }
       }
@@ -344,7 +378,10 @@
           "certificateSigningRequest"
         ],
         "members": {
-          "certificateSigningRequest": {},
+          "certificateSigningRequest": {
+            "type": "string",
+            "min": 1
+          },
           "setAsActive": {
             "location": "querystring",
             "locationName": "setAsActive",
@@ -356,8 +393,12 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {},
-          "certificatePem": {}
+          "certificateId": {
+            "shape": "S2"
+          },
+          "certificatePem": {
+            "shape": "S1l"
+          }
         }
       }
     },
@@ -374,19 +415,28 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "targets": {
             "shape": "Sb"
           },
-          "documentSource": {},
-          "document": {},
-          "description": {},
+          "documentSource": {
+            "shape": "S1n"
+          },
+          "document": {
+            "shape": "S1o"
+          },
+          "description": {
+            "shape": "Sh"
+          },
           "presignedUrlConfig": {
             "shape": "S1p"
           },
-          "targetSelection": {},
+          "targetSelection": {
+            "shape": "S1s"
+          },
           "jobExecutionsRolloutConfig": {
             "shape": "S1t"
           }
@@ -396,8 +446,12 @@
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {},
-          "description": {}
+          "jobId": {
+            "shape": "Sd"
+          },
+          "description": {
+            "shape": "Sh"
+          }
         }
       }
     },
@@ -419,14 +473,22 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {},
-          "certificatePem": {},
+          "certificateId": {
+            "shape": "S2"
+          },
+          "certificatePem": {
+            "shape": "S1l"
+          },
           "keyPair": {
             "type": "structure",
             "members": {
-              "PublicKey": {},
+              "PublicKey": {
+                "type": "string",
+                "min": 1
+              },
               "PrivateKey": {
                 "type": "string",
+                "min": 1,
                 "sensitive": true
               }
             }
@@ -448,21 +510,28 @@
         ],
         "members": {
           "otaUpdateId": {
+            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           },
-          "description": {},
+          "description": {
+            "shape": "S23"
+          },
           "targets": {
             "shape": "S24"
           },
-          "targetSelection": {},
+          "targetSelection": {
+            "shape": "S1s"
+          },
           "awsJobExecutionsRolloutConfig": {
             "shape": "S26"
           },
           "files": {
             "shape": "S28"
           },
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "additionalParameters": {
             "shape": "S35"
           }
@@ -471,11 +540,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "otaUpdateId": {},
+          "otaUpdateId": {
+            "shape": "S22"
+          },
           "awsIotJobId": {},
           "otaUpdateArn": {},
           "awsIotJobArn": {},
-          "otaUpdateStatus": {}
+          "otaUpdateStatus": {
+            "shape": "S3a"
+          }
         }
       }
     },
@@ -491,6 +564,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -500,10 +574,14 @@
       "output": {
         "type": "structure",
         "members": {
-          "policyName": {},
+          "policyName": {
+            "shape": "Sj"
+          },
           "policyArn": {},
           "policyDocument": {},
-          "policyVersionId": {}
+          "policyVersionId": {
+            "shape": "S3f"
+          }
         }
       }
     },
@@ -519,6 +597,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -535,7 +614,9 @@
         "members": {
           "policyArn": {},
           "policyDocument": {},
-          "policyVersionId": {},
+          "policyVersionId": {
+            "shape": "S3f"
+          },
           "isDefaultVersion": {
             "type": "boolean"
           }
@@ -554,19 +635,24 @@
         ],
         "members": {
           "roleAlias": {
+            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           },
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "credentialDurationSeconds": {
-            "type": "integer"
+            "shape": "S3m"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "roleAlias": {},
+          "roleAlias": {
+            "shape": "S3l"
+          },
           "roleAliasArn": {}
         }
       }
@@ -583,13 +669,20 @@
           "scheduledAuditName"
         ],
         "members": {
-          "frequency": {},
-          "dayOfMonth": {},
-          "dayOfWeek": {},
+          "frequency": {
+            "shape": "S3q"
+          },
+          "dayOfMonth": {
+            "shape": "S3r"
+          },
+          "dayOfWeek": {
+            "shape": "S3s"
+          },
           "targetCheckNames": {
             "shape": "S3t"
           },
           "scheduledAuditName": {
+            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -614,10 +707,13 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
-          "securityProfileDescription": {},
+          "securityProfileDescription": {
+            "shape": "S3z"
+          },
           "behaviors": {
             "shape": "S40"
           },
@@ -629,7 +725,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {},
+          "securityProfileName": {
+            "shape": "So"
+          },
           "securityProfileArn": {}
         }
       }
@@ -647,24 +745,33 @@
         ],
         "members": {
           "streamId": {
+            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           },
-          "description": {},
+          "description": {
+            "shape": "S4k"
+          },
           "files": {
             "shape": "S4l"
           },
-          "roleArn": {}
+          "roleArn": {
+            "shape": "S1q"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "streamId": {},
+          "streamId": {
+            "shape": "S2e"
+          },
           "streamArn": {},
-          "description": {},
+          "description": {
+            "shape": "S4k"
+          },
           "streamVersion": {
-            "type": "integer"
+            "shape": "S4p"
           }
         }
       }
@@ -680,10 +787,13 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
-          "thingTypeName": {},
+          "thingTypeName": {
+            "shape": "S4r"
+          },
           "attributePayload": {
             "shape": "S4s"
           }
@@ -692,7 +802,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingName": {},
+          "thingName": {
+            "shape": "S7"
+          },
           "thingArn": {},
           "thingId": {}
         }
@@ -709,10 +821,13 @@
         ],
         "members": {
           "thingGroupName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
-          "parentGroupName": {},
+          "parentGroupName": {
+            "shape": "S5"
+          },
           "thingGroupProperties": {
             "shape": "S50"
           }
@@ -721,9 +836,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingGroupName": {},
+          "thingGroupName": {
+            "shape": "S5"
+          },
           "thingGroupArn": {},
-          "thingGroupId": {}
+          "thingGroupId": {
+            "shape": "S53"
+          }
         }
       }
     },
@@ -738,6 +857,7 @@
         ],
         "members": {
           "thingTypeName": {
+            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           },
@@ -749,7 +869,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingTypeName": {},
+          "thingTypeName": {
+            "shape": "S4r"
+          },
           "thingTypeArn": {},
           "thingTypeId": {}
         }
@@ -767,6 +889,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           },
@@ -809,6 +932,7 @@
         ],
         "members": {
           "authorizerName": {
+            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           }
@@ -831,6 +955,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           }
@@ -853,6 +978,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
@@ -876,6 +1002,7 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
@@ -901,10 +1028,12 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -933,6 +1062,7 @@
         ],
         "members": {
           "otaUpdateId": {
+            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           },
@@ -965,6 +1095,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -984,10 +1115,12 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
+            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -1020,6 +1153,7 @@
         ],
         "members": {
           "roleAlias": {
+            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           }
@@ -1042,6 +1176,7 @@
         ],
         "members": {
           "scheduledAuditName": {
+            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -1064,6 +1199,7 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -1091,6 +1227,7 @@
         ],
         "members": {
           "streamId": {
+            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           }
@@ -1113,6 +1250,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -1140,6 +1278,7 @@
         ],
         "members": {
           "thingGroupName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -1167,6 +1306,7 @@
         ],
         "members": {
           "thingTypeName": {
+            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           }
@@ -1189,6 +1329,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -1208,6 +1349,7 @@
         ],
         "members": {
           "targetType": {
+            "shape": "S7z",
             "location": "querystring",
             "locationName": "targetType"
           },
@@ -1229,6 +1371,7 @@
         ],
         "members": {
           "thingTypeName": {
+            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           },
@@ -1254,7 +1397,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "auditNotificationTargetConfigurations": {
             "shape": "S86"
           },
@@ -1276,6 +1421,7 @@
         ],
         "members": {
           "taskId": {
+            "shape": "Su",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -1284,8 +1430,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskStatus": {},
-          "taskType": {},
+          "taskStatus": {
+            "shape": "S8e"
+          },
+          "taskType": {
+            "shape": "S8f"
+          },
           "taskStartTime": {
             "type": "timestamp"
           },
@@ -1315,14 +1465,26 @@
               }
             }
           },
-          "scheduledAuditName": {},
+          "scheduledAuditName": {
+            "shape": "S3v"
+          },
           "auditDetails": {
             "type": "map",
             "key": {},
             "value": {
               "type": "structure",
               "members": {
-                "checkRunStatus": {},
+                "checkRunStatus": {
+                  "type": "string",
+                  "enum": [
+                    "IN_PROGRESS",
+                    "WAITING_FOR_DATA_COLLECTION",
+                    "CANCELED",
+                    "COMPLETED_COMPLIANT",
+                    "COMPLETED_NON_COMPLIANT",
+                    "FAILED"
+                  ]
+                },
                 "checkCompliant": {
                   "type": "boolean"
                 },
@@ -1333,7 +1495,9 @@
                   "type": "long"
                 },
                 "errorCode": {},
-                "message": {}
+                "message": {
+                  "shape": "S8w"
+                }
               }
             }
           }
@@ -1352,6 +1516,7 @@
         ],
         "members": {
           "authorizerName": {
+            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           }
@@ -1378,6 +1543,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           }
@@ -1390,19 +1556,29 @@
             "type": "structure",
             "members": {
               "certificateArn": {},
-              "certificateId": {},
-              "status": {},
-              "certificatePem": {},
-              "ownedBy": {},
+              "certificateId": {
+                "shape": "S2"
+              },
+              "status": {
+                "shape": "S94"
+              },
+              "certificatePem": {
+                "shape": "S1l"
+              },
+              "ownedBy": {
+                "shape": "S95"
+              },
               "creationDate": {
                 "type": "timestamp"
               },
-              "autoRegistrationStatus": {},
+              "autoRegistrationStatus": {
+                "shape": "S96"
+              },
               "lastModifiedDate": {
                 "type": "timestamp"
               },
               "customerVersion": {
-                "type": "integer"
+                "shape": "S97"
               },
               "generationId": {},
               "validity": {
@@ -1428,6 +1604,7 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           }
@@ -1440,12 +1617,24 @@
             "type": "structure",
             "members": {
               "certificateArn": {},
-              "certificateId": {},
-              "caCertificateId": {},
-              "status": {},
-              "certificatePem": {},
-              "ownedBy": {},
-              "previousOwnedBy": {},
+              "certificateId": {
+                "shape": "S2"
+              },
+              "caCertificateId": {
+                "shape": "S2"
+              },
+              "status": {
+                "shape": "S9f"
+              },
+              "certificatePem": {
+                "shape": "S1l"
+              },
+              "ownedBy": {
+                "shape": "S95"
+              },
+              "previousOwnedBy": {
+                "shape": "S95"
+              },
               "creationDate": {
                 "type": "timestamp"
               },
@@ -1453,13 +1642,17 @@
                 "type": "timestamp"
               },
               "customerVersion": {
-                "type": "integer"
+                "shape": "S97"
               },
               "transferData": {
                 "type": "structure",
                 "members": {
-                  "transferMessage": {},
-                  "rejectReason": {},
+                  "transferMessage": {
+                    "shape": "S9h"
+                  },
+                  "rejectReason": {
+                    "shape": "S9h"
+                  },
                   "transferDate": {
                     "type": "timestamp"
                   },
@@ -1555,6 +1748,7 @@
         ],
         "members": {
           "indexName": {
+            "shape": "S9w",
             "location": "uri",
             "locationName": "indexName"
           }
@@ -1563,8 +1757,17 @@
       "output": {
         "type": "structure",
         "members": {
-          "indexName": {},
-          "indexStatus": {},
+          "indexName": {
+            "shape": "S9w"
+          },
+          "indexStatus": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "BUILDING",
+              "REBUILDING"
+            ]
+          },
           "schema": {}
         }
       }
@@ -1581,6 +1784,7 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           }
@@ -1589,22 +1793,34 @@
       "output": {
         "type": "structure",
         "members": {
-          "documentSource": {},
+          "documentSource": {
+            "shape": "S1n"
+          },
           "job": {
             "type": "structure",
             "members": {
               "jobArn": {},
-              "jobId": {},
-              "targetSelection": {},
-              "status": {},
+              "jobId": {
+                "shape": "Sd"
+              },
+              "targetSelection": {
+                "shape": "S1s"
+              },
+              "status": {
+                "shape": "Sa3"
+              },
               "forceCanceled": {
                 "type": "boolean"
               },
-              "comment": {},
+              "comment": {
+                "shape": "Se"
+              },
               "targets": {
                 "shape": "Sb"
               },
-              "description": {},
+              "description": {
+                "shape": "Sh"
+              },
               "presignedUrlConfig": {
                 "shape": "S1p"
               },
@@ -1668,10 +1884,12 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -1688,8 +1906,12 @@
           "execution": {
             "type": "structure",
             "members": {
-              "jobId": {},
-              "status": {},
+              "jobId": {
+                "shape": "Sd"
+              },
+              "status": {
+                "shape": "Sai"
+              },
               "forceCanceled": {
                 "type": "boolean"
               },
@@ -1734,6 +1956,7 @@
         ],
         "members": {
           "roleAlias": {
+            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           }
@@ -1745,12 +1968,18 @@
           "roleAliasDescription": {
             "type": "structure",
             "members": {
-              "roleAlias": {},
+              "roleAlias": {
+                "shape": "S3l"
+              },
               "roleAliasArn": {},
-              "roleArn": {},
-              "owner": {},
+              "roleArn": {
+                "shape": "S1q"
+              },
+              "owner": {
+                "shape": "S95"
+              },
               "credentialDurationSeconds": {
-                "type": "integer"
+                "shape": "S3m"
               },
               "creationDate": {
                 "type": "timestamp"
@@ -1775,6 +2004,7 @@
         ],
         "members": {
           "scheduledAuditName": {
+            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -1783,13 +2013,21 @@
       "output": {
         "type": "structure",
         "members": {
-          "frequency": {},
-          "dayOfMonth": {},
-          "dayOfWeek": {},
+          "frequency": {
+            "shape": "S3q"
+          },
+          "dayOfMonth": {
+            "shape": "S3r"
+          },
+          "dayOfWeek": {
+            "shape": "S3s"
+          },
           "targetCheckNames": {
             "shape": "S3t"
           },
-          "scheduledAuditName": {},
+          "scheduledAuditName": {
+            "shape": "S3v"
+          },
           "scheduledAuditArn": {}
         }
       }
@@ -1806,6 +2044,7 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           }
@@ -1814,9 +2053,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {},
+          "securityProfileName": {
+            "shape": "So"
+          },
           "securityProfileArn": {},
-          "securityProfileDescription": {},
+          "securityProfileDescription": {
+            "shape": "S3z"
+          },
           "behaviors": {
             "shape": "S40"
           },
@@ -1847,6 +2090,7 @@
         ],
         "members": {
           "streamId": {
+            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           }
@@ -1858,12 +2102,16 @@
           "streamInfo": {
             "type": "structure",
             "members": {
-              "streamId": {},
+              "streamId": {
+                "shape": "S2e"
+              },
               "streamArn": {},
               "streamVersion": {
-                "type": "integer"
+                "shape": "S4p"
               },
-              "description": {},
+              "description": {
+                "shape": "S4k"
+              },
               "files": {
                 "shape": "S4l"
               },
@@ -1873,7 +2121,9 @@
               "lastUpdatedAt": {
                 "type": "timestamp"
               },
-              "roleArn": {}
+              "roleArn": {
+                "shape": "S1q"
+              }
             }
           }
         }
@@ -1891,6 +2141,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -1900,10 +2151,14 @@
         "type": "structure",
         "members": {
           "defaultClientId": {},
-          "thingName": {},
+          "thingName": {
+            "shape": "S7"
+          },
           "thingId": {},
           "thingArn": {},
-          "thingTypeName": {},
+          "thingTypeName": {
+            "shape": "S4r"
+          },
           "attributes": {
             "shape": "S4t"
           },
@@ -1925,6 +2180,7 @@
         ],
         "members": {
           "thingGroupName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           }
@@ -1933,8 +2189,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingGroupName": {},
-          "thingGroupId": {},
+          "thingGroupName": {
+            "shape": "S5"
+          },
+          "thingGroupId": {
+            "shape": "S53"
+          },
           "thingGroupArn": {},
           "version": {
             "type": "long"
@@ -1945,7 +2205,9 @@
           "thingGroupMetadata": {
             "type": "structure",
             "members": {
-              "parentGroupName": {},
+              "parentGroupName": {
+                "shape": "S5"
+              },
               "rootToParentThingGroups": {
                 "shape": "Sb2"
               },
@@ -1969,6 +2231,7 @@
         ],
         "members": {
           "taskId": {
+            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -1977,7 +2240,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {},
+          "taskId": {
+            "shape": "Sb5"
+          },
           "creationDate": {
             "type": "timestamp"
           },
@@ -1985,11 +2250,21 @@
             "type": "timestamp"
           },
           "templateBody": {},
-          "inputFileBucket": {},
-          "inputFileKey": {},
-          "roleArn": {},
-          "status": {},
-          "message": {},
+          "inputFileBucket": {
+            "shape": "Sb7"
+          },
+          "inputFileKey": {
+            "shape": "Sb8"
+          },
+          "roleArn": {
+            "shape": "S1q"
+          },
+          "status": {
+            "shape": "Sb9"
+          },
+          "message": {
+            "shape": "S8w"
+          },
           "successCount": {
             "type": "integer"
           },
@@ -1997,7 +2272,9 @@
             "type": "integer"
           },
           "percentageProgress": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 0
           }
         }
       }
@@ -2014,6 +2291,7 @@
         ],
         "members": {
           "thingTypeName": {
+            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           }
@@ -2022,7 +2300,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingTypeName": {},
+          "thingTypeName": {
+            "shape": "S4r"
+          },
           "thingTypeId": {},
           "thingTypeArn": {},
           "thingTypeProperties": {
@@ -2046,6 +2326,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -2066,6 +2347,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -2090,6 +2372,7 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -2117,6 +2400,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -2142,6 +2426,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2159,6 +2444,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2175,6 +2461,7 @@
           "principal": {},
           "cognitoIdentityPoolId": {},
           "thingName": {
+            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           }
@@ -2188,7 +2475,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "policyName": {},
+                "policyName": {
+                  "shape": "Sj"
+                },
                 "policyArn": {},
                 "policyDocument": {}
               }
@@ -2230,6 +2519,7 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           }
@@ -2238,7 +2528,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "document": {}
+          "document": {
+            "shape": "S1o"
+          }
         }
       }
     },
@@ -2255,7 +2547,9 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "logLevel": {}
+          "logLevel": {
+            "shape": "Sc4"
+          }
         }
       }
     },
@@ -2271,6 +2565,7 @@
         ],
         "members": {
           "otaUpdateId": {
+            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           }
@@ -2282,7 +2577,9 @@
           "otaUpdateInfo": {
             "type": "structure",
             "members": {
-              "otaUpdateId": {},
+              "otaUpdateId": {
+                "shape": "S22"
+              },
               "otaUpdateArn": {},
               "creationDate": {
                 "type": "timestamp"
@@ -2290,18 +2587,24 @@
               "lastModifiedDate": {
                 "type": "timestamp"
               },
-              "description": {},
+              "description": {
+                "shape": "S23"
+              },
               "targets": {
                 "shape": "S24"
               },
               "awsJobExecutionsRolloutConfig": {
                 "shape": "S26"
               },
-              "targetSelection": {},
+              "targetSelection": {
+                "shape": "S1s"
+              },
               "otaUpdateFiles": {
                 "shape": "S28"
               },
-              "otaUpdateStatus": {},
+              "otaUpdateStatus": {
+                "shape": "S3a"
+              },
               "awsIotJobId": {},
               "awsIotJobArn": {},
               "errorInfo": {
@@ -2331,6 +2634,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -2339,10 +2643,14 @@
       "output": {
         "type": "structure",
         "members": {
-          "policyName": {},
+          "policyName": {
+            "shape": "Sj"
+          },
           "policyArn": {},
           "policyDocument": {},
-          "defaultVersionId": {},
+          "defaultVersionId": {
+            "shape": "S3f"
+          },
           "creationDate": {
             "type": "timestamp"
           },
@@ -2366,10 +2674,12 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
+            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -2379,9 +2689,13 @@
         "type": "structure",
         "members": {
           "policyArn": {},
-          "policyName": {},
+          "policyName": {
+            "shape": "Sj"
+          },
           "policyDocument": {},
-          "policyVersionId": {},
+          "policyVersionId": {
+            "shape": "S3f"
+          },
           "isDefaultVersion": {
             "type": "boolean"
           },
@@ -2407,7 +2721,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "registrationCode": {}
+          "registrationCode": {
+            "type": "string",
+            "max": 64,
+            "min": 64,
+            "pattern": "(0x)?[a-fA-F0-9]+"
+          }
         }
       }
     },
@@ -2423,6 +2742,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2435,7 +2755,9 @@
           "rule": {
             "type": "structure",
             "members": {
-              "ruleName": {},
+              "ruleName": {
+                "shape": "S5c"
+              },
               "sql": {},
               "description": {},
               "createdAt": {
@@ -2469,7 +2791,9 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "defaultLogLevel": {},
+          "defaultLogLevel": {
+            "shape": "Sc4"
+          },
           "disableAllLogs": {
             "type": "boolean"
           }
@@ -2485,10 +2809,12 @@
         "type": "structure",
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           },
           "securityProfileName": {
+            "shape": "So",
             "location": "querystring",
             "locationName": "securityProfileName"
           },
@@ -2497,9 +2823,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -2511,9 +2837,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "violationId": {},
-                "thingName": {},
-                "securityProfileName": {},
+                "violationId": {
+                  "shape": "Scw"
+                },
+                "thingName": {
+                  "shape": "S7"
+                },
+                "securityProfileName": {
+                  "shape": "So"
+                },
                 "behavior": {
                   "shape": "S41"
                 },
@@ -2553,13 +2885,14 @@
             "type": "boolean"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           }
         }
       },
@@ -2569,7 +2902,9 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -2580,13 +2915,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "taskId": {},
+          "taskId": {
+            "shape": "Su"
+          },
           "checkName": {},
           "resourceIdentifier": {
             "shape": "Sd5"
           },
           "maxResults": {
-            "type": "integer"
+            "shape": "Scs"
           },
           "nextToken": {},
           "startTime": {
@@ -2605,7 +2942,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {},
+                "taskId": {
+                  "shape": "Su"
+                },
                 "checkName": {},
                 "taskStartTime": {
                   "type": "timestamp"
@@ -2613,11 +2952,21 @@
                 "findingTime": {
                   "type": "timestamp"
                 },
-                "severity": {},
+                "severity": {
+                  "type": "string",
+                  "enum": [
+                    "CRITICAL",
+                    "HIGH",
+                    "MEDIUM",
+                    "LOW"
+                  ]
+                },
                 "nonCompliantResource": {
                   "type": "structure",
                   "members": {
-                    "resourceType": {},
+                    "resourceType": {
+                      "shape": "Sdc"
+                    },
                     "resourceIdentifier": {
                       "shape": "Sd5"
                     },
@@ -2631,7 +2980,9 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "resourceType": {},
+                      "resourceType": {
+                        "shape": "Sdc"
+                      },
                       "resourceIdentifier": {
                         "shape": "Sd5"
                       },
@@ -2673,10 +3024,12 @@
             "type": "timestamp"
           },
           "taskType": {
+            "shape": "S8f",
             "location": "querystring",
             "locationName": "taskType"
           },
           "taskStatus": {
+            "shape": "S8e",
             "location": "querystring",
             "locationName": "taskStatus"
           },
@@ -2685,9 +3038,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -2699,9 +3052,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {},
-                "taskStatus": {},
-                "taskType": {}
+                "taskId": {
+                  "shape": "Su"
+                },
+                "taskStatus": {
+                  "shape": "S8e"
+                },
+                "taskType": {
+                  "shape": "S8f"
+                }
               }
             }
           },
@@ -2718,11 +3077,12 @@
         "type": "structure",
         "members": {
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -2732,6 +3092,7 @@
             "type": "boolean"
           },
           "status": {
+            "shape": "S1e",
             "location": "querystring",
             "locationName": "status"
           }
@@ -2745,12 +3106,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "authorizerName": {},
+                "authorizerName": {
+                  "shape": "S18"
+                },
                 "authorizerArn": {}
               }
             }
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -2763,11 +3128,12 @@
         "type": "structure",
         "members": {
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -2787,15 +3153,21 @@
               "type": "structure",
               "members": {
                 "certificateArn": {},
-                "certificateId": {},
-                "status": {},
+                "certificateId": {
+                  "shape": "S2"
+                },
+                "status": {
+                  "shape": "S94"
+                },
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -2808,11 +3180,12 @@
         "type": "structure",
         "members": {
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -2829,7 +3202,9 @@
           "certificates": {
             "shape": "Sdx"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -2845,15 +3220,17 @@
         ],
         "members": {
           "caCertificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -2870,7 +3247,9 @@
           "certificates": {
             "shape": "Sdx"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -2887,9 +3266,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Se2",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -2898,7 +3277,9 @@
         "members": {
           "indexNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S9w"
+            }
           },
           "nextToken": {}
         }
@@ -2916,17 +3297,19 @@
         ],
         "members": {
           "jobId": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "status": {
+            "shape": "Sai",
             "location": "querystring",
             "locationName": "status"
           },
           "maxResults": {
+            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -2965,17 +3348,19 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
           "status": {
+            "shape": "Sai",
             "location": "querystring",
             "locationName": "status"
           },
           "maxResults": {
+            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -2991,7 +3376,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "jobId": {},
+                "jobId": {
+                  "shape": "Sd"
+                },
                 "jobExecutionSummary": {
                   "shape": "Sea"
                 }
@@ -3011,27 +3398,31 @@
         "type": "structure",
         "members": {
           "status": {
+            "shape": "Sa3",
             "location": "querystring",
             "locationName": "status"
           },
           "targetSelection": {
+            "shape": "S1s",
             "location": "querystring",
             "locationName": "targetSelection"
           },
           "maxResults": {
+            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "thingGroupName": {
+            "shape": "S5",
             "location": "querystring",
             "locationName": "thingGroupName"
           },
           "thingGroupId": {
+            "shape": "S53",
             "location": "querystring",
             "locationName": "thingGroupId"
           }
@@ -3046,10 +3437,18 @@
               "type": "structure",
               "members": {
                 "jobArn": {},
-                "jobId": {},
-                "thingGroupId": {},
-                "targetSelection": {},
-                "status": {},
+                "jobId": {
+                  "shape": "Sd"
+                },
+                "thingGroupId": {
+                  "shape": "S53"
+                },
+                "targetSelection": {
+                  "shape": "S1s"
+                },
+                "status": {
+                  "shape": "Sa3"
+                },
                 "createdAt": {
                   "type": "timestamp"
                 },
@@ -3075,15 +3474,16 @@
         "type": "structure",
         "members": {
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "otaUpdateStatus": {
+            "shape": "S3a",
             "location": "querystring",
             "locationName": "otaUpdateStatus"
           }
@@ -3097,7 +3497,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "otaUpdateId": {},
+                "otaUpdateId": {
+                  "shape": "S22"
+                },
                 "otaUpdateArn": {},
                 "creationDate": {
                   "type": "timestamp"
@@ -3118,11 +3520,12 @@
         "type": "structure",
         "members": {
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3142,19 +3545,27 @@
               "type": "structure",
               "members": {
                 "certificateArn": {},
-                "certificateId": {},
-                "transferredTo": {},
+                "certificateId": {
+                  "shape": "S2"
+                },
+                "transferredTo": {
+                  "shape": "S95"
+                },
                 "transferDate": {
                   "type": "timestamp"
                 },
-                "transferMessage": {},
+                "transferMessage": {
+                  "shape": "S9h"
+                },
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -3167,13 +3578,14 @@
         "type": "structure",
         "members": {
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3188,7 +3600,9 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -3204,17 +3618,19 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "header",
             "locationName": "x-amzn-iot-policy"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3229,7 +3645,9 @@
           "principals": {
             "shape": "Sev"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       },
       "deprecated": true
@@ -3246,6 +3664,7 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -3259,7 +3678,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "versionId": {},
+                "versionId": {
+                  "shape": "S3f"
+                },
                 "isDefaultVersion": {
                   "type": "boolean"
                 },
@@ -3288,13 +3709,14 @@
             "locationName": "x-amzn-iot-principal"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3309,7 +3731,9 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       },
       "deprecated": true
@@ -3330,9 +3754,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "principal": {
             "location": "header",
@@ -3359,11 +3783,12 @@
         "type": "structure",
         "members": {
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3379,9 +3804,13 @@
         "members": {
           "roleAliases": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3l"
+            }
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -3398,9 +3827,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3412,11 +3841,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "scheduledAuditName": {},
+                "scheduledAuditName": {
+                  "shape": "S3v"
+                },
                 "scheduledAuditArn": {},
-                "frequency": {},
-                "dayOfMonth": {},
-                "dayOfWeek": {}
+                "frequency": {
+                  "shape": "S3q"
+                },
+                "dayOfMonth": {
+                  "shape": "S3r"
+                },
+                "dayOfWeek": {
+                  "shape": "S3s"
+                }
               }
             }
           },
@@ -3437,9 +3874,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3472,9 +3909,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "recursive": {
             "location": "querystring",
@@ -3517,9 +3954,9 @@
         "type": "structure",
         "members": {
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -3540,12 +3977,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "streamId": {},
+                "streamId": {
+                  "shape": "S2e"
+                },
                 "streamArn": {},
                 "streamVersion": {
-                  "type": "integer"
+                  "shape": "S4p"
                 },
-                "description": {}
+                "description": {
+                  "shape": "S4k"
+                }
               }
             }
           },
@@ -3564,17 +4005,19 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "marker": {
+            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
+            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize",
-            "type": "integer"
+            "locationName": "pageSize"
           }
         }
       },
@@ -3585,7 +4028,9 @@
             "type": "list",
             "member": {}
           },
-          "nextMarker": {}
+          "nextMarker": {
+            "shape": "Scz"
+          }
         }
       }
     },
@@ -3601,6 +4046,7 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -3609,9 +4055,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3641,15 +4087,17 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "parentGroup": {
+            "shape": "S5",
             "location": "querystring",
             "locationName": "parentGroup"
           },
           "namePrefixFilter": {
+            "shape": "S5",
             "location": "querystring",
             "locationName": "namePrefixFilter"
           },
@@ -3682,6 +4130,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -3690,9 +4139,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3718,6 +4167,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -3745,10 +4195,12 @@
         ],
         "members": {
           "taskId": {
+            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           },
           "reportType": {
+            "shape": "Sg5",
             "location": "querystring",
             "locationName": "reportType"
           },
@@ -3757,9 +4209,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3768,9 +4220,14 @@
         "members": {
           "resourceLinks": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 65535
+            }
           },
-          "reportType": {},
+          "reportType": {
+            "shape": "Sg5"
+          },
           "nextToken": {}
         }
       }
@@ -3788,11 +4245,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "status": {
+            "shape": "Sb9",
             "location": "querystring",
             "locationName": "status"
           }
@@ -3803,7 +4261,9 @@
         "members": {
           "taskIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sb5"
+            }
           },
           "nextToken": {}
         }
@@ -3822,11 +4282,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "thingTypeName": {
+            "shape": "S4r",
             "location": "querystring",
             "locationName": "thingTypeName"
           }
@@ -3840,7 +4301,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingTypeName": {},
+                "thingTypeName": {
+                  "shape": "S4r"
+                },
                 "thingTypeArn": {},
                 "thingTypeProperties": {
                   "shape": "S55"
@@ -3868,19 +4331,22 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "attributeName": {
+            "shape": "S4u",
             "location": "querystring",
             "locationName": "attributeName"
           },
           "attributeValue": {
+            "shape": "S4v",
             "location": "querystring",
             "locationName": "attributeValue"
           },
           "thingTypeName": {
+            "shape": "S4r",
             "location": "querystring",
             "locationName": "thingTypeName"
           }
@@ -3894,8 +4360,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingName": {},
-                "thingTypeName": {},
+                "thingName": {
+                  "shape": "S7"
+                },
+                "thingTypeName": {
+                  "shape": "S4r"
+                },
                 "thingArn": {},
                 "attributes": {
                   "shape": "S4t"
@@ -3922,6 +4392,7 @@
         ],
         "members": {
           "thingGroupName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -3935,9 +4406,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -3966,7 +4437,9 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
           "nextToken": {
             "location": "querystring",
@@ -3988,7 +4461,9 @@
               "type": "structure",
               "members": {
                 "ruleArn": {},
-                "ruleName": {},
+                "ruleName": {
+                  "shape": "S5c"
+                },
                 "topicPattern": {},
                 "createdAt": {
                   "type": "timestamp"
@@ -4012,6 +4487,7 @@
         "type": "structure",
         "members": {
           "targetType": {
+            "shape": "S7z",
             "location": "querystring",
             "locationName": "targetType"
           },
@@ -4022,7 +4498,9 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer"
+            "type": "integer",
+            "max": 250,
+            "min": 1
           }
         }
       },
@@ -4037,7 +4515,9 @@
                 "logTarget": {
                   "shape": "Sgx"
                 },
-                "logLevel": {}
+                "logLevel": {
+                  "shape": "Sc4"
+                }
               }
             }
           },
@@ -4068,10 +4548,12 @@
             "type": "timestamp"
           },
           "thingName": {
+            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           },
           "securityProfileName": {
+            "shape": "So",
             "location": "querystring",
             "locationName": "securityProfileName"
           },
@@ -4080,9 +4562,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -4094,16 +4576,29 @@
             "member": {
               "type": "structure",
               "members": {
-                "violationId": {},
-                "thingName": {},
-                "securityProfileName": {},
+                "violationId": {
+                  "shape": "Scw"
+                },
+                "thingName": {
+                  "shape": "S7"
+                },
+                "securityProfileName": {
+                  "shape": "So"
+                },
                 "behavior": {
                   "shape": "S41"
                 },
                 "metricValue": {
                   "shape": "S46"
                 },
-                "violationEventType": {},
+                "violationEventType": {
+                  "type": "string",
+                  "enum": [
+                    "in-alarm",
+                    "alarm-cleared",
+                    "alarm-invalidated"
+                  ]
+                },
                 "violationEventTime": {
                   "type": "timestamp"
                 }
@@ -4125,8 +4620,12 @@
           "verificationCertificate"
         ],
         "members": {
-          "caCertificate": {},
-          "verificationCertificate": {},
+          "caCertificate": {
+            "shape": "S1l"
+          },
+          "verificationCertificate": {
+            "shape": "S1l"
+          },
           "setAsActive": {
             "location": "querystring",
             "locationName": "setAsActive",
@@ -4146,7 +4645,9 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {}
+          "certificateId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -4160,22 +4661,30 @@
           "certificatePem"
         ],
         "members": {
-          "certificatePem": {},
-          "caCertificatePem": {},
+          "certificatePem": {
+            "shape": "S1l"
+          },
+          "caCertificatePem": {
+            "shape": "S1l"
+          },
           "setAsActive": {
             "deprecated": true,
             "location": "querystring",
             "locationName": "setAsActive",
             "type": "boolean"
           },
-          "status": {}
+          "status": {
+            "shape": "S9f"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {}
+          "certificateId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -4200,7 +4709,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "certificatePem": {},
+          "certificatePem": {
+            "shape": "S1l"
+          },
           "resourceArns": {
             "type": "map",
             "key": {},
@@ -4221,10 +4732,13 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
-          "rejectReason": {}
+          "rejectReason": {
+            "shape": "S9h"
+          }
         }
       }
     },
@@ -4236,9 +4750,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingGroupName": {},
+          "thingGroupName": {
+            "shape": "S5"
+          },
           "thingGroupArn": {},
-          "thingName": {},
+          "thingName": {
+            "shape": "S7"
+          },
           "thingArn": {}
         }
       },
@@ -4260,6 +4778,7 @@
         ],
         "members": {
           "ruleName": {
+            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           },
@@ -4280,11 +4799,16 @@
           "queryString"
         ],
         "members": {
-          "indexName": {},
-          "queryString": {},
+          "indexName": {
+            "shape": "S9w"
+          },
+          "queryString": {
+            "type": "string",
+            "min": 1
+          },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "Se2"
           },
           "queryVersion": {}
         }
@@ -4298,9 +4822,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingName": {},
+                "thingName": {
+                  "shape": "S7"
+                },
                 "thingId": {},
-                "thingTypeName": {},
+                "thingTypeName": {
+                  "shape": "S4r"
+                },
                 "thingGroupNames": {
                   "shape": "Shq"
                 },
@@ -4316,9 +4844,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingGroupName": {},
-                "thingGroupId": {},
-                "thingGroupDescription": {},
+                "thingGroupName": {
+                  "shape": "S5"
+                },
+                "thingGroupId": {
+                  "shape": "S53"
+                },
+                "thingGroupDescription": {
+                  "shape": "S51"
+                },
                 "attributes": {
                   "shape": "S4t"
                 },
@@ -4341,13 +4875,17 @@
           "authorizerName"
         ],
         "members": {
-          "authorizerName": {}
+          "authorizerName": {
+            "shape": "S18"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {},
+          "authorizerName": {
+            "shape": "S18"
+          },
           "authorizerArn": {}
         }
       }
@@ -4365,10 +4903,12 @@
         ],
         "members": {
           "policyName": {
+            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
+            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -4392,7 +4932,9 @@
             ],
             "members": {
               "roleArn": {},
-              "logLevel": {}
+              "logLevel": {
+                "shape": "Sc4"
+              }
             }
           }
         },
@@ -4413,7 +4955,9 @@
           "logTarget": {
             "shape": "Sgx"
           },
-          "logLevel": {}
+          "logLevel": {
+            "shape": "Sc4"
+          }
         }
       }
     },
@@ -4425,7 +4969,9 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "defaultLogLevel": {},
+          "defaultLogLevel": {
+            "shape": "Sc4"
+          },
           "disableAllLogs": {
             "type": "boolean"
           }
@@ -4450,7 +4996,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {}
+          "taskId": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -4468,15 +5016,23 @@
         ],
         "members": {
           "templateBody": {},
-          "inputFileBucket": {},
-          "inputFileKey": {},
-          "roleArn": {}
+          "inputFileBucket": {
+            "shape": "Sb7"
+          },
+          "inputFileKey": {
+            "shape": "Sb8"
+          },
+          "roleArn": {
+            "shape": "S1q"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {}
+          "taskId": {
+            "shape": "Sb5"
+          }
         }
       }
     },
@@ -4492,6 +5048,7 @@
         ],
         "members": {
           "taskId": {
+            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -4518,7 +5075,9 @@
             "type": "list",
             "member": {
               "shape": "Si9"
-            }
+            },
+            "max": 10,
+            "min": 1
           },
           "clientId": {
             "location": "querystring",
@@ -4572,7 +5131,14 @@
                     }
                   }
                 },
-                "authDecision": {},
+                "authDecision": {
+                  "type": "string",
+                  "enum": [
+                    "ALLOWED",
+                    "EXPLICIT_DENY",
+                    "IMPLICIT_DENY"
+                  ]
+                },
                 "missingContextValues": {
                   "type": "list",
                   "member": {}
@@ -4596,11 +5162,21 @@
         ],
         "members": {
           "authorizerName": {
+            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
-          "token": {},
-          "tokenSignature": {}
+          "token": {
+            "type": "string",
+            "max": 6144,
+            "min": 1
+          },
+          "tokenSignature": {
+            "type": "string",
+            "max": 2560,
+            "min": 1,
+            "pattern": "[A-Za-z0-9+/]+={0,2}"
+          }
         }
       },
       "output": {
@@ -4609,7 +5185,12 @@
           "isAuthenticated": {
             "type": "boolean"
           },
-          "principalId": {},
+          "principalId": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "[a-zA-Z0-9]+"
+          },
           "policyDocuments": {
             "type": "list",
             "member": {}
@@ -4636,14 +5217,18 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
           "targetAwsAccount": {
+            "shape": "S95",
             "location": "querystring",
             "locationName": "targetAwsAccount"
           },
-          "transferMessage": {}
+          "transferMessage": {
+            "shape": "S9h"
+          }
         }
       },
       "output": {
@@ -4661,7 +5246,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "auditNotificationTargetConfigurations": {
             "shape": "S86"
           },
@@ -4687,21 +5274,28 @@
         ],
         "members": {
           "authorizerName": {
+            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
           "authorizerFunctionArn": {},
-          "tokenKeyName": {},
+          "tokenKeyName": {
+            "shape": "S1a"
+          },
           "tokenSigningPublicKeys": {
             "shape": "S1b"
           },
-          "status": {}
+          "status": {
+            "shape": "S1e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {},
+          "authorizerName": {
+            "shape": "S18"
+          },
           "authorizerArn": {}
         }
       }
@@ -4718,14 +5312,17 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           },
           "newStatus": {
+            "shape": "S94",
             "location": "querystring",
             "locationName": "newStatus"
           },
           "newAutoRegistrationStatus": {
+            "shape": "S96",
             "location": "querystring",
             "locationName": "newAutoRegistrationStatus"
           },
@@ -4751,10 +5348,12 @@
         ],
         "members": {
           "certificateId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
           "newStatus": {
+            "shape": "S9f",
             "location": "querystring",
             "locationName": "newStatus"
           }
@@ -4811,19 +5410,24 @@
         ],
         "members": {
           "roleAlias": {
+            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           },
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "credentialDurationSeconds": {
-            "type": "integer"
+            "shape": "S3m"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "roleAlias": {},
+          "roleAlias": {
+            "shape": "S3l"
+          },
           "roleAliasArn": {}
         }
       }
@@ -4839,13 +5443,20 @@
           "scheduledAuditName"
         ],
         "members": {
-          "frequency": {},
-          "dayOfMonth": {},
-          "dayOfWeek": {},
+          "frequency": {
+            "shape": "S3q"
+          },
+          "dayOfMonth": {
+            "shape": "S3r"
+          },
+          "dayOfWeek": {
+            "shape": "S3s"
+          },
           "targetCheckNames": {
             "shape": "S3t"
           },
           "scheduledAuditName": {
+            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -4870,10 +5481,13 @@
         ],
         "members": {
           "securityProfileName": {
+            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
-          "securityProfileDescription": {},
+          "securityProfileDescription": {
+            "shape": "S3z"
+          },
           "behaviors": {
             "shape": "S40"
           },
@@ -4890,9 +5504,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {},
+          "securityProfileName": {
+            "shape": "So"
+          },
           "securityProfileArn": {},
-          "securityProfileDescription": {},
+          "securityProfileDescription": {
+            "shape": "S3z"
+          },
           "behaviors": {
             "shape": "S40"
           },
@@ -4923,24 +5541,33 @@
         ],
         "members": {
           "streamId": {
+            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           },
-          "description": {},
+          "description": {
+            "shape": "S4k"
+          },
           "files": {
             "shape": "S4l"
           },
-          "roleArn": {}
+          "roleArn": {
+            "shape": "S1q"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "streamId": {},
+          "streamId": {
+            "shape": "S2e"
+          },
           "streamArn": {},
-          "description": {},
+          "description": {
+            "shape": "S4k"
+          },
           "streamVersion": {
-            "type": "integer"
+            "shape": "S4p"
           }
         }
       }
@@ -4957,10 +5584,13 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
-          "thingTypeName": {},
+          "thingTypeName": {
+            "shape": "S4r"
+          },
           "attributePayload": {
             "shape": "S4s"
           },
@@ -4990,6 +5620,7 @@
         ],
         "members": {
           "thingGroupName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -5018,7 +5649,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingName": {},
+          "thingName": {
+            "shape": "S7"
+          },
           "thingGroupsToAdd": {
             "shape": "Sjn"
           },
@@ -5058,7 +5691,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "errorMessage": {}
+                "errorMessage": {
+                  "shape": "S8w"
+                }
               }
             }
           }
@@ -5067,46 +5702,182 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 64,
+      "min": 64,
+      "pattern": "(0x)?[a-fA-F0-9]+"
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
+    },
+    "S7": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
+    },
     "Sb": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
+    "Se": {
+      "type": "string",
+      "max": 2028,
+      "pattern": "[^\\p{C}]+"
+    },
+    "Sh": {
+      "type": "string",
+      "max": 2028,
+      "pattern": "[^\\p{C}]+"
+    },
+    "Sj": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]+"
+    },
+    "So": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
+    },
+    "Su": {
+      "type": "string",
+      "max": 40,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\-]+"
     },
     "S12": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 128,
+        "min": 1,
+        "pattern": "[a-zA-Z0-9:_-]+"
+      },
+      "value": {
+        "type": "string",
+        "max": 1024,
+        "min": 1,
+        "pattern": "[^\\p{C}]*+"
+      }
+    },
+    "S18": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w=,@-]+"
+    },
+    "S1a": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
     },
     "S1b": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 128,
+        "min": 1,
+        "pattern": "[a-zA-Z0-9:_-]+"
+      },
+      "value": {
+        "type": "string",
+        "max": 5120
+      }
+    },
+    "S1e": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "S1l": {
+      "type": "string",
+      "max": 65536,
+      "min": 1
+    },
+    "S1n": {
+      "type": "string",
+      "max": 1350,
+      "min": 1
+    },
+    "S1o": {
+      "type": "string",
+      "max": 32768
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "roleArn": {},
+        "roleArn": {
+          "shape": "S1q"
+        },
         "expiresInSec": {
-          "type": "long"
+          "type": "long",
+          "max": 3600,
+          "min": 60
         }
       }
+    },
+    "S1q": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S1s": {
+      "type": "string",
+      "enum": [
+        "CONTINUOUS",
+        "SNAPSHOT"
+      ]
     },
     "S1t": {
       "type": "structure",
       "members": {
         "maximumPerMinute": {
-          "type": "integer"
+          "type": "integer",
+          "max": 1000,
+          "min": 1
         }
       }
     },
+    "S22": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
+    "S23": {
+      "type": "string",
+      "max": 2028,
+      "pattern": "[^\\p{C}]+"
+    },
     "S24": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "min": 1
     },
     "S26": {
       "type": "structure",
       "members": {
         "maximumPerMinute": {
-          "type": "integer"
+          "type": "integer",
+          "max": 1000,
+          "min": 1
         }
       }
     },
@@ -5123,9 +5894,11 @@
               "stream": {
                 "type": "structure",
                 "members": {
-                  "streamId": {},
+                  "streamId": {
+                    "shape": "S2e"
+                  },
                   "fileId": {
-                    "type": "integer"
+                    "shape": "S2f"
                   }
                 }
               },
@@ -5156,7 +5929,9 @@
                       "s3Destination": {
                         "type": "structure",
                         "members": {
-                          "bucket": {},
+                          "bucket": {
+                            "shape": "S2h"
+                          },
                           "prefix": {}
                         }
                       }
@@ -5194,30 +5969,113 @@
             "value": {}
           }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
+    },
+    "S2e": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
+    "S2f": {
+      "type": "integer",
+      "max": 255,
+      "min": 0
     },
     "S2g": {
       "type": "structure",
       "members": {
-        "bucket": {},
-        "key": {},
+        "bucket": {
+          "shape": "S2h"
+        },
+        "key": {
+          "type": "string",
+          "min": 1
+        },
         "version": {}
       }
+    },
+    "S2h": {
+      "type": "string",
+      "min": 1
     },
     "S35": {
       "type": "map",
       "key": {},
       "value": {}
     },
+    "S3a": {
+      "type": "string",
+      "enum": [
+        "CREATE_PENDING",
+        "CREATE_IN_PROGRESS",
+        "CREATE_COMPLETE",
+        "CREATE_FAILED"
+      ]
+    },
+    "S3f": {
+      "type": "string",
+      "pattern": "[0-9]+"
+    },
+    "S3l": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w=,@-]+"
+    },
+    "S3m": {
+      "type": "integer",
+      "max": 3600,
+      "min": 900
+    },
+    "S3q": {
+      "type": "string",
+      "enum": [
+        "DAILY",
+        "WEEKLY",
+        "BIWEEKLY",
+        "MONTHLY"
+      ]
+    },
+    "S3r": {
+      "type": "string",
+      "pattern": "^([1-9]|[12][0-9]|3[01])$|^LAST$"
+    },
+    "S3s": {
+      "type": "string",
+      "enum": [
+        "SUN",
+        "MON",
+        "TUE",
+        "WED",
+        "THU",
+        "FRI",
+        "SAT"
+      ]
+    },
     "S3t": {
       "type": "list",
       "member": {}
+    },
+    "S3v": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
+    "S3z": {
+      "type": "string",
+      "max": 1000,
+      "pattern": "[\\p{Graph}\\x20]*"
     },
     "S40": {
       "type": "list",
       "member": {
         "shape": "S41"
-      }
+      },
+      "max": 100
     },
     "S41": {
       "type": "structure",
@@ -5225,12 +6083,29 @@
         "name"
       ],
       "members": {
-        "name": {},
+        "name": {
+          "type": "string",
+          "max": 128,
+          "min": 1,
+          "pattern": "[a-zA-Z0-9:_-]+"
+        },
         "metric": {},
         "criteria": {
           "type": "structure",
           "members": {
-            "comparisonOperator": {},
+            "comparisonOperator": {
+              "type": "string",
+              "enum": [
+                "less-than",
+                "less-than-equals",
+                "greater-than",
+                "greater-than-equals",
+                "in-cidr-set",
+                "not-in-cidr-set",
+                "in-port-set",
+                "not-in-port-set"
+              ]
+            },
             "value": {
               "shape": "S46"
             },
@@ -5245,23 +6120,36 @@
       "type": "structure",
       "members": {
         "count": {
-          "type": "long"
+          "type": "long",
+          "min": 0
         },
         "cidrs": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "max": 43,
+            "min": 2,
+            "pattern": "[a-fA-F0-9:\\.\\/]+"
+          }
         },
         "ports": {
           "type": "list",
           "member": {
-            "type": "integer"
+            "type": "integer",
+            "max": 65535,
+            "min": 0
           }
         }
       }
     },
     "S4d": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "SNS"
+        ]
+      },
       "value": {
         "type": "structure",
         "required": [
@@ -5270,9 +6158,16 @@
         ],
         "members": {
           "alertTargetArn": {},
-          "roleArn": {}
+          "roleArn": {
+            "shape": "S1q"
+          }
         }
       }
+    },
+    "S4k": {
+      "type": "string",
+      "max": 2028,
+      "pattern": "[^\\p{C}]+"
     },
     "S4l": {
       "type": "list",
@@ -5280,13 +6175,26 @@
         "type": "structure",
         "members": {
           "fileId": {
-            "type": "integer"
+            "shape": "S2f"
           },
           "s3Location": {
             "shape": "S2g"
           }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
+    },
+    "S4p": {
+      "type": "integer",
+      "max": 65535,
+      "min": 0
+    },
+    "S4r": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
     },
     "S4s": {
       "type": "structure",
@@ -5301,27 +6209,66 @@
     },
     "S4t": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S4u"
+      },
+      "value": {
+        "shape": "S4v"
+      }
+    },
+    "S4u": {
+      "type": "string",
+      "max": 128,
+      "pattern": "[a-zA-Z0-9_.,@/:#-]+"
+    },
+    "S4v": {
+      "type": "string",
+      "max": 800,
+      "pattern": "[a-zA-Z0-9_.,@/:#-]*"
     },
     "S50": {
       "type": "structure",
       "members": {
-        "thingGroupDescription": {},
+        "thingGroupDescription": {
+          "shape": "S51"
+        },
         "attributePayload": {
           "shape": "S4s"
         }
       }
     },
+    "S51": {
+      "type": "string",
+      "max": 2028,
+      "pattern": "[\\p{Graph}\\x20]*"
+    },
+    "S53": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\-]+"
+    },
     "S55": {
       "type": "structure",
       "members": {
-        "thingTypeDescription": {},
+        "thingTypeDescription": {
+          "type": "string",
+          "max": 2028,
+          "pattern": "[\\p{Graph}\\x20]*"
+        },
         "searchableAttributes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S4u"
+          }
         }
       }
+    },
+    "S5c": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
     },
     "S5d": {
       "type": "structure",
@@ -5348,7 +6295,9 @@
       "type": "list",
       "member": {
         "shape": "S5h"
-      }
+      },
+      "max": 10,
+      "min": 0
     },
     "S5h": {
       "type": "structure",
@@ -5367,10 +6316,14 @@
             "operation": {},
             "hashKeyField": {},
             "hashKeyValue": {},
-            "hashKeyType": {},
+            "hashKeyType": {
+              "shape": "S5o"
+            },
             "rangeKeyField": {},
             "rangeKeyValue": {},
-            "rangeKeyType": {},
+            "rangeKeyType": {
+              "shape": "S5o"
+            },
             "payloadField": {}
           }
         },
@@ -5407,7 +6360,13 @@
           "members": {
             "targetArn": {},
             "roleArn": {},
-            "messageFormat": {}
+            "messageFormat": {
+              "type": "string",
+              "enum": [
+                "RAW",
+                "JSON"
+              ]
+            }
           }
         },
         "sqs": {
@@ -5458,7 +6417,19 @@
             "roleArn": {},
             "bucketName": {},
             "key": {},
-            "cannedAcl": {}
+            "cannedAcl": {
+              "type": "string",
+              "enum": [
+                "private",
+                "public-read",
+                "public-read-write",
+                "aws-exec-read",
+                "authenticated-read",
+                "bucket-owner-read",
+                "bucket-owner-full-control",
+                "log-delivery-write"
+              ]
+            }
           }
         },
         "firehose": {
@@ -5470,7 +6441,10 @@
           "members": {
             "roleArn": {},
             "deliveryStreamName": {},
-            "separator": {}
+            "separator": {
+              "type": "string",
+              "pattern": "([\\n\\t])|(\\r\\n)|(,)"
+            }
           }
         },
         "cloudwatchMetric": {
@@ -5517,7 +6491,10 @@
           ],
           "members": {
             "roleArn": {},
-            "endpoint": {},
+            "endpoint": {
+              "type": "string",
+              "pattern": "https?://.*"
+            },
             "index": {},
             "type": {},
             "id": {}
@@ -5530,8 +6507,15 @@
             "url"
           ],
           "members": {
-            "token": {},
-            "url": {}
+            "token": {
+              "type": "string",
+              "min": 40
+            },
+            "url": {
+              "type": "string",
+              "max": 2000,
+              "pattern": "https://ingestion-[a-zA-Z0-9]{1,12}\\.[a-zA-Z0-9]+\\.((sfdc-matrix\\.net)|(sfdcnow\\.com))/streams/\\w{1,20}/\\w{1,20}/event"
+            }
           }
         },
         "iotAnalytics": {
@@ -5556,14 +6540,35 @@
         }
       }
     },
+    "S5o": {
+      "type": "string",
+      "enum": [
+        "STRING",
+        "NUMBER"
+      ]
+    },
+    "S7z": {
+      "type": "string",
+      "enum": [
+        "DEFAULT",
+        "THING_GROUP"
+      ]
+    },
     "S86": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "SNS"
+        ]
+      },
       "value": {
         "type": "structure",
         "members": {
           "targetArn": {},
-          "roleArn": {},
+          "roleArn": {
+            "shape": "S1q"
+          },
           "enabled": {
             "type": "boolean"
           }
@@ -5582,17 +6587,43 @@
         }
       }
     },
+    "S8e": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "COMPLETED",
+        "FAILED",
+        "CANCELED"
+      ]
+    },
+    "S8f": {
+      "type": "string",
+      "enum": [
+        "ON_DEMAND_AUDIT_TASK",
+        "SCHEDULED_AUDIT_TASK"
+      ]
+    },
+    "S8w": {
+      "type": "string",
+      "max": 2048
+    },
     "S8z": {
       "type": "structure",
       "members": {
-        "authorizerName": {},
+        "authorizerName": {
+          "shape": "S18"
+        },
         "authorizerArn": {},
         "authorizerFunctionArn": {},
-        "tokenKeyName": {},
+        "tokenKeyName": {
+          "shape": "S1a"
+        },
         "tokenSigningPublicKeys": {
           "shape": "S1b"
         },
-        "status": {},
+        "status": {
+          "shape": "S1e"
+        },
         "creationDate": {
           "type": "timestamp"
         },
@@ -5600,6 +6631,30 @@
           "type": "timestamp"
         }
       }
+    },
+    "S94": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "INACTIVE"
+      ]
+    },
+    "S95": {
+      "type": "string",
+      "max": 12,
+      "min": 12,
+      "pattern": "[0-9]+"
+    },
+    "S96": {
+      "type": "string",
+      "enum": [
+        "ENABLE",
+        "DISABLE"
+      ]
+    },
+    "S97": {
+      "type": "integer",
+      "min": 1
     },
     "S99": {
       "type": "structure",
@@ -5616,12 +6671,44 @@
       "type": "structure",
       "members": {
         "templateBody": {},
-        "roleArn": {}
+        "roleArn": {
+          "shape": "S1q"
+        }
       }
+    },
+    "S9f": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "INACTIVE",
+        "REVOKED",
+        "PENDING_TRANSFER",
+        "REGISTER_INACTIVE",
+        "PENDING_ACTIVATION"
+      ]
+    },
+    "S9h": {
+      "type": "string",
+      "max": 128
     },
     "S9q": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "THING",
+          "THING_GROUP",
+          "THING_TYPE",
+          "THING_GROUP_MEMBERSHIP",
+          "THING_GROUP_HIERARCHY",
+          "THING_TYPE_ASSOCIATION",
+          "JOB",
+          "JOB_EXECUTION",
+          "POLICY",
+          "CERTIFICATE",
+          "CA_CERTIFICATE"
+        ]
+      },
       "value": {
         "type": "structure",
         "members": {
@@ -5631,15 +6718,70 @@
         }
       }
     },
+    "S9w": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
+    },
+    "Sa3": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "CANCELED",
+        "COMPLETED",
+        "DELETION_IN_PROGRESS"
+      ]
+    },
+    "Sai": {
+      "type": "string",
+      "enum": [
+        "QUEUED",
+        "IN_PROGRESS",
+        "SUCCEEDED",
+        "FAILED",
+        "REJECTED",
+        "REMOVED",
+        "CANCELED"
+      ]
+    },
     "Sb2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "groupName": {},
+          "groupName": {
+            "shape": "S5"
+          },
           "groupArn": {}
         }
       }
+    },
+    "Sb5": {
+      "type": "string",
+      "max": 40
+    },
+    "Sb7": {
+      "type": "string",
+      "max": 256,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9._-]+"
+    },
+    "Sb8": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9!_.*'()-\\/]+"
+    },
+    "Sb9": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Completed",
+        "Failed",
+        "Cancelled",
+        "Cancelling"
+      ]
     },
     "Sbe": {
       "type": "structure",
@@ -5661,7 +6803,14 @@
         "thingIndexingMode"
       ],
       "members": {
-        "thingIndexingMode": {}
+        "thingIndexingMode": {
+          "type": "string",
+          "enum": [
+            "OFF",
+            "REGISTRY",
+            "REGISTRY_AND_SHADOW"
+          ]
+        }
       }
     },
     "Sby": {
@@ -5670,15 +6819,53 @@
         "thingGroupIndexingMode"
       ],
       "members": {
-        "thingGroupIndexingMode": {}
+        "thingGroupIndexingMode": {
+          "type": "string",
+          "enum": [
+            "OFF",
+            "ON"
+          ]
+        }
       }
+    },
+    "Sc4": {
+      "type": "string",
+      "enum": [
+        "DEBUG",
+        "INFO",
+        "ERROR",
+        "WARN",
+        "DISABLED"
+      ]
+    },
+    "Scs": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
+    },
+    "Scw": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\-]+"
+    },
+    "Scz": {
+      "type": "string",
+      "pattern": "[A-Za-z0-9+/]+={0,2}"
+    },
+    "Sd0": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
     },
     "Sd2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "policyName": {},
+          "policyName": {
+            "shape": "Sj"
+          },
           "policyArn": {}
         }
       }
@@ -5686,19 +6873,40 @@
     "Sd5": {
       "type": "structure",
       "members": {
-        "deviceCertificateId": {},
-        "caCertificateId": {},
+        "deviceCertificateId": {
+          "shape": "S2"
+        },
+        "caCertificateId": {
+          "shape": "S2"
+        },
         "cognitoIdentityPoolId": {},
         "clientId": {},
         "policyVersionIdentifier": {
           "type": "structure",
           "members": {
-            "policyName": {},
-            "policyVersionId": {}
+            "policyName": {
+              "shape": "Sj"
+            },
+            "policyVersionId": {
+              "shape": "S3f"
+            }
           }
         },
-        "account": {}
+        "account": {
+          "shape": "S95"
+        }
       }
+    },
+    "Sdc": {
+      "type": "string",
+      "enum": [
+        "DEVICE_CERTIFICATE",
+        "CA_CERTIFICATE",
+        "IOT_POLICY",
+        "COGNITO_IDENTITY_POOL",
+        "CLIENT_ID",
+        "ACCOUNT_SETTINGS"
+      ]
     },
     "Sdd": {
       "type": "map",
@@ -5711,18 +6919,34 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {},
-          "status": {},
+          "certificateId": {
+            "shape": "S2"
+          },
+          "status": {
+            "shape": "S9f"
+          },
           "creationDate": {
             "type": "timestamp"
           }
         }
       }
     },
+    "Se2": {
+      "type": "integer",
+      "max": 500,
+      "min": 1
+    },
+    "Se6": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
+    },
     "Sea": {
       "type": "structure",
       "members": {
-        "status": {},
+        "status": {
+          "shape": "Sai"
+        },
         "queuedAt": {
           "type": "timestamp"
         },
@@ -5741,9 +6965,16 @@
       "type": "list",
       "member": {}
     },
+    "Sf4": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
+    },
     "Sf6": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S7"
+      }
     },
     "Sfh": {
       "type": "structure",
@@ -5752,7 +6983,9 @@
         "arn"
       ],
       "members": {
-        "name": {},
+        "name": {
+          "shape": "So"
+        },
         "arn": {}
       }
     },
@@ -5765,24 +6998,43 @@
         "arn": {}
       }
     },
+    "Sg5": {
+      "type": "string",
+      "enum": [
+        "ERRORS",
+        "RESULTS"
+      ]
+    },
     "Sgx": {
       "type": "structure",
       "required": [
         "targetType"
       ],
       "members": {
-        "targetType": {},
+        "targetType": {
+          "shape": "S7z"
+        },
         "targetName": {}
       }
     },
     "Shq": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5"
+      }
     },
     "Si9": {
       "type": "structure",
       "members": {
-        "actionType": {},
+        "actionType": {
+          "type": "string",
+          "enum": [
+            "PUBLISH",
+            "SUBSCRIBE",
+            "RECEIVE",
+            "CONNECT"
+          ]
+        },
         "resources": {
           "type": "list",
           "member": {}
@@ -5791,11 +7043,15 @@
     },
     "Sid": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sj"
+      }
     },
     "Sjn": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S5"
+      }
     }
   }
 }

--- a/apis/iot-data-2015-05-28.min.json
+++ b/apis/iot-data-2015-05-28.min.json
@@ -23,6 +23,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -53,6 +54,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -85,7 +87,9 @@
           "qos": {
             "location": "querystring",
             "locationName": "qos",
-            "type": "integer"
+            "type": "integer",
+            "max": 1,
+            "min": 0
           },
           "payload": {
             "type": "blob"
@@ -106,6 +110,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -126,5 +131,12 @@
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    }
+  }
 }

--- a/apis/iot-jobs-data-2017-09-29.min.json
+++ b/apis/iot-jobs-data-2017-09-29.min.json
@@ -25,9 +25,12 @@
         "members": {
           "jobId": {
             "location": "uri",
-            "locationName": "jobId"
+            "locationName": "jobId",
+            "type": "string",
+            "pattern": "[a-zA-Z0-9_-]+|^\\$next"
           },
           "thingName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -64,6 +67,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -93,6 +97,7 @@
         ],
         "members": {
           "thingName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -123,14 +128,18 @@
         ],
         "members": {
           "jobId": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
-          "status": {},
+          "status": {
+            "shape": "S9"
+          },
           "statusDetails": {
             "shape": "Sa"
           },
@@ -154,7 +163,9 @@
           "executionState": {
             "type": "structure",
             "members": {
-              "status": {},
+              "status": {
+                "shape": "S9"
+              },
               "statusDetails": {
                 "shape": "Sa"
               },
@@ -163,18 +174,32 @@
               }
             }
           },
-          "jobDocument": {}
+          "jobDocument": {
+            "shape": "Sh"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9:_-]+"
+    },
     "S7": {
       "type": "structure",
       "members": {
-        "jobId": {},
-        "thingName": {},
-        "status": {},
+        "jobId": {
+          "shape": "S8"
+        },
+        "thingName": {
+          "shape": "S3"
+        },
+        "status": {
+          "shape": "S9"
+        },
         "statusDetails": {
           "shape": "Sa"
         },
@@ -193,20 +218,56 @@
         "executionNumber": {
           "type": "long"
         },
-        "jobDocument": {}
+        "jobDocument": {
+          "shape": "Sh"
+        }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_-]+"
+    },
+    "S9": {
+      "type": "string",
+      "enum": [
+        "QUEUED",
+        "IN_PROGRESS",
+        "SUCCEEDED",
+        "FAILED",
+        "REJECTED",
+        "REMOVED",
+        "CANCELED"
+      ]
     },
     "Sa": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 128,
+        "min": 1,
+        "pattern": "[a-zA-Z0-9:_-]+"
+      },
+      "value": {
+        "type": "string",
+        "max": 1024,
+        "min": 1,
+        "pattern": "[^\\p{C}]*+"
+      }
+    },
+    "Sh": {
+      "type": "string",
+      "max": 32768
     },
     "Sk": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "jobId": {},
+          "jobId": {
+            "shape": "S8"
+          },
           "queuedAt": {
             "type": "long"
           },

--- a/apis/iot1click-devices-2018-05-14.min.json
+++ b/apis/iot1click-devices-2018-05-14.min.json
@@ -33,7 +33,10 @@
         "type": "structure",
         "members": {
           "ClaimCode": {
-            "locationName": "claimCode"
+            "locationName": "claimCode",
+            "type": "string",
+            "min": 12,
+            "max": 40
           },
           "Total": {
             "locationName": "total",
@@ -207,9 +210,9 @@
             "locationName": "fromTimeStamp"
           },
           "MaxResults": {
+            "shape": "So",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -279,9 +282,9 @@
             "locationName": "deviceType"
           },
           "MaxResults": {
+            "shape": "So",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -400,6 +403,11 @@
     "Sn": {
       "type": "timestamp",
       "timestampFormat": "iso8601"
+    },
+    "So": {
+      "type": "integer",
+      "min": 1,
+      "max": 250
     }
   }
 }

--- a/apis/iot1click-projects-2018-05-14.min.json
+++ b/apis/iot1click-projects-2018-05-14.min.json
@@ -28,15 +28,20 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
-          "deviceId": {},
+          "deviceId": {
+            "shape": "S4"
+          },
           "deviceTemplateName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "deviceTemplateName"
           }
@@ -58,8 +63,11 @@
           "projectName"
         ],
         "members": {
-          "placementName": {},
+          "placementName": {
+            "shape": "S3"
+          },
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
@@ -83,8 +91,12 @@
           "projectName"
         ],
         "members": {
-          "projectName": {},
-          "description": {},
+          "projectName": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "Sd"
+          },
           "placementTemplate": {
             "shape": "Se"
           }
@@ -108,10 +120,12 @@
         ],
         "members": {
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -134,6 +148,7 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -157,10 +172,12 @@
         ],
         "members": {
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -182,8 +199,12 @@
               "updatedDate"
             ],
             "members": {
-              "projectName": {},
-              "placementName": {},
+              "projectName": {
+                "shape": "S2"
+              },
+              "placementName": {
+                "shape": "S3"
+              },
               "attributes": {
                 "shape": "S8"
               },
@@ -210,6 +231,7 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -229,8 +251,12 @@
               "updatedDate"
             ],
             "members": {
-              "projectName": {},
-              "description": {},
+              "projectName": {
+                "shape": "S2"
+              },
+              "description": {
+                "shape": "Sd"
+              },
               "createdDate": {
                 "type": "timestamp"
               },
@@ -259,14 +285,17 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "deviceTemplateName": {
+            "shape": "S5",
             "location": "uri",
             "locationName": "deviceTemplateName"
           }
@@ -290,10 +319,12 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           }
@@ -307,8 +338,12 @@
         "members": {
           "devices": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S5"
+            },
+            "value": {
+              "shape": "S4"
+            }
           }
         }
       }
@@ -325,17 +360,19 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "nextToken": {
+            "shape": "S15",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S16",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -356,8 +393,12 @@
                 "updatedDate"
               ],
               "members": {
-                "projectName": {},
-                "placementName": {},
+                "projectName": {
+                  "shape": "S2"
+                },
+                "placementName": {
+                  "shape": "S3"
+                },
                 "createdDate": {
                   "type": "timestamp"
                 },
@@ -367,7 +408,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S15"
+          }
         }
       }
     },
@@ -380,13 +423,14 @@
         "type": "structure",
         "members": {
           "nextToken": {
+            "shape": "S15",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S16",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -406,7 +450,9 @@
                 "updatedDate"
               ],
               "members": {
-                "projectName": {},
+                "projectName": {
+                  "shape": "S2"
+                },
                 "createdDate": {
                   "type": "timestamp"
                 },
@@ -416,7 +462,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "S15"
+          }
         }
       }
     },
@@ -433,10 +481,12 @@
         ],
         "members": {
           "placementName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
@@ -462,10 +512,13 @@
         ],
         "members": {
           "projectName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
-          "description": {},
+          "description": {
+            "shape": "Sd"
+          },
           "placementTemplate": {
             "shape": "Se"
           }
@@ -478,35 +531,100 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[0-9A-Za-z_-]+$"
+    },
+    "S3": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_-]+$"
+    },
+    "S4": {
+      "type": "string",
+      "max": 32,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_-]+$"
+    },
     "S8": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S9"
+      },
+      "value": {
+        "type": "string",
+        "max": 800
+      }
+    },
+    "S9": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 500,
+      "min": 0
     },
     "Se": {
       "type": "structure",
       "members": {
         "defaultAttributes": {
           "type": "map",
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "S9"
+          },
+          "value": {
+            "type": "string",
+            "max": 800
+          }
         },
         "deviceTemplates": {
           "type": "map",
-          "key": {},
+          "key": {
+            "shape": "S5"
+          },
           "value": {
             "type": "structure",
             "members": {
-              "deviceType": {},
+              "deviceType": {
+                "type": "string",
+                "max": 128
+              },
               "callbackOverrides": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
+                "value": {
+                  "type": "string",
+                  "max": 200
+                }
               }
             }
           }
         }
       }
+    },
+    "S15": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S16": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
     }
   }
 }

--- a/apis/iotanalytics-2017-11-27.min.json
+++ b/apis/iotanalytics-2017-11-27.min.json
@@ -23,7 +23,9 @@
           "messages"
         ],
         "members": {
-          "channelName": {},
+          "channelName": {
+            "shape": "S2"
+          },
           "messages": {
             "type": "list",
             "member": {
@@ -33,7 +35,9 @@
                 "payload"
               ],
               "members": {
-                "messageId": {},
+                "messageId": {
+                  "shape": "S5"
+                },
                 "payload": {
                   "type": "blob"
                 }
@@ -50,7 +54,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "messageId": {},
+                "messageId": {
+                  "shape": "S5"
+                },
                 "errorCode": {},
                 "errorMessage": {}
               }
@@ -72,6 +78,7 @@
         ],
         "members": {
           "pipelineName": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -97,7 +104,9 @@
           "channelName"
         ],
         "members": {
-          "channelName": {},
+          "channelName": {
+            "shape": "S2"
+          },
           "retentionPeriod": {
             "shape": "Sh"
           },
@@ -109,7 +118,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "channelName": {},
+          "channelName": {
+            "shape": "S2"
+          },
           "channelArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -129,7 +140,9 @@
           "actions"
         ],
         "members": {
-          "datasetName": {},
+          "datasetName": {
+            "shape": "Sr"
+          },
           "actions": {
             "shape": "Ss"
           },
@@ -147,7 +160,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "datasetName": {},
+          "datasetName": {
+            "shape": "Sr"
+          },
           "datasetArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -166,6 +181,7 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -174,7 +190,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "versionId": {}
+          "versionId": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -189,7 +207,9 @@
           "datastoreName"
         ],
         "members": {
-          "datastoreName": {},
+          "datastoreName": {
+            "shape": "S1r"
+          },
           "retentionPeriod": {
             "shape": "Sh"
           },
@@ -201,7 +221,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "datastoreName": {},
+          "datastoreName": {
+            "shape": "S1r"
+          },
           "datastoreArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -221,7 +243,9 @@
           "pipelineActivities"
         ],
         "members": {
-          "pipelineName": {},
+          "pipelineName": {
+            "shape": "Sd"
+          },
           "pipelineActivities": {
             "shape": "S1v"
           },
@@ -233,7 +257,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "pipelineName": {},
+          "pipelineName": {
+            "shape": "Sd"
+          },
           "pipelineArn": {}
         }
       }
@@ -251,6 +277,7 @@
         ],
         "members": {
           "channelName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           }
@@ -270,6 +297,7 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -289,10 +317,12 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
           "versionId": {
+            "shape": "S1p",
             "location": "querystring",
             "locationName": "versionId"
           }
@@ -312,6 +342,7 @@
         ],
         "members": {
           "datastoreName": {
+            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           }
@@ -331,6 +362,7 @@
         ],
         "members": {
           "pipelineName": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           }
@@ -349,6 +381,7 @@
         ],
         "members": {
           "channelName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
@@ -365,9 +398,13 @@
           "channel": {
             "type": "structure",
             "members": {
-              "name": {},
+              "name": {
+                "shape": "S2"
+              },
               "arn": {},
-              "status": {},
+              "status": {
+                "shape": "S2q"
+              },
               "retentionPeriod": {
                 "shape": "Sh"
               },
@@ -402,6 +439,7 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -413,7 +451,9 @@
           "dataset": {
             "type": "structure",
             "members": {
-              "name": {},
+              "name": {
+                "shape": "Sr"
+              },
               "arn": {},
               "actions": {
                 "shape": "Ss"
@@ -421,7 +461,9 @@
               "triggers": {
                 "shape": "S1g"
               },
-              "status": {},
+              "status": {
+                "shape": "S2y"
+              },
               "creationTime": {
                 "type": "timestamp"
               },
@@ -448,6 +490,7 @@
         ],
         "members": {
           "datastoreName": {
+            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           },
@@ -464,9 +507,13 @@
           "datastore": {
             "type": "structure",
             "members": {
-              "name": {},
+              "name": {
+                "shape": "S1r"
+              },
               "arn": {},
-              "status": {},
+              "status": {
+                "shape": "S32"
+              },
               "retentionPeriod": {
                 "shape": "Sh"
               },
@@ -519,6 +566,7 @@
         ],
         "members": {
           "pipelineName": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           }
@@ -530,7 +578,9 @@
           "pipeline": {
             "type": "structure",
             "members": {
-              "name": {},
+              "name": {
+                "shape": "Sd"
+              },
               "arn": {},
               "activities": {
                 "shape": "S1v"
@@ -561,10 +611,12 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
           "versionId": {
+            "shape": "S1p",
             "location": "querystring",
             "locationName": "versionId"
           }
@@ -605,9 +657,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -619,8 +671,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "channelName": {},
-                "status": {},
+                "channelName": {
+                  "shape": "S2"
+                },
+                "status": {
+                  "shape": "S2q"
+                },
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -646,6 +702,7 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
@@ -654,9 +711,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -668,7 +725,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "version": {},
+                "version": {
+                  "shape": "S1p"
+                },
                 "status": {
                   "shape": "S3l"
                 },
@@ -698,9 +757,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -712,8 +771,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "datasetName": {},
-                "status": {},
+                "datasetName": {
+                  "shape": "Sr"
+                },
+                "status": {
+                  "shape": "S2y"
+                },
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -728,10 +791,20 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "actionName": {},
-                      "actionType": {}
+                      "actionName": {
+                        "shape": "Su"
+                      },
+                      "actionType": {
+                        "type": "string",
+                        "enum": [
+                          "QUERY",
+                          "CONTAINER"
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "max": 1,
+                  "min": 1
                 }
               }
             }
@@ -753,9 +826,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -767,8 +840,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "datastoreName": {},
-                "status": {},
+                "datastoreName": {
+                  "shape": "S1r"
+                },
+                "status": {
+                  "shape": "S32"
+                },
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -795,9 +872,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -809,7 +886,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "pipelineName": {},
+                "pipelineName": {
+                  "shape": "Sd"
+                },
                 "reprocessingSummaries": {
                   "shape": "S3c"
                 },
@@ -838,6 +917,7 @@
         ],
         "members": {
           "resourceArn": {
+            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           }
@@ -910,13 +990,16 @@
         ],
         "members": {
           "channelName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
           "maxMessages": {
             "location": "querystring",
             "locationName": "maxMessages",
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           },
           "startTime": {
             "location": "querystring",
@@ -950,6 +1033,7 @@
         ],
         "members": {
           "pipelineName": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -981,6 +1065,7 @@
         ],
         "members": {
           "resourceArn": {
+            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           },
@@ -1008,6 +1093,7 @@
         ],
         "members": {
           "resourceArn": {
+            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           },
@@ -1015,7 +1101,11 @@
             "location": "querystring",
             "locationName": "tagKeys",
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sm"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -1036,6 +1126,7 @@
         ],
         "members": {
           "channelName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
@@ -1058,6 +1149,7 @@
         ],
         "members": {
           "datasetName": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
@@ -1085,6 +1177,7 @@
         ],
         "members": {
           "datastoreName": {
+            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           },
@@ -1107,6 +1200,7 @@
         ],
         "members": {
           "pipelineName": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -1118,6 +1212,23 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
+    },
     "Sh": {
       "type": "structure",
       "members": {
@@ -1125,7 +1236,8 @@
           "type": "boolean"
         },
         "numberOfDays": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         }
       }
     },
@@ -1138,17 +1250,38 @@
           "value"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "shape": "Sm"
+          },
+          "value": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 1
+    },
+    "Sm": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "Sr": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
     },
     "Ss": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "actionName": {},
+          "actionName": {
+            "shape": "Su"
+          },
           "queryAction": {
             "type": "structure",
             "required": [
@@ -1175,7 +1308,9 @@
                       }
                     }
                   }
-                }
+                },
+                "max": 1,
+                "min": 0
               }
             }
           },
@@ -1187,8 +1322,13 @@
               "resourceConfiguration"
             ],
             "members": {
-              "image": {},
-              "executionRoleArn": {},
+              "image": {
+                "type": "string",
+                "max": 255
+              },
+              "executionRoleArn": {
+                "shape": "S14"
+              },
               "resourceConfiguration": {
                 "type": "structure",
                 "required": [
@@ -1196,9 +1336,17 @@
                   "volumeSizeInGB"
                 ],
                 "members": {
-                  "computeType": {},
+                  "computeType": {
+                    "type": "string",
+                    "enum": [
+                      "ACU_1",
+                      "ACU_2"
+                    ]
+                  },
                   "volumeSizeInGB": {
-                    "type": "integer"
+                    "type": "integer",
+                    "max": 50,
+                    "min": 1
                   }
                 }
               },
@@ -1210,8 +1358,16 @@
                     "name"
                   ],
                   "members": {
-                    "name": {},
-                    "stringValue": {},
+                    "name": {
+                      "type": "string",
+                      "max": 256,
+                      "min": 1
+                    },
+                    "stringValue": {
+                      "type": "string",
+                      "max": 1024,
+                      "min": 0
+                    },
                     "doubleValue": {
                       "type": "double"
                     },
@@ -1221,7 +1377,9 @@
                         "datasetName"
                       ],
                       "members": {
-                        "datasetName": {}
+                        "datasetName": {
+                          "shape": "Sr"
+                        }
                       }
                     },
                     "outputFileUriValue": {
@@ -1230,16 +1388,34 @@
                         "fileName"
                       ],
                       "members": {
-                        "fileName": {}
+                        "fileName": {
+                          "type": "string",
+                          "pattern": "[\\w\\.-]{1,255}"
+                        }
                       }
                     }
                   }
-                }
+                },
+                "max": 50,
+                "min": 0
               }
             }
           }
         }
-      }
+      },
+      "max": 1,
+      "min": 1
+    },
+    "Su": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
+    },
+    "S14": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
     },
     "S1g": {
       "type": "list",
@@ -1258,17 +1434,34 @@
               "name"
             ],
             "members": {
-              "name": {}
+              "name": {
+                "shape": "Sr"
+              }
             }
           }
         }
-      }
+      },
+      "max": 5,
+      "min": 0
+    },
+    "S1p": {
+      "type": "string",
+      "max": 36,
+      "min": 7
+    },
+    "S1r": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9_]+$"
     },
     "S1v": {
       "type": "list",
       "member": {
         "shape": "S1w"
-      }
+      },
+      "max": 25,
+      "min": 1
     },
     "S1w": {
       "type": "structure",
@@ -1280,9 +1473,15 @@
             "channelName"
           ],
           "members": {
-            "name": {},
-            "channelName": {},
-            "next": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "channelName": {
+              "shape": "S2"
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "lambda": {
@@ -1293,12 +1492,23 @@
             "batchSize"
           ],
           "members": {
-            "name": {},
-            "lambdaName": {},
-            "batchSize": {
-              "type": "integer"
+            "name": {
+              "shape": "S1y"
             },
-            "next": {}
+            "lambdaName": {
+              "type": "string",
+              "max": 64,
+              "min": 1,
+              "pattern": "^[a-zA-Z0-9_-]+$"
+            },
+            "batchSize": {
+              "type": "integer",
+              "max": 1000,
+              "min": 1
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "datastore": {
@@ -1308,8 +1518,12 @@
             "datastoreName"
           ],
           "members": {
-            "name": {},
-            "datastoreName": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "datastoreName": {
+              "shape": "S1r"
+            }
           }
         },
         "addAttributes": {
@@ -1319,13 +1533,23 @@
             "attributes"
           ],
           "members": {
-            "name": {},
+            "name": {
+              "shape": "S1y"
+            },
             "attributes": {
               "type": "map",
-              "key": {},
-              "value": {}
+              "key": {
+                "shape": "S25"
+              },
+              "value": {
+                "shape": "S25"
+              },
+              "max": 50,
+              "min": 1
             },
-            "next": {}
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "removeAttributes": {
@@ -1335,11 +1559,15 @@
             "attributes"
           ],
           "members": {
-            "name": {},
+            "name": {
+              "shape": "S1y"
+            },
             "attributes": {
               "shape": "S27"
             },
-            "next": {}
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "selectAttributes": {
@@ -1349,11 +1577,15 @@
             "attributes"
           ],
           "members": {
-            "name": {},
+            "name": {
+              "shape": "S1y"
+            },
             "attributes": {
               "shape": "S27"
             },
-            "next": {}
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "filter": {
@@ -1363,9 +1595,17 @@
             "filter"
           ],
           "members": {
-            "name": {},
-            "filter": {},
-            "next": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "filter": {
+              "type": "string",
+              "max": 256,
+              "min": 1
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "math": {
@@ -1376,10 +1616,20 @@
             "math"
           ],
           "members": {
-            "name": {},
-            "attribute": {},
-            "math": {},
-            "next": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "attribute": {
+              "shape": "S25"
+            },
+            "math": {
+              "type": "string",
+              "max": 256,
+              "min": 1
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "deviceRegistryEnrich": {
@@ -1391,11 +1641,21 @@
             "roleArn"
           ],
           "members": {
-            "name": {},
-            "attribute": {},
-            "thingName": {},
-            "roleArn": {},
-            "next": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "attribute": {
+              "shape": "S25"
+            },
+            "thingName": {
+              "shape": "S25"
+            },
+            "roleArn": {
+              "shape": "S14"
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         },
         "deviceShadowEnrich": {
@@ -1407,18 +1667,50 @@
             "roleArn"
           ],
           "members": {
-            "name": {},
-            "attribute": {},
-            "thingName": {},
-            "roleArn": {},
-            "next": {}
+            "name": {
+              "shape": "S1y"
+            },
+            "attribute": {
+              "shape": "S25"
+            },
+            "thingName": {
+              "shape": "S25"
+            },
+            "roleArn": {
+              "shape": "S14"
+            },
+            "next": {
+              "shape": "S1y"
+            }
           }
         }
       }
     },
+    "S1y": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S25": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
     "S27": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S25"
+      },
+      "max": 50,
+      "min": 1
+    },
+    "S2q": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "ACTIVE",
+        "DELETING"
+      ]
     },
     "S2t": {
       "type": "structure",
@@ -1431,6 +1723,22 @@
         }
       }
     },
+    "S2y": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "ACTIVE",
+        "DELETING"
+      ]
+    },
+    "S32": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "ACTIVE",
+        "DELETING"
+      ]
+    },
     "S36": {
       "type": "structure",
       "required": [
@@ -1439,8 +1747,15 @@
         "enabled"
       ],
       "members": {
-        "roleArn": {},
-        "level": {},
+        "roleArn": {
+          "shape": "S14"
+        },
+        "level": {
+          "type": "string",
+          "enum": [
+            "ERROR"
+          ]
+        },
         "enabled": {
           "type": "boolean"
         }
@@ -1452,7 +1767,15 @@
         "type": "structure",
         "members": {
           "id": {},
-          "status": {},
+          "status": {
+            "type": "string",
+            "enum": [
+              "RUNNING",
+              "SUCCEEDED",
+              "CANCELLED",
+              "FAILED"
+            ]
+          },
           "creationTime": {
             "type": "timestamp"
           }
@@ -1462,15 +1785,34 @@
     "S3l": {
       "type": "structure",
       "members": {
-        "state": {},
+        "state": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "SUCCEEDED",
+            "FAILED"
+          ]
+        },
         "reason": {}
       }
+    },
+    "S3q": {
+      "type": "integer",
+      "max": 250,
+      "min": 1
+    },
+    "S4e": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
     },
     "S4i": {
       "type": "list",
       "member": {
         "type": "blob"
-      }
+      },
+      "max": 10,
+      "min": 1
     }
   }
 }

--- a/apis/kinesis-2013-12-02.min.json
+++ b/apis/kinesis-2013-12-02.min.json
@@ -24,11 +24,19 @@
           "Tags"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "Tags": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S4"
+            },
+            "value": {
+              "shape": "S5"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       }
@@ -41,9 +49,11 @@
           "ShardCount"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "ShardCount": {
-            "type": "integer"
+            "shape": "S7"
           }
         }
       }
@@ -56,9 +66,11 @@
           "RetentionPeriodHours"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "RetentionPeriodHours": {
-            "type": "integer"
+            "shape": "S9"
           }
         }
       }
@@ -70,7 +82,9 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "EnforceConsumerDeletion": {
             "type": "boolean"
           }
@@ -81,9 +95,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamARN": {},
-          "ConsumerName": {},
-          "ConsumerARN": {}
+          "StreamARN": {
+            "shape": "Sd"
+          },
+          "ConsumerName": {
+            "shape": "Se"
+          },
+          "ConsumerARN": {
+            "shape": "Sf"
+          }
         }
       }
     },
@@ -100,10 +120,10 @@
         ],
         "members": {
           "ShardLimit": {
-            "type": "integer"
+            "shape": "Si"
           },
           "OpenShardCount": {
-            "type": "integer"
+            "shape": "Si"
           }
         }
       }
@@ -115,11 +135,17 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {},
-          "Limit": {
-            "type": "integer"
+          "StreamName": {
+            "shape": "S2"
           },
-          "ExclusiveStartShardId": {}
+          "Limit": {
+            "type": "integer",
+            "max": 10000,
+            "min": 1
+          },
+          "ExclusiveStartShardId": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -141,9 +167,15 @@
               "EnhancedMonitoring"
             ],
             "members": {
-              "StreamName": {},
-              "StreamARN": {},
-              "StreamStatus": {},
+              "StreamName": {
+                "shape": "S2"
+              },
+              "StreamARN": {
+                "shape": "Sd"
+              },
+              "StreamStatus": {
+                "shape": "So"
+              },
               "Shards": {
                 "shape": "Sp"
               },
@@ -151,7 +183,7 @@
                 "type": "boolean"
               },
               "RetentionPeriodHours": {
-                "type": "integer"
+                "shape": "S9"
               },
               "StreamCreationTimestamp": {
                 "type": "timestamp"
@@ -159,8 +191,12 @@
               "EnhancedMonitoring": {
                 "shape": "Sw"
               },
-              "EncryptionType": {},
-              "KeyId": {}
+              "EncryptionType": {
+                "shape": "S10"
+              },
+              "KeyId": {
+                "shape": "S11"
+              }
             }
           }
         }
@@ -170,9 +206,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamARN": {},
-          "ConsumerName": {},
-          "ConsumerARN": {}
+          "StreamARN": {
+            "shape": "Sd"
+          },
+          "ConsumerName": {
+            "shape": "Se"
+          },
+          "ConsumerARN": {
+            "shape": "Sf"
+          }
         }
       },
       "output": {
@@ -191,13 +233,21 @@
               "StreamARN"
             ],
             "members": {
-              "ConsumerName": {},
-              "ConsumerARN": {},
-              "ConsumerStatus": {},
+              "ConsumerName": {
+                "shape": "Se"
+              },
+              "ConsumerARN": {
+                "shape": "Sf"
+              },
+              "ConsumerStatus": {
+                "shape": "S15"
+              },
               "ConsumerCreationTimestamp": {
                 "type": "timestamp"
               },
-              "StreamARN": {}
+              "StreamARN": {
+                "shape": "Sd"
+              }
             }
           }
         }
@@ -210,7 +260,9 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {}
+          "StreamName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -231,11 +283,17 @@
               "OpenShardCount"
             ],
             "members": {
-              "StreamName": {},
-              "StreamARN": {},
-              "StreamStatus": {},
+              "StreamName": {
+                "shape": "S2"
+              },
+              "StreamARN": {
+                "shape": "Sd"
+              },
+              "StreamStatus": {
+                "shape": "So"
+              },
               "RetentionPeriodHours": {
-                "type": "integer"
+                "shape": "S7"
               },
               "StreamCreationTimestamp": {
                 "type": "timestamp"
@@ -243,13 +301,19 @@
               "EnhancedMonitoring": {
                 "shape": "Sw"
               },
-              "EncryptionType": {},
-              "KeyId": {},
+              "EncryptionType": {
+                "shape": "S10"
+              },
+              "KeyId": {
+                "shape": "S11"
+              },
               "OpenShardCount": {
-                "type": "integer"
+                "shape": "Si"
               },
               "ConsumerCount": {
-                "type": "integer"
+                "type": "integer",
+                "max": 1000000,
+                "min": 0
               }
             }
           }
@@ -264,7 +328,9 @@
           "ShardLevelMetrics"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "ShardLevelMetrics": {
             "shape": "Sy"
           }
@@ -282,7 +348,9 @@
           "ShardLevelMetrics"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "ShardLevelMetrics": {
             "shape": "Sy"
           }
@@ -299,9 +367,13 @@
           "ShardIterator"
         ],
         "members": {
-          "ShardIterator": {},
+          "ShardIterator": {
+            "shape": "S1e"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           }
         }
       },
@@ -321,21 +393,30 @@
                 "PartitionKey"
               ],
               "members": {
-                "SequenceNumber": {},
+                "SequenceNumber": {
+                  "shape": "Su"
+                },
                 "ApproximateArrivalTimestamp": {
                   "type": "timestamp"
                 },
                 "Data": {
-                  "type": "blob"
+                  "shape": "S1j"
                 },
-                "PartitionKey": {},
-                "EncryptionType": {}
+                "PartitionKey": {
+                  "shape": "S1k"
+                },
+                "EncryptionType": {
+                  "shape": "S10"
+                }
               }
             }
           },
-          "NextShardIterator": {},
+          "NextShardIterator": {
+            "shape": "S1e"
+          },
           "MillisBehindLatest": {
-            "type": "long"
+            "type": "long",
+            "min": 0
           }
         }
       }
@@ -349,10 +430,25 @@
           "ShardIteratorType"
         ],
         "members": {
-          "StreamName": {},
-          "ShardId": {},
-          "ShardIteratorType": {},
-          "StartingSequenceNumber": {},
+          "StreamName": {
+            "shape": "S2"
+          },
+          "ShardId": {
+            "shape": "Sl"
+          },
+          "ShardIteratorType": {
+            "type": "string",
+            "enum": [
+              "AT_SEQUENCE_NUMBER",
+              "AFTER_SEQUENCE_NUMBER",
+              "TRIM_HORIZON",
+              "LATEST",
+              "AT_TIMESTAMP"
+            ]
+          },
+          "StartingSequenceNumber": {
+            "shape": "Su"
+          },
           "Timestamp": {
             "type": "timestamp"
           }
@@ -361,7 +457,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ShardIterator": {}
+          "ShardIterator": {
+            "shape": "S1e"
+          }
         }
       }
     },
@@ -373,9 +471,11 @@
           "RetentionPeriodHours"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "RetentionPeriodHours": {
-            "type": "integer"
+            "shape": "S9"
           }
         }
       }
@@ -384,11 +484,19 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {},
-          "NextToken": {},
-          "ExclusiveStartShardId": {},
+          "StreamName": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S1r"
+          },
+          "ExclusiveStartShardId": {
+            "shape": "Sl"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
           "StreamCreationTimestamp": {
             "type": "timestamp"
@@ -401,7 +509,9 @@
           "Shards": {
             "shape": "Sp"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1r"
+          }
         }
       }
     },
@@ -412,10 +522,16 @@
           "StreamARN"
         ],
         "members": {
-          "StreamARN": {},
-          "NextToken": {},
+          "StreamARN": {
+            "shape": "Sd"
+          },
+          "NextToken": {
+            "shape": "S1r"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
           "StreamCreationTimestamp": {
             "type": "timestamp"
@@ -431,7 +547,9 @@
               "shape": "S1y"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1r"
+          }
         }
       }
     },
@@ -440,9 +558,13 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
-          "ExclusiveStartStreamName": {}
+          "ExclusiveStartStreamName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -454,7 +576,9 @@
         "members": {
           "StreamNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            }
           },
           "HasMoreStreams": {
             "type": "boolean"
@@ -469,10 +593,16 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {},
-          "ExclusiveStartTagKey": {},
+          "StreamName": {
+            "shape": "S2"
+          },
+          "ExclusiveStartTagKey": {
+            "shape": "S4"
+          },
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -491,10 +621,15 @@
                 "Key"
               ],
               "members": {
-                "Key": {},
-                "Value": {}
+                "Key": {
+                  "shape": "S4"
+                },
+                "Value": {
+                  "shape": "S5"
+                }
               }
-            }
+            },
+            "min": 0
           },
           "HasMoreTags": {
             "type": "boolean"
@@ -511,9 +646,15 @@
           "AdjacentShardToMerge"
         ],
         "members": {
-          "StreamName": {},
-          "ShardToMerge": {},
-          "AdjacentShardToMerge": {}
+          "StreamName": {
+            "shape": "S2"
+          },
+          "ShardToMerge": {
+            "shape": "Sl"
+          },
+          "AdjacentShardToMerge": {
+            "shape": "Sl"
+          }
         }
       }
     },
@@ -526,13 +667,21 @@
           "PartitionKey"
         ],
         "members": {
-          "StreamName": {},
-          "Data": {
-            "type": "blob"
+          "StreamName": {
+            "shape": "S2"
           },
-          "PartitionKey": {},
-          "ExplicitHashKey": {},
-          "SequenceNumberForOrdering": {}
+          "Data": {
+            "shape": "S1j"
+          },
+          "PartitionKey": {
+            "shape": "S1k"
+          },
+          "ExplicitHashKey": {
+            "shape": "Ss"
+          },
+          "SequenceNumberForOrdering": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -542,9 +691,15 @@
           "SequenceNumber"
         ],
         "members": {
-          "ShardId": {},
-          "SequenceNumber": {},
-          "EncryptionType": {}
+          "ShardId": {
+            "shape": "Sl"
+          },
+          "SequenceNumber": {
+            "shape": "Su"
+          },
+          "EncryptionType": {
+            "shape": "S10"
+          }
         }
       }
     },
@@ -566,14 +721,22 @@
               ],
               "members": {
                 "Data": {
-                  "type": "blob"
+                  "shape": "S1j"
                 },
-                "ExplicitHashKey": {},
-                "PartitionKey": {}
+                "ExplicitHashKey": {
+                  "shape": "Ss"
+                },
+                "PartitionKey": {
+                  "shape": "S1k"
+                }
               }
-            }
+            },
+            "max": 500,
+            "min": 1
           },
-          "StreamName": {}
+          "StreamName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -583,21 +746,29 @@
         ],
         "members": {
           "FailedRecordCount": {
-            "type": "integer"
+            "shape": "S7"
           },
           "Records": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "SequenceNumber": {},
-                "ShardId": {},
+                "SequenceNumber": {
+                  "shape": "Su"
+                },
+                "ShardId": {
+                  "shape": "Sl"
+                },
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
-            }
+            },
+            "max": 500,
+            "min": 1
           },
-          "EncryptionType": {}
+          "EncryptionType": {
+            "shape": "S10"
+          }
         }
       }
     },
@@ -609,8 +780,12 @@
           "ConsumerName"
         ],
         "members": {
-          "StreamARN": {},
-          "ConsumerName": {}
+          "StreamARN": {
+            "shape": "Sd"
+          },
+          "ConsumerName": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -633,10 +808,16 @@
           "TagKeys"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       }
@@ -650,9 +831,15 @@
           "NewStartingHashKey"
         ],
         "members": {
-          "StreamName": {},
-          "ShardToSplit": {},
-          "NewStartingHashKey": {}
+          "StreamName": {
+            "shape": "S2"
+          },
+          "ShardToSplit": {
+            "shape": "Sl"
+          },
+          "NewStartingHashKey": {
+            "shape": "Ss"
+          }
         }
       }
     },
@@ -665,9 +852,15 @@
           "KeyId"
         ],
         "members": {
-          "StreamName": {},
-          "EncryptionType": {},
-          "KeyId": {}
+          "StreamName": {
+            "shape": "S2"
+          },
+          "EncryptionType": {
+            "shape": "S10"
+          },
+          "KeyId": {
+            "shape": "S11"
+          }
         }
       }
     },
@@ -680,9 +873,15 @@
           "KeyId"
         ],
         "members": {
-          "StreamName": {},
-          "EncryptionType": {},
-          "KeyId": {}
+          "StreamName": {
+            "shape": "S2"
+          },
+          "EncryptionType": {
+            "shape": "S10"
+          },
+          "KeyId": {
+            "shape": "S11"
+          }
         }
       }
     },
@@ -695,28 +894,101 @@
           "ScalingType"
         ],
         "members": {
-          "StreamName": {},
-          "TargetShardCount": {
-            "type": "integer"
+          "StreamName": {
+            "shape": "S2"
           },
-          "ScalingType": {}
+          "TargetShardCount": {
+            "shape": "S7"
+          },
+          "ScalingType": {
+            "type": "string",
+            "enum": [
+              "UNIFORM_SCALING"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "CurrentShardCount": {
-            "type": "integer"
+            "shape": "S7"
           },
           "TargetShardCount": {
-            "type": "integer"
+            "shape": "S7"
           }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S4": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "S7": {
+      "type": "integer",
+      "max": 100000,
+      "min": 1
+    },
+    "S9": {
+      "type": "integer",
+      "max": 168,
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:aws.*:kinesis:.*:\\d{12}:stream/.*"
+    },
+    "Se": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "^(arn):aws.*:kinesis:.*:\\d{12}:.*stream\\/[a-zA-Z0-9_.-]+\\/consumer\\/[a-zA-Z0-9_.-]+:[0-9]+"
+    },
+    "Si": {
+      "type": "integer",
+      "max": 1000000,
+      "min": 0
+    },
+    "Sl": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "DELETING",
+        "ACTIVE",
+        "UPDATING"
+      ]
+    },
     "Sp": {
       "type": "list",
       "member": {
@@ -727,9 +999,15 @@
           "SequenceNumberRange"
         ],
         "members": {
-          "ShardId": {},
-          "ParentShardId": {},
-          "AdjacentParentShardId": {},
+          "ShardId": {
+            "shape": "Sl"
+          },
+          "ParentShardId": {
+            "shape": "Sl"
+          },
+          "AdjacentParentShardId": {
+            "shape": "Sl"
+          },
           "HashKeyRange": {
             "type": "structure",
             "required": [
@@ -737,8 +1015,12 @@
               "EndingHashKey"
             ],
             "members": {
-              "StartingHashKey": {},
-              "EndingHashKey": {}
+              "StartingHashKey": {
+                "shape": "Ss"
+              },
+              "EndingHashKey": {
+                "shape": "Ss"
+              }
             }
           },
           "SequenceNumberRange": {
@@ -747,12 +1029,24 @@
               "StartingSequenceNumber"
             ],
             "members": {
-              "StartingSequenceNumber": {},
-              "EndingSequenceNumber": {}
+              "StartingSequenceNumber": {
+                "shape": "Su"
+              },
+              "EndingSequenceNumber": {
+                "shape": "Su"
+              }
             }
           }
         }
       }
+    },
+    "Ss": {
+      "type": "string",
+      "pattern": "0|([1-9]\\d{0,38})"
+    },
+    "Su": {
+      "type": "string",
+      "pattern": "0|([1-9]\\d{0,128})"
     },
     "Sw": {
       "type": "list",
@@ -767,12 +1061,48 @@
     },
     "Sy": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "IncomingBytes",
+          "IncomingRecords",
+          "OutgoingBytes",
+          "OutgoingRecords",
+          "WriteProvisionedThroughputExceeded",
+          "ReadProvisionedThroughputExceeded",
+          "IteratorAgeMilliseconds",
+          "ALL"
+        ]
+      },
+      "max": 7,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "KMS"
+      ]
+    },
+    "S11": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "DELETING",
+        "ACTIVE"
+      ]
     },
     "S1b": {
       "type": "structure",
       "members": {
-        "StreamName": {},
+        "StreamName": {
+          "shape": "S2"
+        },
         "CurrentShardLevelMetrics": {
           "shape": "Sy"
         },
@@ -780,6 +1110,26 @@
           "shape": "Sy"
         }
       }
+    },
+    "S1e": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
+    "S1j": {
+      "type": "blob",
+      "max": 1048576,
+      "min": 0
+    },
+    "S1k": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S1r": {
+      "type": "string",
+      "max": 1048576,
+      "min": 1
     },
     "S1y": {
       "type": "structure",
@@ -790,9 +1140,15 @@
         "ConsumerCreationTimestamp"
       ],
       "members": {
-        "ConsumerName": {},
-        "ConsumerARN": {},
-        "ConsumerStatus": {},
+        "ConsumerName": {
+          "shape": "Se"
+        },
+        "ConsumerARN": {
+          "shape": "Sf"
+        },
+        "ConsumerStatus": {
+          "shape": "S15"
+        },
         "ConsumerCreationTimestamp": {
           "type": "timestamp"
         }

--- a/apis/kinesis-video-archived-media-2017-09-30.min.json
+++ b/apis/kinesis-video-archived-media-2017-09-30.min.json
@@ -18,13 +18,32 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {},
-          "StreamARN": {},
-          "PlaybackMode": {},
+          "StreamName": {
+            "shape": "S2"
+          },
+          "StreamARN": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
+          },
+          "PlaybackMode": {
+            "type": "string",
+            "enum": [
+              "LIVE",
+              "ON_DEMAND"
+            ]
+          },
           "HLSFragmentSelector": {
             "type": "structure",
             "members": {
-              "FragmentSelectorType": {},
+              "FragmentSelectorType": {
+                "type": "string",
+                "enum": [
+                  "PRODUCER_TIMESTAMP",
+                  "SERVER_TIMESTAMP"
+                ]
+              },
               "TimestampRange": {
                 "type": "structure",
                 "members": {
@@ -38,12 +57,20 @@
               }
             }
           },
-          "DiscontinuityMode": {},
+          "DiscontinuityMode": {
+            "type": "string",
+            "enum": [
+              "ALWAYS",
+              "NEVER"
+            ]
+          },
           "Expires": {
-            "type": "integer"
+            "type": "integer",
+            "max": 43200,
+            "min": 300
           },
           "MaxMediaPlaylistFragmentResults": {
-            "type": "long"
+            "shape": "Sb"
           }
         }
       },
@@ -65,10 +92,19 @@
           "Fragments"
         ],
         "members": {
-          "StreamName": {},
+          "StreamName": {
+            "shape": "S2"
+          },
           "Fragments": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 128,
+              "min": 1,
+              "pattern": "^[0-9]+$"
+            },
+            "max": 1000,
+            "min": 1
           }
         }
       },
@@ -77,7 +113,11 @@
         "members": {
           "ContentType": {
             "location": "header",
-            "locationName": "Content-Type"
+            "locationName": "Content-Type",
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
           },
           "Payload": {
             "type": "blob",
@@ -97,11 +137,15 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {},
-          "MaxResults": {
-            "type": "long"
+          "StreamName": {
+            "shape": "S2"
           },
-          "NextToken": {},
+          "MaxResults": {
+            "shape": "Sb"
+          },
+          "NextToken": {
+            "shape": "Sl"
+          },
           "FragmentSelector": {
             "type": "structure",
             "required": [
@@ -109,7 +153,13 @@
               "TimestampRange"
             ],
             "members": {
-              "FragmentSelectorType": {},
+              "FragmentSelectorType": {
+                "type": "string",
+                "enum": [
+                  "PRODUCER_TIMESTAMP",
+                  "SERVER_TIMESTAMP"
+                ]
+              },
               "TimestampRange": {
                 "type": "structure",
                 "required": [
@@ -137,7 +187,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "FragmentNumber": {},
+                "FragmentNumber": {
+                  "shape": "Sl"
+                },
                 "FragmentSizeInBytes": {
                   "type": "long"
                 },
@@ -153,10 +205,28 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sl"
+          }
         }
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "Sb": {
+      "type": "long",
+      "max": 1000,
+      "min": 1
+    },
+    "Sl": {
+      "type": "string",
+      "min": 1
+    }
+  }
 }

--- a/apis/kinesis-video-media-2017-09-30.min.json
+++ b/apis/kinesis-video-media-2017-09-30.min.json
@@ -21,20 +21,50 @@
           "StartSelector"
         ],
         "members": {
-          "StreamName": {},
-          "StreamARN": {},
+          "StreamName": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "pattern": "[a-zA-Z0-9_.-]+"
+          },
+          "StreamARN": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
+          },
           "StartSelector": {
             "type": "structure",
             "required": [
               "StartSelectorType"
             ],
             "members": {
-              "StartSelectorType": {},
-              "AfterFragmentNumber": {},
+              "StartSelectorType": {
+                "type": "string",
+                "enum": [
+                  "FRAGMENT_NUMBER",
+                  "SERVER_TIMESTAMP",
+                  "PRODUCER_TIMESTAMP",
+                  "NOW",
+                  "EARLIEST",
+                  "CONTINUATION_TOKEN"
+                ]
+              },
+              "AfterFragmentNumber": {
+                "type": "string",
+                "max": 128,
+                "min": 1,
+                "pattern": "^[0-9]+$"
+              },
               "StartTimestamp": {
                 "type": "timestamp"
               },
-              "ContinuationToken": {}
+              "ContinuationToken": {
+                "type": "string",
+                "max": 128,
+                "min": 1,
+                "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
+              }
             }
           }
         }
@@ -44,7 +74,11 @@
         "members": {
           "ContentType": {
             "location": "header",
-            "locationName": "Content-Type"
+            "locationName": "Content-Type",
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
           },
           "Payload": {
             "type": "blob",

--- a/apis/kinesisanalytics-2015-08-14.min.json
+++ b/apis/kinesisanalytics-2015-08-14.min.json
@@ -23,9 +23,11 @@
           "CloudWatchLoggingOption"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CurrentApplicationVersionId": {
-            "type": "long"
+            "shape": "S3"
           },
           "CloudWatchLoggingOption": {
             "shape": "S4"
@@ -46,9 +48,11 @@
           "Input"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CurrentApplicationVersionId": {
-            "type": "long"
+            "shape": "S3"
           },
           "Input": {
             "shape": "S9"
@@ -70,11 +74,15 @@
           "InputProcessingConfiguration"
         ],
         "members": {
-          "ApplicationName": {},
-          "CurrentApplicationVersionId": {
-            "type": "long"
+          "ApplicationName": {
+            "shape": "S2"
           },
-          "InputId": {},
+          "CurrentApplicationVersionId": {
+            "shape": "S3"
+          },
+          "InputId": {
+            "shape": "Sz"
+          },
           "InputProcessingConfiguration": {
             "shape": "Sb"
           }
@@ -94,9 +102,11 @@
           "Output"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CurrentApplicationVersionId": {
-            "type": "long"
+            "shape": "S3"
           },
           "Output": {
             "shape": "S12"
@@ -117,9 +127,11 @@
           "ReferenceDataSource"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CurrentApplicationVersionId": {
-            "type": "long"
+            "shape": "S3"
           },
           "ReferenceDataSource": {
             "type": "structure",
@@ -128,7 +140,9 @@
               "ReferenceSchema"
             ],
             "members": {
-              "TableName": {},
+              "TableName": {
+                "shape": "S1a"
+              },
               "S3ReferenceDataSource": {
                 "type": "structure",
                 "required": [
@@ -137,9 +151,15 @@
                   "ReferenceRoleARN"
                 ],
                 "members": {
-                  "BucketARN": {},
-                  "FileKey": {},
-                  "ReferenceRoleARN": {}
+                  "BucketARN": {
+                    "shape": "S1c"
+                  },
+                  "FileKey": {
+                    "shape": "S1d"
+                  },
+                  "ReferenceRoleARN": {
+                    "shape": "S6"
+                  }
                 }
               },
               "ReferenceSchema": {
@@ -161,8 +181,12 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {},
-          "ApplicationDescription": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
+          "ApplicationDescription": {
+            "shape": "S1g"
+          },
           "Inputs": {
             "type": "list",
             "member": {
@@ -181,7 +205,9 @@
               "shape": "S4"
             }
           },
-          "ApplicationCode": {}
+          "ApplicationCode": {
+            "shape": "S1k"
+          }
         }
       },
       "output": {
@@ -204,7 +230,9 @@
           "CreateTimestamp"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CreateTimestamp": {
             "type": "timestamp"
           }
@@ -224,11 +252,15 @@
           "CloudWatchLoggingOptionId"
         ],
         "members": {
-          "ApplicationName": {},
-          "CurrentApplicationVersionId": {
-            "type": "long"
+          "ApplicationName": {
+            "shape": "S2"
           },
-          "CloudWatchLoggingOptionId": {}
+          "CurrentApplicationVersionId": {
+            "shape": "S3"
+          },
+          "CloudWatchLoggingOptionId": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -245,11 +277,15 @@
           "InputId"
         ],
         "members": {
-          "ApplicationName": {},
-          "CurrentApplicationVersionId": {
-            "type": "long"
+          "ApplicationName": {
+            "shape": "S2"
           },
-          "InputId": {}
+          "CurrentApplicationVersionId": {
+            "shape": "S3"
+          },
+          "InputId": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -266,11 +302,15 @@
           "OutputId"
         ],
         "members": {
-          "ApplicationName": {},
-          "CurrentApplicationVersionId": {
-            "type": "long"
+          "ApplicationName": {
+            "shape": "S2"
           },
-          "OutputId": {}
+          "CurrentApplicationVersionId": {
+            "shape": "S3"
+          },
+          "OutputId": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -287,11 +327,15 @@
           "ReferenceId"
         ],
         "members": {
-          "ApplicationName": {},
-          "CurrentApplicationVersionId": {
-            "type": "long"
+          "ApplicationName": {
+            "shape": "S2"
           },
-          "ReferenceId": {}
+          "CurrentApplicationVersionId": {
+            "shape": "S3"
+          },
+          "ReferenceId": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -306,7 +350,9 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {}
+          "ApplicationName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -324,10 +370,18 @@
               "ApplicationVersionId"
             ],
             "members": {
-              "ApplicationName": {},
-              "ApplicationDescription": {},
-              "ApplicationARN": {},
-              "ApplicationStatus": {},
+              "ApplicationName": {
+                "shape": "S2"
+              },
+              "ApplicationDescription": {
+                "shape": "S1g"
+              },
+              "ApplicationARN": {
+                "shape": "Sd"
+              },
+              "ApplicationStatus": {
+                "shape": "S1n"
+              },
               "CreateTimestamp": {
                 "type": "timestamp"
               },
@@ -339,11 +393,17 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "InputId": {},
-                    "NamePrefix": {},
+                    "InputId": {
+                      "shape": "Sz"
+                    },
+                    "NamePrefix": {
+                      "shape": "Sa"
+                    },
                     "InAppStreamNames": {
                       "type": "list",
-                      "member": {}
+                      "member": {
+                        "shape": "Sa"
+                      }
                     },
                     "InputProcessingConfigurationDescription": {
                       "type": "structure",
@@ -351,8 +411,12 @@
                         "InputLambdaProcessorDescription": {
                           "type": "structure",
                           "members": {
-                            "ResourceARN": {},
-                            "RoleARN": {}
+                            "ResourceARN": {
+                              "shape": "Sd"
+                            },
+                            "RoleARN": {
+                              "shape": "S6"
+                            }
                           }
                         }
                       }
@@ -360,15 +424,23 @@
                     "KinesisStreamsInputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {},
-                        "RoleARN": {}
+                        "ResourceARN": {
+                          "shape": "Sd"
+                        },
+                        "RoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "KinesisFirehoseInputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {},
-                        "RoleARN": {}
+                        "ResourceARN": {
+                          "shape": "Sd"
+                        },
+                        "RoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "InputSchema": {
@@ -388,27 +460,43 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "OutputId": {},
-                    "Name": {},
+                    "OutputId": {
+                      "shape": "Sz"
+                    },
+                    "Name": {
+                      "shape": "Sa"
+                    },
                     "KinesisStreamsOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {},
-                        "RoleARN": {}
+                        "ResourceARN": {
+                          "shape": "Sd"
+                        },
+                        "RoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "KinesisFirehoseOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {},
-                        "RoleARN": {}
+                        "ResourceARN": {
+                          "shape": "Sd"
+                        },
+                        "RoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "LambdaOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {},
-                        "RoleARN": {}
+                        "ResourceARN": {
+                          "shape": "Sd"
+                        },
+                        "RoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "DestinationSchema": {
@@ -427,8 +515,12 @@
                     "S3ReferenceDataSourceDescription"
                   ],
                   "members": {
-                    "ReferenceId": {},
-                    "TableName": {},
+                    "ReferenceId": {
+                      "shape": "Sz"
+                    },
+                    "TableName": {
+                      "shape": "S1a"
+                    },
                     "S3ReferenceDataSourceDescription": {
                       "type": "structure",
                       "required": [
@@ -437,9 +529,15 @@
                         "ReferenceRoleARN"
                       ],
                       "members": {
-                        "BucketARN": {},
-                        "FileKey": {},
-                        "ReferenceRoleARN": {}
+                        "BucketARN": {
+                          "shape": "S1c"
+                        },
+                        "FileKey": {
+                          "shape": "S1d"
+                        },
+                        "ReferenceRoleARN": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "ReferenceSchema": {
@@ -457,15 +555,23 @@
                     "RoleARN"
                   ],
                   "members": {
-                    "CloudWatchLoggingOptionId": {},
-                    "LogStreamARN": {},
-                    "RoleARN": {}
+                    "CloudWatchLoggingOptionId": {
+                      "shape": "Sz"
+                    },
+                    "LogStreamARN": {
+                      "shape": "S5"
+                    },
+                    "RoleARN": {
+                      "shape": "S6"
+                    }
                   }
                 }
               },
-              "ApplicationCode": {},
+              "ApplicationCode": {
+                "shape": "S1k"
+              },
               "ApplicationVersionId": {
-                "type": "long"
+                "shape": "S3"
               }
             }
           }
@@ -476,8 +582,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "ResourceARN": {},
-          "RoleARN": {},
+          "ResourceARN": {
+            "shape": "Sd"
+          },
+          "RoleARN": {
+            "shape": "S6"
+          },
           "InputStartingPositionConfiguration": {
             "shape": "S29"
           },
@@ -489,9 +599,15 @@
               "FileKey"
             ],
             "members": {
-              "RoleARN": {},
-              "BucketARN": {},
-              "FileKey": {}
+              "RoleARN": {
+                "shape": "S6"
+              },
+              "BucketARN": {
+                "shape": "S1c"
+              },
+              "FileKey": {
+                "shape": "S1d"
+              }
             }
           },
           "InputProcessingConfiguration": {
@@ -528,9 +644,13 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 1
           },
-          "ExclusiveStartApplicationName": {}
+          "ExclusiveStartApplicationName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -560,7 +680,9 @@
           "InputConfigurations"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "InputConfigurations": {
             "type": "list",
             "member": {
@@ -570,7 +692,9 @@
                 "InputStartingPositionConfiguration"
               ],
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "Sz"
+                },
                 "InputStartingPositionConfiguration": {
                   "shape": "S29"
                 }
@@ -591,7 +715,9 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {}
+          "ApplicationName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -608,9 +734,11 @@
           "ApplicationUpdate"
         ],
         "members": {
-          "ApplicationName": {},
+          "ApplicationName": {
+            "shape": "S2"
+          },
           "CurrentApplicationVersionId": {
-            "type": "long"
+            "shape": "S3"
           },
           "ApplicationUpdate": {
             "type": "structure",
@@ -623,8 +751,12 @@
                     "InputId"
                   ],
                   "members": {
-                    "InputId": {},
-                    "NamePrefixUpdate": {},
+                    "InputId": {
+                      "shape": "Sz"
+                    },
+                    "NamePrefixUpdate": {
+                      "shape": "Sa"
+                    },
                     "InputProcessingConfigurationUpdate": {
                       "type": "structure",
                       "required": [
@@ -634,8 +766,12 @@
                         "InputLambdaProcessorUpdate": {
                           "type": "structure",
                           "members": {
-                            "ResourceARNUpdate": {},
-                            "RoleARNUpdate": {}
+                            "ResourceARNUpdate": {
+                              "shape": "Sd"
+                            },
+                            "RoleARNUpdate": {
+                              "shape": "S6"
+                            }
                           }
                         }
                       }
@@ -643,15 +779,23 @@
                     "KinesisStreamsInputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {},
-                        "RoleARNUpdate": {}
+                        "ResourceARNUpdate": {
+                          "shape": "Sd"
+                        },
+                        "RoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "KinesisFirehoseInputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {},
-                        "RoleARNUpdate": {}
+                        "ResourceARNUpdate": {
+                          "shape": "Sd"
+                        },
+                        "RoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "InputSchemaUpdate": {
@@ -660,7 +804,9 @@
                         "RecordFormatUpdate": {
                           "shape": "Sj"
                         },
-                        "RecordEncodingUpdate": {},
+                        "RecordEncodingUpdate": {
+                          "shape": "Sr"
+                        },
                         "RecordColumnUpdates": {
                           "shape": "Ss"
                         }
@@ -670,14 +816,16 @@
                       "type": "structure",
                       "members": {
                         "CountUpdate": {
-                          "type": "integer"
+                          "shape": "Sh"
                         }
                       }
                     }
                   }
                 }
               },
-              "ApplicationCodeUpdate": {},
+              "ApplicationCodeUpdate": {
+                "shape": "S1k"
+              },
               "OutputUpdates": {
                 "type": "list",
                 "member": {
@@ -686,27 +834,43 @@
                     "OutputId"
                   ],
                   "members": {
-                    "OutputId": {},
-                    "NameUpdate": {},
+                    "OutputId": {
+                      "shape": "Sz"
+                    },
+                    "NameUpdate": {
+                      "shape": "Sa"
+                    },
                     "KinesisStreamsOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {},
-                        "RoleARNUpdate": {}
+                        "ResourceARNUpdate": {
+                          "shape": "Sd"
+                        },
+                        "RoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "KinesisFirehoseOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {},
-                        "RoleARNUpdate": {}
+                        "ResourceARNUpdate": {
+                          "shape": "Sd"
+                        },
+                        "RoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "LambdaOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {},
-                        "RoleARNUpdate": {}
+                        "ResourceARNUpdate": {
+                          "shape": "Sd"
+                        },
+                        "RoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "DestinationSchemaUpdate": {
@@ -723,14 +887,24 @@
                     "ReferenceId"
                   ],
                   "members": {
-                    "ReferenceId": {},
-                    "TableNameUpdate": {},
+                    "ReferenceId": {
+                      "shape": "Sz"
+                    },
+                    "TableNameUpdate": {
+                      "shape": "S1a"
+                    },
                     "S3ReferenceDataSourceUpdate": {
                       "type": "structure",
                       "members": {
-                        "BucketARNUpdate": {},
-                        "FileKeyUpdate": {},
-                        "ReferenceRoleARNUpdate": {}
+                        "BucketARNUpdate": {
+                          "shape": "S1c"
+                        },
+                        "FileKeyUpdate": {
+                          "shape": "S1d"
+                        },
+                        "ReferenceRoleARNUpdate": {
+                          "shape": "S6"
+                        }
                       }
                     },
                     "ReferenceSchemaUpdate": {
@@ -747,9 +921,15 @@
                     "CloudWatchLoggingOptionId"
                   ],
                   "members": {
-                    "CloudWatchLoggingOptionId": {},
-                    "LogStreamARNUpdate": {},
-                    "RoleARNUpdate": {}
+                    "CloudWatchLoggingOptionId": {
+                      "shape": "Sz"
+                    },
+                    "LogStreamARNUpdate": {
+                      "shape": "S5"
+                    },
+                    "RoleARNUpdate": {
+                      "shape": "S6"
+                    }
                   }
                 }
               }
@@ -764,6 +944,17 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S3": {
+      "type": "long",
+      "max": 999999999,
+      "min": 1
+    },
     "S4": {
       "type": "structure",
       "required": [
@@ -771,9 +962,25 @@
         "RoleARN"
       ],
       "members": {
-        "LogStreamARN": {},
-        "RoleARN": {}
+        "LogStreamARN": {
+          "shape": "S5"
+        },
+        "RoleARN": {
+          "shape": "S6"
+        }
       }
+    },
+    "S5": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
+    "S6": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
     },
     "S9": {
       "type": "structure",
@@ -782,7 +989,9 @@
         "InputSchema"
       ],
       "members": {
-        "NamePrefix": {},
+        "NamePrefix": {
+          "shape": "Sa"
+        },
         "InputProcessingConfiguration": {
           "shape": "Sb"
         },
@@ -793,8 +1002,12 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         },
         "KinesisFirehoseInput": {
@@ -804,8 +1017,12 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         },
         "InputParallelism": {
@@ -815,6 +1032,12 @@
           "shape": "Si"
         }
       }
+    },
+    "Sa": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "[a-zA-Z][a-zA-Z0-9_]+"
     },
     "Sb": {
       "type": "structure",
@@ -829,19 +1052,34 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         }
       }
+    },
+    "Sd": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:.*"
     },
     "Sg": {
       "type": "structure",
       "members": {
         "Count": {
-          "type": "integer"
+          "shape": "Sh"
         }
       }
+    },
+    "Sh": {
+      "type": "integer",
+      "max": 64,
+      "min": 1
     },
     "Si": {
       "type": "structure",
@@ -853,7 +1091,9 @@
         "RecordFormat": {
           "shape": "Sj"
         },
-        "RecordEncoding": {},
+        "RecordEncoding": {
+          "shape": "Sr"
+        },
         "RecordColumns": {
           "shape": "Ss"
         }
@@ -865,7 +1105,9 @@
         "RecordFormatType"
       ],
       "members": {
-        "RecordFormatType": {},
+        "RecordFormatType": {
+          "shape": "Sk"
+        },
         "MappingParameters": {
           "type": "structure",
           "members": {
@@ -875,7 +1117,10 @@
                 "RecordRowPath"
               ],
               "members": {
-                "RecordRowPath": {}
+                "RecordRowPath": {
+                  "type": "string",
+                  "min": 1
+                }
               }
             },
             "CSVMappingParameters": {
@@ -885,13 +1130,30 @@
                 "RecordColumnDelimiter"
               ],
               "members": {
-                "RecordRowDelimiter": {},
-                "RecordColumnDelimiter": {}
+                "RecordRowDelimiter": {
+                  "type": "string",
+                  "min": 1
+                },
+                "RecordColumnDelimiter": {
+                  "type": "string",
+                  "min": 1
+                }
               }
             }
           }
         }
       }
+    },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "JSON",
+        "CSV"
+      ]
+    },
+    "Sr": {
+      "type": "string",
+      "pattern": "UTF-8"
     },
     "Ss": {
       "type": "list",
@@ -902,11 +1164,25 @@
           "SqlType"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "type": "string",
+            "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
+          },
           "Mapping": {},
-          "SqlType": {}
+          "SqlType": {
+            "type": "string",
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 1000,
+      "min": 1
+    },
+    "Sz": {
+      "type": "string",
+      "max": 50,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
     },
     "S12": {
       "type": "structure",
@@ -915,7 +1191,9 @@
         "DestinationSchema"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "shape": "Sa"
+        },
         "KinesisStreamsOutput": {
           "type": "structure",
           "required": [
@@ -923,8 +1201,12 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         },
         "KinesisFirehoseOutput": {
@@ -934,8 +1216,12 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         },
         "LambdaOutput": {
@@ -945,8 +1231,12 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {},
-            "RoleARN": {}
+            "ResourceARN": {
+              "shape": "Sd"
+            },
+            "RoleARN": {
+              "shape": "S6"
+            }
           }
         },
         "DestinationSchema": {
@@ -957,8 +1247,37 @@
     "S16": {
       "type": "structure",
       "members": {
-        "RecordFormatType": {}
+        "RecordFormatType": {
+          "shape": "Sk"
+        }
       }
+    },
+    "S1a": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "[a-zA-Z][a-zA-Z0-9_]+"
+    },
+    "S1c": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "arn:.*"
+    },
+    "S1d": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S1g": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
+    "S1k": {
+      "type": "string",
+      "max": 51200,
+      "min": 0
     },
     "S1m": {
       "type": "structure",
@@ -968,15 +1287,39 @@
         "ApplicationStatus"
       ],
       "members": {
-        "ApplicationName": {},
-        "ApplicationARN": {},
-        "ApplicationStatus": {}
+        "ApplicationName": {
+          "shape": "S2"
+        },
+        "ApplicationARN": {
+          "shape": "Sd"
+        },
+        "ApplicationStatus": {
+          "shape": "S1n"
+        }
       }
+    },
+    "S1n": {
+      "type": "string",
+      "enum": [
+        "DELETING",
+        "STARTING",
+        "STOPPING",
+        "READY",
+        "RUNNING",
+        "UPDATING"
+      ]
     },
     "S29": {
       "type": "structure",
       "members": {
-        "InputStartingPosition": {}
+        "InputStartingPosition": {
+          "type": "string",
+          "enum": [
+            "NOW",
+            "TRIM_HORIZON",
+            "LAST_STOPPED_POINT"
+          ]
+        }
       }
     }
   }

--- a/apis/kinesisvideo-2017-09-30.min.json
+++ b/apis/kinesisvideo-2017-09-30.min.json
@@ -21,19 +21,29 @@
           "StreamName"
         ],
         "members": {
-          "DeviceName": {},
-          "StreamName": {},
-          "MediaType": {},
-          "KmsKeyId": {},
+          "DeviceName": {
+            "shape": "S2"
+          },
+          "StreamName": {
+            "shape": "S3"
+          },
+          "MediaType": {
+            "shape": "S4"
+          },
+          "KmsKeyId": {
+            "shape": "S5"
+          },
           "DataRetentionInHours": {
-            "type": "integer"
+            "shape": "S6"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamARN": {}
+          "StreamARN": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -47,8 +57,12 @@
           "StreamARN"
         ],
         "members": {
-          "StreamARN": {},
-          "CurrentVersion": {}
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "CurrentVersion": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -63,8 +77,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {},
-          "StreamARN": {}
+          "StreamName": {
+            "shape": "S3"
+          },
+          "StreamARN": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -86,9 +104,22 @@
           "APIName"
         ],
         "members": {
-          "StreamName": {},
-          "StreamARN": {},
-          "APIName": {}
+          "StreamName": {
+            "shape": "S3"
+          },
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "APIName": {
+            "type": "string",
+            "enum": [
+              "PUT_MEDIA",
+              "GET_MEDIA",
+              "LIST_FRAGMENTS",
+              "GET_MEDIA_FOR_FRAGMENT_LIST",
+              "GET_HLS_STREAMING_SESSION_URL"
+            ]
+          }
         }
       },
       "output": {
@@ -106,14 +137,25 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10000,
+            "min": 1
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sn"
+          },
           "StreamNameCondition": {
             "type": "structure",
             "members": {
-              "ComparisonOperator": {},
-              "ComparisonValue": {}
+              "ComparisonOperator": {
+                "type": "string",
+                "enum": [
+                  "BEGINS_WITH"
+                ]
+              },
+              "ComparisonValue": {
+                "shape": "S3"
+              }
             }
           }
         }
@@ -127,7 +169,9 @@
               "shape": "Se"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -138,15 +182,23 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "StreamARN": {},
-          "StreamName": {}
+          "NextToken": {
+            "shape": "Sn"
+          },
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "StreamName": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sn"
+          },
           "Tags": {
             "shape": "Su"
           }
@@ -163,8 +215,12 @@
           "Tags"
         ],
         "members": {
-          "StreamARN": {},
-          "StreamName": {},
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "StreamName": {
+            "shape": "S3"
+          },
           "Tags": {
             "shape": "Su"
           }
@@ -185,11 +241,19 @@
           "TagKeyList"
         ],
         "members": {
-          "StreamARN": {},
-          "StreamName": {},
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "StreamName": {
+            "shape": "S3"
+          },
           "TagKeyList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sv"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -210,12 +274,25 @@
           "DataRetentionChangeInHours"
         ],
         "members": {
-          "StreamName": {},
-          "StreamARN": {},
-          "CurrentVersion": {},
-          "Operation": {},
+          "StreamName": {
+            "shape": "S3"
+          },
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "CurrentVersion": {
+            "shape": "Sa"
+          },
+          "Operation": {
+            "type": "string",
+            "enum": [
+              "INCREASE_DATA_RETENTION",
+              "DECREASE_DATA_RETENTION"
+            ]
+          },
           "DataRetentionChangeInHours": {
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           }
         }
       },
@@ -234,11 +311,21 @@
           "CurrentVersion"
         ],
         "members": {
-          "StreamName": {},
-          "StreamARN": {},
-          "CurrentVersion": {},
-          "DeviceName": {},
-          "MediaType": {}
+          "StreamName": {
+            "shape": "S3"
+          },
+          "StreamARN": {
+            "shape": "S8"
+          },
+          "CurrentVersion": {
+            "shape": "Sa"
+          },
+          "DeviceName": {
+            "shape": "S2"
+          },
+          "MediaType": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -248,28 +335,105 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S3": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S4": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w\\-\\.\\+]+/[\\w\\-\\.\\+]+"
+    },
+    "S5": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S6": {
+      "type": "integer",
+      "min": 0
+    },
+    "S8": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9]+"
+    },
     "Se": {
       "type": "structure",
       "members": {
-        "DeviceName": {},
-        "StreamName": {},
-        "StreamARN": {},
-        "MediaType": {},
-        "KmsKeyId": {},
-        "Version": {},
-        "Status": {},
+        "DeviceName": {
+          "shape": "S2"
+        },
+        "StreamName": {
+          "shape": "S3"
+        },
+        "StreamARN": {
+          "shape": "S8"
+        },
+        "MediaType": {
+          "shape": "S4"
+        },
+        "KmsKeyId": {
+          "shape": "S5"
+        },
+        "Version": {
+          "shape": "Sa"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "CREATING",
+            "ACTIVE",
+            "UPDATING",
+            "DELETING"
+          ]
+        },
         "CreationTime": {
           "type": "timestamp"
         },
         "DataRetentionInHours": {
-          "type": "integer"
+          "shape": "S6"
         }
       }
     },
+    "Sn": {
+      "type": "string",
+      "max": 512,
+      "min": 0
+    },
     "Su": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "Sv"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "min": 0
+      },
+      "max": 50,
+      "min": 1
+    },
+    "Sv": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     }
   }
 }

--- a/apis/kms-2014-11-01.min.json
+++ b/apis/kms-2014-11-01.min.json
@@ -20,13 +20,17 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -38,8 +42,12 @@
           "TargetKeyId"
         ],
         "members": {
-          "AliasName": {},
-          "TargetKeyId": {}
+          "AliasName": {
+            "shape": "S5"
+          },
+          "TargetKeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -52,9 +60,15 @@
           "Operations"
         ],
         "members": {
-          "KeyId": {},
-          "GranteePrincipal": {},
-          "RetiringPrincipal": {},
+          "KeyId": {
+            "shape": "S2"
+          },
+          "GranteePrincipal": {
+            "shape": "S7"
+          },
+          "RetiringPrincipal": {
+            "shape": "S7"
+          },
           "Operations": {
             "shape": "S8"
           },
@@ -64,14 +78,20 @@
           "GrantTokens": {
             "shape": "Se"
           },
-          "Name": {}
+          "Name": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GrantToken": {},
-          "GrantId": {}
+          "GrantToken": {
+            "shape": "Sf"
+          },
+          "GrantId": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -79,10 +99,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "Policy": {},
-          "Description": {},
-          "KeyUsage": {},
-          "Origin": {},
+          "Policy": {
+            "shape": "Sk"
+          },
+          "Description": {
+            "shape": "Sl"
+          },
+          "KeyUsage": {
+            "shape": "Sm"
+          },
+          "Origin": {
+            "shape": "Sn"
+          },
           "BypassPolicyLockoutSafetyCheck": {
             "type": "boolean"
           },
@@ -108,7 +136,7 @@
         ],
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
           "EncryptionContext": {
             "shape": "Sb"
@@ -121,7 +149,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "Plaintext": {
             "shape": "S14"
           }
@@ -135,7 +165,9 @@
           "AliasName"
         ],
         "members": {
-          "AliasName": {}
+          "AliasName": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -146,7 +178,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -157,7 +191,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "GrantTokens": {
             "shape": "Se"
           }
@@ -179,7 +215,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -190,7 +228,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -201,7 +241,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -212,7 +254,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -224,7 +268,9 @@
           "Plaintext"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "Plaintext": {
             "shape": "S14"
           },
@@ -240,9 +286,11 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -253,14 +301,18 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "EncryptionContext": {
             "shape": "Sb"
           },
           "NumberOfBytes": {
-            "type": "integer"
+            "shape": "S1g"
           },
-          "KeySpec": {},
+          "KeySpec": {
+            "shape": "S1h"
+          },
           "GrantTokens": {
             "shape": "Se"
           }
@@ -270,12 +322,14 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
           "Plaintext": {
             "shape": "S14"
           },
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -286,13 +340,17 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "EncryptionContext": {
             "shape": "Sb"
           },
-          "KeySpec": {},
+          "KeySpec": {
+            "shape": "S1h"
+          },
           "NumberOfBytes": {
-            "type": "integer"
+            "shape": "S1g"
           },
           "GrantTokens": {
             "shape": "Se"
@@ -303,9 +361,11 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -314,7 +374,7 @@
         "type": "structure",
         "members": {
           "NumberOfBytes": {
-            "type": "integer"
+            "shape": "S1g"
           }
         }
       },
@@ -335,14 +395,20 @@
           "PolicyName"
         ],
         "members": {
-          "KeyId": {},
-          "PolicyName": {}
+          "KeyId": {
+            "shape": "S2"
+          },
+          "PolicyName": {
+            "shape": "S1o"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {}
+          "Policy": {
+            "shape": "Sk"
+          }
         }
       }
     },
@@ -353,7 +419,9 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {}
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -374,17 +442,33 @@
           "WrappingKeySpec"
         ],
         "members": {
-          "KeyId": {},
-          "WrappingAlgorithm": {},
-          "WrappingKeySpec": {}
+          "KeyId": {
+            "shape": "S2"
+          },
+          "WrappingAlgorithm": {
+            "type": "string",
+            "enum": [
+              "RSAES_PKCS1_V1_5",
+              "RSAES_OAEP_SHA_1",
+              "RSAES_OAEP_SHA_256"
+            ]
+          },
+          "WrappingKeySpec": {
+            "type": "string",
+            "enum": [
+              "RSA_2048"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "ImportToken": {
-            "type": "blob"
+            "shape": "S12"
           },
           "PublicKey": {
             "shape": "S14"
@@ -404,17 +488,21 @@
           "EncryptedKeyMaterial"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "ImportToken": {
-            "type": "blob"
+            "shape": "S12"
           },
           "EncryptedKeyMaterial": {
-            "type": "blob"
+            "shape": "S12"
           },
           "ValidTo": {
             "type": "timestamp"
           },
-          "ExpirationModel": {}
+          "ExpirationModel": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -426,11 +514,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "KeyId": {},
-          "Limit": {
-            "type": "integer"
+          "KeyId": {
+            "shape": "S2"
           },
-          "Marker": {}
+          "Limit": {
+            "shape": "S1z"
+          },
+          "Marker": {
+            "shape": "S20"
+          }
         }
       },
       "output": {
@@ -441,13 +533,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "AliasName": {},
-                "AliasArn": {},
-                "TargetKeyId": {}
+                "AliasName": {
+                  "shape": "S5"
+                },
+                "AliasArn": {
+                  "shape": "Sw"
+                },
+                "TargetKeyId": {
+                  "shape": "S2"
+                }
               }
             }
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S20"
+          },
           "Truncated": {
             "type": "boolean"
           }
@@ -462,10 +562,14 @@
         ],
         "members": {
           "Limit": {
-            "type": "integer"
+            "shape": "S1z"
           },
-          "Marker": {},
-          "KeyId": {}
+          "Marker": {
+            "shape": "S20"
+          },
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -479,11 +583,15 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
-          "Limit": {
-            "type": "integer"
+          "KeyId": {
+            "shape": "S2"
           },
-          "Marker": {}
+          "Limit": {
+            "shape": "S1z"
+          },
+          "Marker": {
+            "shape": "S20"
+          }
         }
       },
       "output": {
@@ -491,9 +599,13 @@
         "members": {
           "PolicyNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1o"
+            }
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S20"
+          },
           "Truncated": {
             "type": "boolean"
           }
@@ -505,9 +617,11 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer"
+            "shape": "S1z"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S20"
+          }
         }
       },
       "output": {
@@ -518,12 +632,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "KeyId": {},
-                "KeyArn": {}
+                "KeyId": {
+                  "shape": "S2"
+                },
+                "KeyArn": {
+                  "shape": "Sw"
+                }
               }
             }
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S20"
+          },
           "Truncated": {
             "type": "boolean"
           }
@@ -537,11 +657,15 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
-          "Limit": {
-            "type": "integer"
+          "KeyId": {
+            "shape": "S2"
           },
-          "Marker": {}
+          "Limit": {
+            "shape": "S1z"
+          },
+          "Marker": {
+            "shape": "S20"
+          }
         }
       },
       "output": {
@@ -550,7 +674,9 @@
           "Tags": {
             "shape": "Sp"
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S20"
+          },
           "Truncated": {
             "type": "boolean"
           }
@@ -565,10 +691,14 @@
         ],
         "members": {
           "Limit": {
-            "type": "integer"
+            "shape": "S1z"
           },
-          "Marker": {},
-          "RetiringPrincipal": {}
+          "Marker": {
+            "shape": "S20"
+          },
+          "RetiringPrincipal": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -584,9 +714,15 @@
           "Policy"
         ],
         "members": {
-          "KeyId": {},
-          "PolicyName": {},
-          "Policy": {},
+          "KeyId": {
+            "shape": "S2"
+          },
+          "PolicyName": {
+            "shape": "S1o"
+          },
+          "Policy": {
+            "shape": "Sk"
+          },
           "BypassPolicyLockoutSafetyCheck": {
             "type": "boolean"
           }
@@ -602,12 +738,14 @@
         ],
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
           "SourceEncryptionContext": {
             "shape": "Sb"
           },
-          "DestinationKeyId": {},
+          "DestinationKeyId": {
+            "shape": "S2"
+          },
           "DestinationEncryptionContext": {
             "shape": "Sb"
           },
@@ -620,10 +758,14 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "type": "blob"
+            "shape": "S12"
           },
-          "SourceKeyId": {},
-          "KeyId": {}
+          "SourceKeyId": {
+            "shape": "S2"
+          },
+          "KeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -631,9 +773,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "GrantToken": {},
-          "KeyId": {},
-          "GrantId": {}
+          "GrantToken": {
+            "shape": "Sf"
+          },
+          "KeyId": {
+            "shape": "S2"
+          },
+          "GrantId": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -645,8 +793,12 @@
           "GrantId"
         ],
         "members": {
-          "KeyId": {},
-          "GrantId": {}
+          "KeyId": {
+            "shape": "S2"
+          },
+          "GrantId": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -657,16 +809,22 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "PendingWindowInDays": {
-            "type": "integer"
+            "type": "integer",
+            "max": 365,
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "DeletionDate": {
             "type": "timestamp"
           }
@@ -681,7 +839,9 @@
           "Tags"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "Sp"
           }
@@ -696,10 +856,14 @@
           "TagKeys"
         ],
         "members": {
-          "KeyId": {},
+          "KeyId": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sr"
+            }
           }
         }
       }
@@ -712,8 +876,12 @@
           "TargetKeyId"
         ],
         "members": {
-          "AliasName": {},
-          "TargetKeyId": {}
+          "AliasName": {
+            "shape": "S5"
+          },
+          "TargetKeyId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -725,16 +893,49 @@
           "Description"
         ],
         "members": {
-          "KeyId": {},
-          "Description": {}
+          "KeyId": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "Sl"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9:/_-]+$"
+    },
+    "S7": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
     "S8": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "Decrypt",
+          "Encrypt",
+          "GenerateDataKey",
+          "GenerateDataKeyWithoutPlaintext",
+          "ReEncryptFrom",
+          "ReEncryptTo",
+          "CreateGrant",
+          "RetireGrant",
+          "DescribeKey"
+        ]
+      }
     },
     "Sa": {
       "type": "structure",
@@ -754,7 +955,51 @@
     },
     "Se": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sf"
+      },
+      "max": 10,
+      "min": 0
+    },
+    "Sf": {
+      "type": "string",
+      "max": 8192,
+      "min": 1
+    },
+    "Sg": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9:/_-]+$"
+    },
+    "Si": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "Sk": {
+      "type": "string",
+      "max": 131072,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "Sl": {
+      "type": "string",
+      "max": 8192,
+      "min": 0
+    },
+    "Sm": {
+      "type": "string",
+      "enum": [
+        "ENCRYPT_DECRYPT"
+      ]
+    },
+    "Sn": {
+      "type": "string",
+      "enum": [
+        "AWS_KMS",
+        "EXTERNAL"
+      ]
     },
     "Sp": {
       "type": "list",
@@ -765,10 +1010,21 @@
           "TagValue"
         ],
         "members": {
-          "TagKey": {},
-          "TagValue": {}
+          "TagKey": {
+            "shape": "Sr"
+          },
+          "TagValue": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+          }
         }
       }
+    },
+    "Sr": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "Su": {
       "type": "structure",
@@ -777,31 +1033,105 @@
       ],
       "members": {
         "AWSAccountId": {},
-        "KeyId": {},
-        "Arn": {},
+        "KeyId": {
+          "shape": "S2"
+        },
+        "Arn": {
+          "shape": "Sw"
+        },
         "CreationDate": {
           "type": "timestamp"
         },
         "Enabled": {
           "type": "boolean"
         },
-        "Description": {},
-        "KeyUsage": {},
-        "KeyState": {},
+        "Description": {
+          "shape": "Sl"
+        },
+        "KeyUsage": {
+          "shape": "Sm"
+        },
+        "KeyState": {
+          "type": "string",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "PendingDeletion",
+            "PendingImport"
+          ]
+        },
         "DeletionDate": {
           "type": "timestamp"
         },
         "ValidTo": {
           "type": "timestamp"
         },
-        "Origin": {},
-        "ExpirationModel": {},
-        "KeyManager": {}
+        "Origin": {
+          "shape": "Sn"
+        },
+        "ExpirationModel": {
+          "shape": "Sz"
+        },
+        "KeyManager": {
+          "type": "string",
+          "enum": [
+            "AWS",
+            "CUSTOMER"
+          ]
+        }
       }
+    },
+    "Sw": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "KEY_MATERIAL_EXPIRES",
+        "KEY_MATERIAL_DOES_NOT_EXPIRE"
+      ]
+    },
+    "S12": {
+      "type": "blob",
+      "max": 6144,
+      "min": 1
     },
     "S14": {
       "type": "blob",
+      "max": 4096,
+      "min": 1,
       "sensitive": true
+    },
+    "S1g": {
+      "type": "integer",
+      "max": 1024,
+      "min": 1
+    },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "AES_256",
+        "AES_128"
+      ]
+    },
+    "S1o": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w]+"
+    },
+    "S1z": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
+    "S20": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "[\\u0020-\\u00FF]*"
     },
     "S25": {
       "type": "structure",
@@ -811,15 +1141,27 @@
           "member": {
             "type": "structure",
             "members": {
-              "KeyId": {},
-              "GrantId": {},
-              "Name": {},
+              "KeyId": {
+                "shape": "S2"
+              },
+              "GrantId": {
+                "shape": "Si"
+              },
+              "Name": {
+                "shape": "Sg"
+              },
               "CreationDate": {
                 "type": "timestamp"
               },
-              "GranteePrincipal": {},
-              "RetiringPrincipal": {},
-              "IssuingAccount": {},
+              "GranteePrincipal": {
+                "shape": "S7"
+              },
+              "RetiringPrincipal": {
+                "shape": "S7"
+              },
+              "IssuingAccount": {
+                "shape": "S7"
+              },
               "Operations": {
                 "shape": "S8"
               },
@@ -829,7 +1171,9 @@
             }
           }
         },
-        "NextMarker": {},
+        "NextMarker": {
+          "shape": "S20"
+        },
         "Truncated": {
           "type": "boolean"
         }

--- a/apis/lambda-2014-11-11.min.json
+++ b/apis/lambda-2014-11-11.min.json
@@ -21,8 +21,12 @@
         ],
         "members": {
           "EventSource": {},
-          "FunctionName": {},
-          "Role": {},
+          "FunctionName": {
+            "shape": "S3"
+          },
+          "Role": {
+            "shape": "S4"
+          },
           "BatchSize": {
             "type": "integer"
           },
@@ -48,6 +52,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -89,6 +94,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -123,6 +129,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -145,6 +152,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -178,6 +186,7 @@
             "locationName": "EventSource"
           },
           "FunctionName": {
+            "shape": "S3",
             "location": "querystring",
             "locationName": "FunctionName"
           },
@@ -186,9 +195,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "Su",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -219,9 +228,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "Su",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -270,30 +279,34 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Role": {
+            "shape": "S4",
             "location": "querystring",
             "locationName": "Role"
           },
           "Handler": {
+            "shape": "Sh",
             "location": "querystring",
             "locationName": "Handler"
           },
           "Description": {
+            "shape": "Sk",
             "location": "querystring",
             "locationName": "Description"
           },
           "Timeout": {
+            "shape": "Sl",
             "location": "querystring",
-            "locationName": "Timeout",
-            "type": "integer"
+            "locationName": "Timeout"
           },
           "MemorySize": {
+            "shape": "Sm",
             "location": "querystring",
-            "locationName": "MemorySize",
-            "type": "integer"
+            "locationName": "MemorySize"
           }
         }
       },
@@ -319,6 +332,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -326,34 +340,39 @@
             "shape": "Sq"
           },
           "Runtime": {
+            "shape": "Sg",
             "location": "querystring",
             "locationName": "Runtime"
           },
           "Role": {
+            "shape": "S4",
             "location": "querystring",
             "locationName": "Role"
           },
           "Handler": {
+            "shape": "Sh",
             "location": "querystring",
             "locationName": "Handler"
           },
           "Mode": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "Mode"
           },
           "Description": {
+            "shape": "Sk",
             "location": "querystring",
             "locationName": "Description"
           },
           "Timeout": {
+            "shape": "Sl",
             "location": "querystring",
-            "locationName": "Timeout",
-            "type": "integer"
+            "locationName": "Timeout"
           },
           "MemorySize": {
+            "shape": "Sm",
             "location": "querystring",
-            "locationName": "MemorySize",
-            "type": "integer"
+            "locationName": "MemorySize"
           }
         },
         "payload": "FunctionZip"
@@ -364,6 +383,16 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "[a-zA-Z0-9-_]+"
+    },
+    "S4": {
+      "type": "string",
+      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
     "S6": {
       "type": "map",
       "key": {},
@@ -377,11 +406,15 @@
           "type": "integer"
         },
         "EventSource": {},
-        "FunctionName": {},
+        "FunctionName": {
+          "shape": "S3"
+        },
         "Parameters": {
           "shape": "S6"
         },
-        "Role": {},
+        "Role": {
+          "shape": "S4"
+        },
         "LastModified": {
           "type": "timestamp"
         },
@@ -394,31 +427,82 @@
     "Se": {
       "type": "structure",
       "members": {
-        "FunctionName": {},
-        "FunctionARN": {},
+        "FunctionName": {
+          "shape": "S3"
+        },
+        "FunctionARN": {
+          "type": "string",
+          "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_]+(\\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?"
+        },
         "ConfigurationId": {},
-        "Runtime": {},
-        "Role": {},
-        "Handler": {},
-        "Mode": {},
+        "Runtime": {
+          "shape": "Sg"
+        },
+        "Role": {
+          "shape": "S4"
+        },
+        "Handler": {
+          "shape": "Sh"
+        },
+        "Mode": {
+          "shape": "Si"
+        },
         "CodeSize": {
           "type": "long"
         },
-        "Description": {},
+        "Description": {
+          "shape": "Sk"
+        },
         "Timeout": {
-          "type": "integer"
+          "shape": "Sl"
         },
         "MemorySize": {
-          "type": "integer"
+          "shape": "Sm"
         },
         "LastModified": {
           "type": "timestamp"
         }
       }
     },
+    "Sg": {
+      "type": "string",
+      "enum": [
+        "nodejs"
+      ]
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "[a-zA-Z0-9./\\-_]+"
+    },
+    "Si": {
+      "type": "string",
+      "enum": [
+        "event"
+      ]
+    },
+    "Sk": {
+      "type": "string",
+      "min": 0,
+      "max": 256
+    },
+    "Sl": {
+      "type": "integer",
+      "min": 1,
+      "max": 60
+    },
+    "Sm": {
+      "type": "integer",
+      "min": 128,
+      "max": 1024
+    },
     "Sq": {
       "type": "blob",
       "streaming": true
+    },
+    "Su": {
+      "type": "integer",
+      "min": 1,
+      "max": 10000
     }
   }
 }

--- a/apis/lambda-2015-03-31.min.json
+++ b/apis/lambda-2015-03-31.min.json
@@ -25,16 +25,39 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "StatementId": {},
-          "Action": {},
-          "Principal": {},
-          "SourceArn": {},
-          "SourceAccount": {},
-          "EventSourceToken": {},
+          "StatementId": {
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "([a-zA-Z0-9-_]+)"
+          },
+          "Action": {
+            "type": "string",
+            "pattern": "(lambda:[*]|lambda:[a-zA-Z]+|[*])"
+          },
+          "Principal": {
+            "type": "string",
+            "pattern": ".*"
+          },
+          "SourceArn": {
+            "shape": "S6"
+          },
+          "SourceAccount": {
+            "type": "string",
+            "pattern": "\\d{12}"
+          },
+          "EventSourceToken": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "[a-zA-Z0-9._\\-]+"
+          },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           },
@@ -62,12 +85,19 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "Name": {},
-          "FunctionVersion": {},
-          "Description": {},
+          "Name": {
+            "shape": "Sd"
+          },
+          "FunctionVersion": {
+            "shape": "Se"
+          },
+          "Description": {
+            "shape": "Sf"
+          },
           "RoutingConfig": {
             "shape": "Sg"
           }
@@ -89,15 +119,26 @@
           "FunctionName"
         ],
         "members": {
-          "EventSourceArn": {},
-          "FunctionName": {},
+          "EventSourceArn": {
+            "shape": "S6"
+          },
+          "FunctionName": {
+            "shape": "S2"
+          },
           "Enabled": {
             "type": "boolean"
           },
           "BatchSize": {
-            "type": "integer"
+            "shape": "So"
           },
-          "StartingPosition": {},
+          "StartingPosition": {
+            "type": "string",
+            "enum": [
+              "TRIM_HORIZON",
+              "LATEST",
+              "AT_TIMESTAMP"
+            ]
+          },
           "StartingPositionTimestamp": {
             "type": "timestamp"
           }
@@ -122,27 +163,43 @@
           "Code"
         ],
         "members": {
-          "FunctionName": {},
-          "Runtime": {},
-          "Role": {},
-          "Handler": {},
+          "FunctionName": {
+            "shape": "S2"
+          },
+          "Runtime": {
+            "shape": "St"
+          },
+          "Role": {
+            "shape": "Su"
+          },
+          "Handler": {
+            "shape": "Sv"
+          },
           "Code": {
             "type": "structure",
             "members": {
               "ZipFile": {
                 "shape": "Sx"
               },
-              "S3Bucket": {},
-              "S3Key": {},
-              "S3ObjectVersion": {}
+              "S3Bucket": {
+                "shape": "Sy"
+              },
+              "S3Key": {
+                "shape": "Sz"
+              },
+              "S3ObjectVersion": {
+                "shape": "S10"
+              }
             }
           },
-          "Description": {},
+          "Description": {
+            "shape": "Sf"
+          },
           "Timeout": {
-            "type": "integer"
+            "shape": "S11"
           },
           "MemorySize": {
-            "type": "integer"
+            "shape": "S12"
           },
           "Publish": {
             "type": "boolean"
@@ -156,7 +213,9 @@
           "Environment": {
             "shape": "S1b"
           },
-          "KMSKeyArn": {},
+          "KMSKeyArn": {
+            "shape": "S1f"
+          },
           "TracingConfig": {
             "shape": "S1g"
           },
@@ -183,10 +242,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           }
@@ -228,10 +289,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -251,6 +314,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -286,7 +350,8 @@
                 "type": "integer"
               },
               "UnreservedConcurrentExecutions": {
-                "type": "integer"
+                "type": "integer",
+                "min": 0
               }
             }
           },
@@ -318,10 +383,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           }
@@ -366,10 +433,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -410,10 +479,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -436,10 +507,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -464,16 +537,28 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "InvocationType": {
             "location": "header",
-            "locationName": "X-Amz-Invocation-Type"
+            "locationName": "X-Amz-Invocation-Type",
+            "type": "string",
+            "enum": [
+              "Event",
+              "RequestResponse",
+              "DryRun"
+            ]
           },
           "LogType": {
             "location": "header",
-            "locationName": "X-Amz-Log-Type"
+            "locationName": "X-Amz-Log-Type",
+            "type": "string",
+            "enum": [
+              "None",
+              "Tail"
+            ]
           },
           "ClientContext": {
             "location": "header",
@@ -483,6 +568,7 @@
             "shape": "Sx"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -508,6 +594,7 @@
             "shape": "Sx"
           },
           "ExecutedVersion": {
+            "shape": "Se",
             "location": "header",
             "locationName": "X-Amz-Executed-Version"
           }
@@ -528,6 +615,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -564,10 +652,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "FunctionVersion": {
+            "shape": "Se",
             "location": "querystring",
             "locationName": "FunctionVersion"
           },
@@ -576,9 +666,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -605,10 +695,12 @@
         "type": "structure",
         "members": {
           "EventSourceArn": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "EventSourceArn"
           },
           "FunctionName": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "FunctionName"
           },
@@ -617,9 +709,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -647,20 +739,26 @@
         "members": {
           "MasterRegion": {
             "location": "querystring",
-            "locationName": "MasterRegion"
+            "locationName": "MasterRegion",
+            "type": "string",
+            "pattern": "ALL|[a-z]{2}(-gov)?-[a-z]+-\\d{1}"
           },
           "FunctionVersion": {
             "location": "querystring",
-            "locationName": "FunctionVersion"
+            "locationName": "FunctionVersion",
+            "type": "string",
+            "enum": [
+              "ALL"
+            ]
           },
           "Marker": {
             "location": "querystring",
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -686,6 +784,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           }
@@ -713,6 +812,7 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -721,9 +821,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
+            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems",
-            "type": "integer"
+            "locationName": "MaxItems"
           }
         }
       },
@@ -749,11 +849,14 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "CodeSha256": {},
-          "Description": {},
+          "Description": {
+            "shape": "Sf"
+          },
           "RevisionId": {}
         }
       },
@@ -775,11 +878,12 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "ReservedConcurrentExecutions": {
-            "type": "integer"
+            "shape": "S2c"
           }
         }
       },
@@ -801,14 +905,20 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "StatementId": {
             "location": "uri",
-            "locationName": "StatementId"
+            "locationName": "StatementId",
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "([a-zA-Z0-9-_.]+)"
           },
           "Qualifier": {
+            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           },
@@ -832,6 +942,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           },
@@ -855,6 +966,7 @@
         ],
         "members": {
           "Resource": {
+            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           },
@@ -881,15 +993,21 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
+            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           },
-          "FunctionVersion": {},
-          "Description": {},
+          "FunctionVersion": {
+            "shape": "Se"
+          },
+          "Description": {
+            "shape": "Sf"
+          },
           "RoutingConfig": {
             "shape": "Sg"
           },
@@ -916,12 +1034,14 @@
             "location": "uri",
             "locationName": "UUID"
           },
-          "FunctionName": {},
+          "FunctionName": {
+            "shape": "S2"
+          },
           "Enabled": {
             "type": "boolean"
           },
           "BatchSize": {
-            "type": "integer"
+            "shape": "So"
           }
         }
       },
@@ -942,15 +1062,22 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "ZipFile": {
             "shape": "Sx"
           },
-          "S3Bucket": {},
-          "S3Key": {},
-          "S3ObjectVersion": {},
+          "S3Bucket": {
+            "shape": "Sy"
+          },
+          "S3Key": {
+            "shape": "Sz"
+          },
+          "S3ObjectVersion": {
+            "shape": "S10"
+          },
           "Publish": {
             "type": "boolean"
           },
@@ -977,17 +1104,24 @@
         ],
         "members": {
           "FunctionName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "Role": {},
-          "Handler": {},
-          "Description": {},
+          "Role": {
+            "shape": "Su"
+          },
+          "Handler": {
+            "shape": "Sv"
+          },
+          "Description": {
+            "shape": "Sf"
+          },
           "Timeout": {
-            "type": "integer"
+            "shape": "S11"
           },
           "MemorySize": {
-            "type": "integer"
+            "shape": "S12"
           },
           "VpcConfig": {
             "shape": "S14"
@@ -995,11 +1129,15 @@
           "Environment": {
             "shape": "S1b"
           },
-          "Runtime": {},
+          "Runtime": {
+            "shape": "St"
+          },
           "DeadLetterConfig": {
             "shape": "S19"
           },
-          "KMSKeyArn": {},
+          "KMSKeyArn": {
+            "shape": "S1f"
+          },
           "TracingConfig": {
             "shape": "S1g"
           },
@@ -1012,14 +1150,54 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 140,
+      "min": 1,
+      "pattern": "(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+    },
+    "S6": {
+      "type": "string",
+      "pattern": "arn:aws:([a-zA-Z0-9\\-])+:([a-z]{2}-[a-z]+-\\d{1})?:(\\d{12})?:(.*)"
+    },
+    "S9": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "(|[a-zA-Z0-9$_-]+)"
+    },
+    "Sd": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "(?!^[0-9]+$)([a-zA-Z0-9-_]+)"
+    },
+    "Se": {
+      "type": "string",
+      "max": 1024,
+      "min": 1,
+      "pattern": "(\\$LATEST|[0-9]+)"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
     "Sg": {
       "type": "structure",
       "members": {
         "AdditionalVersionWeights": {
           "type": "map",
-          "key": {},
+          "key": {
+            "type": "string",
+            "max": 1024,
+            "min": 1,
+            "pattern": "[0-9]+"
+          },
           "value": {
-            "type": "double"
+            "type": "double",
+            "max": 1,
+            "min": 0
           }
         }
       }
@@ -1027,25 +1205,46 @@
     "Sk": {
       "type": "structure",
       "members": {
-        "AliasArn": {},
-        "Name": {},
-        "FunctionVersion": {},
-        "Description": {},
+        "AliasArn": {
+          "shape": "Sl"
+        },
+        "Name": {
+          "shape": "Sd"
+        },
+        "FunctionVersion": {
+          "shape": "Se"
+        },
+        "Description": {
+          "shape": "Sf"
+        },
         "RoutingConfig": {
           "shape": "Sg"
         },
         "RevisionId": {}
       }
     },
+    "Sl": {
+      "type": "string",
+      "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+    },
+    "So": {
+      "type": "integer",
+      "max": 10000,
+      "min": 1
+    },
     "Sr": {
       "type": "structure",
       "members": {
         "UUID": {},
         "BatchSize": {
-          "type": "integer"
+          "shape": "So"
         },
-        "EventSourceArn": {},
-        "FunctionArn": {},
+        "EventSourceArn": {
+          "shape": "S6"
+        },
+        "FunctionArn": {
+          "shape": "Sl"
+        },
         "LastModified": {
           "type": "timestamp"
         },
@@ -1054,9 +1253,60 @@
         "StateTransitionReason": {}
       }
     },
+    "St": {
+      "type": "string",
+      "enum": [
+        "nodejs",
+        "nodejs4.3",
+        "nodejs6.10",
+        "nodejs8.10",
+        "java8",
+        "python2.7",
+        "python3.6",
+        "dotnetcore1.0",
+        "dotnetcore2.0",
+        "dotnetcore2.1",
+        "nodejs4.3-edge",
+        "go1.x"
+      ]
+    },
+    "Su": {
+      "type": "string",
+      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
+    "Sv": {
+      "type": "string",
+      "max": 128,
+      "pattern": "[^\\s]+"
+    },
     "Sx": {
       "type": "blob",
       "sensitive": true
+    },
+    "Sy": {
+      "type": "string",
+      "max": 63,
+      "min": 3,
+      "pattern": "^[0-9A-Za-z\\.\\-_]*(?<!\\.)$"
+    },
+    "Sz": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S11": {
+      "type": "integer",
+      "min": 1
+    },
+    "S12": {
+      "type": "integer",
+      "max": 3008,
+      "min": 128
     },
     "S14": {
       "type": "structure",
@@ -1071,16 +1321,21 @@
     },
     "S15": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 16
     },
     "S17": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 5
     },
     "S19": {
       "type": "structure",
       "members": {
-        "TargetArn": {}
+        "TargetArn": {
+          "type": "string",
+          "pattern": "(arn:aws:[a-z0-9-.]+:.*)|()"
+        }
       }
     },
     "S1b": {
@@ -1095,6 +1350,7 @@
       "type": "map",
       "key": {
         "type": "string",
+        "pattern": "[a-zA-Z]([a-zA-Z0-9_])+",
         "sensitive": true
       },
       "value": {
@@ -1103,11 +1359,24 @@
       },
       "sensitive": true
     },
+    "S1f": {
+      "type": "string",
+      "pattern": "(arn:aws:[a-z0-9-.]+:.*)|()"
+    },
     "S1g": {
       "type": "structure",
       "members": {
-        "Mode": {}
+        "Mode": {
+          "shape": "S1h"
+        }
       }
+    },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "Active",
+        "PassThrough"
+      ]
     },
     "S1i": {
       "type": "map",
@@ -1117,24 +1386,39 @@
     "S1l": {
       "type": "structure",
       "members": {
-        "FunctionName": {},
-        "FunctionArn": {},
-        "Runtime": {},
-        "Role": {},
-        "Handler": {},
+        "FunctionName": {
+          "shape": "S1m"
+        },
+        "FunctionArn": {
+          "type": "string",
+          "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_\\.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
+        },
+        "Runtime": {
+          "shape": "St"
+        },
+        "Role": {
+          "shape": "Su"
+        },
+        "Handler": {
+          "shape": "Sv"
+        },
         "CodeSize": {
           "type": "long"
         },
-        "Description": {},
+        "Description": {
+          "shape": "Sf"
+        },
         "Timeout": {
-          "type": "integer"
+          "shape": "S11"
         },
         "MemorySize": {
-          "type": "integer"
+          "shape": "S12"
         },
         "LastModified": {},
         "CodeSha256": {},
-        "Version": {},
+        "Version": {
+          "shape": "Se"
+        },
         "VpcConfig": {
           "type": "structure",
           "members": {
@@ -1168,24 +1452,45 @@
             }
           }
         },
-        "KMSKeyArn": {},
+        "KMSKeyArn": {
+          "shape": "S1f"
+        },
         "TracingConfig": {
           "type": "structure",
           "members": {
-            "Mode": {}
+            "Mode": {
+              "shape": "S1h"
+            }
           }
         },
-        "MasterArn": {},
+        "MasterArn": {
+          "shape": "Sl"
+        },
         "RevisionId": {}
       }
+    },
+    "S1m": {
+      "type": "string",
+      "max": 170,
+      "min": 1,
+      "pattern": "(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
     },
     "S2b": {
       "type": "structure",
       "members": {
         "ReservedConcurrentExecutions": {
-          "type": "integer"
+          "shape": "S2c"
         }
       }
+    },
+    "S2c": {
+      "type": "integer",
+      "min": 0
+    },
+    "S2p": {
+      "type": "integer",
+      "max": 10000,
+      "min": 1
     },
     "S2z": {
       "type": "list",

--- a/apis/lex-models-2017-04-19.min.json
+++ b/apis/lex-models-2017-04-19.min.json
@@ -24,6 +24,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -33,8 +34,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "intents": {
             "shape": "S6"
           },
@@ -44,7 +49,9 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {},
+          "status": {
+            "shape": "Sj"
+          },
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -53,12 +60,16 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {},
-          "locale": {},
+          "version": {
+            "shape": "S9"
+          },
+          "locale": {
+            "shape": "Sm"
+          },
           "childDirected": {
             "type": "boolean"
           }
@@ -77,6 +88,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
@@ -86,8 +98,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S8"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "slots": {
             "shape": "Sq"
           },
@@ -119,7 +135,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {}
         }
       }
@@ -136,6 +154,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
@@ -145,8 +164,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S17"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "enumerationValues": {
             "shape": "S19"
           },
@@ -156,9 +179,13 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {},
-          "valueSelectionStrategy": {}
+          "valueSelectionStrategy": {
+            "shape": "S1d"
+          }
         }
       }
     },
@@ -175,6 +202,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           }
@@ -195,10 +223,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           }
@@ -220,14 +250,17 @@
         ],
         "members": {
           "name": {
+            "shape": "S1i",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
+            "shape": "S1g",
             "location": "uri",
             "locationName": "aliasName"
           }
@@ -248,10 +281,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
+            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -271,6 +306,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           }
@@ -291,10 +327,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
+            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -314,6 +352,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           }
@@ -334,10 +373,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
+            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -358,12 +399,16 @@
         ],
         "members": {
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "userId": {
             "location": "uri",
-            "locationName": "userId"
+            "locationName": "userId",
+            "type": "string",
+            "max": 100,
+            "min": 2
           }
         }
       }
@@ -382,6 +427,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -394,8 +440,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "intents": {
             "shape": "S6"
           },
@@ -405,7 +455,9 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {},
+          "status": {
+            "shape": "Sj"
+          },
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -414,12 +466,16 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {},
-          "locale": {},
+          "version": {
+            "shape": "S9"
+          },
+          "locale": {
+            "shape": "Sm"
+          },
           "childDirected": {
             "type": "boolean"
           }
@@ -440,10 +496,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           }
@@ -452,10 +510,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
-          "botVersion": {},
-          "botName": {},
+          "name": {
+            "shape": "S1g"
+          },
+          "description": {
+            "shape": "S5"
+          },
+          "botVersion": {
+            "shape": "S9"
+          },
+          "botName": {
+            "shape": "S2"
+          },
           "lastUpdatedDate": {
             "type": "timestamp"
           },
@@ -479,6 +545,7 @@
         ],
         "members": {
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
@@ -487,11 +554,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nameContains": {
+            "shape": "S1g",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -505,10 +573,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {},
-                "description": {},
-                "botVersion": {},
-                "botName": {},
+                "name": {
+                  "shape": "S1g"
+                },
+                "description": {
+                  "shape": "S5"
+                },
+                "botVersion": {
+                  "shape": "S9"
+                },
+                "botName": {
+                  "shape": "S2"
+                },
                 "lastUpdatedDate": {
                   "type": "timestamp"
                 },
@@ -538,14 +614,17 @@
         ],
         "members": {
           "name": {
+            "shape": "S1i",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
+            "shape": "S1g",
             "location": "uri",
             "locationName": "aliasName"
           }
@@ -554,18 +633,30 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
-          "botAlias": {},
-          "botName": {},
+          "name": {
+            "shape": "S1i"
+          },
+          "description": {
+            "shape": "S5"
+          },
+          "botAlias": {
+            "shape": "S1g"
+          },
+          "botName": {
+            "shape": "S2"
+          },
           "createdDate": {
             "type": "timestamp"
           },
-          "type": {},
+          "type": {
+            "shape": "S23"
+          },
           "botConfiguration": {
             "shape": "S24"
           },
-          "status": {},
+          "status": {
+            "shape": "S25"
+          },
           "failureReason": {}
         }
       }
@@ -584,23 +675,29 @@
         ],
         "members": {
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
             "location": "uri",
-            "locationName": "aliasName"
+            "locationName": "aliasName",
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "^(-|^([A-Za-z]_?)+$)$"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nameContains": {
+            "shape": "S1i",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -614,18 +711,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {},
-                "description": {},
-                "botAlias": {},
-                "botName": {},
+                "name": {
+                  "shape": "S1i"
+                },
+                "description": {
+                  "shape": "S5"
+                },
+                "botAlias": {
+                  "shape": "S1g"
+                },
+                "botName": {
+                  "shape": "S2"
+                },
                 "createdDate": {
                   "type": "timestamp"
                 },
-                "type": {},
+                "type": {
+                  "shape": "S23"
+                },
                 "botConfiguration": {
                   "shape": "S24"
                 },
-                "status": {},
+                "status": {
+                  "shape": "S25"
+                },
                 "failureReason": {}
               }
             }
@@ -647,6 +756,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -655,9 +765,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -685,11 +795,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nameContains": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -752,6 +863,7 @@
         "type": "structure",
         "members": {
           "locale": {
+            "shape": "Sm",
             "location": "querystring",
             "locationName": "locale"
           },
@@ -764,9 +876,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -799,6 +911,7 @@
         "type": "structure",
         "members": {
           "locale": {
+            "shape": "Sm",
             "location": "querystring",
             "locationName": "locale"
           },
@@ -811,9 +924,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -852,18 +965,22 @@
         ],
         "members": {
           "name": {
+            "shape": "S2w",
             "location": "querystring",
             "locationName": "name"
           },
           "version": {
+            "shape": "S1k",
             "location": "querystring",
             "locationName": "version"
           },
           "resourceType": {
+            "shape": "S2x",
             "location": "querystring",
             "locationName": "resourceType"
           },
           "exportType": {
+            "shape": "S2y",
             "location": "querystring",
             "locationName": "exportType"
           }
@@ -872,11 +989,26 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "version": {},
-          "resourceType": {},
-          "exportType": {},
-          "exportStatus": {},
+          "name": {
+            "shape": "S2w"
+          },
+          "version": {
+            "shape": "S1k"
+          },
+          "resourceType": {
+            "shape": "S2x"
+          },
+          "exportType": {
+            "shape": "S2y"
+          },
+          "exportStatus": {
+            "type": "string",
+            "enum": [
+              "IN_PROGRESS",
+              "READY",
+              "FAILED"
+            ]
+          },
           "failureReason": {},
           "url": {}
         }
@@ -903,11 +1035,19 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "resourceType": {},
-          "mergeStrategy": {},
+          "name": {
+            "shape": "S2w"
+          },
+          "resourceType": {
+            "shape": "S2x"
+          },
+          "mergeStrategy": {
+            "shape": "S33"
+          },
           "importId": {},
-          "importStatus": {},
+          "importStatus": {
+            "shape": "S34"
+          },
           "failureReason": {
             "type": "list",
             "member": {}
@@ -932,10 +1072,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
+            "shape": "S9",
             "location": "uri",
             "locationName": "version"
           }
@@ -944,8 +1086,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S8"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "slots": {
             "shape": "Sq"
           },
@@ -977,7 +1123,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {}
         }
       }
@@ -995,6 +1143,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
@@ -1003,9 +1152,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -1033,11 +1182,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nameContains": {
+            "shape": "S8",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -1067,10 +1217,12 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
+            "shape": "S9",
             "location": "uri",
             "locationName": "version"
           }
@@ -1079,8 +1231,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S17"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "enumerationValues": {
             "shape": "S19"
           },
@@ -1090,9 +1246,13 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {},
-          "valueSelectionStrategy": {}
+          "valueSelectionStrategy": {
+            "shape": "S1d"
+          }
         }
       }
     },
@@ -1109,6 +1269,7 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
@@ -1117,9 +1278,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           }
         }
       },
@@ -1147,11 +1308,12 @@
             "locationName": "nextToken"
           },
           "maxResults": {
+            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nameContains": {
+            "shape": "S17",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -1182,6 +1344,7 @@
         ],
         "members": {
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botname"
           },
@@ -1189,30 +1352,47 @@
             "location": "querystring",
             "locationName": "bot_versions",
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S9"
+            },
+            "max": 5,
+            "min": 1
           },
           "statusType": {
             "location": "querystring",
-            "locationName": "status_type"
+            "locationName": "status_type",
+            "type": "string",
+            "enum": [
+              "Detected",
+              "Missed"
+            ]
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "botName": {},
+          "botName": {
+            "shape": "S2"
+          },
           "utterances": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "botVersion": {},
+                "botVersion": {
+                  "shape": "S9"
+                },
                 "utterances": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "utteranceString": {},
+                      "utteranceString": {
+                        "type": "string",
+                        "max": 2000,
+                        "min": 1
+                      },
                       "count": {
                         "type": "integer"
                       },
@@ -1249,10 +1429,13 @@
         ],
         "members": {
           "name": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {},
+          "description": {
+            "shape": "S5"
+          },
           "intents": {
             "shape": "S6"
           },
@@ -1263,12 +1446,20 @@
             "shape": "Si"
           },
           "idleSessionTTLInSeconds": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "voiceId": {},
           "checksum": {},
-          "processBehavior": {},
-          "locale": {},
+          "processBehavior": {
+            "type": "string",
+            "enum": [
+              "SAVE",
+              "BUILD"
+            ]
+          },
+          "locale": {
+            "shape": "Sm"
+          },
           "childDirected": {
             "type": "boolean"
           },
@@ -1280,8 +1471,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "intents": {
             "shape": "S6"
           },
@@ -1291,7 +1486,9 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {},
+          "status": {
+            "shape": "Sj"
+          },
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -1300,12 +1497,16 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "type": "integer"
+            "shape": "Sl"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {},
-          "locale": {},
+          "version": {
+            "shape": "S9"
+          },
+          "locale": {
+            "shape": "Sm"
+          },
           "childDirected": {
             "type": "boolean"
           },
@@ -1330,12 +1531,18 @@
         ],
         "members": {
           "name": {
+            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {},
-          "botVersion": {},
+          "description": {
+            "shape": "S5"
+          },
+          "botVersion": {
+            "shape": "S9"
+          },
           "botName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
@@ -1345,10 +1552,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
-          "botVersion": {},
-          "botName": {},
+          "name": {
+            "shape": "S1g"
+          },
+          "description": {
+            "shape": "S5"
+          },
+          "botVersion": {
+            "shape": "S9"
+          },
+          "botName": {
+            "shape": "S2"
+          },
           "lastUpdatedDate": {
             "type": "timestamp"
           },
@@ -1372,10 +1587,13 @@
         ],
         "members": {
           "name": {
+            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {},
+          "description": {
+            "shape": "S5"
+          },
           "slots": {
             "shape": "Sq"
           },
@@ -1410,8 +1628,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S8"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "slots": {
             "shape": "Sq"
           },
@@ -1443,7 +1665,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {},
           "createVersion": {
             "type": "boolean"
@@ -1464,15 +1688,20 @@
         ],
         "members": {
           "name": {
+            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {},
+          "description": {
+            "shape": "S5"
+          },
           "enumerationValues": {
             "shape": "S19"
           },
           "checksum": {},
-          "valueSelectionStrategy": {},
+          "valueSelectionStrategy": {
+            "shape": "S1d"
+          },
           "createVersion": {
             "type": "boolean"
           }
@@ -1481,8 +1710,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S17"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "enumerationValues": {
             "shape": "S19"
           },
@@ -1492,9 +1725,13 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {},
+          "version": {
+            "shape": "S9"
+          },
           "checksum": {},
-          "valueSelectionStrategy": {},
+          "valueSelectionStrategy": {
+            "shape": "S1d"
+          },
           "createVersion": {
             "type": "boolean"
           }
@@ -1517,18 +1754,30 @@
           "payload": {
             "type": "blob"
           },
-          "resourceType": {},
-          "mergeStrategy": {}
+          "resourceType": {
+            "shape": "S2x"
+          },
+          "mergeStrategy": {
+            "shape": "S33"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "name": {},
-          "resourceType": {},
-          "mergeStrategy": {},
+          "name": {
+            "shape": "S2w"
+          },
+          "resourceType": {
+            "shape": "S2x"
+          },
+          "mergeStrategy": {
+            "shape": "S33"
+          },
           "importId": {},
-          "importStatus": {},
+          "importStatus": {
+            "shape": "S34"
+          },
           "createdDate": {
             "type": "timestamp"
           }
@@ -1537,6 +1786,17 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 50,
+      "min": 2,
+      "pattern": "^([A-Za-z]_?)+$"
+    },
+    "S5": {
+      "type": "string",
+      "max": 200,
+      "min": 0
+    },
     "S6": {
       "type": "list",
       "member": {
@@ -1546,10 +1806,26 @@
           "intentVersion"
         ],
         "members": {
-          "intentName": {},
-          "intentVersion": {}
+          "intentName": {
+            "shape": "S8"
+          },
+          "intentVersion": {
+            "shape": "S9"
+          }
         }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^([A-Za-z]_?)+$"
+    },
+    "S9": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "\\$LATEST|[0-9]+"
     },
     "Sa": {
       "type": "structure",
@@ -1562,9 +1838,13 @@
           "shape": "Sb"
         },
         "maxAttempts": {
-          "type": "integer"
+          "type": "integer",
+          "max": 5,
+          "min": 1
         },
-        "responseCard": {}
+        "responseCard": {
+          "shape": "Sh"
+        }
       }
     },
     "Sb": {
@@ -1576,13 +1856,33 @@
           "content"
         ],
         "members": {
-          "contentType": {},
-          "content": {},
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "PlainText",
+              "SSML",
+              "CustomPayload"
+            ]
+          },
+          "content": {
+            "type": "string",
+            "max": 1000,
+            "min": 1
+          },
           "groupNumber": {
-            "type": "integer"
+            "type": "integer",
+            "max": 5,
+            "min": 1
           }
         }
-      }
+      },
+      "max": 15,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 50000,
+      "min": 1
     },
     "Si": {
       "type": "structure",
@@ -1593,8 +1893,33 @@
         "messages": {
           "shape": "Sb"
         },
-        "responseCard": {}
+        "responseCard": {
+          "shape": "Sh"
+        }
       }
+    },
+    "Sj": {
+      "type": "string",
+      "enum": [
+        "BUILDING",
+        "READY",
+        "READY_BASIC_TESTING",
+        "FAILED",
+        "NOT_BUILT"
+      ]
+    },
+    "Sl": {
+      "type": "integer",
+      "max": 86400,
+      "min": 60
+    },
+    "Sm": {
+      "type": "string",
+      "enum": [
+        "en-US",
+        "en-GB",
+        "de-DE"
+      ]
     },
     "Sq": {
       "type": "list",
@@ -1605,28 +1930,67 @@
           "slotConstraint"
         ],
         "members": {
-          "name": {},
-          "description": {},
-          "slotConstraint": {},
-          "slotType": {},
-          "slotTypeVersion": {},
+          "name": {
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "^([A-Za-z](-|_|.)?)+$"
+          },
+          "description": {
+            "shape": "S5"
+          },
+          "slotConstraint": {
+            "type": "string",
+            "enum": [
+              "Required",
+              "Optional"
+            ]
+          },
+          "slotType": {
+            "type": "string",
+            "max": 100,
+            "min": 1,
+            "pattern": "^((AMAZON\\.)_?|[A-Za-z]_?)+"
+          },
+          "slotTypeVersion": {
+            "shape": "S9"
+          },
           "valueElicitationPrompt": {
             "shape": "Sa"
           },
           "priority": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 0
           },
           "sampleUtterances": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sx"
+            },
+            "max": 10,
+            "min": 0
           },
-          "responseCard": {}
+          "responseCard": {
+            "shape": "Sh"
+          }
         }
-      }
+      },
+      "max": 100,
+      "min": 0
+    },
+    "Sx": {
+      "type": "string",
+      "max": 200,
+      "min": 1
     },
     "Sy": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sx"
+      },
+      "max": 1500,
+      "min": 0
     },
     "Sz": {
       "type": "structure",
@@ -1650,8 +2014,17 @@
         "messageVersion"
       ],
       "members": {
-        "uri": {},
-        "messageVersion": {}
+        "uri": {
+          "type": "string",
+          "max": 2048,
+          "min": 20,
+          "pattern": "arn:aws:lambda:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:function:[a-zA-Z0-9-_]+(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?(:[a-zA-Z0-9-_]+)?"
+        },
+        "messageVersion": {
+          "type": "string",
+          "max": 5,
+          "min": 1
+        }
       }
     },
     "S13": {
@@ -1660,11 +2033,23 @@
         "type"
       ],
       "members": {
-        "type": {},
+        "type": {
+          "type": "string",
+          "enum": [
+            "ReturnIntent",
+            "CodeHook"
+          ]
+        },
         "codeHook": {
           "shape": "S10"
         }
       }
+    },
+    "S17": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^([A-Za-z]_?)+$"
     },
     "S19": {
       "type": "list",
@@ -1674,56 +2059,168 @@
           "value"
         ],
         "members": {
-          "value": {},
+          "value": {
+            "shape": "S1b"
+          },
           "synonyms": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1b"
+            }
           }
         }
-      }
+      },
+      "max": 10000,
+      "min": 1
+    },
+    "S1b": {
+      "type": "string",
+      "max": 140,
+      "min": 1
+    },
+    "S1d": {
+      "type": "string",
+      "enum": [
+        "ORIGINAL_VALUE",
+        "TOP_RESOLUTION"
+      ]
+    },
+    "S1g": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^([A-Za-z]_?)+$"
+    },
+    "S1i": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^([A-Za-z]_?)+$"
+    },
+    "S1k": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[0-9]+"
+    },
+    "S1x": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
+    },
+    "S23": {
+      "type": "string",
+      "enum": [
+        "Facebook",
+        "Slack",
+        "Twilio-Sms",
+        "Kik"
+      ]
     },
     "S24": {
       "type": "map",
       "key": {},
       "value": {},
+      "max": 10,
+      "min": 1,
       "sensitive": true
+    },
+    "S25": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "CREATED",
+        "FAILED"
+      ]
     },
     "S2d": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
-          "status": {},
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "S5"
+          },
+          "status": {
+            "shape": "Sj"
+          },
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {}
+          "version": {
+            "shape": "S9"
+          }
         }
       }
     },
     "S2j": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sm"
+      }
+    },
+    "S2w": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[a-zA-Z_]+"
+    },
+    "S2x": {
+      "type": "string",
+      "enum": [
+        "BOT",
+        "INTENT",
+        "SLOT_TYPE"
+      ]
+    },
+    "S2y": {
+      "type": "string",
+      "enum": [
+        "ALEXA_SKILLS_KIT",
+        "LEX"
+      ]
+    },
+    "S33": {
+      "type": "string",
+      "enum": [
+        "OVERWRITE_LATEST",
+        "FAIL_ON_CONFLICT"
+      ]
+    },
+    "S34": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "COMPLETE",
+        "FAILED"
+      ]
     },
     "S3a": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S8"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {}
+          "version": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -1732,15 +2229,21 @@
       "member": {
         "type": "structure",
         "members": {
-          "name": {},
-          "description": {},
+          "name": {
+            "shape": "S17"
+          },
+          "description": {
+            "shape": "S5"
+          },
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {}
+          "version": {
+            "shape": "S9"
+          }
         }
       }
     }

--- a/apis/lightsail-2016-11-28.min.json
+++ b/apis/lightsail-2016-11-28.min.json
@@ -19,7 +19,9 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {}
+          "staticIpName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -40,9 +42,15 @@
           "diskPath"
         ],
         "members": {
-          "diskName": {},
-          "instanceName": {},
-          "diskPath": {}
+          "diskName": {
+            "shape": "S2"
+          },
+          "instanceName": {
+            "shape": "S2"
+          },
+          "diskPath": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -62,7 +70,9 @@
           "instanceNames"
         ],
         "members": {
-          "loadBalancerName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
           "instanceNames": {
             "shape": "Si"
           }
@@ -85,8 +95,12 @@
           "certificateName"
         ],
         "members": {
-          "loadBalancerName": {},
-          "certificateName": {}
+          "loadBalancerName": {
+            "shape": "S2"
+          },
+          "certificateName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -106,8 +120,12 @@
           "instanceName"
         ],
         "members": {
-          "staticIpName": {},
-          "instanceName": {}
+          "staticIpName": {
+            "shape": "S2"
+          },
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -130,7 +148,9 @@
           "portInfo": {
             "shape": "Sp"
           },
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -151,8 +171,12 @@
           "sizeInGb"
         ],
         "members": {
-          "diskName": {},
-          "availabilityZone": {},
+          "diskName": {
+            "shape": "S2"
+          },
+          "availabilityZone": {
+            "shape": "S6"
+          },
           "sizeInGb": {
             "type": "integer"
           }
@@ -177,9 +201,15 @@
           "sizeInGb"
         ],
         "members": {
-          "diskName": {},
-          "diskSnapshotName": {},
-          "availabilityZone": {},
+          "diskName": {
+            "shape": "S2"
+          },
+          "diskSnapshotName": {
+            "shape": "S2"
+          },
+          "availabilityZone": {
+            "shape": "S6"
+          },
           "sizeInGb": {
             "type": "integer"
           }
@@ -202,8 +232,12 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskName": {},
-          "diskSnapshotName": {}
+          "diskName": {
+            "shape": "S2"
+          },
+          "diskSnapshotName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -265,8 +299,12 @@
           "instanceName"
         ],
         "members": {
-          "instanceSnapshotName": {},
-          "instanceName": {}
+          "instanceSnapshotName": {
+            "shape": "S2"
+          },
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -293,12 +331,19 @@
           },
           "availabilityZone": {},
           "customImageName": {
+            "shape": "S2",
             "deprecated": true
           },
-          "blueprintId": {},
-          "bundleId": {},
+          "blueprintId": {
+            "shape": "S6"
+          },
+          "bundleId": {
+            "shape": "S6"
+          },
           "userData": {},
-          "keyPairName": {}
+          "keyPairName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -325,23 +370,35 @@
           },
           "attachedDiskMapping": {
             "type": "map",
-            "key": {},
+            "key": {
+              "shape": "S2"
+            },
             "value": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "originalDiskPath": {},
-                  "newDiskName": {}
+                  "originalDiskPath": {
+                    "shape": "S6"
+                  },
+                  "newDiskName": {
+                    "shape": "S2"
+                  }
                 }
               }
             }
           },
           "availabilityZone": {},
-          "instanceSnapshotName": {},
-          "bundleId": {},
+          "instanceSnapshotName": {
+            "shape": "S2"
+          },
+          "bundleId": {
+            "shape": "S6"
+          },
           "userData": {},
-          "keyPairName": {}
+          "keyPairName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -360,7 +417,9 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {}
+          "keyPairName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -385,12 +444,16 @@
           "instancePort"
         ],
         "members": {
-          "loadBalancerName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
           "instancePort": {
-            "type": "integer"
+            "shape": "Sq"
           },
           "healthCheckPath": {},
-          "certificateName": {},
+          "certificateName": {
+            "shape": "S2"
+          },
           "certificateDomainName": {},
           "certificateAlternativeNames": {
             "shape": "S1o"
@@ -415,8 +478,12 @@
           "certificateDomainName"
         ],
         "members": {
-          "loadBalancerName": {},
-          "certificateName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
+          "certificateName": {
+            "shape": "S2"
+          },
           "certificateDomainName": {},
           "certificateAlternativeNames": {
             "shape": "S1o"
@@ -439,7 +506,9 @@
           "diskName"
         ],
         "members": {
-          "diskName": {}
+          "diskName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -458,7 +527,9 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskSnapshotName": {}
+          "diskSnapshotName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -519,7 +590,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -538,7 +611,9 @@
           "instanceSnapshotName"
         ],
         "members": {
-          "instanceSnapshotName": {}
+          "instanceSnapshotName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -557,7 +632,9 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {}
+          "keyPairName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -576,7 +653,9 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {}
+          "loadBalancerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -596,8 +675,12 @@
           "certificateName"
         ],
         "members": {
-          "loadBalancerName": {},
-          "certificateName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
+          "certificateName": {
+            "shape": "S2"
+          },
           "force": {
             "type": "boolean"
           }
@@ -619,7 +702,9 @@
           "diskName"
         ],
         "members": {
-          "diskName": {}
+          "diskName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -639,7 +724,9 @@
           "instanceNames"
         ],
         "members": {
-          "loadBalancerName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
           "instanceNames": {
             "shape": "Si"
           }
@@ -661,7 +748,9 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {}
+          "staticIpName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -721,10 +810,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "blueprintId": {},
-                "name": {},
-                "group": {},
-                "type": {},
+                "blueprintId": {
+                  "shape": "S6"
+                },
+                "name": {
+                  "shape": "S2"
+                },
+                "group": {
+                  "shape": "S6"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "os",
+                    "app"
+                  ]
+                },
                 "description": {},
                 "isActive": {
                   "type": "boolean"
@@ -736,7 +837,9 @@
                 "versionCode": {},
                 "productUrl": {},
                 "licenseUrl": {},
-                "platform": {}
+                "platform": {
+                  "shape": "S2p"
+                }
               }
             }
           },
@@ -771,7 +874,9 @@
                 "diskSizeInGb": {
                   "type": "integer"
                 },
-                "bundleId": {},
+                "bundleId": {
+                  "shape": "S6"
+                },
                 "instanceType": {},
                 "isActive": {
                   "type": "boolean"
@@ -788,7 +893,9 @@
                 },
                 "supportedPlatforms": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S2p"
+                  }
                 }
               }
             }
@@ -804,7 +911,9 @@
           "diskName"
         ],
         "members": {
-          "diskName": {}
+          "diskName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -823,7 +932,9 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskSnapshotName": {}
+          "diskSnapshotName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -918,7 +1029,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -937,8 +1050,12 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {},
-          "protocol": {}
+          "instanceName": {
+            "shape": "S2"
+          },
+          "protocol": {
+            "shape": "S3v"
+          }
         }
       },
       "output": {
@@ -951,18 +1068,26 @@
               "expiresAt": {
                 "type": "timestamp"
               },
-              "ipAddress": {},
+              "ipAddress": {
+                "shape": "S3k"
+              },
               "password": {},
               "passwordData": {
                 "type": "structure",
                 "members": {
                   "ciphertext": {},
-                  "keyPairName": {}
+                  "keyPairName": {
+                    "shape": "S2"
+                  }
                 }
               },
               "privateKey": {},
-              "protocol": {},
-              "instanceName": {},
+              "protocol": {
+                "shape": "S3v"
+              },
+              "instanceName": {
+                "shape": "S2"
+              },
               "username": {}
             }
           }
@@ -982,10 +1107,14 @@
           "statistics"
         ],
         "members": {
-          "instanceName": {},
-          "metricName": {},
+          "instanceName": {
+            "shape": "S2"
+          },
+          "metricName": {
+            "shape": "S40"
+          },
           "period": {
-            "type": "integer"
+            "shape": "S41"
           },
           "startTime": {
             "type": "timestamp"
@@ -993,7 +1122,9 @@
           "endTime": {
             "type": "timestamp"
           },
-          "unit": {},
+          "unit": {
+            "shape": "S43"
+          },
           "statistics": {
             "shape": "S44"
           }
@@ -1002,7 +1133,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "metricName": {},
+          "metricName": {
+            "shape": "S40"
+          },
           "metricData": {
             "shape": "S47"
           }
@@ -1016,7 +1149,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1028,13 +1163,21 @@
               "type": "structure",
               "members": {
                 "fromPort": {
-                  "type": "integer"
+                  "shape": "Sq"
                 },
                 "toPort": {
-                  "type": "integer"
+                  "shape": "Sq"
                 },
-                "protocol": {},
-                "state": {}
+                "protocol": {
+                  "shape": "Sr"
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "open",
+                    "closed"
+                  ]
+                }
               }
             }
           }
@@ -1048,7 +1191,9 @@
           "instanceSnapshotName"
         ],
         "members": {
-          "instanceSnapshotName": {}
+          "instanceSnapshotName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1087,7 +1232,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1126,7 +1273,9 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {}
+          "keyPairName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1165,7 +1314,9 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {}
+          "loadBalancerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1190,10 +1341,14 @@
           "statistics"
         ],
         "members": {
-          "loadBalancerName": {},
-          "metricName": {},
+          "loadBalancerName": {
+            "shape": "S2"
+          },
+          "metricName": {
+            "shape": "S5b"
+          },
           "period": {
-            "type": "integer"
+            "shape": "S41"
           },
           "startTime": {
             "type": "timestamp"
@@ -1201,7 +1356,9 @@
           "endTime": {
             "type": "timestamp"
           },
-          "unit": {},
+          "unit": {
+            "shape": "S43"
+          },
           "statistics": {
             "shape": "S44"
           }
@@ -1210,7 +1367,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "metricName": {},
+          "metricName": {
+            "shape": "S5b"
+          },
           "metricData": {
             "shape": "S47"
           }
@@ -1224,7 +1383,9 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {}
+          "loadBalancerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1235,8 +1396,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {},
-                "arn": {},
+                "name": {
+                  "shape": "S2"
+                },
+                "arn": {
+                  "shape": "S6"
+                },
                 "supportCode": {},
                 "createdAt": {
                   "type": "timestamp"
@@ -1244,32 +1409,69 @@
                 "location": {
                   "shape": "S9"
                 },
-                "resourceType": {},
-                "loadBalancerName": {},
+                "resourceType": {
+                  "shape": "S7"
+                },
+                "loadBalancerName": {
+                  "shape": "S2"
+                },
                 "isAttached": {
                   "type": "boolean"
                 },
-                "status": {},
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "PENDING_VALIDATION",
+                    "ISSUED",
+                    "INACTIVE",
+                    "EXPIRED",
+                    "VALIDATION_TIMED_OUT",
+                    "REVOKED",
+                    "FAILED",
+                    "UNKNOWN"
+                  ]
+                },
                 "domainName": {},
                 "domainValidationRecords": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "name": {},
-                      "type": {},
-                      "value": {},
-                      "validationStatus": {},
+                      "name": {
+                        "shape": "S6"
+                      },
+                      "type": {
+                        "shape": "S6"
+                      },
+                      "value": {
+                        "shape": "S6"
+                      },
+                      "validationStatus": {
+                        "shape": "S5k"
+                      },
                       "domainName": {}
                     }
                   }
                 },
-                "failureReason": {},
+                "failureReason": {
+                  "type": "string",
+                  "enum": [
+                    "NO_AVAILABLE_CONTACTS",
+                    "ADDITIONAL_VERIFICATION_REQUIRED",
+                    "DOMAIN_NOT_ALLOWED",
+                    "INVALID_PUBLIC_DOMAIN",
+                    "OTHER"
+                  ]
+                },
                 "issuedAt": {
                   "type": "timestamp"
                 },
-                "issuer": {},
-                "keyAlgorithm": {},
+                "issuer": {
+                  "shape": "S6"
+                },
+                "keyAlgorithm": {
+                  "shape": "S6"
+                },
                 "notAfter": {
                   "type": "timestamp"
                 },
@@ -1279,26 +1481,56 @@
                 "renewalSummary": {
                   "type": "structure",
                   "members": {
-                    "renewalStatus": {},
+                    "renewalStatus": {
+                      "type": "string",
+                      "enum": [
+                        "PENDING_AUTO_RENEWAL",
+                        "PENDING_VALIDATION",
+                        "SUCCESS",
+                        "FAILED"
+                      ]
+                    },
                     "domainValidationOptions": {
                       "type": "list",
                       "member": {
                         "type": "structure",
                         "members": {
                           "domainName": {},
-                          "validationStatus": {}
+                          "validationStatus": {
+                            "shape": "S5k"
+                          }
                         }
                       }
                     }
                   }
                 },
-                "revocationReason": {},
+                "revocationReason": {
+                  "type": "string",
+                  "enum": [
+                    "UNSPECIFIED",
+                    "KEY_COMPROMISE",
+                    "CA_COMPROMISE",
+                    "AFFILIATION_CHANGED",
+                    "SUPERCEDED",
+                    "CESSATION_OF_OPERATION",
+                    "CERTIFICATE_HOLD",
+                    "REMOVE_FROM_CRL",
+                    "PRIVILEGE_WITHDRAWN",
+                    "A_A_COMPROMISE"
+                  ]
+                },
                 "revokedAt": {
                   "type": "timestamp"
                 },
-                "serial": {},
-                "signatureAlgorithm": {},
-                "subject": {},
+                "serial": {
+                  "shape": "S6"
+                },
+                "signatureAlgorithm": {
+                  "shape": "S6"
+                },
+                "subject": {
+                  "shape": "S6"
+                },
                 "subjectAlternativeNames": {
                   "shape": "S1c"
                 }
@@ -1335,7 +1567,9 @@
           "operationId"
         ],
         "members": {
-          "operationId": {}
+          "operationId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -1371,7 +1605,9 @@
           "resourceName"
         ],
         "members": {
-          "resourceName": {},
+          "resourceName": {
+            "shape": "S2"
+          },
           "pageToken": {}
         }
       },
@@ -1408,14 +1644,20 @@
                 "continentCode": {},
                 "description": {},
                 "displayName": {},
-                "name": {},
+                "name": {
+                  "shape": "Sb"
+                },
                 "availabilityZones": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "zoneName": {},
-                      "state": {}
+                      "zoneName": {
+                        "shape": "S6"
+                      },
+                      "state": {
+                        "shape": "S6"
+                      }
                     }
                   }
                 }
@@ -1432,7 +1674,9 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {}
+          "staticIpName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1472,7 +1716,9 @@
           "publicKeyBase64"
         ],
         "members": {
-          "keyPairName": {},
+          "keyPairName": {
+            "shape": "S2"
+          },
           "publicKeyBase64": {}
         }
       },
@@ -1510,7 +1756,9 @@
           "portInfo": {
             "shape": "Sp"
           },
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1550,7 +1798,9 @@
               "shape": "Sp"
             }
           },
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1569,7 +1819,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1588,7 +1840,9 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {}
+          "staticIpName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1607,7 +1861,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {}
+          "instanceName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1626,7 +1882,9 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {},
+          "instanceName": {
+            "shape": "S2"
+          },
           "force": {
             "type": "boolean"
           }
@@ -1687,9 +1945,17 @@
           "attributeValue"
         ],
         "members": {
-          "loadBalancerName": {},
-          "attributeName": {},
-          "attributeValue": {}
+          "loadBalancerName": {
+            "shape": "S2"
+          },
+          "attributeName": {
+            "shape": "S59"
+          },
+          "attributeValue": {
+            "type": "string",
+            "max": 256,
+            "min": 1
+          }
         }
       },
       "output": {
@@ -1703,6 +1969,10 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "\\w[\\w\\-]*\\w"
+    },
     "S4": {
       "type": "list",
       "member": {
@@ -1712,9 +1982,15 @@
     "S5": {
       "type": "structure",
       "members": {
-        "id": {},
-        "resourceName": {},
-        "resourceType": {},
+        "id": {
+          "shape": "S6"
+        },
+        "resourceName": {
+          "shape": "S2"
+        },
+        "resourceType": {
+          "shape": "S7"
+        },
         "createdAt": {
           "type": "timestamp"
         },
@@ -1725,8 +2001,55 @@
           "type": "boolean"
         },
         "operationDetails": {},
-        "operationType": {},
-        "status": {},
+        "operationType": {
+          "type": "string",
+          "enum": [
+            "DeleteInstance",
+            "CreateInstance",
+            "StopInstance",
+            "StartInstance",
+            "RebootInstance",
+            "OpenInstancePublicPorts",
+            "PutInstancePublicPorts",
+            "CloseInstancePublicPorts",
+            "AllocateStaticIp",
+            "ReleaseStaticIp",
+            "AttachStaticIp",
+            "DetachStaticIp",
+            "UpdateDomainEntry",
+            "DeleteDomainEntry",
+            "CreateDomain",
+            "DeleteDomain",
+            "CreateInstanceSnapshot",
+            "DeleteInstanceSnapshot",
+            "CreateInstancesFromSnapshot",
+            "CreateLoadBalancer",
+            "DeleteLoadBalancer",
+            "AttachInstancesToLoadBalancer",
+            "DetachInstancesFromLoadBalancer",
+            "UpdateLoadBalancerAttribute",
+            "CreateLoadBalancerTlsCertificate",
+            "DeleteLoadBalancerTlsCertificate",
+            "AttachLoadBalancerTlsCertificate",
+            "CreateDisk",
+            "DeleteDisk",
+            "AttachDisk",
+            "DetachDisk",
+            "CreateDiskSnapshot",
+            "DeleteDiskSnapshot",
+            "CreateDiskFromSnapshot"
+          ]
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NotStarted",
+            "Started",
+            "Failed",
+            "Completed",
+            "Succeeded"
+          ]
+        },
         "statusChangedAt": {
           "type": "timestamp"
         },
@@ -1734,33 +2057,90 @@
         "errorDetails": {}
       }
     },
+    "S6": {
+      "type": "string",
+      "pattern": ".*\\S.*"
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "Instance",
+        "StaticIp",
+        "KeyPair",
+        "InstanceSnapshot",
+        "Domain",
+        "PeeredVpc",
+        "LoadBalancer",
+        "LoadBalancerTlsCertificate",
+        "Disk",
+        "DiskSnapshot"
+      ]
+    },
     "S9": {
       "type": "structure",
       "members": {
         "availabilityZone": {},
-        "regionName": {}
+        "regionName": {
+          "shape": "Sb"
+        }
       }
+    },
+    "Sb": {
+      "type": "string",
+      "enum": [
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "ap-northeast-2"
+      ]
     },
     "Si": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2"
+      }
     },
     "Sp": {
       "type": "structure",
       "members": {
         "fromPort": {
-          "type": "integer"
+          "shape": "Sq"
         },
         "toPort": {
-          "type": "integer"
+          "shape": "Sq"
         },
-        "protocol": {}
+        "protocol": {
+          "shape": "Sr"
+        }
       }
+    },
+    "Sq": {
+      "type": "integer",
+      "max": 65535,
+      "min": 0
+    },
+    "Sr": {
+      "type": "string",
+      "enum": [
+        "tcp",
+        "all",
+        "udp"
+      ]
     },
     "S14": {
       "type": "structure",
       "members": {
-        "id": {},
+        "id": {
+          "shape": "S6"
+        },
         "name": {},
         "target": {},
         "isAlias": {
@@ -1782,8 +2162,12 @@
     "S1l": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -1791,7 +2175,9 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
+        "resourceType": {
+          "shape": "S7"
+        },
         "fingerprint": {}
       }
     },
@@ -1799,11 +2185,22 @@
       "type": "list",
       "member": {}
     },
+    "S2p": {
+      "type": "string",
+      "enum": [
+        "LINUX_UNIX",
+        "WINDOWS"
+      ]
+    },
     "S2y": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -1811,7 +2208,9 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
+        "resourceType": {
+          "shape": "S7"
+        },
         "sizeInGb": {
           "type": "integer"
         },
@@ -1822,8 +2221,19 @@
           "type": "integer"
         },
         "path": {},
-        "state": {},
-        "attachedTo": {},
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "error",
+            "available",
+            "in-use",
+            "unknown"
+          ]
+        },
+        "attachedTo": {
+          "shape": "S2"
+        },
         "isAttached": {
           "type": "boolean"
         },
@@ -1839,8 +2249,12 @@
     "S32": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -1848,14 +2262,28 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
+        "resourceType": {
+          "shape": "S7"
+        },
         "sizeInGb": {
           "type": "integer"
         },
-        "state": {},
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "completed",
+            "error",
+            "unknown"
+          ]
+        },
         "progress": {},
-        "fromDiskName": {},
-        "fromDiskArn": {}
+        "fromDiskName": {
+          "shape": "S2"
+        },
+        "fromDiskArn": {
+          "shape": "S6"
+        }
       }
     },
     "S39": {
@@ -1867,8 +2295,12 @@
     "S3c": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -1876,7 +2308,9 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
+        "resourceType": {
+          "shape": "S7"
+        },
         "domainEntries": {
           "type": "list",
           "member": {
@@ -1888,8 +2322,12 @@
     "S3j": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -1897,16 +2335,31 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
-        "blueprintId": {},
-        "blueprintName": {},
-        "bundleId": {},
+        "resourceType": {
+          "shape": "S7"
+        },
+        "blueprintId": {
+          "shape": "S6"
+        },
+        "blueprintName": {
+          "shape": "S6"
+        },
+        "bundleId": {
+          "shape": "S6"
+        },
         "isStaticIp": {
           "type": "boolean"
         },
-        "privateIpAddress": {},
-        "publicIpAddress": {},
-        "ipv6Address": {},
+        "privateIpAddress": {
+          "shape": "S3k"
+        },
+        "publicIpAddress": {
+          "shape": "S3k"
+        },
+        "ipv6Address": {
+          "type": "string",
+          "pattern": "([A-F0-9]{1,4}:){7}[A-F0-9]{1,4}"
+        },
         "hardware": {
           "type": "structure",
           "members": {
@@ -1938,16 +2391,30 @@
                 "type": "structure",
                 "members": {
                   "fromPort": {
-                    "type": "integer"
+                    "shape": "Sq"
                   },
                   "toPort": {
-                    "type": "integer"
+                    "shape": "Sq"
                   },
-                  "protocol": {},
+                  "protocol": {
+                    "shape": "Sr"
+                  },
                   "accessFrom": {},
-                  "accessType": {},
+                  "accessType": {
+                    "type": "string",
+                    "enum": [
+                      "Public",
+                      "Private"
+                    ]
+                  },
                   "commonName": {},
-                  "accessDirection": {}
+                  "accessDirection": {
+                    "type": "string",
+                    "enum": [
+                      "inbound",
+                      "outbound"
+                    ]
+                  }
                 }
               }
             }
@@ -1956,9 +2423,17 @@
         "state": {
           "shape": "S3t"
         },
-        "username": {},
-        "sshKeyName": {}
+        "username": {
+          "shape": "S6"
+        },
+        "sshKeyName": {
+          "shape": "S2"
+        }
       }
+    },
+    "S3k": {
+      "type": "string",
+      "pattern": "([0-9]{1,3}\\.){3}[0-9]{1,3}"
     },
     "S3t": {
       "type": "structure",
@@ -1969,9 +2444,73 @@
         "name": {}
       }
     },
+    "S3v": {
+      "type": "string",
+      "enum": [
+        "ssh",
+        "rdp"
+      ]
+    },
+    "S40": {
+      "type": "string",
+      "enum": [
+        "CPUUtilization",
+        "NetworkIn",
+        "NetworkOut",
+        "StatusCheckFailed",
+        "StatusCheckFailed_Instance",
+        "StatusCheckFailed_System"
+      ]
+    },
+    "S41": {
+      "type": "integer",
+      "max": 86400,
+      "min": 60
+    },
+    "S43": {
+      "type": "string",
+      "enum": [
+        "Seconds",
+        "Microseconds",
+        "Milliseconds",
+        "Bytes",
+        "Kilobytes",
+        "Megabytes",
+        "Gigabytes",
+        "Terabytes",
+        "Bits",
+        "Kilobits",
+        "Megabits",
+        "Gigabits",
+        "Terabits",
+        "Percent",
+        "Count",
+        "Bytes/Second",
+        "Kilobytes/Second",
+        "Megabytes/Second",
+        "Gigabytes/Second",
+        "Terabytes/Second",
+        "Bits/Second",
+        "Kilobits/Second",
+        "Megabits/Second",
+        "Gigabits/Second",
+        "Terabits/Second",
+        "Count/Second",
+        "None"
+      ]
+    },
     "S44": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "Minimum",
+          "Maximum",
+          "Sum",
+          "Average",
+          "SampleCount"
+        ]
+      }
     },
     "S47": {
       "type": "list",
@@ -1996,15 +2535,21 @@
           "timestamp": {
             "type": "timestamp"
           },
-          "unit": {}
+          "unit": {
+            "shape": "S43"
+          }
         }
       }
     },
     "S4h": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2012,14 +2557,27 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
-        "state": {},
+        "resourceType": {
+          "shape": "S7"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "error",
+            "available"
+          ]
+        },
         "progress": {},
         "fromAttachedDisks": {
           "shape": "S39"
         },
-        "fromInstanceName": {},
-        "fromInstanceArn": {},
+        "fromInstanceName": {
+          "shape": "S2"
+        },
+        "fromInstanceArn": {
+          "shape": "S6"
+        },
         "fromBlueprintId": {},
         "fromBundleId": {},
         "sizeInGb": {
@@ -2030,8 +2588,12 @@
     "S4y": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2039,17 +2601,38 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
-        "dnsName": {},
-        "state": {},
-        "protocol": {},
+        "resourceType": {
+          "shape": "S7"
+        },
+        "dnsName": {
+          "shape": "S6"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "active",
+            "provisioning",
+            "active_impaired",
+            "failed",
+            "unknown"
+          ]
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "HTTP_HTTPS",
+            "HTTP"
+          ]
+        },
         "publicPorts": {
           "type": "list",
           "member": {
-            "type": "integer"
+            "shape": "Sq"
           }
         },
-        "healthCheckPath": {},
+        "healthCheckPath": {
+          "shape": "S6"
+        },
         "instancePort": {
           "type": "integer"
         },
@@ -2058,9 +2641,36 @@
           "member": {
             "type": "structure",
             "members": {
-              "instanceName": {},
-              "instanceHealth": {},
-              "instanceHealthReason": {}
+              "instanceName": {
+                "shape": "S2"
+              },
+              "instanceHealth": {
+                "type": "string",
+                "enum": [
+                  "initial",
+                  "healthy",
+                  "unhealthy",
+                  "unused",
+                  "draining",
+                  "unavailable"
+                ]
+              },
+              "instanceHealthReason": {
+                "type": "string",
+                "enum": [
+                  "Lb.RegistrationInProgress",
+                  "Lb.InitialHealthChecking",
+                  "Lb.InternalError",
+                  "Instance.ResponseCodeMismatch",
+                  "Instance.Timeout",
+                  "Instance.FailedHealthChecks",
+                  "Instance.NotRegistered",
+                  "Instance.NotInUse",
+                  "Instance.DeregistrationInProgress",
+                  "Instance.InvalidState",
+                  "Instance.IpUnusable"
+                ]
+              }
             }
           }
         },
@@ -2069,7 +2679,9 @@
           "member": {
             "type": "structure",
             "members": {
-              "name": {},
+              "name": {
+                "shape": "S2"
+              },
               "isAttached": {
                 "type": "boolean"
               }
@@ -2078,16 +2690,55 @@
         },
         "configurationOptions": {
           "type": "map",
-          "key": {},
+          "key": {
+            "shape": "S59"
+          },
           "value": {}
         }
       }
     },
+    "S59": {
+      "type": "string",
+      "enum": [
+        "HealthCheckPath",
+        "SessionStickinessEnabled",
+        "SessionStickiness_LB_CookieDurationSeconds"
+      ]
+    },
+    "S5b": {
+      "type": "string",
+      "enum": [
+        "ClientTLSNegotiationErrorCount",
+        "HealthyHostCount",
+        "UnhealthyHostCount",
+        "HTTPCode_LB_4XX_Count",
+        "HTTPCode_LB_5XX_Count",
+        "HTTPCode_Instance_2XX_Count",
+        "HTTPCode_Instance_3XX_Count",
+        "HTTPCode_Instance_4XX_Count",
+        "HTTPCode_Instance_5XX_Count",
+        "InstanceResponseTime",
+        "RejectedConnectionCount",
+        "RequestCount"
+      ]
+    },
+    "S5k": {
+      "type": "string",
+      "enum": [
+        "PENDING_VALIDATION",
+        "FAILED",
+        "SUCCESS"
+      ]
+    },
     "S68": {
       "type": "structure",
       "members": {
-        "name": {},
-        "arn": {},
+        "name": {
+          "shape": "S2"
+        },
+        "arn": {
+          "shape": "S6"
+        },
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2095,9 +2746,15 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {},
-        "ipAddress": {},
-        "attachedTo": {},
+        "resourceType": {
+          "shape": "S7"
+        },
+        "ipAddress": {
+          "shape": "S3k"
+        },
+        "attachedTo": {
+          "shape": "S2"
+        },
         "isAttached": {
           "type": "boolean"
         }

--- a/apis/logs-2014-03-28.min.json
+++ b/apis/logs-2014-03-28.min.json
@@ -20,8 +20,12 @@
           "kmsKeyId"
         ],
         "members": {
-          "logGroupName": {},
-          "kmsKeyId": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "kmsKeyId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -32,7 +36,9 @@
           "taskId"
         ],
         "members": {
-          "taskId": {}
+          "taskId": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -46,23 +52,33 @@
           "destination"
         ],
         "members": {
-          "taskName": {},
-          "logGroupName": {},
-          "logStreamNamePrefix": {},
+          "taskName": {
+            "shape": "S7"
+          },
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamNamePrefix": {
+            "shape": "S8"
+          },
           "from": {
-            "type": "long"
+            "shape": "S9"
           },
           "to": {
-            "type": "long"
+            "shape": "S9"
           },
-          "destination": {},
+          "destination": {
+            "shape": "Sa"
+          },
           "destinationPrefix": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {}
+          "taskId": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -73,8 +89,12 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {},
-          "kmsKeyId": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "kmsKeyId": {
+            "shape": "S3"
+          },
           "tags": {
             "shape": "Se"
           }
@@ -89,8 +109,12 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {},
-          "logStreamName": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamName": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -101,7 +125,9 @@
           "destinationName"
         ],
         "members": {
-          "destinationName": {}
+          "destinationName": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -112,7 +138,9 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {}
+          "logGroupName": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -124,8 +152,12 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {},
-          "logStreamName": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamName": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -137,8 +169,12 @@
           "filterName"
         ],
         "members": {
-          "logGroupName": {},
-          "filterName": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "filterName": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -157,7 +193,9 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {}
+          "logGroupName": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -169,8 +207,12 @@
           "filterName"
         ],
         "members": {
-          "logGroupName": {},
-          "filterName": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "filterName": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -178,10 +220,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "DestinationNamePrefix": {},
-          "nextToken": {},
+          "DestinationNamePrefix": {
+            "shape": "Sj"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -194,7 +240,9 @@
               "shape": "Sx"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -202,11 +250,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "taskId": {},
-          "statusCode": {},
-          "nextToken": {},
+          "taskId": {
+            "shape": "S5"
+          },
+          "statusCode": {
+            "shape": "S13"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -218,21 +272,31 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {},
-                "taskName": {},
-                "logGroupName": {},
+                "taskId": {
+                  "shape": "S5"
+                },
+                "taskName": {
+                  "shape": "S7"
+                },
+                "logGroupName": {
+                  "shape": "S2"
+                },
                 "from": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "to": {
-                  "type": "long"
+                  "shape": "S9"
                 },
-                "destination": {},
+                "destination": {
+                  "shape": "Sa"
+                },
                 "destinationPrefix": {},
                 "status": {
                   "type": "structure",
                   "members": {
-                    "code": {},
+                    "code": {
+                      "shape": "S13"
+                    },
                     "message": {}
                   }
                 },
@@ -240,17 +304,19 @@
                   "type": "structure",
                   "members": {
                     "creationTime": {
-                      "type": "long"
+                      "shape": "S9"
                     },
                     "completionTime": {
-                      "type": "long"
+                      "shape": "S9"
                     }
                   }
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -258,10 +324,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "logGroupNamePrefix": {},
-          "nextToken": {},
+          "logGroupNamePrefix": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -273,9 +343,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "logGroupName": {},
+                "logGroupName": {
+                  "shape": "S2"
+                },
                 "creationTime": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "retentionInDays": {
                   "type": "integer"
@@ -285,13 +357,17 @@
                 },
                 "arn": {},
                 "storedBytes": {
-                  "type": "long"
+                  "shape": "S1g"
                 },
-                "kmsKeyId": {}
+                "kmsKeyId": {
+                  "shape": "S3"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -302,15 +378,27 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {},
-          "logStreamNamePrefix": {},
-          "orderBy": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamNamePrefix": {
+            "shape": "S8"
+          },
+          "orderBy": {
+            "type": "string",
+            "enum": [
+              "LogStreamName",
+              "LastEventTime"
+            ]
+          },
           "descending": {
             "type": "boolean"
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -322,28 +410,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {},
+                "logStreamName": {
+                  "shape": "S8"
+                },
                 "creationTime": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "firstEventTimestamp": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "lastEventTimestamp": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "lastIngestionTime": {
-                  "type": "long"
+                  "shape": "S9"
                 },
-                "uploadSequenceToken": {},
+                "uploadSequenceToken": {
+                  "shape": "S1n"
+                },
                 "arn": {},
                 "storedBytes": {
-                  "type": "long"
+                  "shape": "S1g"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -351,14 +445,24 @@
       "input": {
         "type": "structure",
         "members": {
-          "logGroupName": {},
-          "filterNamePrefix": {},
-          "nextToken": {},
-          "limit": {
-            "type": "integer"
+          "logGroupName": {
+            "shape": "S2"
           },
-          "metricName": {},
-          "metricNamespace": {}
+          "filterNamePrefix": {
+            "shape": "Sn"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
+          "limit": {
+            "shape": "Su"
+          },
+          "metricName": {
+            "shape": "S1p"
+          },
+          "metricNamespace": {
+            "shape": "S1q"
+          }
         }
       },
       "output": {
@@ -369,19 +473,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "filterName": {},
-                "filterPattern": {},
+                "filterName": {
+                  "shape": "Sn"
+                },
+                "filterPattern": {
+                  "shape": "S1u"
+                },
                 "metricTransformations": {
                   "shape": "S1v"
                 },
                 "creationTime": {
-                  "type": "long"
+                  "shape": "S9"
                 },
-                "logGroupName": {}
+                "logGroupName": {
+                  "shape": "S2"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -389,9 +501,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {},
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -404,7 +518,9 @@
               "shape": "S22"
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -415,11 +531,17 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {},
-          "filterNamePrefix": {},
-          "nextToken": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "filterNamePrefix": {
+            "shape": "Sn"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "Su"
           }
         }
       },
@@ -431,19 +553,33 @@
             "member": {
               "type": "structure",
               "members": {
-                "filterName": {},
-                "logGroupName": {},
-                "filterPattern": {},
-                "destinationArn": {},
-                "roleArn": {},
-                "distribution": {},
+                "filterName": {
+                  "shape": "Sn"
+                },
+                "logGroupName": {
+                  "shape": "S2"
+                },
+                "filterPattern": {
+                  "shape": "S1u"
+                },
+                "destinationArn": {
+                  "shape": "S28"
+                },
+                "roleArn": {
+                  "shape": "Sz"
+                },
+                "distribution": {
+                  "shape": "S29"
+                },
                 "creationTime": {
-                  "type": "long"
+                  "shape": "S9"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -454,7 +590,9 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {}
+          "logGroupName": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -465,22 +603,34 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
           "logStreamNames": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S8"
+            },
+            "max": 100,
+            "min": 1
           },
-          "logStreamNamePrefix": {},
+          "logStreamNamePrefix": {
+            "shape": "S8"
+          },
           "startTime": {
-            "type": "long"
+            "shape": "S9"
           },
           "endTime": {
-            "type": "long"
+            "shape": "S9"
           },
-          "filterPattern": {},
-          "nextToken": {},
+          "filterPattern": {
+            "shape": "S1u"
+          },
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "S2d"
           },
           "interleaved": {
             "type": "boolean"
@@ -495,13 +645,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {},
-                "timestamp": {
-                  "type": "long"
+                "logStreamName": {
+                  "shape": "S8"
                 },
-                "message": {},
+                "timestamp": {
+                  "shape": "S9"
+                },
+                "message": {
+                  "shape": "S2i"
+                },
                 "ingestionTime": {
-                  "type": "long"
+                  "shape": "S9"
                 },
                 "eventId": {}
               }
@@ -512,14 +666,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {},
+                "logStreamName": {
+                  "shape": "S8"
+                },
                 "searchedCompletely": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -531,17 +689,23 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {},
-          "logStreamName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamName": {
+            "shape": "S8"
+          },
           "startTime": {
-            "type": "long"
+            "shape": "S9"
           },
           "endTime": {
-            "type": "long"
+            "shape": "S9"
           },
-          "nextToken": {},
+          "nextToken": {
+            "shape": "St"
+          },
           "limit": {
-            "type": "integer"
+            "shape": "S2d"
           },
           "startFromHead": {
             "type": "boolean"
@@ -557,17 +721,23 @@
               "type": "structure",
               "members": {
                 "timestamp": {
-                  "type": "long"
+                  "shape": "S9"
                 },
-                "message": {},
+                "message": {
+                  "shape": "S2i"
+                },
                 "ingestionTime": {
-                  "type": "long"
+                  "shape": "S9"
                 }
               }
             }
           },
-          "nextForwardToken": {},
-          "nextBackwardToken": {}
+          "nextForwardToken": {
+            "shape": "St"
+          },
+          "nextBackwardToken": {
+            "shape": "St"
+          }
         }
       }
     },
@@ -578,7 +748,9 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {}
+          "logGroupName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -599,9 +771,15 @@
           "roleArn"
         ],
         "members": {
-          "destinationName": {},
-          "targetArn": {},
-          "roleArn": {}
+          "destinationName": {
+            "shape": "Sj"
+          },
+          "targetArn": {
+            "shape": "Sy"
+          },
+          "roleArn": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -621,8 +799,12 @@
           "accessPolicy"
         ],
         "members": {
-          "destinationName": {},
-          "accessPolicy": {}
+          "destinationName": {
+            "shape": "Sj"
+          },
+          "accessPolicy": {
+            "shape": "S10"
+          }
         }
       }
     },
@@ -635,8 +817,12 @@
           "logEvents"
         ],
         "members": {
-          "logGroupName": {},
-          "logStreamName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "logStreamName": {
+            "shape": "S8"
+          },
           "logEvents": {
             "type": "list",
             "member": {
@@ -647,19 +833,27 @@
               ],
               "members": {
                 "timestamp": {
-                  "type": "long"
+                  "shape": "S9"
                 },
-                "message": {}
+                "message": {
+                  "shape": "S2i"
+                }
               }
-            }
+            },
+            "max": 10000,
+            "min": 1
           },
-          "sequenceToken": {}
+          "sequenceToken": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "nextSequenceToken": {},
+          "nextSequenceToken": {
+            "shape": "S1n"
+          },
           "rejectedLogEventsInfo": {
             "type": "structure",
             "members": {
@@ -687,9 +881,15 @@
           "metricTransformations"
         ],
         "members": {
-          "logGroupName": {},
-          "filterName": {},
-          "filterPattern": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "filterName": {
+            "shape": "Sn"
+          },
+          "filterPattern": {
+            "shape": "S1u"
+          },
           "metricTransformations": {
             "shape": "S1v"
           }
@@ -701,7 +901,9 @@
         "type": "structure",
         "members": {
           "policyName": {},
-          "policyDocument": {}
+          "policyDocument": {
+            "shape": "S23"
+          }
         }
       },
       "output": {
@@ -721,7 +923,9 @@
           "retentionInDays"
         ],
         "members": {
-          "logGroupName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
           "retentionInDays": {
             "type": "integer"
           }
@@ -738,12 +942,24 @@
           "destinationArn"
         ],
         "members": {
-          "logGroupName": {},
-          "filterName": {},
-          "filterPattern": {},
-          "destinationArn": {},
-          "roleArn": {},
-          "distribution": {}
+          "logGroupName": {
+            "shape": "S2"
+          },
+          "filterName": {
+            "shape": "Sn"
+          },
+          "filterPattern": {
+            "shape": "S1u"
+          },
+          "destinationArn": {
+            "shape": "S28"
+          },
+          "roleArn": {
+            "shape": "Sz"
+          },
+          "distribution": {
+            "shape": "S29"
+          }
         }
       }
     },
@@ -755,7 +971,9 @@
           "tags"
         ],
         "members": {
-          "logGroupName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
           "tags": {
             "shape": "Se"
           }
@@ -770,10 +988,16 @@
           "logEventMessages"
         ],
         "members": {
-          "filterPattern": {},
+          "filterPattern": {
+            "shape": "S1u"
+          },
           "logEventMessages": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2i"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -788,7 +1012,9 @@
                 "eventNumber": {
                   "type": "long"
                 },
-                "eventMessage": {},
+                "eventMessage": {
+                  "shape": "S2i"
+                },
                 "extractedValues": {
                   "type": "map",
                   "key": {},
@@ -808,33 +1034,162 @@
           "tags"
         ],
         "members": {
-          "logGroupName": {},
+          "logGroupName": {
+            "shape": "S2"
+          },
           "tags": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sf"
+            },
+            "min": 1
           }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[\\.\\-_/#A-Za-z0-9]+"
+    },
+    "S3": {
+      "type": "string",
+      "max": 256
+    },
+    "S5": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
+    "S8": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[^:*]*"
+    },
+    "S9": {
+      "type": "long",
+      "min": 0
+    },
+    "Sa": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
     "Se": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "Sf"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      },
+      "max": 50,
+      "min": 1
+    },
+    "Sf": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]+)$"
+    },
+    "Sj": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[^:*]*"
+    },
+    "Sn": {
+      "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[^:*]*"
+    },
+    "St": {
+      "type": "string",
+      "min": 1
+    },
+    "Su": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
     },
     "Sx": {
       "type": "structure",
       "members": {
-        "destinationName": {},
-        "targetArn": {},
-        "roleArn": {},
-        "accessPolicy": {},
+        "destinationName": {
+          "shape": "Sj"
+        },
+        "targetArn": {
+          "shape": "Sy"
+        },
+        "roleArn": {
+          "shape": "Sz"
+        },
+        "accessPolicy": {
+          "shape": "S10"
+        },
         "arn": {},
         "creationTime": {
-          "type": "long"
+          "shape": "S9"
         }
       }
+    },
+    "Sy": {
+      "type": "string",
+      "min": 1
+    },
+    "Sz": {
+      "type": "string",
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "min": 1
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "CANCELLED",
+        "COMPLETED",
+        "FAILED",
+        "PENDING",
+        "PENDING_CANCEL",
+        "RUNNING"
+      ]
+    },
+    "S1g": {
+      "type": "long",
+      "min": 0
+    },
+    "S1n": {
+      "type": "string",
+      "min": 1
+    },
+    "S1p": {
+      "type": "string",
+      "max": 255,
+      "pattern": "[^:*$]*"
+    },
+    "S1q": {
+      "type": "string",
+      "max": 255,
+      "pattern": "[^:*$]*"
+    },
+    "S1u": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
     },
     "S1v": {
       "type": "list",
@@ -846,24 +1201,60 @@
           "metricValue"
         ],
         "members": {
-          "metricName": {},
-          "metricNamespace": {},
-          "metricValue": {},
+          "metricName": {
+            "shape": "S1p"
+          },
+          "metricNamespace": {
+            "shape": "S1q"
+          },
+          "metricValue": {
+            "type": "string",
+            "max": 100
+          },
           "defaultValue": {
             "type": "double"
           }
         }
-      }
+      },
+      "max": 1,
+      "min": 1
     },
     "S22": {
       "type": "structure",
       "members": {
         "policyName": {},
-        "policyDocument": {},
+        "policyDocument": {
+          "shape": "S23"
+        },
         "lastUpdatedTime": {
-          "type": "long"
+          "shape": "S9"
         }
       }
+    },
+    "S23": {
+      "type": "string",
+      "max": 5120,
+      "min": 1
+    },
+    "S28": {
+      "type": "string",
+      "min": 1
+    },
+    "S29": {
+      "type": "string",
+      "enum": [
+        "Random",
+        "ByLogStream"
+      ]
+    },
+    "S2d": {
+      "type": "integer",
+      "max": 10000,
+      "min": 1
+    },
+    "S2i": {
+      "type": "string",
+      "min": 1
     }
   }
 }

--- a/apis/machinelearning-2014-12-12.min.json
+++ b/apis/machinelearning-2014-12-12.min.json
@@ -24,15 +24,23 @@
           "Tags": {
             "shape": "S2"
           },
-          "ResourceId": {},
-          "ResourceType": {}
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {},
-          "ResourceType": {}
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -46,17 +54,29 @@
           "OutputUri"
         ],
         "members": {
-          "BatchPredictionId": {},
-          "BatchPredictionName": {},
-          "MLModelId": {},
-          "BatchPredictionDataSourceId": {},
-          "OutputUri": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          },
+          "BatchPredictionName": {
+            "shape": "Sa"
+          },
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "BatchPredictionDataSourceId": {
+            "shape": "S6"
+          },
+          "OutputUri": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -69,8 +89,12 @@
           "RoleARN"
         ],
         "members": {
-          "DataSourceId": {},
-          "DataSourceName": {},
+          "DataSourceId": {
+            "shape": "S6"
+          },
+          "DataSourceName": {
+            "shape": "Sa"
+          },
           "RDSData": {
             "type": "structure",
             "required": [
@@ -87,7 +111,9 @@
               "DatabaseInformation": {
                 "shape": "Sf"
               },
-              "SelectSqlQuery": {},
+              "SelectSqlQuery": {
+                "shape": "Si"
+              },
               "DatabaseCredentials": {
                 "type": "structure",
                 "required": [
@@ -95,24 +121,50 @@
                   "Password"
                 ],
                 "members": {
-                  "Username": {},
-                  "Password": {}
+                  "Username": {
+                    "shape": "Sk"
+                  },
+                  "Password": {
+                    "type": "string",
+                    "min": 8,
+                    "max": 128
+                  }
                 }
               },
-              "S3StagingLocation": {},
+              "S3StagingLocation": {
+                "shape": "Sb"
+              },
               "DataRearrangement": {},
-              "DataSchema": {},
-              "DataSchemaUri": {},
-              "ResourceRole": {},
-              "ServiceRole": {},
-              "SubnetId": {},
+              "DataSchema": {
+                "shape": "Sn"
+              },
+              "DataSchemaUri": {
+                "shape": "Sb"
+              },
+              "ResourceRole": {
+                "shape": "So"
+              },
+              "ServiceRole": {
+                "shape": "Sp"
+              },
+              "SubnetId": {
+                "type": "string",
+                "min": 1,
+                "max": 255
+              },
               "SecurityGroupIds": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "type": "string",
+                  "min": 1,
+                  "max": 255
+                }
               }
             }
           },
-          "RoleARN": {},
+          "RoleARN": {
+            "shape": "St"
+          },
           "ComputeStatistics": {
             "type": "boolean"
           }
@@ -121,7 +173,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -134,8 +188,12 @@
           "RoleARN"
         ],
         "members": {
-          "DataSourceId": {},
-          "DataSourceName": {},
+          "DataSourceId": {
+            "shape": "S6"
+          },
+          "DataSourceName": {
+            "shape": "Sa"
+          },
           "DataSpec": {
             "type": "structure",
             "required": [
@@ -148,7 +206,9 @@
               "DatabaseInformation": {
                 "shape": "Sy"
               },
-              "SelectSqlQuery": {},
+              "SelectSqlQuery": {
+                "shape": "S11"
+              },
               "DatabaseCredentials": {
                 "type": "structure",
                 "required": [
@@ -156,17 +216,31 @@
                   "Password"
                 ],
                 "members": {
-                  "Username": {},
-                  "Password": {}
+                  "Username": {
+                    "shape": "S13"
+                  },
+                  "Password": {
+                    "type": "string",
+                    "min": 8,
+                    "max": 64
+                  }
                 }
               },
-              "S3StagingLocation": {},
+              "S3StagingLocation": {
+                "shape": "Sb"
+              },
               "DataRearrangement": {},
-              "DataSchema": {},
-              "DataSchemaUri": {}
+              "DataSchema": {
+                "shape": "Sn"
+              },
+              "DataSchemaUri": {
+                "shape": "Sb"
+              }
             }
           },
-          "RoleARN": {},
+          "RoleARN": {
+            "shape": "St"
+          },
           "ComputeStatistics": {
             "type": "boolean"
           }
@@ -175,7 +249,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -187,18 +263,28 @@
           "DataSpec"
         ],
         "members": {
-          "DataSourceId": {},
-          "DataSourceName": {},
+          "DataSourceId": {
+            "shape": "S6"
+          },
+          "DataSourceName": {
+            "shape": "Sa"
+          },
           "DataSpec": {
             "type": "structure",
             "required": [
               "DataLocationS3"
             ],
             "members": {
-              "DataLocationS3": {},
+              "DataLocationS3": {
+                "shape": "Sb"
+              },
               "DataRearrangement": {},
-              "DataSchema": {},
-              "DataSchemaLocationS3": {}
+              "DataSchema": {
+                "shape": "Sn"
+              },
+              "DataSchemaLocationS3": {
+                "shape": "Sb"
+              }
             }
           },
           "ComputeStatistics": {
@@ -209,7 +295,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -222,16 +310,26 @@
           "EvaluationDataSourceId"
         ],
         "members": {
-          "EvaluationId": {},
-          "EvaluationName": {},
-          "MLModelId": {},
-          "EvaluationDataSourceId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          },
+          "EvaluationName": {
+            "shape": "Sa"
+          },
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "EvaluationDataSourceId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -244,21 +342,35 @@
           "TrainingDataSourceId"
         ],
         "members": {
-          "MLModelId": {},
-          "MLModelName": {},
-          "MLModelType": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "MLModelName": {
+            "shape": "Sa"
+          },
+          "MLModelType": {
+            "shape": "S1c"
+          },
           "Parameters": {
             "shape": "S1d"
           },
-          "TrainingDataSourceId": {},
-          "Recipe": {},
-          "RecipeUri": {}
+          "TrainingDataSourceId": {
+            "shape": "S6"
+          },
+          "Recipe": {
+            "shape": "S1f"
+          },
+          "RecipeUri": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -269,13 +381,17 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
           "RealtimeEndpointInfo": {
             "shape": "S1j"
           }
@@ -289,13 +405,17 @@
           "BatchPredictionId"
         ],
         "members": {
-          "BatchPredictionId": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -306,13 +426,17 @@
           "DataSourceId"
         ],
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -323,13 +447,17 @@
           "EvaluationId"
         ],
         "members": {
-          "EvaluationId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -340,13 +468,17 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -357,13 +489,17 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
           "RealtimeEndpointInfo": {
             "shape": "S1j"
           }
@@ -381,17 +517,28 @@
         "members": {
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4"
+            },
+            "max": 100
           },
-          "ResourceId": {},
-          "ResourceType": {}
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {},
-          "ResourceType": {}
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -399,18 +546,46 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {},
-          "EQ": {},
-          "GT": {},
-          "LT": {},
-          "GE": {},
-          "LE": {},
-          "NE": {},
-          "Prefix": {},
-          "SortOrder": {},
+          "FilterVariable": {
+            "type": "string",
+            "enum": [
+              "CreatedAt",
+              "LastUpdatedAt",
+              "Status",
+              "Name",
+              "IAMUser",
+              "MLModelId",
+              "DataSourceId",
+              "DataURI"
+            ]
+          },
+          "EQ": {
+            "shape": "S23"
+          },
+          "GT": {
+            "shape": "S23"
+          },
+          "LT": {
+            "shape": "S23"
+          },
+          "GE": {
+            "shape": "S23"
+          },
+          "LE": {
+            "shape": "S23"
+          },
+          "NE": {
+            "shape": "S23"
+          },
+          "Prefix": {
+            "shape": "S23"
+          },
+          "SortOrder": {
+            "shape": "S24"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S25"
           }
         }
       },
@@ -422,21 +597,39 @@
             "member": {
               "type": "structure",
               "members": {
-                "BatchPredictionId": {},
-                "MLModelId": {},
-                "BatchPredictionDataSourceId": {},
-                "InputDataLocationS3": {},
-                "CreatedByIamUser": {},
+                "BatchPredictionId": {
+                  "shape": "S6"
+                },
+                "MLModelId": {
+                  "shape": "S6"
+                },
+                "BatchPredictionDataSourceId": {
+                  "shape": "S6"
+                },
+                "InputDataLocationS3": {
+                  "shape": "Sb"
+                },
+                "CreatedByIamUser": {
+                  "shape": "S29"
+                },
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {},
-                "Status": {},
-                "OutputUri": {},
-                "Message": {},
+                "Name": {
+                  "shape": "Sa"
+                },
+                "Status": {
+                  "shape": "S2a"
+                },
+                "OutputUri": {
+                  "shape": "Sb"
+                },
+                "Message": {
+                  "shape": "S2b"
+                },
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -463,18 +656,44 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {},
-          "EQ": {},
-          "GT": {},
-          "LT": {},
-          "GE": {},
-          "LE": {},
-          "NE": {},
-          "Prefix": {},
-          "SortOrder": {},
+          "FilterVariable": {
+            "type": "string",
+            "enum": [
+              "CreatedAt",
+              "LastUpdatedAt",
+              "Status",
+              "Name",
+              "DataLocationS3",
+              "IAMUser"
+            ]
+          },
+          "EQ": {
+            "shape": "S23"
+          },
+          "GT": {
+            "shape": "S23"
+          },
+          "LT": {
+            "shape": "S23"
+          },
+          "GE": {
+            "shape": "S23"
+          },
+          "LE": {
+            "shape": "S23"
+          },
+          "NE": {
+            "shape": "S23"
+          },
+          "Prefix": {
+            "shape": "S23"
+          },
+          "SortOrder": {
+            "shape": "S24"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S25"
           }
         }
       },
@@ -486,10 +705,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "DataSourceId": {},
-                "DataLocationS3": {},
+                "DataSourceId": {
+                  "shape": "S6"
+                },
+                "DataLocationS3": {
+                  "shape": "Sb"
+                },
                 "DataRearrangement": {},
-                "CreatedByIamUser": {},
+                "CreatedByIamUser": {
+                  "shape": "S29"
+                },
                 "CreatedAt": {
                   "type": "timestamp"
                 },
@@ -502,16 +727,24 @@
                 "NumberOfFiles": {
                   "type": "long"
                 },
-                "Name": {},
-                "Status": {},
-                "Message": {},
+                "Name": {
+                  "shape": "Sa"
+                },
+                "Status": {
+                  "shape": "S2a"
+                },
+                "Message": {
+                  "shape": "S2b"
+                },
                 "RedshiftMetadata": {
                   "shape": "S2i"
                 },
                 "RDSMetadata": {
                   "shape": "S2j"
                 },
-                "RoleARN": {},
+                "RoleARN": {
+                  "shape": "St"
+                },
                 "ComputeStatistics": {
                   "type": "boolean"
                 },
@@ -535,18 +768,46 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {},
-          "EQ": {},
-          "GT": {},
-          "LT": {},
-          "GE": {},
-          "LE": {},
-          "NE": {},
-          "Prefix": {},
-          "SortOrder": {},
+          "FilterVariable": {
+            "type": "string",
+            "enum": [
+              "CreatedAt",
+              "LastUpdatedAt",
+              "Status",
+              "Name",
+              "IAMUser",
+              "MLModelId",
+              "DataSourceId",
+              "DataURI"
+            ]
+          },
+          "EQ": {
+            "shape": "S23"
+          },
+          "GT": {
+            "shape": "S23"
+          },
+          "LT": {
+            "shape": "S23"
+          },
+          "GE": {
+            "shape": "S23"
+          },
+          "LE": {
+            "shape": "S23"
+          },
+          "NE": {
+            "shape": "S23"
+          },
+          "Prefix": {
+            "shape": "S23"
+          },
+          "SortOrder": {
+            "shape": "S24"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S25"
           }
         }
       },
@@ -558,23 +819,39 @@
             "member": {
               "type": "structure",
               "members": {
-                "EvaluationId": {},
-                "MLModelId": {},
-                "EvaluationDataSourceId": {},
-                "InputDataLocationS3": {},
-                "CreatedByIamUser": {},
+                "EvaluationId": {
+                  "shape": "S6"
+                },
+                "MLModelId": {
+                  "shape": "S6"
+                },
+                "EvaluationDataSourceId": {
+                  "shape": "S6"
+                },
+                "InputDataLocationS3": {
+                  "shape": "Sb"
+                },
+                "CreatedByIamUser": {
+                  "shape": "S29"
+                },
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {},
-                "Status": {},
+                "Name": {
+                  "shape": "Sa"
+                },
+                "Status": {
+                  "shape": "S2a"
+                },
                 "PerformanceMetrics": {
                   "shape": "S2q"
                 },
-                "Message": {},
+                "Message": {
+                  "shape": "S2b"
+                },
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -595,18 +872,48 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {},
-          "EQ": {},
-          "GT": {},
-          "LT": {},
-          "GE": {},
-          "LE": {},
-          "NE": {},
-          "Prefix": {},
-          "SortOrder": {},
+          "FilterVariable": {
+            "type": "string",
+            "enum": [
+              "CreatedAt",
+              "LastUpdatedAt",
+              "Status",
+              "Name",
+              "IAMUser",
+              "TrainingDataSourceId",
+              "RealtimeEndpointStatus",
+              "MLModelType",
+              "Algorithm",
+              "TrainingDataURI"
+            ]
+          },
+          "EQ": {
+            "shape": "S23"
+          },
+          "GT": {
+            "shape": "S23"
+          },
+          "LT": {
+            "shape": "S23"
+          },
+          "GE": {
+            "shape": "S23"
+          },
+          "LE": {
+            "shape": "S23"
+          },
+          "NE": {
+            "shape": "S23"
+          },
+          "Prefix": {
+            "shape": "S23"
+          },
+          "SortOrder": {
+            "shape": "S24"
+          },
           "NextToken": {},
           "Limit": {
-            "type": "integer"
+            "shape": "S25"
           }
         }
       },
@@ -618,17 +925,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "MLModelId": {},
-                "TrainingDataSourceId": {},
-                "CreatedByIamUser": {},
+                "MLModelId": {
+                  "shape": "S6"
+                },
+                "TrainingDataSourceId": {
+                  "shape": "S6"
+                },
+                "CreatedByIamUser": {
+                  "shape": "S29"
+                },
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {},
-                "Status": {},
+                "Name": {
+                  "shape": "S2z"
+                },
+                "Status": {
+                  "shape": "S2a"
+                },
                 "SizeInBytes": {
                   "type": "long"
                 },
@@ -638,16 +955,27 @@
                 "TrainingParameters": {
                   "shape": "S1d"
                 },
-                "InputDataLocationS3": {},
-                "Algorithm": {},
-                "MLModelType": {},
+                "InputDataLocationS3": {
+                  "shape": "Sb"
+                },
+                "Algorithm": {
+                  "type": "string",
+                  "enum": [
+                    "sgd"
+                  ]
+                },
+                "MLModelType": {
+                  "shape": "S1c"
+                },
                 "ScoreThreshold": {
                   "type": "float"
                 },
                 "ScoreThresholdLastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Message": {},
+                "Message": {
+                  "shape": "S2b"
+                },
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -672,15 +1000,23 @@
           "ResourceType"
         ],
         "members": {
-          "ResourceId": {},
-          "ResourceType": {}
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {},
-          "ResourceType": {},
+          "ResourceId": {
+            "shape": "S6"
+          },
+          "ResourceType": {
+            "shape": "S7"
+          },
           "Tags": {
             "shape": "S2"
           }
@@ -694,28 +1030,48 @@
           "BatchPredictionId"
         ],
         "members": {
-          "BatchPredictionId": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {},
-          "MLModelId": {},
-          "BatchPredictionDataSourceId": {},
-          "InputDataLocationS3": {},
-          "CreatedByIamUser": {},
+          "BatchPredictionId": {
+            "shape": "S6"
+          },
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "BatchPredictionDataSourceId": {
+            "shape": "S6"
+          },
+          "InputDataLocationS3": {
+            "shape": "Sb"
+          },
+          "CreatedByIamUser": {
+            "shape": "S29"
+          },
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {},
-          "Status": {},
-          "OutputUri": {},
+          "Name": {
+            "shape": "Sa"
+          },
+          "Status": {
+            "shape": "S2a"
+          },
+          "OutputUri": {
+            "shape": "Sb"
+          },
           "LogUri": {},
-          "Message": {},
+          "Message": {
+            "shape": "S2b"
+          },
           "ComputeTime": {
             "type": "long"
           },
@@ -741,7 +1097,9 @@
           "DataSourceId"
         ],
         "members": {
-          "DataSourceId": {},
+          "DataSourceId": {
+            "shape": "S6"
+          },
           "Verbose": {
             "type": "boolean"
           }
@@ -750,10 +1108,16 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {},
-          "DataLocationS3": {},
+          "DataSourceId": {
+            "shape": "S6"
+          },
+          "DataLocationS3": {
+            "shape": "Sb"
+          },
           "DataRearrangement": {},
-          "CreatedByIamUser": {},
+          "CreatedByIamUser": {
+            "shape": "S29"
+          },
           "CreatedAt": {
             "type": "timestamp"
           },
@@ -766,17 +1130,25 @@
           "NumberOfFiles": {
             "type": "long"
           },
-          "Name": {},
-          "Status": {},
+          "Name": {
+            "shape": "Sa"
+          },
+          "Status": {
+            "shape": "S2a"
+          },
           "LogUri": {},
-          "Message": {},
+          "Message": {
+            "shape": "S2b"
+          },
           "RedshiftMetadata": {
             "shape": "S2i"
           },
           "RDSMetadata": {
             "shape": "S2j"
           },
-          "RoleARN": {},
+          "RoleARN": {
+            "shape": "St"
+          },
           "ComputeStatistics": {
             "type": "boolean"
           },
@@ -789,7 +1161,9 @@
           "StartedAt": {
             "type": "timestamp"
           },
-          "DataSourceSchema": {}
+          "DataSourceSchema": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -800,30 +1174,48 @@
           "EvaluationId"
         ],
         "members": {
-          "EvaluationId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {},
-          "MLModelId": {},
-          "EvaluationDataSourceId": {},
-          "InputDataLocationS3": {},
-          "CreatedByIamUser": {},
+          "EvaluationId": {
+            "shape": "S6"
+          },
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "EvaluationDataSourceId": {
+            "shape": "S6"
+          },
+          "InputDataLocationS3": {
+            "shape": "Sb"
+          },
+          "CreatedByIamUser": {
+            "shape": "S29"
+          },
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {},
-          "Status": {},
+          "Name": {
+            "shape": "Sa"
+          },
+          "Status": {
+            "shape": "S2a"
+          },
           "PerformanceMetrics": {
             "shape": "S2q"
           },
           "LogUri": {},
-          "Message": {},
+          "Message": {
+            "shape": "S2b"
+          },
           "ComputeTime": {
             "type": "long"
           },
@@ -843,7 +1235,9 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
           "Verbose": {
             "type": "boolean"
           }
@@ -852,17 +1246,27 @@
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {},
-          "TrainingDataSourceId": {},
-          "CreatedByIamUser": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "TrainingDataSourceId": {
+            "shape": "S6"
+          },
+          "CreatedByIamUser": {
+            "shape": "S29"
+          },
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {},
-          "Status": {},
+          "Name": {
+            "shape": "S2z"
+          },
+          "Status": {
+            "shape": "S2a"
+          },
           "SizeInBytes": {
             "type": "long"
           },
@@ -872,8 +1276,12 @@
           "TrainingParameters": {
             "shape": "S1d"
           },
-          "InputDataLocationS3": {},
-          "MLModelType": {},
+          "InputDataLocationS3": {
+            "shape": "Sb"
+          },
+          "MLModelType": {
+            "shape": "S1c"
+          },
           "ScoreThreshold": {
             "type": "float"
           },
@@ -881,7 +1289,9 @@
             "type": "timestamp"
           },
           "LogUri": {},
-          "Message": {},
+          "Message": {
+            "shape": "S2b"
+          },
           "ComputeTime": {
             "type": "long"
           },
@@ -891,8 +1301,12 @@
           "StartedAt": {
             "type": "timestamp"
           },
-          "Recipe": {},
-          "Schema": {}
+          "Recipe": {
+            "shape": "S1f"
+          },
+          "Schema": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -905,13 +1319,17 @@
           "PredictEndpoint"
         ],
         "members": {
-          "MLModelId": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
           "Record": {
             "type": "map",
             "key": {},
             "value": {}
           },
-          "PredictEndpoint": {}
+          "PredictEndpoint": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -920,21 +1338,34 @@
           "Prediction": {
             "type": "structure",
             "members": {
-              "predictedLabel": {},
+              "predictedLabel": {
+                "shape": "S3k"
+              },
               "predictedValue": {
                 "type": "float"
               },
               "predictedScores": {
                 "type": "map",
-                "key": {},
+                "key": {
+                  "shape": "S3k"
+                },
                 "value": {
                   "type": "float"
                 }
               },
               "details": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "PredictiveModelType",
+                    "Algorithm"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "min": 1
+                }
               }
             }
           }
@@ -949,14 +1380,20 @@
           "BatchPredictionName"
         ],
         "members": {
-          "BatchPredictionId": {},
-          "BatchPredictionName": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          },
+          "BatchPredictionName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {}
+          "BatchPredictionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -968,14 +1405,20 @@
           "DataSourceName"
         ],
         "members": {
-          "DataSourceId": {},
-          "DataSourceName": {}
+          "DataSourceId": {
+            "shape": "S6"
+          },
+          "DataSourceName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {}
+          "DataSourceId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -987,14 +1430,20 @@
           "EvaluationName"
         ],
         "members": {
-          "EvaluationId": {},
-          "EvaluationName": {}
+          "EvaluationId": {
+            "shape": "S6"
+          },
+          "EvaluationName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {}
+          "EvaluationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -1005,8 +1454,12 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {},
-          "MLModelName": {},
+          "MLModelId": {
+            "shape": "S6"
+          },
+          "MLModelName": {
+            "shape": "Sa"
+          },
           "ScoreThreshold": {
             "type": "float"
           }
@@ -1015,7 +1468,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {}
+          "MLModelId": {
+            "shape": "S6"
+          }
         }
       }
     }
@@ -1026,10 +1481,49 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S4"
+          },
+          "Value": {
+            "type": "string",
+            "min": 0,
+            "max": 256,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "max": 100
+    },
+    "S4": {
+      "type": "string",
+      "min": 1,
+      "max": 128,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "S6": {
+      "type": "string",
+      "min": 1,
+      "max": 64,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "BatchPrediction",
+        "DataSource",
+        "Evaluation",
+        "MLModel"
+      ]
+    },
+    "Sa": {
+      "type": "string",
+      "max": 1024,
+      "pattern": ".*\\S.*|^$"
+    },
+    "Sb": {
+      "type": "string",
+      "max": 2048,
+      "pattern": "s3://([^/]+)(/.*)?"
     },
     "Sf": {
       "type": "structure",
@@ -1038,9 +1532,47 @@
         "DatabaseName"
       ],
       "members": {
-        "InstanceIdentifier": {},
-        "DatabaseName": {}
+        "InstanceIdentifier": {
+          "type": "string",
+          "min": 1,
+          "max": 63,
+          "pattern": "[a-z0-9-]+"
+        },
+        "DatabaseName": {
+          "type": "string",
+          "min": 1,
+          "max": 64
+        }
       }
+    },
+    "Si": {
+      "type": "string",
+      "min": 1,
+      "max": 16777216
+    },
+    "Sk": {
+      "type": "string",
+      "min": 1,
+      "max": 128
+    },
+    "Sn": {
+      "type": "string",
+      "max": 131071
+    },
+    "So": {
+      "type": "string",
+      "min": 1,
+      "max": 64
+    },
+    "Sp": {
+      "type": "string",
+      "min": 1,
+      "max": 64
+    },
+    "St": {
+      "type": "string",
+      "min": 1,
+      "max": 110
     },
     "Sy": {
       "type": "structure",
@@ -1049,14 +1581,46 @@
         "ClusterIdentifier"
       ],
       "members": {
-        "DatabaseName": {},
-        "ClusterIdentifier": {}
+        "DatabaseName": {
+          "type": "string",
+          "min": 1,
+          "max": 64,
+          "pattern": "[a-z0-9]+"
+        },
+        "ClusterIdentifier": {
+          "type": "string",
+          "min": 1,
+          "max": 63,
+          "pattern": "[a-z0-9-]+"
+        }
       }
+    },
+    "S11": {
+      "type": "string",
+      "min": 1,
+      "max": 16777216
+    },
+    "S13": {
+      "type": "string",
+      "min": 1,
+      "max": 128
+    },
+    "S1c": {
+      "type": "string",
+      "enum": [
+        "REGRESSION",
+        "BINARY",
+        "MULTICLASS"
+      ]
     },
     "S1d": {
       "type": "map",
       "key": {},
       "value": {}
+    },
+    "S1f": {
+      "type": "string",
+      "max": 131071
     },
     "S1j": {
       "type": "structure",
@@ -1067,9 +1631,59 @@
         "CreatedAt": {
           "type": "timestamp"
         },
-        "EndpointUrl": {},
-        "EndpointStatus": {}
+        "EndpointUrl": {
+          "shape": "S1m"
+        },
+        "EndpointStatus": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "READY",
+            "UPDATING",
+            "FAILED"
+          ]
+        }
       }
+    },
+    "S1m": {
+      "type": "string",
+      "max": 2048,
+      "pattern": "https://[a-zA-Z0-9-.]*\\.amazon(aws)?\\.com[/]?"
+    },
+    "S23": {
+      "type": "string",
+      "max": 1024,
+      "pattern": ".*\\S.*|^$"
+    },
+    "S24": {
+      "type": "string",
+      "enum": [
+        "asc",
+        "dsc"
+      ]
+    },
+    "S25": {
+      "type": "integer",
+      "min": 1,
+      "max": 100
+    },
+    "S29": {
+      "type": "string",
+      "pattern": "arn:aws:iam::[0-9]+:((user/.+)|(root))"
+    },
+    "S2a": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "INPROGRESS",
+        "FAILED",
+        "COMPLETED",
+        "DELETED"
+      ]
+    },
+    "S2b": {
+      "type": "string",
+      "max": 10240
     },
     "S2i": {
       "type": "structure",
@@ -1077,8 +1691,12 @@
         "RedshiftDatabase": {
           "shape": "Sy"
         },
-        "DatabaseUserName": {},
-        "SelectSqlQuery": {}
+        "DatabaseUserName": {
+          "shape": "S13"
+        },
+        "SelectSqlQuery": {
+          "shape": "S11"
+        }
       }
     },
     "S2j": {
@@ -1087,11 +1705,23 @@
         "Database": {
           "shape": "Sf"
         },
-        "DatabaseUserName": {},
-        "SelectSqlQuery": {},
-        "ResourceRole": {},
-        "ServiceRole": {},
-        "DataPipelineId": {}
+        "DatabaseUserName": {
+          "shape": "Sk"
+        },
+        "SelectSqlQuery": {
+          "shape": "Si"
+        },
+        "ResourceRole": {
+          "shape": "So"
+        },
+        "ServiceRole": {
+          "shape": "Sp"
+        },
+        "DataPipelineId": {
+          "type": "string",
+          "min": 1,
+          "max": 1024
+        }
       }
     },
     "S2q": {
@@ -1103,6 +1733,14 @@
           "value": {}
         }
       }
+    },
+    "S2z": {
+      "type": "string",
+      "max": 1024
+    },
+    "S3k": {
+      "type": "string",
+      "min": 1
     }
   },
   "examples": {}

--- a/apis/macie-2017-12-19.min.json
+++ b/apis/macie-2017-12-19.min.json
@@ -19,7 +19,9 @@
           "memberAccountId"
         ],
         "members": {
-          "memberAccountId": {}
+          "memberAccountId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -30,7 +32,9 @@
           "s3Resources"
         ],
         "members": {
-          "memberAccountId": {},
+          "memberAccountId": {
+            "shape": "S2"
+          },
           "s3Resources": {
             "shape": "S4"
           }
@@ -52,7 +56,9 @@
           "memberAccountId"
         ],
         "members": {
-          "memberAccountId": {}
+          "memberAccountId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -63,7 +69,9 @@
           "associatedS3Resources"
         ],
         "members": {
-          "memberAccountId": {},
+          "memberAccountId": {
+            "shape": "S2"
+          },
           "associatedS3Resources": {
             "type": "list",
             "member": {
@@ -85,9 +93,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {},
+          "nextToken": {
+            "shape": "Sm"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sn"
           }
         }
       },
@@ -99,11 +109,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "accountId": {}
+                "accountId": {
+                  "shape": "S2"
+                }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sm"
+          }
         }
       }
     },
@@ -111,10 +125,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "memberAccountId": {},
-          "nextToken": {},
+          "memberAccountId": {
+            "shape": "S2"
+          },
+          "nextToken": {
+            "shape": "Sm"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Sn"
           }
         }
       },
@@ -124,7 +142,9 @@
           "s3Resources": {
             "shape": "S4"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Sm"
+          }
         }
       }
     },
@@ -135,7 +155,9 @@
           "s3ResourcesUpdate"
         ],
         "members": {
-          "memberAccountId": {},
+          "memberAccountId": {
+            "shape": "S2"
+          },
           "s3ResourcesUpdate": {
             "type": "list",
             "member": {
@@ -145,13 +167,21 @@
                 "classificationTypeUpdate"
               ],
               "members": {
-                "bucketName": {},
-                "prefix": {},
+                "bucketName": {
+                  "shape": "S6"
+                },
+                "prefix": {
+                  "shape": "S7"
+                },
                 "classificationTypeUpdate": {
                   "type": "structure",
                   "members": {
-                    "oneTime": {},
-                    "continuous": {}
+                    "oneTime": {
+                      "shape": "S9"
+                    },
+                    "continuous": {
+                      "shape": "Sa"
+                    }
                   }
                 }
               }
@@ -170,6 +200,10 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "[0-9]{12}"
+    },
     "S4": {
       "type": "list",
       "member": {
@@ -179,8 +213,12 @@
           "classificationType"
         ],
         "members": {
-          "bucketName": {},
-          "prefix": {},
+          "bucketName": {
+            "shape": "S6"
+          },
+          "prefix": {
+            "shape": "S7"
+          },
           "classificationType": {
             "type": "structure",
             "required": [
@@ -188,12 +226,37 @@
               "continuous"
             ],
             "members": {
-              "oneTime": {},
-              "continuous": {}
+              "oneTime": {
+                "shape": "S9"
+              },
+              "continuous": {
+                "shape": "Sa"
+              }
             }
           }
         }
       }
+    },
+    "S6": {
+      "type": "string",
+      "max": 500
+    },
+    "S7": {
+      "type": "string",
+      "max": 10000
+    },
+    "S9": {
+      "type": "string",
+      "enum": [
+        "FULL",
+        "NONE"
+      ]
+    },
+    "Sa": {
+      "type": "string",
+      "enum": [
+        "FULL"
+      ]
     },
     "Sc": {
       "type": "list",
@@ -203,8 +266,14 @@
           "failedItem": {
             "shape": "Se"
           },
-          "errorCode": {},
-          "errorMessage": {}
+          "errorCode": {
+            "type": "string",
+            "max": 10
+          },
+          "errorMessage": {
+            "type": "string",
+            "max": 10000
+          }
         }
       }
     },
@@ -214,9 +283,21 @@
         "bucketName"
       ],
       "members": {
-        "bucketName": {},
-        "prefix": {}
+        "bucketName": {
+          "shape": "S6"
+        },
+        "prefix": {
+          "shape": "S7"
+        }
       }
+    },
+    "Sm": {
+      "type": "string",
+      "max": 500
+    },
+    "Sn": {
+      "type": "integer",
+      "max": 250
     }
   }
 }

--- a/apis/marketplacecommerceanalytics-2015-07-01.min.json
+++ b/apis/marketplacecommerceanalytics-2015-07-01.min.json
@@ -24,14 +24,47 @@
           "snsTopicArn"
         ],
         "members": {
-          "dataSetType": {},
+          "dataSetType": {
+            "type": "string",
+            "enum": [
+              "customer_subscriber_hourly_monthly_subscriptions",
+              "customer_subscriber_annual_subscriptions",
+              "daily_business_usage_by_instance_type",
+              "daily_business_fees",
+              "daily_business_free_trial_conversions",
+              "daily_business_new_instances",
+              "daily_business_new_product_subscribers",
+              "daily_business_canceled_product_subscribers",
+              "monthly_revenue_billing_and_revenue_data",
+              "monthly_revenue_annual_subscriptions",
+              "disbursed_amount_by_product",
+              "disbursed_amount_by_product_with_uncollected_funds",
+              "disbursed_amount_by_instance_hours",
+              "disbursed_amount_by_customer_geo",
+              "disbursed_amount_by_age_of_uncollected_funds",
+              "disbursed_amount_by_age_of_disbursed_funds",
+              "customer_profile_by_industry",
+              "customer_profile_by_revenue",
+              "customer_profile_by_geography",
+              "sales_compensation_billed_revenue",
+              "us_sales_and_use_tax_records"
+            ],
+            "max": 255,
+            "min": 1
+          },
           "dataSetPublicationDate": {
             "type": "timestamp"
           },
-          "roleNameArn": {},
-          "destinationS3BucketName": {},
+          "roleNameArn": {
+            "shape": "S4"
+          },
+          "destinationS3BucketName": {
+            "shape": "S5"
+          },
           "destinationS3Prefix": {},
-          "snsTopicArn": {},
+          "snsTopicArn": {
+            "shape": "S7"
+          },
           "customerDefinedValues": {
             "shape": "S8"
           }
@@ -55,14 +88,28 @@
           "snsTopicArn"
         ],
         "members": {
-          "dataSetType": {},
+          "dataSetType": {
+            "type": "string",
+            "enum": [
+              "customer_support_contacts_data",
+              "test_customer_support_contacts_data"
+            ],
+            "max": 255,
+            "min": 1
+          },
           "fromDate": {
             "type": "timestamp"
           },
-          "roleNameArn": {},
-          "destinationS3BucketName": {},
+          "roleNameArn": {
+            "shape": "S4"
+          },
+          "destinationS3BucketName": {
+            "shape": "S5"
+          },
           "destinationS3Prefix": {},
-          "snsTopicArn": {},
+          "snsTopicArn": {
+            "shape": "S7"
+          },
           "customerDefinedValues": {
             "shape": "S8"
           }
@@ -77,10 +124,32 @@
     }
   },
   "shapes": {
+    "S4": {
+      "type": "string",
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "min": 1
+    },
     "S8": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      },
+      "value": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      },
+      "max": 5,
+      "min": 1
     }
   }
 }

--- a/apis/mediaconvert-2017-08-29.min.json
+++ b/apis/mediaconvert-2017-08-29.min.json
@@ -44,6 +44,7 @@
         "type": "structure",
         "members": {
           "BillingTagsSource": {
+            "shape": "S5",
             "locationName": "billingTagsSource"
           },
           "ClientRequestToken": {
@@ -183,6 +184,7 @@
             "locationName": "name"
           },
           "PricingPlan": {
+            "shape": "Sc4",
             "locationName": "pricingPlan"
           },
           "ReservationPlanSettings": {
@@ -290,7 +292,12 @@
             "type": "integer"
           },
           "Mode": {
-            "locationName": "mode"
+            "locationName": "mode",
+            "type": "string",
+            "enum": [
+              "DEFAULT",
+              "GET_ONLY"
+            ]
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -445,18 +452,25 @@
           },
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "string",
+            "enum": [
+              "NAME",
+              "CREATION_DATE",
+              "SYSTEM"
+            ]
           },
           "MaxResults": {
+            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring",
-            "type": "integer"
+            "location": "querystring"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
+            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -488,15 +502,16 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring",
-            "type": "integer"
+            "location": "querystring"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
+            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           },
@@ -505,6 +520,7 @@
             "location": "querystring"
           },
           "Status": {
+            "shape": "Sbo",
             "locationName": "status",
             "location": "querystring"
           }
@@ -541,18 +557,25 @@
           },
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "string",
+            "enum": [
+              "NAME",
+              "CREATION_DATE",
+              "SYSTEM"
+            ]
           },
           "MaxResults": {
+            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring",
-            "type": "integer"
+            "location": "querystring"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
+            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -585,18 +608,24 @@
         "members": {
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "string",
+            "enum": [
+              "NAME",
+              "CREATION_DATE"
+            ]
           },
           "MaxResults": {
+            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring",
-            "type": "integer"
+            "location": "querystring"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
+            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -809,6 +838,7 @@
             "locationName": "reservationPlanSettings"
           },
           "Status": {
+            "shape": "Scc",
             "locationName": "status"
           }
         },
@@ -828,12 +858,20 @@
     }
   },
   "shapes": {
+    "S5": {
+      "type": "string",
+      "enum": [
+        "QUEUE",
+        "PRESET",
+        "JOB_TEMPLATE"
+      ]
+    },
     "S6": {
       "type": "structure",
       "members": {
         "AdAvailOffset": {
-          "locationName": "adAvailOffset",
-          "type": "integer"
+          "shape": "S7",
+          "locationName": "adAvailOffset"
         },
         "AvailBlanking": {
           "shape": "S8",
@@ -858,33 +896,40 @@
                 "locationName": "captionSelectors"
               },
               "DeblockFilter": {
+                "shape": "S1e",
                 "locationName": "deblockFilter"
               },
               "DenoiseFilter": {
+                "shape": "S1f",
                 "locationName": "denoiseFilter"
               },
               "FileInput": {
-                "locationName": "fileInput"
+                "locationName": "fileInput",
+                "type": "string",
+                "pattern": "^(s3:\\/\\/)([^\\/]+\\/)+([^\\/\\.]+|(([^\\/]*)\\.([mM]2[vV]|[mM][pP][eE][gG]|[aA][vV][iI]|[mM][pP]4|[fF][lL][vV]|[mM][pP][tT]|[mM][pP][gG]|[mM]4[vV]|[tT][rR][pP]|[fF]4[vV]|[mM]2[tT][sS]|[tT][sS]|264|[hH]264|[mM][kK][vV]|[mM][oO][vV]|[mM][tT][sS]|[mM]2[tT]|[wW][mM][vV]|[aA][sS][fF]|[vV][oO][bB]|3[gG][pP]|3[gG][pP][pP]|[mM][xX][fF]|[dD][iI][vV][xX]|[xX][vV][iI][dD]|[rR][aA][wW]|[dD][vV]|[gG][xX][fF]|[mM]1[vV]|3[gG]2|[vV][mM][fF]|[mM]3[uU]8|[lL][cC][hH]|[gG][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF][hH][dD]|[wW][aA][vV]|[yY]4[mM])))$"
               },
               "FilterEnable": {
+                "shape": "S1h",
                 "locationName": "filterEnable"
               },
               "FilterStrength": {
-                "locationName": "filterStrength",
-                "type": "integer"
+                "shape": "S1i",
+                "locationName": "filterStrength"
               },
               "InputClippings": {
                 "shape": "S1j",
                 "locationName": "inputClippings"
               },
               "ProgramNumber": {
-                "locationName": "programNumber",
-                "type": "integer"
+                "shape": "So",
+                "locationName": "programNumber"
               },
               "PsiControl": {
+                "shape": "S1m",
                 "locationName": "psiControl"
               },
               "TimecodeSource": {
+                "shape": "S1n",
                 "locationName": "timecodeSource"
               },
               "VideoSelector": {
@@ -912,11 +957,19 @@
         }
       }
     },
+    "S7": {
+      "type": "integer",
+      "min": -1000,
+      "max": 1000
+    },
     "S8": {
       "type": "structure",
       "members": {
         "AvailBlankingImage": {
-          "locationName": "availBlankingImage"
+          "locationName": "availBlankingImage",
+          "type": "string",
+          "min": 14,
+          "pattern": "^(s3:\\/\\/)(.*?)\\.(bmp|BMP|png|PNG)$"
         }
       }
     },
@@ -929,10 +982,16 @@
           "AudioSelectorNames": {
             "locationName": "audioSelectorNames",
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sf"
+            }
           }
         }
       }
+    },
+    "Sf": {
+      "type": "string",
+      "min": 1
     },
     "Sg": {
       "type": "map",
@@ -941,20 +1000,29 @@
         "type": "structure",
         "members": {
           "CustomLanguageCode": {
+            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "DefaultSelection": {
-            "locationName": "defaultSelection"
+            "locationName": "defaultSelection",
+            "type": "string",
+            "enum": [
+              "DEFAULT",
+              "NOT_DEFAULT"
+            ]
           },
           "ExternalAudioFileInput": {
-            "locationName": "externalAudioFileInput"
+            "locationName": "externalAudioFileInput",
+            "type": "string",
+            "pattern": "^(s3:\\/\\/)([^\\/]+\\/)+([^\\/\\.]+|(([^\\/]*)\\.([mM]2[vV]|[mM][pP][eE][gG]|[aA][vV][iI]|[mM][pP]4|[fF][lL][vV]|[mM][pP][tT]|[mM][pP][gG]|[mM]4[vV]|[tT][rR][pP]|[fF]4[vV]|[mM]2[tT][sS]|[tT][sS]|264|[hH]264|[mM][kK][vV]|[mM][oO][vV]|[mM][tT][sS]|[mM]2[tT]|[wW][mM][vV]|[aA][sS][fF]|[vV][oO][bB]|3[gG][pP]|3[gG][pP][pP]|[mM][xX][fF]|[dD][iI][vV][xX]|[xX][vV][iI][dD]|[rR][aA][wW]|[dD][vV]|[gG][xX][fF]|[mM]1[vV]|3[gG]2|[vV][mM][fF]|[mM]3[uU]8|[lL][cC][hH]|[gG][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF][hH][dD]|[wW][aA][vV]|[yY]4[mM]|[aA][aA][cC]|[aA][iI][fF][fF]|[mM][pP]2|[aA][cC]3|[eE][cC]3|[dD][tT][sS][eE])))$"
           },
           "LanguageCode": {
+            "shape": "Sl",
             "locationName": "languageCode"
           },
           "Offset": {
-            "locationName": "offset",
-            "type": "integer"
+            "shape": "Sm",
+            "locationName": "offset"
           },
           "Pids": {
             "shape": "Sn",
@@ -962,14 +1030,22 @@
           },
           "ProgramSelection": {
             "locationName": "programSelection",
-            "type": "integer"
+            "type": "integer",
+            "min": 0,
+            "max": 8
           },
           "RemixSettings": {
             "shape": "Sq",
             "locationName": "remixSettings"
           },
           "SelectorType": {
-            "locationName": "selectorType"
+            "locationName": "selectorType",
+            "type": "string",
+            "enum": [
+              "PID",
+              "TRACK",
+              "LANGUAGE_CODE"
+            ]
           },
           "Tracks": {
             "shape": "Sn",
@@ -978,11 +1054,223 @@
         }
       }
     },
+    "Si": {
+      "type": "string",
+      "min": 3,
+      "max": 3,
+      "pattern": "^[A-Za-z]{3}$"
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "ENG",
+        "SPA",
+        "FRA",
+        "DEU",
+        "GER",
+        "ZHO",
+        "ARA",
+        "HIN",
+        "JPN",
+        "RUS",
+        "POR",
+        "ITA",
+        "URD",
+        "VIE",
+        "KOR",
+        "PAN",
+        "ABK",
+        "AAR",
+        "AFR",
+        "AKA",
+        "SQI",
+        "AMH",
+        "ARG",
+        "HYE",
+        "ASM",
+        "AVA",
+        "AVE",
+        "AYM",
+        "AZE",
+        "BAM",
+        "BAK",
+        "EUS",
+        "BEL",
+        "BEN",
+        "BIH",
+        "BIS",
+        "BOS",
+        "BRE",
+        "BUL",
+        "MYA",
+        "CAT",
+        "KHM",
+        "CHA",
+        "CHE",
+        "NYA",
+        "CHU",
+        "CHV",
+        "COR",
+        "COS",
+        "CRE",
+        "HRV",
+        "CES",
+        "DAN",
+        "DIV",
+        "NLD",
+        "DZO",
+        "ENM",
+        "EPO",
+        "EST",
+        "EWE",
+        "FAO",
+        "FIJ",
+        "FIN",
+        "FRM",
+        "FUL",
+        "GLA",
+        "GLG",
+        "LUG",
+        "KAT",
+        "ELL",
+        "GRN",
+        "GUJ",
+        "HAT",
+        "HAU",
+        "HEB",
+        "HER",
+        "HMO",
+        "HUN",
+        "ISL",
+        "IDO",
+        "IBO",
+        "IND",
+        "INA",
+        "ILE",
+        "IKU",
+        "IPK",
+        "GLE",
+        "JAV",
+        "KAL",
+        "KAN",
+        "KAU",
+        "KAS",
+        "KAZ",
+        "KIK",
+        "KIN",
+        "KIR",
+        "KOM",
+        "KON",
+        "KUA",
+        "KUR",
+        "LAO",
+        "LAT",
+        "LAV",
+        "LIM",
+        "LIN",
+        "LIT",
+        "LUB",
+        "LTZ",
+        "MKD",
+        "MLG",
+        "MSA",
+        "MAL",
+        "MLT",
+        "GLV",
+        "MRI",
+        "MAR",
+        "MAH",
+        "MON",
+        "NAU",
+        "NAV",
+        "NDE",
+        "NBL",
+        "NDO",
+        "NEP",
+        "SME",
+        "NOR",
+        "NOB",
+        "NNO",
+        "OCI",
+        "OJI",
+        "ORI",
+        "ORM",
+        "OSS",
+        "PLI",
+        "FAS",
+        "POL",
+        "PUS",
+        "QUE",
+        "QAA",
+        "RON",
+        "ROH",
+        "RUN",
+        "SMO",
+        "SAG",
+        "SAN",
+        "SRD",
+        "SRB",
+        "SNA",
+        "III",
+        "SND",
+        "SIN",
+        "SLK",
+        "SLV",
+        "SOM",
+        "SOT",
+        "SUN",
+        "SWA",
+        "SSW",
+        "SWE",
+        "TGL",
+        "TAH",
+        "TGK",
+        "TAM",
+        "TAT",
+        "TEL",
+        "THA",
+        "BOD",
+        "TIR",
+        "TON",
+        "TSO",
+        "TSN",
+        "TUR",
+        "TUK",
+        "TWI",
+        "UIG",
+        "UKR",
+        "UZB",
+        "VEN",
+        "VOL",
+        "WLN",
+        "CYM",
+        "FRY",
+        "WOL",
+        "XHO",
+        "YID",
+        "YOR",
+        "ZHA",
+        "ZUL",
+        "ORJ",
+        "QPC",
+        "TNG"
+      ]
+    },
+    "Sm": {
+      "type": "integer",
+      "min": -2147483648,
+      "max": 2147483647
+    },
     "Sn": {
       "type": "list",
       "member": {
-        "type": "integer"
+        "shape": "So"
       }
+    },
+    "So": {
+      "type": "integer",
+      "min": 1,
+      "max": 2147483647
     },
     "Sq": {
       "type": "structure",
@@ -1001,7 +1289,9 @@
                     "locationName": "inputChannels",
                     "type": "list",
                     "member": {
-                      "type": "integer"
+                      "type": "integer",
+                      "min": -60,
+                      "max": 6
                     }
                   }
                 }
@@ -1011,13 +1301,20 @@
         },
         "ChannelsIn": {
           "locationName": "channelsIn",
-          "type": "integer"
+          "type": "integer",
+          "min": 1,
+          "max": 16
         },
         "ChannelsOut": {
-          "locationName": "channelsOut",
-          "type": "integer"
+          "shape": "Sx",
+          "locationName": "channelsOut"
         }
       }
+    },
+    "Sx": {
+      "type": "integer",
+      "min": 1,
+      "max": 8
     },
     "Sz": {
       "type": "map",
@@ -1026,9 +1323,11 @@
         "type": "structure",
         "members": {
           "CustomLanguageCode": {
+            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "LanguageCode": {
+            "shape": "Sl",
             "locationName": "languageCode"
           },
           "SourceSettings": {
@@ -1040,8 +1339,8 @@
                 "type": "structure",
                 "members": {
                   "SourceAncillaryChannelNumber": {
-                    "locationName": "sourceAncillaryChannelNumber",
-                    "type": "integer"
+                    "shape": "S13",
+                    "locationName": "sourceAncillaryChannelNumber"
                   }
                 }
               },
@@ -1050,8 +1349,8 @@
                 "type": "structure",
                 "members": {
                   "Pid": {
-                    "locationName": "pid",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "pid"
                   }
                 }
               },
@@ -1060,15 +1359,22 @@
                 "type": "structure",
                 "members": {
                   "Convert608To708": {
-                    "locationName": "convert608To708"
+                    "locationName": "convert608To708",
+                    "type": "string",
+                    "enum": [
+                      "UPCONVERT",
+                      "DISABLED"
+                    ]
                   },
                   "Source608ChannelNumber": {
-                    "locationName": "source608ChannelNumber",
-                    "type": "integer"
+                    "shape": "S13",
+                    "locationName": "source608ChannelNumber"
                   },
                   "Source608TrackNumber": {
                     "locationName": "source608TrackNumber",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 1,
+                    "max": 1
                   }
                 }
               },
@@ -1077,25 +1383,46 @@
                 "type": "structure",
                 "members": {
                   "Convert608To708": {
-                    "locationName": "convert608To708"
+                    "locationName": "convert608To708",
+                    "type": "string",
+                    "enum": [
+                      "UPCONVERT",
+                      "DISABLED"
+                    ]
                   },
                   "SourceFile": {
-                    "locationName": "sourceFile"
+                    "locationName": "sourceFile",
+                    "type": "string",
+                    "min": 14,
+                    "pattern": "^(s3:\\/\\/)(.*?)\\.(scc|SCC|ttml|TTML|dfxp|DFXP|stl|STL|srt|SRT|smi|SMI)$"
                   },
                   "TimeDelta": {
-                    "locationName": "timeDelta",
-                    "type": "integer"
+                    "shape": "Sm",
+                    "locationName": "timeDelta"
                   }
                 }
               },
               "SourceType": {
-                "locationName": "sourceType"
+                "locationName": "sourceType",
+                "type": "string",
+                "enum": [
+                  "ANCILLARY",
+                  "DVB_SUB",
+                  "EMBEDDED",
+                  "SCC",
+                  "TTML",
+                  "STL",
+                  "SRT",
+                  "TELETEXT",
+                  "NULL_SOURCE"
+                ]
               },
               "TeletextSourceSettings": {
                 "locationName": "teletextSourceSettings",
                 "type": "structure",
                 "members": {
                   "PageNumber": {
+                    "shape": "S1d",
                     "locationName": "pageNumber"
                   }
                 }
@@ -1105,40 +1432,112 @@
         }
       }
     },
+    "S13": {
+      "type": "integer",
+      "min": 1,
+      "max": 4
+    },
+    "S1d": {
+      "type": "string",
+      "min": 3,
+      "max": 3,
+      "pattern": "^[1-8][0-9a-fA-F][0-9a-eA-E]$"
+    },
+    "S1e": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
+    "S1f": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
+    },
+    "S1h": {
+      "type": "string",
+      "enum": [
+        "AUTO",
+        "DISABLE",
+        "FORCE"
+      ]
+    },
+    "S1i": {
+      "type": "integer",
+      "min": -5,
+      "max": 5
+    },
     "S1j": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "EndTimecode": {
+            "shape": "S1l",
             "locationName": "endTimecode"
           },
           "StartTimecode": {
+            "shape": "S1l",
             "locationName": "startTimecode"
           }
         }
       }
     },
+    "S1l": {
+      "type": "string",
+      "pattern": "^([01][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9][:;][0-9]{2}$"
+    },
+    "S1m": {
+      "type": "string",
+      "enum": [
+        "IGNORE_PSI",
+        "USE_PSI"
+      ]
+    },
+    "S1n": {
+      "type": "string",
+      "enum": [
+        "EMBEDDED",
+        "ZEROBASED",
+        "SPECIFIEDSTART"
+      ]
+    },
     "S1o": {
       "type": "structure",
       "members": {
         "ColorSpace": {
-          "locationName": "colorSpace"
+          "locationName": "colorSpace",
+          "type": "string",
+          "enum": [
+            "FOLLOW",
+            "REC_601",
+            "REC_709",
+            "HDR10",
+            "HLG_2020"
+          ]
         },
         "ColorSpaceUsage": {
-          "locationName": "colorSpaceUsage"
+          "locationName": "colorSpaceUsage",
+          "type": "string",
+          "enum": [
+            "FORCE",
+            "FALLBACK"
+          ]
         },
         "Hdr10Metadata": {
           "shape": "S1r",
           "locationName": "hdr10Metadata"
         },
         "Pid": {
-          "locationName": "pid",
-          "type": "integer"
+          "shape": "So",
+          "locationName": "pid"
         },
         "ProgramNumber": {
-          "locationName": "programNumber",
-          "type": "integer"
+          "shape": "Sm",
+          "locationName": "programNumber"
         }
       }
     },
@@ -1146,61 +1545,78 @@
       "type": "structure",
       "members": {
         "BluePrimaryX": {
-          "locationName": "bluePrimaryX",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "bluePrimaryX"
         },
         "BluePrimaryY": {
-          "locationName": "bluePrimaryY",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "bluePrimaryY"
         },
         "GreenPrimaryX": {
-          "locationName": "greenPrimaryX",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "greenPrimaryX"
         },
         "GreenPrimaryY": {
-          "locationName": "greenPrimaryY",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "greenPrimaryY"
         },
         "MaxContentLightLevel": {
-          "locationName": "maxContentLightLevel",
-          "type": "integer"
+          "shape": "S1t",
+          "locationName": "maxContentLightLevel"
         },
         "MaxFrameAverageLightLevel": {
-          "locationName": "maxFrameAverageLightLevel",
-          "type": "integer"
+          "shape": "S1t",
+          "locationName": "maxFrameAverageLightLevel"
         },
         "MaxLuminance": {
-          "locationName": "maxLuminance",
-          "type": "integer"
+          "shape": "S1u",
+          "locationName": "maxLuminance"
         },
         "MinLuminance": {
-          "locationName": "minLuminance",
-          "type": "integer"
+          "shape": "S1u",
+          "locationName": "minLuminance"
         },
         "RedPrimaryX": {
-          "locationName": "redPrimaryX",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "redPrimaryX"
         },
         "RedPrimaryY": {
-          "locationName": "redPrimaryY",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "redPrimaryY"
         },
         "WhitePointX": {
-          "locationName": "whitePointX",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "whitePointX"
         },
         "WhitePointY": {
-          "locationName": "whitePointY",
-          "type": "integer"
+          "shape": "S1s",
+          "locationName": "whitePointY"
         }
       }
+    },
+    "S1s": {
+      "type": "integer",
+      "min": 0,
+      "max": 50000
+    },
+    "S1t": {
+      "type": "integer",
+      "min": 0,
+      "max": 65535
+    },
+    "S1u": {
+      "type": "integer",
+      "min": 0,
+      "max": 2147483647
     },
     "S1v": {
       "type": "structure",
       "members": {
         "BreakoutCode": {
           "locationName": "breakoutCode",
-          "type": "integer"
+          "type": "integer",
+          "min": 0,
+          "max": 9
         },
         "DistributorId": {
           "locationName": "distributorId"
@@ -1230,12 +1646,23 @@
                     "locationName": "baseUrl"
                   },
                   "ClientCache": {
-                    "locationName": "clientCache"
+                    "locationName": "clientCache",
+                    "type": "string",
+                    "enum": [
+                      "DISABLED",
+                      "ENABLED"
+                    ]
                   },
                   "CodecSpecification": {
-                    "locationName": "codecSpecification"
+                    "locationName": "codecSpecification",
+                    "type": "string",
+                    "enum": [
+                      "RFC_6381",
+                      "RFC_4281"
+                    ]
                   },
                   "Destination": {
+                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -1243,56 +1670,100 @@
                     "type": "structure",
                     "members": {
                       "ConstantInitializationVector": {
+                        "shape": "S25",
                         "locationName": "constantInitializationVector"
                       },
                       "EncryptionMethod": {
-                        "locationName": "encryptionMethod"
+                        "locationName": "encryptionMethod",
+                        "type": "string",
+                        "enum": [
+                          "SAMPLE_AES"
+                        ]
                       },
                       "InitializationVectorInManifest": {
-                        "locationName": "initializationVectorInManifest"
+                        "locationName": "initializationVectorInManifest",
+                        "type": "string",
+                        "enum": [
+                          "INCLUDE",
+                          "EXCLUDE"
+                        ]
                       },
                       "StaticKeyProvider": {
                         "shape": "S28",
                         "locationName": "staticKeyProvider"
                       },
                       "Type": {
-                        "locationName": "type"
+                        "locationName": "type",
+                        "type": "string",
+                        "enum": [
+                          "STATIC_KEY"
+                        ]
                       }
                     }
                   },
                   "FragmentLength": {
-                    "locationName": "fragmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "fragmentLength"
                   },
                   "ManifestCompression": {
-                    "locationName": "manifestCompression"
+                    "locationName": "manifestCompression",
+                    "type": "string",
+                    "enum": [
+                      "GZIP",
+                      "NONE"
+                    ]
                   },
                   "ManifestDurationFormat": {
-                    "locationName": "manifestDurationFormat"
+                    "locationName": "manifestDurationFormat",
+                    "type": "string",
+                    "enum": [
+                      "FLOATING_POINT",
+                      "INTEGER"
+                    ]
                   },
                   "MinBufferTime": {
-                    "locationName": "minBufferTime",
-                    "type": "integer"
+                    "shape": "S1u",
+                    "locationName": "minBufferTime"
                   },
                   "MinFinalSegmentLength": {
                     "locationName": "minFinalSegmentLength",
                     "type": "double"
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl"
+                    "locationName": "segmentControl",
+                    "type": "string",
+                    "enum": [
+                      "SINGLE_FILE",
+                      "SEGMENTED_FILES"
+                    ]
                   },
                   "SegmentLength": {
-                    "locationName": "segmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "segmentLength"
                   },
                   "StreamInfResolution": {
-                    "locationName": "streamInfResolution"
+                    "locationName": "streamInfResolution",
+                    "type": "string",
+                    "enum": [
+                      "INCLUDE",
+                      "EXCLUDE"
+                    ]
                   },
                   "WriteDashManifest": {
-                    "locationName": "writeDashManifest"
+                    "locationName": "writeDashManifest",
+                    "type": "string",
+                    "enum": [
+                      "DISABLED",
+                      "ENABLED"
+                    ]
                   },
                   "WriteHlsManifest": {
-                    "locationName": "writeHlsManifest"
+                    "locationName": "writeHlsManifest",
+                    "type": "string",
+                    "enum": [
+                      "DISABLED",
+                      "ENABLED"
+                    ]
                   }
                 }
               },
@@ -1304,6 +1775,7 @@
                     "locationName": "baseUrl"
                   },
                   "Destination": {
+                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -1317,25 +1789,40 @@
                     }
                   },
                   "FragmentLength": {
-                    "locationName": "fragmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "fragmentLength"
                   },
                   "HbbtvCompliance": {
-                    "locationName": "hbbtvCompliance"
+                    "locationName": "hbbtvCompliance",
+                    "type": "string",
+                    "enum": [
+                      "HBBTV_1_5",
+                      "NONE"
+                    ]
                   },
                   "MinBufferTime": {
-                    "locationName": "minBufferTime",
-                    "type": "integer"
+                    "shape": "S1u",
+                    "locationName": "minBufferTime"
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl"
+                    "locationName": "segmentControl",
+                    "type": "string",
+                    "enum": [
+                      "SINGLE_FILE",
+                      "SEGMENTED_FILES"
+                    ]
                   },
                   "SegmentLength": {
-                    "locationName": "segmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "segmentLength"
                   },
                   "WriteSegmentTimelineInRepresentation": {
-                    "locationName": "writeSegmentTimelineInRepresentation"
+                    "locationName": "writeSegmentTimelineInRepresentation",
+                    "type": "string",
+                    "enum": [
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   }
                 }
               },
@@ -1344,6 +1831,7 @@
                 "type": "structure",
                 "members": {
                   "Destination": {
+                    "shape": "S23",
                     "locationName": "destination"
                   }
                 }
@@ -1355,7 +1843,13 @@
                   "AdMarkers": {
                     "locationName": "adMarkers",
                     "type": "list",
-                    "member": {}
+                    "member": {
+                      "type": "string",
+                      "enum": [
+                        "ELEMENTAL",
+                        "ELEMENTAL_SCTE35"
+                      ]
+                    }
                   },
                   "BaseUrl": {
                     "locationName": "baseUrl"
@@ -1367,13 +1861,15 @@
                       "type": "structure",
                       "members": {
                         "CaptionChannel": {
-                          "locationName": "captionChannel",
-                          "type": "integer"
+                          "shape": "Sm",
+                          "locationName": "captionChannel"
                         },
                         "CustomLanguageCode": {
+                          "shape": "Si",
                           "locationName": "customLanguageCode"
                         },
                         "LanguageCode": {
+                          "shape": "Sl",
                           "locationName": "languageCode"
                         },
                         "LanguageDescription": {
@@ -1383,32 +1879,65 @@
                     }
                   },
                   "CaptionLanguageSetting": {
-                    "locationName": "captionLanguageSetting"
+                    "locationName": "captionLanguageSetting",
+                    "type": "string",
+                    "enum": [
+                      "INSERT",
+                      "OMIT",
+                      "NONE"
+                    ]
                   },
                   "ClientCache": {
-                    "locationName": "clientCache"
+                    "locationName": "clientCache",
+                    "type": "string",
+                    "enum": [
+                      "DISABLED",
+                      "ENABLED"
+                    ]
                   },
                   "CodecSpecification": {
-                    "locationName": "codecSpecification"
+                    "locationName": "codecSpecification",
+                    "type": "string",
+                    "enum": [
+                      "RFC_6381",
+                      "RFC_4281"
+                    ]
                   },
                   "Destination": {
+                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "DirectoryStructure": {
-                    "locationName": "directoryStructure"
+                    "locationName": "directoryStructure",
+                    "type": "string",
+                    "enum": [
+                      "SINGLE_DIRECTORY",
+                      "SUBDIRECTORY_PER_STREAM"
+                    ]
                   },
                   "Encryption": {
                     "locationName": "encryption",
                     "type": "structure",
                     "members": {
                       "ConstantInitializationVector": {
+                        "shape": "S25",
                         "locationName": "constantInitializationVector"
                       },
                       "EncryptionMethod": {
-                        "locationName": "encryptionMethod"
+                        "locationName": "encryptionMethod",
+                        "type": "string",
+                        "enum": [
+                          "AES128",
+                          "SAMPLE_AES"
+                        ]
                       },
                       "InitializationVectorInManifest": {
-                        "locationName": "initializationVectorInManifest"
+                        "locationName": "initializationVectorInManifest",
+                        "type": "string",
+                        "enum": [
+                          "INCLUDE",
+                          "EXCLUDE"
+                        ]
                       },
                       "SpekeKeyProvider": {
                         "shape": "S2m",
@@ -1419,58 +1948,101 @@
                         "locationName": "staticKeyProvider"
                       },
                       "Type": {
-                        "locationName": "type"
+                        "locationName": "type",
+                        "type": "string",
+                        "enum": [
+                          "SPEKE",
+                          "STATIC_KEY"
+                        ]
                       }
                     }
                   },
                   "ManifestCompression": {
-                    "locationName": "manifestCompression"
+                    "locationName": "manifestCompression",
+                    "type": "string",
+                    "enum": [
+                      "GZIP",
+                      "NONE"
+                    ]
                   },
                   "ManifestDurationFormat": {
-                    "locationName": "manifestDurationFormat"
+                    "locationName": "manifestDurationFormat",
+                    "type": "string",
+                    "enum": [
+                      "FLOATING_POINT",
+                      "INTEGER"
+                    ]
                   },
                   "MinFinalSegmentLength": {
                     "locationName": "minFinalSegmentLength",
                     "type": "double"
                   },
                   "MinSegmentLength": {
-                    "locationName": "minSegmentLength",
-                    "type": "integer"
+                    "shape": "S1u",
+                    "locationName": "minSegmentLength"
                   },
                   "OutputSelection": {
-                    "locationName": "outputSelection"
+                    "locationName": "outputSelection",
+                    "type": "string",
+                    "enum": [
+                      "MANIFESTS_AND_SEGMENTS",
+                      "SEGMENTS_ONLY"
+                    ]
                   },
                   "ProgramDateTime": {
-                    "locationName": "programDateTime"
+                    "locationName": "programDateTime",
+                    "type": "string",
+                    "enum": [
+                      "INCLUDE",
+                      "EXCLUDE"
+                    ]
                   },
                   "ProgramDateTimePeriod": {
                     "locationName": "programDateTimePeriod",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 0,
+                    "max": 3600
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl"
+                    "locationName": "segmentControl",
+                    "type": "string",
+                    "enum": [
+                      "SINGLE_FILE",
+                      "SEGMENTED_FILES"
+                    ]
                   },
                   "SegmentLength": {
-                    "locationName": "segmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "segmentLength"
                   },
                   "SegmentsPerSubdirectory": {
-                    "locationName": "segmentsPerSubdirectory",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "segmentsPerSubdirectory"
                   },
                   "StreamInfResolution": {
-                    "locationName": "streamInfResolution"
+                    "locationName": "streamInfResolution",
+                    "type": "string",
+                    "enum": [
+                      "INCLUDE",
+                      "EXCLUDE"
+                    ]
                   },
                   "TimedMetadataId3Frame": {
-                    "locationName": "timedMetadataId3Frame"
+                    "locationName": "timedMetadataId3Frame",
+                    "type": "string",
+                    "enum": [
+                      "NONE",
+                      "PRIV",
+                      "TDRL"
+                    ]
                   },
                   "TimedMetadataId3Period": {
-                    "locationName": "timedMetadataId3Period",
-                    "type": "integer"
+                    "shape": "Sm",
+                    "locationName": "timedMetadataId3Period"
                   },
                   "TimestampDeltaMilliseconds": {
-                    "locationName": "timestampDeltaMilliseconds",
-                    "type": "integer"
+                    "shape": "Sm",
+                    "locationName": "timestampDeltaMilliseconds"
                   }
                 }
               },
@@ -1479,9 +2051,15 @@
                 "type": "structure",
                 "members": {
                   "AudioDeduplication": {
-                    "locationName": "audioDeduplication"
+                    "locationName": "audioDeduplication",
+                    "type": "string",
+                    "enum": [
+                      "COMBINE_DUPLICATE_STREAMS",
+                      "NONE"
+                    ]
                   },
                   "Destination": {
+                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -1495,16 +2073,29 @@
                     }
                   },
                   "FragmentLength": {
-                    "locationName": "fragmentLength",
-                    "type": "integer"
+                    "shape": "So",
+                    "locationName": "fragmentLength"
                   },
                   "ManifestEncoding": {
-                    "locationName": "manifestEncoding"
+                    "locationName": "manifestEncoding",
+                    "type": "string",
+                    "enum": [
+                      "UTF8",
+                      "UTF16"
+                    ]
                   }
                 }
               },
               "Type": {
-                "locationName": "type"
+                "locationName": "type",
+                "type": "string",
+                "enum": [
+                  "HLS_GROUP_SETTINGS",
+                  "DASH_ISO_GROUP_SETTINGS",
+                  "FILE_GROUP_SETTINGS",
+                  "MS_SMOOTH_GROUP_SETTINGS",
+                  "CMAF_GROUP_SETTINGS"
+                ]
               }
             }
           },
@@ -1525,9 +2116,11 @@
                     "type": "structure",
                     "members": {
                       "CaptionSelectorName": {
+                        "shape": "Sf",
                         "locationName": "captionSelectorName"
                       },
                       "CustomLanguageCode": {
+                        "shape": "Si",
                         "locationName": "customLanguageCode"
                       },
                       "DestinationSettings": {
@@ -1535,6 +2128,7 @@
                         "locationName": "destinationSettings"
                       },
                       "LanguageCode": {
+                        "shape": "Sl",
                         "locationName": "languageCode"
                       },
                       "LanguageDescription": {
@@ -1551,6 +2145,7 @@
                   "locationName": "extension"
                 },
                 "NameModifier": {
+                  "shape": "Sf",
                   "locationName": "nameModifier"
                 },
                 "OutputSettings": {
@@ -1568,10 +2163,22 @@
                           "locationName": "audioRenditionSets"
                         },
                         "AudioTrackType": {
-                          "locationName": "audioTrackType"
+                          "locationName": "audioTrackType",
+                          "type": "string",
+                          "enum": [
+                            "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT",
+                            "ALTERNATE_AUDIO_AUTO_SELECT",
+                            "ALTERNATE_AUDIO_NOT_AUTO_SELECT",
+                            "AUDIO_ONLY_VARIANT_STREAM"
+                          ]
                         },
                         "IFrameOnlyManifest": {
-                          "locationName": "iFrameOnlyManifest"
+                          "locationName": "iFrameOnlyManifest",
+                          "type": "string",
+                          "enum": [
+                            "INCLUDE",
+                            "EXCLUDE"
+                          ]
                         },
                         "SegmentModifier": {
                           "locationName": "segmentModifier"
@@ -1581,7 +2188,9 @@
                   }
                 },
                 "Preset": {
-                  "locationName": "preset"
+                  "locationName": "preset",
+                  "type": "string",
+                  "min": 0
                 },
                 "VideoDescription": {
                   "shape": "S7e",
@@ -1593,17 +2202,33 @@
         }
       }
     },
+    "S23": {
+      "type": "string",
+      "pattern": "^s3:\\/\\/"
+    },
+    "S25": {
+      "type": "string",
+      "min": 32,
+      "max": 32,
+      "pattern": "^[0-9a-fA-F]{32}$"
+    },
     "S28": {
       "type": "structure",
       "members": {
         "KeyFormat": {
-          "locationName": "keyFormat"
+          "locationName": "keyFormat",
+          "type": "string",
+          "pattern": "^(identity|[A-Za-z]{2,6}(\\.[A-Za-z0-9-]{1,63})+)$"
         },
         "KeyFormatVersions": {
-          "locationName": "keyFormatVersions"
+          "locationName": "keyFormatVersions",
+          "type": "string",
+          "pattern": "^(\\d+(\\/\\d+)*)$"
         },
         "StaticKeyValue": {
-          "locationName": "staticKeyValue"
+          "locationName": "staticKeyValue",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9]{32}$"
         },
         "Url": {
           "locationName": "url"
@@ -1619,10 +2244,15 @@
         "SystemIds": {
           "locationName": "systemIds",
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          }
         },
         "Url": {
-          "locationName": "url"
+          "locationName": "url",
+          "type": "string",
+          "pattern": "^https:\\/\\/"
         }
       }
     },
@@ -1636,20 +2266,42 @@
             "type": "structure",
             "members": {
               "Algorithm": {
-                "locationName": "algorithm"
+                "locationName": "algorithm",
+                "type": "string",
+                "enum": [
+                  "ITU_BS_1770_1",
+                  "ITU_BS_1770_2"
+                ]
               },
               "AlgorithmControl": {
-                "locationName": "algorithmControl"
+                "locationName": "algorithmControl",
+                "type": "string",
+                "enum": [
+                  "CORRECT_AUDIO",
+                  "MEASURE_ONLY"
+                ]
               },
               "CorrectionGateLevel": {
                 "locationName": "correctionGateLevel",
-                "type": "integer"
+                "type": "integer",
+                "min": -70,
+                "max": 0
               },
               "LoudnessLogging": {
-                "locationName": "loudnessLogging"
+                "locationName": "loudnessLogging",
+                "type": "string",
+                "enum": [
+                  "LOG",
+                  "DONT_LOG"
+                ]
               },
               "PeakCalculation": {
-                "locationName": "peakCalculation"
+                "locationName": "peakCalculation",
+                "type": "string",
+                "enum": [
+                  "TRUE_PEAK",
+                  "NONE"
+                ]
               },
               "TargetLkfs": {
                 "locationName": "targetLkfs",
@@ -1661,11 +2313,16 @@
             "locationName": "audioSourceName"
           },
           "AudioType": {
-            "locationName": "audioType",
-            "type": "integer"
+            "shape": "S3v",
+            "locationName": "audioType"
           },
           "AudioTypeControl": {
-            "locationName": "audioTypeControl"
+            "locationName": "audioTypeControl",
+            "type": "string",
+            "enum": [
+              "FOLLOW_INPUT",
+              "USE_CONFIGURED"
+            ]
           },
           "CodecSettings": {
             "locationName": "codecSettings",
@@ -1676,33 +2333,78 @@
                 "type": "structure",
                 "members": {
                   "AudioDescriptionBroadcasterMix": {
-                    "locationName": "audioDescriptionBroadcasterMix"
+                    "locationName": "audioDescriptionBroadcasterMix",
+                    "type": "string",
+                    "enum": [
+                      "BROADCASTER_MIXED_AD",
+                      "NORMAL"
+                    ]
                   },
                   "Bitrate": {
                     "locationName": "bitrate",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 6000,
+                    "max": 1024000
                   },
                   "CodecProfile": {
-                    "locationName": "codecProfile"
+                    "locationName": "codecProfile",
+                    "type": "string",
+                    "enum": [
+                      "LC",
+                      "HEV1",
+                      "HEV2"
+                    ]
                   },
                   "CodingMode": {
-                    "locationName": "codingMode"
+                    "locationName": "codingMode",
+                    "type": "string",
+                    "enum": [
+                      "AD_RECEIVER_MIX",
+                      "CODING_MODE_1_0",
+                      "CODING_MODE_1_1",
+                      "CODING_MODE_2_0",
+                      "CODING_MODE_5_1"
+                    ]
                   },
                   "RateControlMode": {
-                    "locationName": "rateControlMode"
+                    "locationName": "rateControlMode",
+                    "type": "string",
+                    "enum": [
+                      "CBR",
+                      "VBR"
+                    ]
                   },
                   "RawFormat": {
-                    "locationName": "rawFormat"
+                    "locationName": "rawFormat",
+                    "type": "string",
+                    "enum": [
+                      "LATM_LOAS",
+                      "NONE"
+                    ]
                   },
                   "SampleRate": {
                     "locationName": "sampleRate",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 8000,
+                    "max": 96000
                   },
                   "Specification": {
-                    "locationName": "specification"
+                    "locationName": "specification",
+                    "type": "string",
+                    "enum": [
+                      "MPEG2",
+                      "MPEG4"
+                    ]
                   },
                   "VbrQuality": {
-                    "locationName": "vbrQuality"
+                    "locationName": "vbrQuality",
+                    "type": "string",
+                    "enum": [
+                      "LOW",
+                      "MEDIUM_LOW",
+                      "MEDIUM_HIGH",
+                      "HIGH"
+                    ]
                   }
                 }
               },
@@ -1711,31 +2413,64 @@
                 "type": "structure",
                 "members": {
                   "Bitrate": {
-                    "locationName": "bitrate",
-                    "type": "integer"
+                    "shape": "S49",
+                    "locationName": "bitrate"
                   },
                   "BitstreamMode": {
-                    "locationName": "bitstreamMode"
+                    "locationName": "bitstreamMode",
+                    "type": "string",
+                    "enum": [
+                      "COMPLETE_MAIN",
+                      "COMMENTARY",
+                      "DIALOGUE",
+                      "EMERGENCY",
+                      "HEARING_IMPAIRED",
+                      "MUSIC_AND_EFFECTS",
+                      "VISUALLY_IMPAIRED",
+                      "VOICE_OVER"
+                    ]
                   },
                   "CodingMode": {
-                    "locationName": "codingMode"
+                    "locationName": "codingMode",
+                    "type": "string",
+                    "enum": [
+                      "CODING_MODE_1_0",
+                      "CODING_MODE_1_1",
+                      "CODING_MODE_2_0",
+                      "CODING_MODE_3_2_LFE"
+                    ]
                   },
                   "Dialnorm": {
-                    "locationName": "dialnorm",
-                    "type": "integer"
+                    "shape": "S4c",
+                    "locationName": "dialnorm"
                   },
                   "DynamicRangeCompressionProfile": {
-                    "locationName": "dynamicRangeCompressionProfile"
+                    "locationName": "dynamicRangeCompressionProfile",
+                    "type": "string",
+                    "enum": [
+                      "FILM_STANDARD",
+                      "NONE"
+                    ]
                   },
                   "LfeFilter": {
-                    "locationName": "lfeFilter"
+                    "locationName": "lfeFilter",
+                    "type": "string",
+                    "enum": [
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   },
                   "MetadataControl": {
-                    "locationName": "metadataControl"
+                    "locationName": "metadataControl",
+                    "type": "string",
+                    "enum": [
+                      "FOLLOW_INPUT",
+                      "USE_CONFIGURED"
+                    ]
                   },
                   "SampleRate": {
-                    "locationName": "sampleRate",
-                    "type": "integer"
+                    "shape": "S4g",
+                    "locationName": "sampleRate"
                   }
                 }
               },
@@ -1744,57 +2479,119 @@
                 "type": "structure",
                 "members": {
                   "BitDepth": {
-                    "locationName": "bitDepth",
-                    "type": "integer"
+                    "shape": "S4i",
+                    "locationName": "bitDepth"
                   },
                   "Channels": {
-                    "locationName": "channels",
-                    "type": "integer"
+                    "shape": "S4j",
+                    "locationName": "channels"
                   },
                   "SampleRate": {
-                    "locationName": "sampleRate",
-                    "type": "integer"
+                    "shape": "S4k",
+                    "locationName": "sampleRate"
                   }
                 }
               },
               "Codec": {
-                "locationName": "codec"
+                "locationName": "codec",
+                "type": "string",
+                "enum": [
+                  "AAC",
+                  "MP2",
+                  "WAV",
+                  "AIFF",
+                  "AC3",
+                  "EAC3",
+                  "PASSTHROUGH"
+                ]
               },
               "Eac3Settings": {
                 "locationName": "eac3Settings",
                 "type": "structure",
                 "members": {
                   "AttenuationControl": {
-                    "locationName": "attenuationControl"
+                    "locationName": "attenuationControl",
+                    "type": "string",
+                    "enum": [
+                      "ATTENUATE_3_DB",
+                      "NONE"
+                    ]
                   },
                   "Bitrate": {
-                    "locationName": "bitrate",
-                    "type": "integer"
+                    "shape": "S49",
+                    "locationName": "bitrate"
                   },
                   "BitstreamMode": {
-                    "locationName": "bitstreamMode"
+                    "locationName": "bitstreamMode",
+                    "type": "string",
+                    "enum": [
+                      "COMPLETE_MAIN",
+                      "COMMENTARY",
+                      "EMERGENCY",
+                      "HEARING_IMPAIRED",
+                      "VISUALLY_IMPAIRED"
+                    ]
                   },
                   "CodingMode": {
-                    "locationName": "codingMode"
+                    "locationName": "codingMode",
+                    "type": "string",
+                    "enum": [
+                      "CODING_MODE_1_0",
+                      "CODING_MODE_2_0",
+                      "CODING_MODE_3_2"
+                    ]
                   },
                   "DcFilter": {
-                    "locationName": "dcFilter"
+                    "locationName": "dcFilter",
+                    "type": "string",
+                    "enum": [
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   },
                   "Dialnorm": {
-                    "locationName": "dialnorm",
-                    "type": "integer"
+                    "shape": "S4c",
+                    "locationName": "dialnorm"
                   },
                   "DynamicRangeCompressionLine": {
-                    "locationName": "dynamicRangeCompressionLine"
+                    "locationName": "dynamicRangeCompressionLine",
+                    "type": "string",
+                    "enum": [
+                      "NONE",
+                      "FILM_STANDARD",
+                      "FILM_LIGHT",
+                      "MUSIC_STANDARD",
+                      "MUSIC_LIGHT",
+                      "SPEECH"
+                    ]
                   },
                   "DynamicRangeCompressionRf": {
-                    "locationName": "dynamicRangeCompressionRf"
+                    "locationName": "dynamicRangeCompressionRf",
+                    "type": "string",
+                    "enum": [
+                      "NONE",
+                      "FILM_STANDARD",
+                      "FILM_LIGHT",
+                      "MUSIC_STANDARD",
+                      "MUSIC_LIGHT",
+                      "SPEECH"
+                    ]
                   },
                   "LfeControl": {
-                    "locationName": "lfeControl"
+                    "locationName": "lfeControl",
+                    "type": "string",
+                    "enum": [
+                      "LFE",
+                      "NO_LFE"
+                    ]
                   },
                   "LfeFilter": {
-                    "locationName": "lfeFilter"
+                    "locationName": "lfeFilter",
+                    "type": "string",
+                    "enum": [
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   },
                   "LoRoCenterMixLevel": {
                     "locationName": "loRoCenterMixLevel",
@@ -1813,26 +2610,60 @@
                     "type": "double"
                   },
                   "MetadataControl": {
-                    "locationName": "metadataControl"
+                    "locationName": "metadataControl",
+                    "type": "string",
+                    "enum": [
+                      "FOLLOW_INPUT",
+                      "USE_CONFIGURED"
+                    ]
                   },
                   "PassthroughControl": {
-                    "locationName": "passthroughControl"
+                    "locationName": "passthroughControl",
+                    "type": "string",
+                    "enum": [
+                      "WHEN_POSSIBLE",
+                      "NO_PASSTHROUGH"
+                    ]
                   },
                   "PhaseControl": {
-                    "locationName": "phaseControl"
+                    "locationName": "phaseControl",
+                    "type": "string",
+                    "enum": [
+                      "SHIFT_90_DEGREES",
+                      "NO_SHIFT"
+                    ]
                   },
                   "SampleRate": {
-                    "locationName": "sampleRate",
-                    "type": "integer"
+                    "shape": "S4g",
+                    "locationName": "sampleRate"
                   },
                   "StereoDownmix": {
-                    "locationName": "stereoDownmix"
+                    "locationName": "stereoDownmix",
+                    "type": "string",
+                    "enum": [
+                      "NOT_INDICATED",
+                      "LO_RO",
+                      "LT_RT",
+                      "DPL2"
+                    ]
                   },
                   "SurroundExMode": {
-                    "locationName": "surroundExMode"
+                    "locationName": "surroundExMode",
+                    "type": "string",
+                    "enum": [
+                      "NOT_INDICATED",
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   },
                   "SurroundMode": {
-                    "locationName": "surroundMode"
+                    "locationName": "surroundMode",
+                    "type": "string",
+                    "enum": [
+                      "NOT_INDICATED",
+                      "ENABLED",
+                      "DISABLED"
+                    ]
                   }
                 }
               },
@@ -1842,15 +2673,19 @@
                 "members": {
                   "Bitrate": {
                     "locationName": "bitrate",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 32000,
+                    "max": 384000
                   },
                   "Channels": {
-                    "locationName": "channels",
-                    "type": "integer"
+                    "shape": "S4j",
+                    "locationName": "channels"
                   },
                   "SampleRate": {
                     "locationName": "sampleRate",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 32000,
+                    "max": 48000
                   }
                 }
               },
@@ -1859,42 +2694,91 @@
                 "type": "structure",
                 "members": {
                   "BitDepth": {
-                    "locationName": "bitDepth",
-                    "type": "integer"
+                    "shape": "S4i",
+                    "locationName": "bitDepth"
                   },
                   "Channels": {
-                    "locationName": "channels",
-                    "type": "integer"
+                    "shape": "Sx",
+                    "locationName": "channels"
                   },
                   "Format": {
-                    "locationName": "format"
+                    "locationName": "format",
+                    "type": "string",
+                    "enum": [
+                      "RIFF",
+                      "RF64"
+                    ]
                   },
                   "SampleRate": {
-                    "locationName": "sampleRate",
-                    "type": "integer"
+                    "shape": "S4k",
+                    "locationName": "sampleRate"
                   }
                 }
               }
             }
           },
           "CustomLanguageCode": {
+            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "LanguageCode": {
+            "shape": "Sl",
             "locationName": "languageCode"
           },
           "LanguageCodeControl": {
-            "locationName": "languageCodeControl"
+            "locationName": "languageCodeControl",
+            "type": "string",
+            "enum": [
+              "FOLLOW_INPUT",
+              "USE_CONFIGURED"
+            ]
           },
           "RemixSettings": {
             "shape": "Sq",
             "locationName": "remixSettings"
           },
           "StreamName": {
-            "locationName": "streamName"
+            "locationName": "streamName",
+            "type": "string",
+            "pattern": "^[\\w\\s]*$"
           }
         }
       }
+    },
+    "S3v": {
+      "type": "integer",
+      "min": 0,
+      "max": 255
+    },
+    "S49": {
+      "type": "integer",
+      "min": 64000,
+      "max": 640000
+    },
+    "S4c": {
+      "type": "integer",
+      "min": 1,
+      "max": 31
+    },
+    "S4g": {
+      "type": "integer",
+      "min": 48000,
+      "max": 48000
+    },
+    "S4i": {
+      "type": "integer",
+      "min": 16,
+      "max": 24
+    },
+    "S4j": {
+      "type": "integer",
+      "min": 1,
+      "max": 2
+    },
+    "S4k": {
+      "type": "integer",
+      "min": 8000,
+      "max": 192000
     },
     "S5c": {
       "type": "structure",
@@ -1904,129 +2788,220 @@
           "type": "structure",
           "members": {
             "Alignment": {
-              "locationName": "alignment"
+              "locationName": "alignment",
+              "type": "string",
+              "enum": [
+                "CENTERED",
+                "LEFT"
+              ]
             },
             "BackgroundColor": {
-              "locationName": "backgroundColor"
+              "locationName": "backgroundColor",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "BLACK",
+                "WHITE"
+              ]
             },
             "BackgroundOpacity": {
-              "locationName": "backgroundOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "backgroundOpacity"
             },
             "FontColor": {
-              "locationName": "fontColor"
+              "locationName": "fontColor",
+              "type": "string",
+              "enum": [
+                "WHITE",
+                "BLACK",
+                "YELLOW",
+                "RED",
+                "GREEN",
+                "BLUE"
+              ]
             },
             "FontOpacity": {
-              "locationName": "fontOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "fontOpacity"
             },
             "FontResolution": {
-              "locationName": "fontResolution",
-              "type": "integer"
+              "shape": "S5h",
+              "locationName": "fontResolution"
             },
             "FontSize": {
-              "locationName": "fontSize",
-              "type": "integer"
+              "shape": "S5i",
+              "locationName": "fontSize"
             },
             "OutlineColor": {
-              "locationName": "outlineColor"
+              "locationName": "outlineColor",
+              "type": "string",
+              "enum": [
+                "BLACK",
+                "WHITE",
+                "YELLOW",
+                "RED",
+                "GREEN",
+                "BLUE"
+              ]
             },
             "OutlineSize": {
-              "locationName": "outlineSize",
-              "type": "integer"
+              "shape": "S5k",
+              "locationName": "outlineSize"
             },
             "ShadowColor": {
-              "locationName": "shadowColor"
+              "locationName": "shadowColor",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "BLACK",
+                "WHITE"
+              ]
             },
             "ShadowOpacity": {
-              "locationName": "shadowOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "shadowOpacity"
             },
             "ShadowXOffset": {
-              "locationName": "shadowXOffset",
-              "type": "integer"
+              "shape": "Sm",
+              "locationName": "shadowXOffset"
             },
             "ShadowYOffset": {
-              "locationName": "shadowYOffset",
-              "type": "integer"
+              "shape": "Sm",
+              "locationName": "shadowYOffset"
             },
             "TeletextSpacing": {
-              "locationName": "teletextSpacing"
+              "locationName": "teletextSpacing",
+              "type": "string",
+              "enum": [
+                "FIXED_GRID",
+                "PROPORTIONAL"
+              ]
             },
             "XPosition": {
-              "locationName": "xPosition",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "xPosition"
             },
             "YPosition": {
-              "locationName": "yPosition",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "yPosition"
             }
           }
         },
         "DestinationType": {
-          "locationName": "destinationType"
+          "locationName": "destinationType",
+          "type": "string",
+          "enum": [
+            "BURN_IN",
+            "DVB_SUB",
+            "EMBEDDED",
+            "SCC",
+            "SRT",
+            "TELETEXT",
+            "TTML",
+            "WEBVTT"
+          ]
         },
         "DvbSubDestinationSettings": {
           "locationName": "dvbSubDestinationSettings",
           "type": "structure",
           "members": {
             "Alignment": {
-              "locationName": "alignment"
+              "locationName": "alignment",
+              "type": "string",
+              "enum": [
+                "CENTERED",
+                "LEFT"
+              ]
             },
             "BackgroundColor": {
-              "locationName": "backgroundColor"
+              "locationName": "backgroundColor",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "BLACK",
+                "WHITE"
+              ]
             },
             "BackgroundOpacity": {
-              "locationName": "backgroundOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "backgroundOpacity"
             },
             "FontColor": {
-              "locationName": "fontColor"
+              "locationName": "fontColor",
+              "type": "string",
+              "enum": [
+                "WHITE",
+                "BLACK",
+                "YELLOW",
+                "RED",
+                "GREEN",
+                "BLUE"
+              ]
             },
             "FontOpacity": {
-              "locationName": "fontOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "fontOpacity"
             },
             "FontResolution": {
-              "locationName": "fontResolution",
-              "type": "integer"
+              "shape": "S5h",
+              "locationName": "fontResolution"
             },
             "FontSize": {
-              "locationName": "fontSize",
-              "type": "integer"
+              "shape": "S5i",
+              "locationName": "fontSize"
             },
             "OutlineColor": {
-              "locationName": "outlineColor"
+              "locationName": "outlineColor",
+              "type": "string",
+              "enum": [
+                "BLACK",
+                "WHITE",
+                "YELLOW",
+                "RED",
+                "GREEN",
+                "BLUE"
+              ]
             },
             "OutlineSize": {
-              "locationName": "outlineSize",
-              "type": "integer"
+              "shape": "S5k",
+              "locationName": "outlineSize"
             },
             "ShadowColor": {
-              "locationName": "shadowColor"
+              "locationName": "shadowColor",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "BLACK",
+                "WHITE"
+              ]
             },
             "ShadowOpacity": {
-              "locationName": "shadowOpacity",
-              "type": "integer"
+              "shape": "S3v",
+              "locationName": "shadowOpacity"
             },
             "ShadowXOffset": {
-              "locationName": "shadowXOffset",
-              "type": "integer"
+              "shape": "Sm",
+              "locationName": "shadowXOffset"
             },
             "ShadowYOffset": {
-              "locationName": "shadowYOffset",
-              "type": "integer"
+              "shape": "Sm",
+              "locationName": "shadowYOffset"
             },
             "TeletextSpacing": {
-              "locationName": "teletextSpacing"
+              "locationName": "teletextSpacing",
+              "type": "string",
+              "enum": [
+                "FIXED_GRID",
+                "PROPORTIONAL"
+              ]
             },
             "XPosition": {
-              "locationName": "xPosition",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "xPosition"
             },
             "YPosition": {
-              "locationName": "yPosition",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "yPosition"
             }
           }
         },
@@ -2035,7 +3010,14 @@
           "type": "structure",
           "members": {
             "Framerate": {
-              "locationName": "framerate"
+              "locationName": "framerate",
+              "type": "string",
+              "enum": [
+                "FRAMERATE_23_97",
+                "FRAMERATE_24",
+                "FRAMERATE_29_97_DROPFRAME",
+                "FRAMERATE_29_97_NON_DROPFRAME"
+              ]
             }
           }
         },
@@ -2044,6 +3026,7 @@
           "type": "structure",
           "members": {
             "PageNumber": {
+              "shape": "S1d",
               "locationName": "pageNumber"
             }
           }
@@ -2053,24 +3036,62 @@
           "type": "structure",
           "members": {
             "StylePassthrough": {
-              "locationName": "stylePassthrough"
+              "locationName": "stylePassthrough",
+              "type": "string",
+              "enum": [
+                "ENABLED",
+                "DISABLED"
+              ]
             }
           }
         }
       }
     },
+    "S5h": {
+      "type": "integer",
+      "min": 96,
+      "max": 600
+    },
+    "S5i": {
+      "type": "integer",
+      "min": 0,
+      "max": 96
+    },
+    "S5k": {
+      "type": "integer",
+      "min": 0,
+      "max": 10
+    },
     "S60": {
       "type": "structure",
       "members": {
         "Container": {
-          "locationName": "container"
+          "locationName": "container",
+          "type": "string",
+          "enum": [
+            "F4V",
+            "ISMV",
+            "M2TS",
+            "M3U8",
+            "CMFC",
+            "MOV",
+            "MP4",
+            "MPD",
+            "MXF",
+            "RAW"
+          ]
         },
         "F4vSettings": {
           "locationName": "f4vSettings",
           "type": "structure",
           "members": {
             "MoovPlacement": {
-              "locationName": "moovPlacement"
+              "locationName": "moovPlacement",
+              "type": "string",
+              "enum": [
+                "PROGRESSIVE_DOWNLOAD",
+                "NORMAL"
+              ]
             }
           }
         },
@@ -2079,37 +3100,50 @@
           "type": "structure",
           "members": {
             "AudioBufferModel": {
-              "locationName": "audioBufferModel"
+              "locationName": "audioBufferModel",
+              "type": "string",
+              "enum": [
+                "DVB",
+                "ATSC"
+              ]
             },
             "AudioFramesPerPes": {
-              "locationName": "audioFramesPerPes",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "audioFramesPerPes"
             },
             "AudioPids": {
               "shape": "S66",
               "locationName": "audioPids"
             },
             "Bitrate": {
-              "locationName": "bitrate",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "bitrate"
             },
             "BufferModel": {
-              "locationName": "bufferModel"
+              "locationName": "bufferModel",
+              "type": "string",
+              "enum": [
+                "MULTIPLEX",
+                "NONE"
+              ]
             },
             "DvbNitSettings": {
               "locationName": "dvbNitSettings",
               "type": "structure",
               "members": {
                 "NetworkId": {
-                  "locationName": "networkId",
-                  "type": "integer"
+                  "shape": "S1t",
+                  "locationName": "networkId"
                 },
                 "NetworkName": {
+                  "shape": "S6a",
                   "locationName": "networkName"
                 },
                 "NitInterval": {
                   "locationName": "nitInterval",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 25,
+                  "max": 10000
                 }
               }
             },
@@ -2118,16 +3152,27 @@
               "type": "structure",
               "members": {
                 "OutputSdt": {
-                  "locationName": "outputSdt"
+                  "locationName": "outputSdt",
+                  "type": "string",
+                  "enum": [
+                    "SDT_FOLLOW",
+                    "SDT_FOLLOW_IF_PRESENT",
+                    "SDT_MANUAL",
+                    "SDT_NONE"
+                  ]
                 },
                 "SdtInterval": {
                   "locationName": "sdtInterval",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 25,
+                  "max": 2000
                 },
                 "ServiceName": {
+                  "shape": "S6a",
                   "locationName": "serviceName"
                 },
                 "ServiceProviderName": {
+                  "shape": "S6a",
                   "locationName": "serviceProviderName"
                 }
               }
@@ -2142,22 +3187,39 @@
               "members": {
                 "TdtInterval": {
                   "locationName": "tdtInterval",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1000,
+                  "max": 30000
                 }
               }
             },
             "DvbTeletextPid": {
-              "locationName": "dvbTeletextPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "dvbTeletextPid"
             },
             "EbpAudioInterval": {
-              "locationName": "ebpAudioInterval"
+              "locationName": "ebpAudioInterval",
+              "type": "string",
+              "enum": [
+                "VIDEO_AND_FIXED_INTERVALS",
+                "VIDEO_INTERVAL"
+              ]
             },
             "EbpPlacement": {
-              "locationName": "ebpPlacement"
+              "locationName": "ebpPlacement",
+              "type": "string",
+              "enum": [
+                "VIDEO_AND_AUDIO_PIDS",
+                "VIDEO_PID"
+              ]
             },
             "EsRateInPes": {
-              "locationName": "esRateInPes"
+              "locationName": "esRateInPes",
+              "type": "string",
+              "enum": [
+                "INCLUDE",
+                "EXCLUDE"
+              ]
             },
             "FragmentTime": {
               "locationName": "fragmentTime",
@@ -2165,77 +3227,115 @@
             },
             "MaxPcrInterval": {
               "locationName": "maxPcrInterval",
-              "type": "integer"
+              "type": "integer",
+              "min": 0,
+              "max": 500
             },
             "MinEbpInterval": {
               "locationName": "minEbpInterval",
-              "type": "integer"
+              "type": "integer",
+              "min": 0,
+              "max": 10000
             },
             "NielsenId3": {
-              "locationName": "nielsenId3"
+              "locationName": "nielsenId3",
+              "type": "string",
+              "enum": [
+                "INSERT",
+                "NONE"
+              ]
             },
             "NullPacketBitrate": {
               "locationName": "nullPacketBitrate",
               "type": "double"
             },
             "PatInterval": {
-              "locationName": "patInterval",
-              "type": "integer"
+              "shape": "S6o",
+              "locationName": "patInterval"
             },
             "PcrControl": {
-              "locationName": "pcrControl"
+              "locationName": "pcrControl",
+              "type": "string",
+              "enum": [
+                "PCR_EVERY_PES_PACKET",
+                "CONFIGURED_PCR_PERIOD"
+              ]
             },
             "PcrPid": {
-              "locationName": "pcrPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "pcrPid"
             },
             "PmtInterval": {
-              "locationName": "pmtInterval",
-              "type": "integer"
+              "shape": "S6o",
+              "locationName": "pmtInterval"
             },
             "PmtPid": {
-              "locationName": "pmtPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "pmtPid"
             },
             "PrivateMetadataPid": {
-              "locationName": "privateMetadataPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "privateMetadataPid"
             },
             "ProgramNumber": {
-              "locationName": "programNumber",
-              "type": "integer"
+              "shape": "S1t",
+              "locationName": "programNumber"
             },
             "RateMode": {
-              "locationName": "rateMode"
+              "locationName": "rateMode",
+              "type": "string",
+              "enum": [
+                "VBR",
+                "CBR"
+              ]
             },
             "Scte35Pid": {
-              "locationName": "scte35Pid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "scte35Pid"
             },
             "Scte35Source": {
-              "locationName": "scte35Source"
+              "locationName": "scte35Source",
+              "type": "string",
+              "enum": [
+                "PASSTHROUGH",
+                "NONE"
+              ]
             },
             "SegmentationMarkers": {
-              "locationName": "segmentationMarkers"
+              "locationName": "segmentationMarkers",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "RAI_SEGSTART",
+                "RAI_ADAPT",
+                "PSI_SEGSTART",
+                "EBP",
+                "EBP_LEGACY"
+              ]
             },
             "SegmentationStyle": {
-              "locationName": "segmentationStyle"
+              "locationName": "segmentationStyle",
+              "type": "string",
+              "enum": [
+                "MAINTAIN_CADENCE",
+                "RESET_CADENCE"
+              ]
             },
             "SegmentationTime": {
               "locationName": "segmentationTime",
               "type": "double"
             },
             "TimedMetadataPid": {
-              "locationName": "timedMetadataPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "timedMetadataPid"
             },
             "TransportStreamId": {
-              "locationName": "transportStreamId",
-              "type": "integer"
+              "shape": "S1t",
+              "locationName": "transportStreamId"
             },
             "VideoPid": {
-              "locationName": "videoPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "videoPid"
             }
           }
         },
@@ -2244,64 +3344,84 @@
           "type": "structure",
           "members": {
             "AudioFramesPerPes": {
-              "locationName": "audioFramesPerPes",
-              "type": "integer"
+              "shape": "S1u",
+              "locationName": "audioFramesPerPes"
             },
             "AudioPids": {
               "shape": "S66",
               "locationName": "audioPids"
             },
             "NielsenId3": {
-              "locationName": "nielsenId3"
+              "locationName": "nielsenId3",
+              "type": "string",
+              "enum": [
+                "INSERT",
+                "NONE"
+              ]
             },
             "PatInterval": {
-              "locationName": "patInterval",
-              "type": "integer"
+              "shape": "S6o",
+              "locationName": "patInterval"
             },
             "PcrControl": {
-              "locationName": "pcrControl"
+              "locationName": "pcrControl",
+              "type": "string",
+              "enum": [
+                "PCR_EVERY_PES_PACKET",
+                "CONFIGURED_PCR_PERIOD"
+              ]
             },
             "PcrPid": {
-              "locationName": "pcrPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "pcrPid"
             },
             "PmtInterval": {
-              "locationName": "pmtInterval",
-              "type": "integer"
+              "shape": "S6o",
+              "locationName": "pmtInterval"
             },
             "PmtPid": {
-              "locationName": "pmtPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "pmtPid"
             },
             "PrivateMetadataPid": {
-              "locationName": "privateMetadataPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "privateMetadataPid"
             },
             "ProgramNumber": {
-              "locationName": "programNumber",
-              "type": "integer"
+              "shape": "S1t",
+              "locationName": "programNumber"
             },
             "Scte35Pid": {
-              "locationName": "scte35Pid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "scte35Pid"
             },
             "Scte35Source": {
-              "locationName": "scte35Source"
+              "locationName": "scte35Source",
+              "type": "string",
+              "enum": [
+                "PASSTHROUGH",
+                "NONE"
+              ]
             },
             "TimedMetadata": {
-              "locationName": "timedMetadata"
+              "locationName": "timedMetadata",
+              "type": "string",
+              "enum": [
+                "PASSTHROUGH",
+                "NONE"
+              ]
             },
             "TimedMetadataPid": {
-              "locationName": "timedMetadataPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "timedMetadataPid"
             },
             "TransportStreamId": {
-              "locationName": "transportStreamId",
-              "type": "integer"
+              "shape": "S1t",
+              "locationName": "transportStreamId"
             },
             "VideoPid": {
-              "locationName": "videoPid",
-              "type": "integer"
+              "shape": "S67",
+              "locationName": "videoPid"
             }
           }
         },
@@ -2310,19 +3430,44 @@
           "type": "structure",
           "members": {
             "ClapAtom": {
-              "locationName": "clapAtom"
+              "locationName": "clapAtom",
+              "type": "string",
+              "enum": [
+                "INCLUDE",
+                "EXCLUDE"
+              ]
             },
             "CslgAtom": {
-              "locationName": "cslgAtom"
+              "locationName": "cslgAtom",
+              "type": "string",
+              "enum": [
+                "INCLUDE",
+                "EXCLUDE"
+              ]
             },
             "Mpeg2FourCCControl": {
-              "locationName": "mpeg2FourCCControl"
+              "locationName": "mpeg2FourCCControl",
+              "type": "string",
+              "enum": [
+                "XDCAM",
+                "MPEG"
+              ]
             },
             "PaddingControl": {
-              "locationName": "paddingControl"
+              "locationName": "paddingControl",
+              "type": "string",
+              "enum": [
+                "OMNEON",
+                "NONE"
+              ]
             },
             "Reference": {
-              "locationName": "reference"
+              "locationName": "reference",
+              "type": "string",
+              "enum": [
+                "SELF_CONTAINED",
+                "EXTERNAL"
+              ]
             }
           }
         },
@@ -2331,13 +3476,28 @@
           "type": "structure",
           "members": {
             "CslgAtom": {
-              "locationName": "cslgAtom"
+              "locationName": "cslgAtom",
+              "type": "string",
+              "enum": [
+                "INCLUDE",
+                "EXCLUDE"
+              ]
             },
             "FreeSpaceBox": {
-              "locationName": "freeSpaceBox"
+              "locationName": "freeSpaceBox",
+              "type": "string",
+              "enum": [
+                "INCLUDE",
+                "EXCLUDE"
+              ]
             },
             "MoovPlacement": {
-              "locationName": "moovPlacement"
+              "locationName": "moovPlacement",
+              "type": "string",
+              "enum": [
+                "PROGRESSIVE_DOWNLOAD",
+                "NORMAL"
+              ]
             },
             "Mp4MajorBrand": {
               "locationName": "mp4MajorBrand"
@@ -2349,44 +3509,80 @@
     "S66": {
       "type": "list",
       "member": {
-        "type": "integer"
+        "shape": "S67"
       }
+    },
+    "S67": {
+      "type": "integer",
+      "min": 32,
+      "max": 8182
+    },
+    "S6a": {
+      "type": "string",
+      "min": 1,
+      "max": 256
+    },
+    "S6o": {
+      "type": "integer",
+      "min": 0,
+      "max": 1000
     },
     "S7e": {
       "type": "structure",
       "members": {
         "AfdSignaling": {
-          "locationName": "afdSignaling"
+          "locationName": "afdSignaling",
+          "type": "string",
+          "enum": [
+            "NONE",
+            "AUTO",
+            "FIXED"
+          ]
         },
         "AntiAlias": {
-          "locationName": "antiAlias"
+          "locationName": "antiAlias",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "ENABLED"
+          ]
         },
         "CodecSettings": {
           "locationName": "codecSettings",
           "type": "structure",
           "members": {
             "Codec": {
-              "locationName": "codec"
+              "locationName": "codec",
+              "type": "string",
+              "enum": [
+                "FRAME_CAPTURE",
+                "H_264",
+                "H_265",
+                "MPEG2",
+                "PRORES"
+              ]
             },
             "FrameCaptureSettings": {
               "locationName": "frameCaptureSettings",
               "type": "structure",
               "members": {
                 "FramerateDenominator": {
-                  "locationName": "framerateDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateDenominator"
                 },
                 "FramerateNumerator": {
-                  "locationName": "framerateNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateNumerator"
                 },
                 "MaxCaptures": {
                   "locationName": "maxCaptures",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1,
+                  "max": 10000000
                 },
                 "Quality": {
-                  "locationName": "quality",
-                  "type": "integer"
+                  "shape": "S7l",
+                  "locationName": "quality"
                 }
               }
             },
@@ -2395,147 +3591,293 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization"
+                  "locationName": "adaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "OFF",
+                    "LOW",
+                    "MEDIUM",
+                    "HIGH",
+                    "HIGHER",
+                    "MAX"
+                  ]
                 },
                 "Bitrate": {
-                  "locationName": "bitrate",
-                  "type": "integer"
+                  "shape": "S7o",
+                  "locationName": "bitrate"
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel"
+                  "locationName": "codecLevel",
+                  "type": "string",
+                  "enum": [
+                    "AUTO",
+                    "LEVEL_1",
+                    "LEVEL_1_1",
+                    "LEVEL_1_2",
+                    "LEVEL_1_3",
+                    "LEVEL_2",
+                    "LEVEL_2_1",
+                    "LEVEL_2_2",
+                    "LEVEL_3",
+                    "LEVEL_3_1",
+                    "LEVEL_3_2",
+                    "LEVEL_4",
+                    "LEVEL_4_1",
+                    "LEVEL_4_2",
+                    "LEVEL_5",
+                    "LEVEL_5_1",
+                    "LEVEL_5_2"
+                  ]
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile"
+                  "locationName": "codecProfile",
+                  "type": "string",
+                  "enum": [
+                    "BASELINE",
+                    "HIGH",
+                    "HIGH_10BIT",
+                    "HIGH_422",
+                    "HIGH_422_10BIT",
+                    "MAIN"
+                  ]
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop"
+                  "locationName": "dynamicSubGop",
+                  "type": "string",
+                  "enum": [
+                    "ADAPTIVE",
+                    "STATIC"
+                  ]
                 },
                 "EntropyEncoding": {
-                  "locationName": "entropyEncoding"
+                  "locationName": "entropyEncoding",
+                  "type": "string",
+                  "enum": [
+                    "CABAC",
+                    "CAVLC"
+                  ]
                 },
                 "FieldEncoding": {
-                  "locationName": "fieldEncoding"
+                  "locationName": "fieldEncoding",
+                  "type": "string",
+                  "enum": [
+                    "PAFF",
+                    "FORCE_FIELD"
+                  ]
                 },
                 "FlickerAdaptiveQuantization": {
-                  "locationName": "flickerAdaptiveQuantization"
+                  "locationName": "flickerAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl"
+                  "locationName": "framerateControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm"
+                  "locationName": "framerateConversionAlgorithm",
+                  "type": "string",
+                  "enum": [
+                    "DUPLICATE_DROP",
+                    "INTERPOLATE"
+                  ]
                 },
                 "FramerateDenominator": {
-                  "locationName": "framerateDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateDenominator"
                 },
                 "FramerateNumerator": {
-                  "locationName": "framerateNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateNumerator"
                 },
                 "GopBReference": {
-                  "locationName": "gopBReference"
+                  "locationName": "gopBReference",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "GopClosedCadence": {
-                  "locationName": "gopClosedCadence",
-                  "type": "integer"
+                  "shape": "S1u",
+                  "locationName": "gopClosedCadence"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits"
+                  "locationName": "gopSizeUnits",
+                  "type": "string",
+                  "enum": [
+                    "FRAMES",
+                    "SECONDS"
+                  ]
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "locationName": "hrdBufferInitialFillPercentage",
-                  "type": "integer"
+                  "shape": "S7z",
+                  "locationName": "hrdBufferInitialFillPercentage"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0,
+                  "max": 1152000000
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode"
+                  "locationName": "interlaceMode",
+                  "type": "string",
+                  "enum": [
+                    "PROGRESSIVE",
+                    "TOP_FIELD",
+                    "BOTTOM_FIELD",
+                    "FOLLOW_TOP_FIELD",
+                    "FOLLOW_BOTTOM_FIELD"
+                  ]
                 },
                 "MaxBitrate": {
-                  "locationName": "maxBitrate",
-                  "type": "integer"
+                  "shape": "S7o",
+                  "locationName": "maxBitrate"
                 },
                 "MinIInterval": {
-                  "locationName": "minIInterval",
-                  "type": "integer"
+                  "shape": "S82",
+                  "locationName": "minIInterval"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "locationName": "numberBFramesBetweenReferenceFrames",
-                  "type": "integer"
+                  "shape": "S83",
+                  "locationName": "numberBFramesBetweenReferenceFrames"
                 },
                 "NumberReferenceFrames": {
-                  "locationName": "numberReferenceFrames",
-                  "type": "integer"
+                  "shape": "S84",
+                  "locationName": "numberReferenceFrames"
                 },
                 "ParControl": {
-                  "locationName": "parControl"
+                  "locationName": "parControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "ParDenominator": {
-                  "locationName": "parDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parDenominator"
                 },
                 "ParNumerator": {
-                  "locationName": "parNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parNumerator"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel"
+                  "locationName": "qualityTuningLevel",
+                  "type": "string",
+                  "enum": [
+                    "SINGLE_PASS",
+                    "SINGLE_PASS_HQ",
+                    "MULTI_PASS_HQ"
+                  ]
                 },
                 "QvbrSettings": {
                   "locationName": "qvbrSettings",
                   "type": "structure",
                   "members": {
                     "MaxAverageBitrate": {
-                      "locationName": "maxAverageBitrate",
-                      "type": "integer"
+                      "shape": "S7o",
+                      "locationName": "maxAverageBitrate"
                     },
                     "QvbrQualityLevel": {
-                      "locationName": "qvbrQualityLevel",
-                      "type": "integer"
+                      "shape": "S88",
+                      "locationName": "qvbrQualityLevel"
                     }
                   }
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode"
+                  "locationName": "rateControlMode",
+                  "type": "string",
+                  "enum": [
+                    "VBR",
+                    "CBR",
+                    "QVBR"
+                  ]
                 },
                 "RepeatPps": {
-                  "locationName": "repeatPps"
+                  "locationName": "repeatPps",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect"
+                  "locationName": "sceneChangeDetect",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Slices": {
-                  "locationName": "slices",
-                  "type": "integer"
+                  "shape": "S8c",
+                  "locationName": "slices"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal"
+                  "locationName": "slowPal",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Softness": {
-                  "locationName": "softness",
-                  "type": "integer"
+                  "shape": "S8e",
+                  "locationName": "softness"
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization"
+                  "locationName": "spatialAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Syntax": {
-                  "locationName": "syntax"
+                  "locationName": "syntax",
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "RP2027"
+                  ]
                 },
                 "Telecine": {
-                  "locationName": "telecine"
+                  "locationName": "telecine",
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "HARD"
+                  ]
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization"
+                  "locationName": "temporalAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "UnregisteredSeiTimecode": {
-                  "locationName": "unregisteredSeiTimecode"
+                  "locationName": "unregisteredSeiTimecode",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 }
               }
             },
@@ -2544,146 +3886,297 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization"
+                  "locationName": "adaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "OFF",
+                    "LOW",
+                    "MEDIUM",
+                    "HIGH",
+                    "HIGHER",
+                    "MAX"
+                  ]
                 },
                 "AlternateTransferFunctionSei": {
-                  "locationName": "alternateTransferFunctionSei"
+                  "locationName": "alternateTransferFunctionSei",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Bitrate": {
-                  "locationName": "bitrate",
-                  "type": "integer"
+                  "shape": "S8n",
+                  "locationName": "bitrate"
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel"
+                  "locationName": "codecLevel",
+                  "type": "string",
+                  "enum": [
+                    "AUTO",
+                    "LEVEL_1",
+                    "LEVEL_2",
+                    "LEVEL_2_1",
+                    "LEVEL_3",
+                    "LEVEL_3_1",
+                    "LEVEL_4",
+                    "LEVEL_4_1",
+                    "LEVEL_5",
+                    "LEVEL_5_1",
+                    "LEVEL_5_2",
+                    "LEVEL_6",
+                    "LEVEL_6_1",
+                    "LEVEL_6_2"
+                  ]
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile"
+                  "locationName": "codecProfile",
+                  "type": "string",
+                  "enum": [
+                    "MAIN_MAIN",
+                    "MAIN_HIGH",
+                    "MAIN10_MAIN",
+                    "MAIN10_HIGH",
+                    "MAIN_422_8BIT_MAIN",
+                    "MAIN_422_8BIT_HIGH",
+                    "MAIN_422_10BIT_MAIN",
+                    "MAIN_422_10BIT_HIGH"
+                  ]
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop"
+                  "locationName": "dynamicSubGop",
+                  "type": "string",
+                  "enum": [
+                    "ADAPTIVE",
+                    "STATIC"
+                  ]
                 },
                 "FlickerAdaptiveQuantization": {
-                  "locationName": "flickerAdaptiveQuantization"
+                  "locationName": "flickerAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl"
+                  "locationName": "framerateControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm"
+                  "locationName": "framerateConversionAlgorithm",
+                  "type": "string",
+                  "enum": [
+                    "DUPLICATE_DROP",
+                    "INTERPOLATE"
+                  ]
                 },
                 "FramerateDenominator": {
-                  "locationName": "framerateDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateDenominator"
                 },
                 "FramerateNumerator": {
-                  "locationName": "framerateNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateNumerator"
                 },
                 "GopBReference": {
-                  "locationName": "gopBReference"
+                  "locationName": "gopBReference",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "GopClosedCadence": {
-                  "locationName": "gopClosedCadence",
-                  "type": "integer"
+                  "shape": "S1u",
+                  "locationName": "gopClosedCadence"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits"
+                  "locationName": "gopSizeUnits",
+                  "type": "string",
+                  "enum": [
+                    "FRAMES",
+                    "SECONDS"
+                  ]
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "locationName": "hrdBufferInitialFillPercentage",
-                  "type": "integer"
+                  "shape": "S7z",
+                  "locationName": "hrdBufferInitialFillPercentage"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0,
+                  "max": 1466400000
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode"
+                  "locationName": "interlaceMode",
+                  "type": "string",
+                  "enum": [
+                    "PROGRESSIVE",
+                    "TOP_FIELD",
+                    "BOTTOM_FIELD",
+                    "FOLLOW_TOP_FIELD",
+                    "FOLLOW_BOTTOM_FIELD"
+                  ]
                 },
                 "MaxBitrate": {
-                  "locationName": "maxBitrate",
-                  "type": "integer"
+                  "shape": "S8n",
+                  "locationName": "maxBitrate"
                 },
                 "MinIInterval": {
-                  "locationName": "minIInterval",
-                  "type": "integer"
+                  "shape": "S82",
+                  "locationName": "minIInterval"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "locationName": "numberBFramesBetweenReferenceFrames",
-                  "type": "integer"
+                  "shape": "S83",
+                  "locationName": "numberBFramesBetweenReferenceFrames"
                 },
                 "NumberReferenceFrames": {
-                  "locationName": "numberReferenceFrames",
-                  "type": "integer"
+                  "shape": "S84",
+                  "locationName": "numberReferenceFrames"
                 },
                 "ParControl": {
-                  "locationName": "parControl"
+                  "locationName": "parControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "ParDenominator": {
-                  "locationName": "parDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parDenominator"
                 },
                 "ParNumerator": {
-                  "locationName": "parNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parNumerator"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel"
+                  "locationName": "qualityTuningLevel",
+                  "type": "string",
+                  "enum": [
+                    "SINGLE_PASS",
+                    "SINGLE_PASS_HQ",
+                    "MULTI_PASS_HQ"
+                  ]
                 },
                 "QvbrSettings": {
                   "locationName": "qvbrSettings",
                   "type": "structure",
                   "members": {
                     "MaxAverageBitrate": {
-                      "locationName": "maxAverageBitrate",
-                      "type": "integer"
+                      "shape": "S8n",
+                      "locationName": "maxAverageBitrate"
                     },
                     "QvbrQualityLevel": {
-                      "locationName": "qvbrQualityLevel",
-                      "type": "integer"
+                      "shape": "S88",
+                      "locationName": "qvbrQualityLevel"
                     }
                   }
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode"
+                  "locationName": "rateControlMode",
+                  "type": "string",
+                  "enum": [
+                    "VBR",
+                    "CBR",
+                    "QVBR"
+                  ]
                 },
                 "SampleAdaptiveOffsetFilterMode": {
-                  "locationName": "sampleAdaptiveOffsetFilterMode"
+                  "locationName": "sampleAdaptiveOffsetFilterMode",
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "ADAPTIVE",
+                    "OFF"
+                  ]
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect"
+                  "locationName": "sceneChangeDetect",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Slices": {
-                  "locationName": "slices",
-                  "type": "integer"
+                  "shape": "S8c",
+                  "locationName": "slices"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal"
+                  "locationName": "slowPal",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization"
+                  "locationName": "spatialAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Telecine": {
-                  "locationName": "telecine"
+                  "locationName": "telecine",
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "HARD"
+                  ]
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization"
+                  "locationName": "temporalAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "TemporalIds": {
-                  "locationName": "temporalIds"
+                  "locationName": "temporalIds",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Tiles": {
-                  "locationName": "tiles"
+                  "locationName": "tiles",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "UnregisteredSeiTimecode": {
-                  "locationName": "unregisteredSeiTimecode"
+                  "locationName": "unregisteredSeiTimecode",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "WriteMp4PackagingType": {
-                  "locationName": "writeMp4PackagingType"
+                  "locationName": "writeMp4PackagingType",
+                  "type": "string",
+                  "enum": [
+                    "HVC1",
+                    "HEV1"
+                  ]
                 }
               }
             },
@@ -2692,110 +4185,222 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization"
+                  "locationName": "adaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "OFF",
+                    "LOW",
+                    "MEDIUM",
+                    "HIGH"
+                  ]
                 },
                 "Bitrate": {
                   "locationName": "bitrate",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1000,
+                  "max": 288000000
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel"
+                  "locationName": "codecLevel",
+                  "type": "string",
+                  "enum": [
+                    "AUTO",
+                    "LOW",
+                    "MAIN",
+                    "HIGH1440",
+                    "HIGH"
+                  ]
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile"
+                  "locationName": "codecProfile",
+                  "type": "string",
+                  "enum": [
+                    "MAIN",
+                    "PROFILE_422"
+                  ]
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop"
+                  "locationName": "dynamicSubGop",
+                  "type": "string",
+                  "enum": [
+                    "ADAPTIVE",
+                    "STATIC"
+                  ]
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl"
+                  "locationName": "framerateControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm"
+                  "locationName": "framerateConversionAlgorithm",
+                  "type": "string",
+                  "enum": [
+                    "DUPLICATE_DROP",
+                    "INTERPOLATE"
+                  ]
                 },
                 "FramerateDenominator": {
                   "locationName": "framerateDenominator",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1,
+                  "max": 1001
                 },
                 "FramerateNumerator": {
                   "locationName": "framerateNumerator",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 24,
+                  "max": 60000
                 },
                 "GopClosedCadence": {
-                  "locationName": "gopClosedCadence",
-                  "type": "integer"
+                  "shape": "S1u",
+                  "locationName": "gopClosedCadence"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits"
+                  "locationName": "gopSizeUnits",
+                  "type": "string",
+                  "enum": [
+                    "FRAMES",
+                    "SECONDS"
+                  ]
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "locationName": "hrdBufferInitialFillPercentage",
-                  "type": "integer"
+                  "shape": "S7z",
+                  "locationName": "hrdBufferInitialFillPercentage"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0,
+                  "max": 47185920
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode"
+                  "locationName": "interlaceMode",
+                  "type": "string",
+                  "enum": [
+                    "PROGRESSIVE",
+                    "TOP_FIELD",
+                    "BOTTOM_FIELD",
+                    "FOLLOW_TOP_FIELD",
+                    "FOLLOW_BOTTOM_FIELD"
+                  ]
                 },
                 "IntraDcPrecision": {
-                  "locationName": "intraDcPrecision"
+                  "locationName": "intraDcPrecision",
+                  "type": "string",
+                  "enum": [
+                    "AUTO",
+                    "INTRA_DC_PRECISION_8",
+                    "INTRA_DC_PRECISION_9",
+                    "INTRA_DC_PRECISION_10",
+                    "INTRA_DC_PRECISION_11"
+                  ]
                 },
                 "MaxBitrate": {
                   "locationName": "maxBitrate",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1000,
+                  "max": 300000000
                 },
                 "MinIInterval": {
-                  "locationName": "minIInterval",
-                  "type": "integer"
+                  "shape": "S82",
+                  "locationName": "minIInterval"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "locationName": "numberBFramesBetweenReferenceFrames",
-                  "type": "integer"
+                  "shape": "S83",
+                  "locationName": "numberBFramesBetweenReferenceFrames"
                 },
                 "ParControl": {
-                  "locationName": "parControl"
+                  "locationName": "parControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "ParDenominator": {
-                  "locationName": "parDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parDenominator"
                 },
                 "ParNumerator": {
-                  "locationName": "parNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parNumerator"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel"
+                  "locationName": "qualityTuningLevel",
+                  "type": "string",
+                  "enum": [
+                    "SINGLE_PASS",
+                    "MULTI_PASS"
+                  ]
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode"
+                  "locationName": "rateControlMode",
+                  "type": "string",
+                  "enum": [
+                    "VBR",
+                    "CBR"
+                  ]
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect"
+                  "locationName": "sceneChangeDetect",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "SlowPal": {
-                  "locationName": "slowPal"
+                  "locationName": "slowPal",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Softness": {
-                  "locationName": "softness",
-                  "type": "integer"
+                  "shape": "S8e",
+                  "locationName": "softness"
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization"
+                  "locationName": "spatialAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Syntax": {
-                  "locationName": "syntax"
+                  "locationName": "syntax",
+                  "type": "string",
+                  "enum": [
+                    "DEFAULT",
+                    "D_10"
+                  ]
                 },
                 "Telecine": {
-                  "locationName": "telecine"
+                  "locationName": "telecine",
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "SOFT",
+                    "HARD"
+                  ]
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization"
+                  "locationName": "temporalAdaptiveQuantization",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 }
               }
             },
@@ -2804,80 +4409,150 @@
               "type": "structure",
               "members": {
                 "CodecProfile": {
-                  "locationName": "codecProfile"
+                  "locationName": "codecProfile",
+                  "type": "string",
+                  "enum": [
+                    "APPLE_PRORES_422",
+                    "APPLE_PRORES_422_HQ",
+                    "APPLE_PRORES_422_LT",
+                    "APPLE_PRORES_422_PROXY"
+                  ]
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl"
+                  "locationName": "framerateControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm"
+                  "locationName": "framerateConversionAlgorithm",
+                  "type": "string",
+                  "enum": [
+                    "DUPLICATE_DROP",
+                    "INTERPOLATE"
+                  ]
                 },
                 "FramerateDenominator": {
-                  "locationName": "framerateDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateDenominator"
                 },
                 "FramerateNumerator": {
-                  "locationName": "framerateNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "framerateNumerator"
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode"
+                  "locationName": "interlaceMode",
+                  "type": "string",
+                  "enum": [
+                    "PROGRESSIVE",
+                    "TOP_FIELD",
+                    "BOTTOM_FIELD",
+                    "FOLLOW_TOP_FIELD",
+                    "FOLLOW_BOTTOM_FIELD"
+                  ]
                 },
                 "ParControl": {
-                  "locationName": "parControl"
+                  "locationName": "parControl",
+                  "type": "string",
+                  "enum": [
+                    "INITIALIZE_FROM_SOURCE",
+                    "SPECIFIED"
+                  ]
                 },
                 "ParDenominator": {
-                  "locationName": "parDenominator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parDenominator"
                 },
                 "ParNumerator": {
-                  "locationName": "parNumerator",
-                  "type": "integer"
+                  "shape": "So",
+                  "locationName": "parNumerator"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal"
+                  "locationName": "slowPal",
+                  "type": "string",
+                  "enum": [
+                    "DISABLED",
+                    "ENABLED"
+                  ]
                 },
                 "Telecine": {
-                  "locationName": "telecine"
+                  "locationName": "telecine",
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "HARD"
+                  ]
                 }
               }
             }
           }
         },
         "ColorMetadata": {
-          "locationName": "colorMetadata"
+          "locationName": "colorMetadata",
+          "type": "string",
+          "enum": [
+            "IGNORE",
+            "INSERT"
+          ]
         },
         "Crop": {
           "shape": "Sa9",
           "locationName": "crop"
         },
         "DropFrameTimecode": {
-          "locationName": "dropFrameTimecode"
+          "locationName": "dropFrameTimecode",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "ENABLED"
+          ]
         },
         "FixedAfd": {
           "locationName": "fixedAfd",
-          "type": "integer"
+          "type": "integer",
+          "min": 0,
+          "max": 15
         },
         "Height": {
           "locationName": "height",
-          "type": "integer"
+          "type": "integer",
+          "min": 32,
+          "max": 2160
         },
         "Position": {
           "shape": "Sa9",
           "locationName": "position"
         },
         "RespondToAfd": {
-          "locationName": "respondToAfd"
+          "locationName": "respondToAfd",
+          "type": "string",
+          "enum": [
+            "NONE",
+            "RESPOND",
+            "PASSTHROUGH"
+          ]
         },
         "ScalingBehavior": {
-          "locationName": "scalingBehavior"
+          "locationName": "scalingBehavior",
+          "type": "string",
+          "enum": [
+            "DEFAULT",
+            "STRETCH_TO_OUTPUT"
+          ]
         },
         "Sharpness": {
-          "locationName": "sharpness",
-          "type": "integer"
+          "shape": "S7z",
+          "locationName": "sharpness"
         },
         "TimecodeInsertion": {
-          "locationName": "timecodeInsertion"
+          "locationName": "timecodeInsertion",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "PIC_TIMING_SEI"
+          ]
         },
         "VideoPreprocessors": {
           "locationName": "videoPreprocessors",
@@ -2888,15 +4563,23 @@
               "type": "structure",
               "members": {
                 "Brightness": {
-                  "locationName": "brightness",
-                  "type": "integer"
+                  "shape": "S7l",
+                  "locationName": "brightness"
                 },
                 "ColorSpaceConversion": {
-                  "locationName": "colorSpaceConversion"
+                  "locationName": "colorSpaceConversion",
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "FORCE_601",
+                    "FORCE_709",
+                    "FORCE_HDR10",
+                    "FORCE_HLG_2020"
+                  ]
                 },
                 "Contrast": {
-                  "locationName": "contrast",
-                  "type": "integer"
+                  "shape": "S7l",
+                  "locationName": "contrast"
                 },
                 "Hdr10Metadata": {
                   "shape": "S1r",
@@ -2904,11 +4587,13 @@
                 },
                 "Hue": {
                   "locationName": "hue",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": -180,
+                  "max": 180
                 },
                 "Saturation": {
-                  "locationName": "saturation",
-                  "type": "integer"
+                  "shape": "S7l",
+                  "locationName": "saturation"
                 }
               }
             },
@@ -2917,13 +4602,31 @@
               "type": "structure",
               "members": {
                 "Algorithm": {
-                  "locationName": "algorithm"
+                  "locationName": "algorithm",
+                  "type": "string",
+                  "enum": [
+                    "INTERPOLATE",
+                    "INTERPOLATE_TICKER",
+                    "BLEND",
+                    "BLEND_TICKER"
+                  ]
                 },
                 "Control": {
-                  "locationName": "control"
+                  "locationName": "control",
+                  "type": "string",
+                  "enum": [
+                    "FORCE_ALL_FRAMES",
+                    "NORMAL"
+                  ]
                 },
                 "Mode": {
-                  "locationName": "mode"
+                  "locationName": "mode",
+                  "type": "string",
+                  "enum": [
+                    "DEINTERLACE",
+                    "INVERSE_TELECINE",
+                    "ADAPTIVE"
+                  ]
                 }
               }
             },
@@ -2938,46 +4641,53 @@
                     "type": "structure",
                     "members": {
                       "Duration": {
-                        "locationName": "duration",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "duration"
                       },
                       "FadeIn": {
-                        "locationName": "fadeIn",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "fadeIn"
                       },
                       "FadeOut": {
-                        "locationName": "fadeOut",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "fadeOut"
                       },
                       "Height": {
-                        "locationName": "height",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "height"
                       },
                       "ImageInserterInput": {
-                        "locationName": "imageInserterInput"
+                        "locationName": "imageInserterInput",
+                        "type": "string",
+                        "min": 14,
+                        "pattern": "^(s3:\\/\\/)(.*?)\\.(bmp|BMP|png|PNG|tga|TGA)$"
                       },
                       "ImageX": {
-                        "locationName": "imageX",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "imageX"
                       },
                       "ImageY": {
-                        "locationName": "imageY",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "imageY"
                       },
                       "Layer": {
                         "locationName": "layer",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 0,
+                        "max": 99
                       },
                       "Opacity": {
-                        "locationName": "opacity",
-                        "type": "integer"
+                        "shape": "S7z",
+                        "locationName": "opacity"
                       },
                       "StartTime": {
-                        "locationName": "startTime"
+                        "locationName": "startTime",
+                        "type": "string",
+                        "pattern": "^((([0-1]\\d)|(2[0-3]))(:[0-5]\\d){2}([:;][0-5]\\d))$"
                       },
                       "Width": {
-                        "locationName": "width",
-                        "type": "integer"
+                        "shape": "Sm",
+                        "locationName": "width"
                       }
                     }
                   }
@@ -2989,15 +4699,25 @@
               "type": "structure",
               "members": {
                 "Filter": {
-                  "locationName": "filter"
+                  "locationName": "filter",
+                  "type": "string",
+                  "enum": [
+                    "BILATERAL",
+                    "MEAN",
+                    "GAUSSIAN",
+                    "LANCZOS",
+                    "SHARPEN",
+                    "CONSERVE",
+                    "SPATIAL"
+                  ]
                 },
                 "FilterSettings": {
                   "locationName": "filterSettings",
                   "type": "structure",
                   "members": {
                     "Strength": {
-                      "locationName": "strength",
-                      "type": "integer"
+                      "shape": "Say",
+                      "locationName": "strength"
                     }
                   }
                 },
@@ -3006,16 +4726,20 @@
                   "type": "structure",
                   "members": {
                     "PostFilterSharpenStrength": {
-                      "locationName": "postFilterSharpenStrength",
-                      "type": "integer"
+                      "shape": "Say",
+                      "locationName": "postFilterSharpenStrength"
                     },
                     "Speed": {
                       "locationName": "speed",
-                      "type": "integer"
+                      "type": "integer",
+                      "min": -2,
+                      "max": 3
                     },
                     "Strength": {
                       "locationName": "strength",
-                      "type": "integer"
+                      "type": "integer",
+                      "min": 0,
+                      "max": 16
                     }
                   }
                 }
@@ -3027,13 +4751,29 @@
               "members": {
                 "FontSize": {
                   "locationName": "fontSize",
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 10,
+                  "max": 48
                 },
                 "Position": {
-                  "locationName": "position"
+                  "locationName": "position",
+                  "type": "string",
+                  "enum": [
+                    "TOP_CENTER",
+                    "TOP_LEFT",
+                    "TOP_RIGHT",
+                    "MIDDLE_LEFT",
+                    "MIDDLE_CENTER",
+                    "MIDDLE_RIGHT",
+                    "BOTTOM_LEFT",
+                    "BOTTOM_CENTER",
+                    "BOTTOM_RIGHT"
+                  ]
                 },
                 "Prefix": {
-                  "locationName": "prefix"
+                  "locationName": "prefix",
+                  "type": "string",
+                  "pattern": "^[ -~]+$"
                 }
               }
             }
@@ -3041,45 +4781,117 @@
         },
         "Width": {
           "locationName": "width",
-          "type": "integer"
+          "type": "integer",
+          "min": 32,
+          "max": 4096
         }
       }
+    },
+    "S7l": {
+      "type": "integer",
+      "min": 1,
+      "max": 100
+    },
+    "S7o": {
+      "type": "integer",
+      "min": 1000,
+      "max": 1152000000
+    },
+    "S7z": {
+      "type": "integer",
+      "min": 0,
+      "max": 100
+    },
+    "S82": {
+      "type": "integer",
+      "min": 0,
+      "max": 30
+    },
+    "S83": {
+      "type": "integer",
+      "min": 0,
+      "max": 7
+    },
+    "S84": {
+      "type": "integer",
+      "min": 1,
+      "max": 6
+    },
+    "S88": {
+      "type": "integer",
+      "min": 1,
+      "max": 10
+    },
+    "S8c": {
+      "type": "integer",
+      "min": 1,
+      "max": 32
+    },
+    "S8e": {
+      "type": "integer",
+      "min": 0,
+      "max": 128
+    },
+    "S8n": {
+      "type": "integer",
+      "min": 1000,
+      "max": 1466400000
     },
     "Sa9": {
       "type": "structure",
       "members": {
         "Height": {
-          "locationName": "height",
-          "type": "integer"
+          "shape": "Saa",
+          "locationName": "height"
         },
         "Width": {
-          "locationName": "width",
-          "type": "integer"
+          "shape": "Saa",
+          "locationName": "width"
         },
         "X": {
-          "locationName": "x",
-          "type": "integer"
+          "shape": "S1u",
+          "locationName": "x"
         },
         "Y": {
-          "locationName": "y",
-          "type": "integer"
+          "shape": "S1u",
+          "locationName": "y"
         }
       }
+    },
+    "Saa": {
+      "type": "integer",
+      "min": 2,
+      "max": 2147483647
+    },
+    "Say": {
+      "type": "integer",
+      "min": 0,
+      "max": 3
     },
     "Sb7": {
       "type": "structure",
       "members": {
         "Anchor": {
+          "shape": "S1l",
           "locationName": "anchor"
         },
         "Source": {
-          "locationName": "source"
+          "locationName": "source",
+          "type": "string",
+          "enum": [
+            "EMBEDDED",
+            "ZEROBASED",
+            "SPECIFIEDSTART"
+          ]
         },
         "Start": {
+          "shape": "S1l",
           "locationName": "start"
         },
         "TimestampOffset": {
-          "locationName": "timestampOffset"
+          "locationName": "timestampOffset",
+          "type": "string",
+          "pattern": "^([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
         }
       }
     },
@@ -3093,9 +4905,12 @@
             "type": "structure",
             "members": {
               "Id3": {
-                "locationName": "id3"
+                "locationName": "id3",
+                "type": "string",
+                "pattern": "^[A-Za-z0-9+\\/]+={0,2}$"
               },
               "Timecode": {
+                "shape": "S1l",
                 "locationName": "timecode"
               }
             }
@@ -3115,6 +4930,7 @@
           "locationName": "arn"
         },
         "BillingTagsSource": {
+          "shape": "S5",
           "locationName": "billingTagsSource"
         },
         "CreatedAt": {
@@ -3181,6 +4997,7 @@
           "locationName": "settings"
         },
         "Status": {
+          "shape": "Sbo",
           "locationName": "status"
         },
         "Timing": {
@@ -3215,12 +5032,22 @@
       "type": "timestamp",
       "timestampFormat": "unixTimestamp"
     },
+    "Sbo": {
+      "type": "string",
+      "enum": [
+        "SUBMITTED",
+        "PROGRESSING",
+        "COMPLETE",
+        "CANCELED",
+        "ERROR"
+      ]
+    },
     "Sbr": {
       "type": "structure",
       "members": {
         "AdAvailOffset": {
-          "locationName": "adAvailOffset",
-          "type": "integer"
+          "shape": "S7",
+          "locationName": "adAvailOffset"
         },
         "AvailBlanking": {
           "shape": "S8",
@@ -3245,30 +5072,35 @@
                 "locationName": "captionSelectors"
               },
               "DeblockFilter": {
+                "shape": "S1e",
                 "locationName": "deblockFilter"
               },
               "DenoiseFilter": {
+                "shape": "S1f",
                 "locationName": "denoiseFilter"
               },
               "FilterEnable": {
+                "shape": "S1h",
                 "locationName": "filterEnable"
               },
               "FilterStrength": {
-                "locationName": "filterStrength",
-                "type": "integer"
+                "shape": "S1i",
+                "locationName": "filterStrength"
               },
               "InputClippings": {
                 "shape": "S1j",
                 "locationName": "inputClippings"
               },
               "ProgramNumber": {
-                "locationName": "programNumber",
-                "type": "integer"
+                "shape": "So",
+                "locationName": "programNumber"
               },
               "PsiControl": {
+                "shape": "S1m",
                 "locationName": "psiControl"
               },
               "TimecodeSource": {
+                "shape": "S1n",
                 "locationName": "timecodeSource"
               },
               "VideoSelector": {
@@ -3327,12 +5159,20 @@
           "locationName": "settings"
         },
         "Type": {
+          "shape": "Sbw",
           "locationName": "type"
         }
       },
       "required": [
         "Settings",
         "Name"
+      ]
+    },
+    "Sbw": {
+      "type": "string",
+      "enum": [
+        "SYSTEM",
+        "CUSTOM"
       ]
     },
     "Sby": {
@@ -3349,6 +5189,7 @@
             "type": "structure",
             "members": {
               "CustomLanguageCode": {
+                "shape": "Si",
                 "locationName": "customLanguageCode"
               },
               "DestinationSettings": {
@@ -3356,6 +5197,7 @@
                 "locationName": "destinationSettings"
               },
               "LanguageCode": {
+                "shape": "Sl",
                 "locationName": "languageCode"
               },
               "LanguageDescription": {
@@ -3402,6 +5244,7 @@
           "locationName": "settings"
         },
         "Type": {
+          "shape": "Sbw",
           "locationName": "type"
         }
       },
@@ -3410,13 +5253,22 @@
         "Name"
       ]
     },
+    "Sc4": {
+      "type": "string",
+      "enum": [
+        "ON_DEMAND",
+        "RESERVED"
+      ]
+    },
     "Sc5": {
       "type": "structure",
       "members": {
         "Commitment": {
+          "shape": "Sc6",
           "locationName": "commitment"
         },
         "RenewalType": {
+          "shape": "Sc7",
           "locationName": "renewalType"
         },
         "ReservedSlots": {
@@ -3428,6 +5280,19 @@
         "ReservedSlots",
         "Commitment",
         "RenewalType"
+      ]
+    },
+    "Sc6": {
+      "type": "string",
+      "enum": [
+        "ONE_YEAR"
+      ]
+    },
+    "Sc7": {
+      "type": "string",
+      "enum": [
+        "AUTO_RENEW",
+        "EXPIRE"
       ]
     },
     "Sc9": {
@@ -3451,6 +5316,7 @@
           "locationName": "name"
         },
         "PricingPlan": {
+          "shape": "Sc4",
           "locationName": "pricingPlan"
         },
         "ProgressingJobsCount": {
@@ -3462,6 +5328,7 @@
           "type": "structure",
           "members": {
             "Commitment": {
+              "shape": "Sc6",
               "locationName": "commitment"
             },
             "ExpiresAt": {
@@ -3473,6 +5340,7 @@
               "locationName": "purchasedAt"
             },
             "RenewalType": {
+              "shape": "Sc7",
               "locationName": "renewalType"
             },
             "ReservedSlots": {
@@ -3480,11 +5348,17 @@
               "type": "integer"
             },
             "Status": {
-              "locationName": "status"
+              "locationName": "status",
+              "type": "string",
+              "enum": [
+                "ACTIVE",
+                "EXPIRED"
+              ]
             }
           }
         },
         "Status": {
+          "shape": "Scc",
           "locationName": "status"
         },
         "SubmittedJobsCount": {
@@ -3492,11 +5366,31 @@
           "type": "integer"
         },
         "Type": {
+          "shape": "Sbw",
           "locationName": "type"
         }
       },
       "required": [
         "Name"
+      ]
+    },
+    "Scc": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "PAUSED"
+      ]
+    },
+    "Scy": {
+      "type": "integer",
+      "min": 1,
+      "max": 20
+    },
+    "Scz": {
+      "type": "string",
+      "enum": [
+        "ASCENDING",
+        "DESCENDING"
       ]
     }
   }

--- a/apis/medialive-2017-10-14.min.json
+++ b/apis/medialive-2017-10-14.min.json
@@ -113,6 +113,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -169,6 +170,7 @@
             "locationName": "sources"
           },
           "Type": {
+            "shape": "S9y",
             "locationName": "type"
           }
         }
@@ -255,6 +257,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -268,6 +271,7 @@
             "locationName": "roleArn"
           },
           "State": {
+            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -355,6 +359,7 @@
             "type": "integer"
           },
           "DurationUnits": {
+            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "End": {
@@ -374,6 +379,7 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
+            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -390,6 +396,7 @@
             "locationName": "start"
           },
           "State": {
+            "shape": "Saw",
             "locationName": "state"
           },
           "UsagePrice": {
@@ -447,6 +454,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -460,6 +468,7 @@
             "locationName": "roleArn"
           },
           "State": {
+            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -512,9 +521,11 @@
             "locationName": "sources"
           },
           "State": {
+            "shape": "Sa5",
             "locationName": "state"
           },
           "Type": {
+            "shape": "S9y",
             "locationName": "type"
           }
         }
@@ -552,6 +563,7 @@
             "locationName": "inputs"
           },
           "State": {
+            "shape": "Sab",
             "locationName": "state"
           },
           "WhitelistRules": {
@@ -593,6 +605,7 @@
             "type": "integer"
           },
           "DurationUnits": {
+            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "FixedPrice": {
@@ -606,6 +619,7 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
+            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -658,6 +672,7 @@
             "type": "integer"
           },
           "DurationUnits": {
+            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "End": {
@@ -677,6 +692,7 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
+            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -693,6 +709,7 @@
             "locationName": "start"
           },
           "State": {
+            "shape": "Saw",
             "locationName": "state"
           },
           "UsagePrice": {
@@ -716,9 +733,9 @@
             "locationName": "channelId"
           },
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -752,9 +769,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -794,6 +811,7 @@
                   "locationName": "inputSpecification"
                 },
                 "LogLevel": {
+                  "shape": "S9n",
                   "locationName": "logLevel"
                 },
                 "Name": {
@@ -807,6 +825,7 @@
                   "locationName": "roleArn"
                 },
                 "State": {
+                  "shape": "S9s",
                   "locationName": "state"
                 }
               }
@@ -828,9 +847,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -864,9 +883,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -908,9 +927,9 @@
             "locationName": "codec"
           },
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "MaximumBitrate": {
             "location": "querystring",
@@ -965,6 +984,7 @@
                   "type": "integer"
                 },
                 "DurationUnits": {
+                  "shape": "Sam",
                   "locationName": "durationUnits"
                 },
                 "FixedPrice": {
@@ -978,6 +998,7 @@
                   "locationName": "offeringId"
                 },
                 "OfferingType": {
+                  "shape": "San",
                   "locationName": "offeringType"
                 },
                 "Region": {
@@ -1011,9 +1032,9 @@
             "locationName": "codec"
           },
           "MaxResults": {
+            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "MaximumBitrate": {
             "location": "querystring",
@@ -1070,8 +1091,8 @@
         "type": "structure",
         "members": {
           "Count": {
-            "locationName": "count",
-            "type": "integer"
+            "shape": "Sq",
+            "locationName": "count"
           },
           "Name": {
             "locationName": "name"
@@ -1146,6 +1167,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1159,6 +1181,7 @@
             "locationName": "roleArn"
           },
           "State": {
+            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -1211,6 +1234,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1224,6 +1248,7 @@
             "locationName": "roleArn"
           },
           "State": {
+            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -1259,6 +1284,7 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
+            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1376,8 +1402,8 @@
                 "type": "structure",
                 "members": {
                   "SpliceEventId": {
-                    "locationName": "spliceEventId",
-                    "type": "long"
+                    "shape": "S8",
+                    "locationName": "spliceEventId"
                   }
                 },
                 "required": [
@@ -1390,11 +1416,13 @@
                 "members": {
                   "Duration": {
                     "locationName": "duration",
-                    "type": "long"
+                    "type": "long",
+                    "min": 0,
+                    "max": 8589934591
                   },
                   "SpliceEventId": {
-                    "locationName": "spliceEventId",
-                    "type": "long"
+                    "shape": "S8",
+                    "locationName": "spliceEventId"
                   }
                 },
                 "required": [
@@ -1424,16 +1452,38 @@
                                   "type": "structure",
                                   "members": {
                                     "ArchiveAllowedFlag": {
-                                      "locationName": "archiveAllowedFlag"
+                                      "locationName": "archiveAllowedFlag",
+                                      "type": "string",
+                                      "enum": [
+                                        "ARCHIVE_NOT_ALLOWED",
+                                        "ARCHIVE_ALLOWED"
+                                      ]
                                     },
                                     "DeviceRestrictions": {
-                                      "locationName": "deviceRestrictions"
+                                      "locationName": "deviceRestrictions",
+                                      "type": "string",
+                                      "enum": [
+                                        "NONE",
+                                        "RESTRICT_GROUP0",
+                                        "RESTRICT_GROUP1",
+                                        "RESTRICT_GROUP2"
+                                      ]
                                     },
                                     "NoRegionalBlackoutFlag": {
-                                      "locationName": "noRegionalBlackoutFlag"
+                                      "locationName": "noRegionalBlackoutFlag",
+                                      "type": "string",
+                                      "enum": [
+                                        "REGIONAL_BLACKOUT",
+                                        "NO_REGIONAL_BLACKOUT"
+                                      ]
                                     },
                                     "WebDeliveryAllowedFlag": {
-                                      "locationName": "webDeliveryAllowedFlag"
+                                      "locationName": "webDeliveryAllowedFlag",
+                                      "type": "string",
+                                      "enum": [
+                                        "WEB_DELIVERY_NOT_ALLOWED",
+                                        "WEB_DELIVERY_ALLOWED"
+                                      ]
                                     }
                                   },
                                   "required": [
@@ -1444,42 +1494,49 @@
                                   ]
                                 },
                                 "SegmentNum": {
-                                  "locationName": "segmentNum",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "segmentNum"
                                 },
                                 "SegmentationCancelIndicator": {
-                                  "locationName": "segmentationCancelIndicator"
+                                  "locationName": "segmentationCancelIndicator",
+                                  "type": "string",
+                                  "enum": [
+                                    "SEGMENTATION_EVENT_NOT_CANCELED",
+                                    "SEGMENTATION_EVENT_CANCELED"
+                                  ]
                                 },
                                 "SegmentationDuration": {
                                   "locationName": "segmentationDuration",
-                                  "type": "long"
+                                  "type": "long",
+                                  "min": 0,
+                                  "max": 1099511627775
                                 },
                                 "SegmentationEventId": {
-                                  "locationName": "segmentationEventId",
-                                  "type": "long"
+                                  "shape": "S8",
+                                  "locationName": "segmentationEventId"
                                 },
                                 "SegmentationTypeId": {
-                                  "locationName": "segmentationTypeId",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "segmentationTypeId"
                                 },
                                 "SegmentationUpid": {
                                   "locationName": "segmentationUpid"
                                 },
                                 "SegmentationUpidType": {
-                                  "locationName": "segmentationUpidType",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "segmentationUpidType"
                                 },
                                 "SegmentsExpected": {
-                                  "locationName": "segmentsExpected",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "segmentsExpected"
                                 },
                                 "SubSegmentNum": {
-                                  "locationName": "subSegmentNum",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "subSegmentNum"
                                 },
                                 "SubSegmentsExpected": {
-                                  "locationName": "subSegmentsExpected",
-                                  "type": "integer"
+                                  "shape": "Sl",
+                                  "locationName": "subSegmentsExpected"
                                 }
                               },
                               "required": [
@@ -1508,44 +1565,44 @@
                 "type": "structure",
                 "members": {
                   "Duration": {
-                    "locationName": "duration",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "duration"
                   },
                   "FadeIn": {
-                    "locationName": "fadeIn",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "fadeIn"
                   },
                   "FadeOut": {
-                    "locationName": "fadeOut",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "fadeOut"
                   },
                   "Height": {
-                    "locationName": "height",
-                    "type": "integer"
+                    "shape": "Sq",
+                    "locationName": "height"
                   },
                   "Image": {
                     "shape": "Sr",
                     "locationName": "image"
                   },
                   "ImageX": {
-                    "locationName": "imageX",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "imageX"
                   },
                   "ImageY": {
-                    "locationName": "imageY",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "imageY"
                   },
                   "Layer": {
-                    "locationName": "layer",
-                    "type": "integer"
+                    "shape": "Ss",
+                    "locationName": "layer"
                   },
                   "Opacity": {
-                    "locationName": "opacity",
-                    "type": "integer"
+                    "shape": "St",
+                    "locationName": "opacity"
                   },
                   "Width": {
-                    "locationName": "width",
-                    "type": "integer"
+                    "shape": "Sq",
+                    "locationName": "width"
                   }
                 },
                 "required": [
@@ -1557,12 +1614,12 @@
                 "type": "structure",
                 "members": {
                   "FadeOut": {
-                    "locationName": "fadeOut",
-                    "type": "integer"
+                    "shape": "Sp",
+                    "locationName": "fadeOut"
                   },
                   "Layer": {
-                    "locationName": "layer",
-                    "type": "integer"
+                    "shape": "Ss",
+                    "locationName": "layer"
                   }
                 }
               }
@@ -1591,6 +1648,24 @@
         ]
       }
     },
+    "S8": {
+      "type": "long",
+      "min": 0,
+      "max": 4294967295
+    },
+    "Sl": {
+      "type": "integer",
+      "min": 0,
+      "max": 255
+    },
+    "Sp": {
+      "type": "integer",
+      "min": 0
+    },
+    "Sq": {
+      "type": "integer",
+      "min": 1
+    },
     "Sr": {
       "type": "structure",
       "members": {
@@ -1607,6 +1682,16 @@
       "required": [
         "Uri"
       ]
+    },
+    "Ss": {
+      "type": "integer",
+      "min": 0,
+      "max": 7
+    },
+    "St": {
+      "type": "integer",
+      "min": 0,
+      "max": 100
     },
     "Sy": {
       "type": "list",
@@ -1658,10 +1743,19 @@
                 "type": "structure",
                 "members": {
                   "Algorithm": {
-                    "locationName": "algorithm"
+                    "locationName": "algorithm",
+                    "type": "string",
+                    "enum": [
+                      "ITU_1770_1",
+                      "ITU_1770_2"
+                    ]
                   },
                   "AlgorithmControl": {
-                    "locationName": "algorithmControl"
+                    "locationName": "algorithmControl",
+                    "type": "string",
+                    "enum": [
+                      "CORRECT_AUDIO"
+                    ]
                   },
                   "TargetLkfs": {
                     "locationName": "targetLkfs",
@@ -1673,10 +1767,22 @@
                 "locationName": "audioSelectorName"
               },
               "AudioType": {
-                "locationName": "audioType"
+                "locationName": "audioType",
+                "type": "string",
+                "enum": [
+                  "CLEAN_EFFECTS",
+                  "HEARING_IMPAIRED",
+                  "UNDEFINED",
+                  "VISUAL_IMPAIRED_COMMENTARY"
+                ]
               },
               "AudioTypeControl": {
-                "locationName": "audioTypeControl"
+                "locationName": "audioTypeControl",
+                "type": "string",
+                "enum": [
+                  "FOLLOW_INPUT",
+                  "USE_CONFIGURED"
+                ]
               },
               "CodecSettings": {
                 "locationName": "codecSettings",
@@ -1691,29 +1797,70 @@
                         "type": "double"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode"
+                        "locationName": "codingMode",
+                        "type": "string",
+                        "enum": [
+                          "AD_RECEIVER_MIX",
+                          "CODING_MODE_1_0",
+                          "CODING_MODE_1_1",
+                          "CODING_MODE_2_0",
+                          "CODING_MODE_5_1"
+                        ]
                       },
                       "InputType": {
-                        "locationName": "inputType"
+                        "locationName": "inputType",
+                        "type": "string",
+                        "enum": [
+                          "BROADCASTER_MIXED_AD",
+                          "NORMAL"
+                        ]
                       },
                       "Profile": {
-                        "locationName": "profile"
+                        "locationName": "profile",
+                        "type": "string",
+                        "enum": [
+                          "HEV1",
+                          "HEV2",
+                          "LC"
+                        ]
                       },
                       "RateControlMode": {
-                        "locationName": "rateControlMode"
+                        "locationName": "rateControlMode",
+                        "type": "string",
+                        "enum": [
+                          "CBR",
+                          "VBR"
+                        ]
                       },
                       "RawFormat": {
-                        "locationName": "rawFormat"
+                        "locationName": "rawFormat",
+                        "type": "string",
+                        "enum": [
+                          "LATM_LOAS",
+                          "NONE"
+                        ]
                       },
                       "SampleRate": {
                         "locationName": "sampleRate",
                         "type": "double"
                       },
                       "Spec": {
-                        "locationName": "spec"
+                        "locationName": "spec",
+                        "type": "string",
+                        "enum": [
+                          "MPEG2",
+                          "MPEG4"
+                        ]
                       },
                       "VbrQuality": {
-                        "locationName": "vbrQuality"
+                        "locationName": "vbrQuality",
+                        "type": "string",
+                        "enum": [
+                          "HIGH",
+                          "LOW",
+                          "MEDIUM_HIGH",
+                          "MEDIUM_LOW"
+                        ]
                       }
                     }
                   },
@@ -1726,23 +1873,56 @@
                         "type": "double"
                       },
                       "BitstreamMode": {
-                        "locationName": "bitstreamMode"
+                        "locationName": "bitstreamMode",
+                        "type": "string",
+                        "enum": [
+                          "COMMENTARY",
+                          "COMPLETE_MAIN",
+                          "DIALOGUE",
+                          "EMERGENCY",
+                          "HEARING_IMPAIRED",
+                          "MUSIC_AND_EFFECTS",
+                          "VISUALLY_IMPAIRED",
+                          "VOICE_OVER"
+                        ]
                       },
                       "CodingMode": {
-                        "locationName": "codingMode"
+                        "locationName": "codingMode",
+                        "type": "string",
+                        "enum": [
+                          "CODING_MODE_1_0",
+                          "CODING_MODE_1_1",
+                          "CODING_MODE_2_0",
+                          "CODING_MODE_3_2_LFE"
+                        ]
                       },
                       "Dialnorm": {
-                        "locationName": "dialnorm",
-                        "type": "integer"
+                        "shape": "S1t",
+                        "locationName": "dialnorm"
                       },
                       "DrcProfile": {
-                        "locationName": "drcProfile"
+                        "locationName": "drcProfile",
+                        "type": "string",
+                        "enum": [
+                          "FILM_STANDARD",
+                          "NONE"
+                        ]
                       },
                       "LfeFilter": {
-                        "locationName": "lfeFilter"
+                        "locationName": "lfeFilter",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "MetadataControl": {
-                        "locationName": "metadataControl"
+                        "locationName": "metadataControl",
+                        "type": "string",
+                        "enum": [
+                          "FOLLOW_INPUT",
+                          "USE_CONFIGURED"
+                        ]
                       }
                     }
                   },
@@ -1751,36 +1931,88 @@
                     "type": "structure",
                     "members": {
                       "AttenuationControl": {
-                        "locationName": "attenuationControl"
+                        "locationName": "attenuationControl",
+                        "type": "string",
+                        "enum": [
+                          "ATTENUATE_3_DB",
+                          "NONE"
+                        ]
                       },
                       "Bitrate": {
                         "locationName": "bitrate",
                         "type": "double"
                       },
                       "BitstreamMode": {
-                        "locationName": "bitstreamMode"
+                        "locationName": "bitstreamMode",
+                        "type": "string",
+                        "enum": [
+                          "COMMENTARY",
+                          "COMPLETE_MAIN",
+                          "EMERGENCY",
+                          "HEARING_IMPAIRED",
+                          "VISUALLY_IMPAIRED"
+                        ]
                       },
                       "CodingMode": {
-                        "locationName": "codingMode"
+                        "locationName": "codingMode",
+                        "type": "string",
+                        "enum": [
+                          "CODING_MODE_1_0",
+                          "CODING_MODE_2_0",
+                          "CODING_MODE_3_2"
+                        ]
                       },
                       "DcFilter": {
-                        "locationName": "dcFilter"
+                        "locationName": "dcFilter",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "Dialnorm": {
-                        "locationName": "dialnorm",
-                        "type": "integer"
+                        "shape": "S1t",
+                        "locationName": "dialnorm"
                       },
                       "DrcLine": {
-                        "locationName": "drcLine"
+                        "locationName": "drcLine",
+                        "type": "string",
+                        "enum": [
+                          "FILM_LIGHT",
+                          "FILM_STANDARD",
+                          "MUSIC_LIGHT",
+                          "MUSIC_STANDARD",
+                          "NONE",
+                          "SPEECH"
+                        ]
                       },
                       "DrcRf": {
-                        "locationName": "drcRf"
+                        "locationName": "drcRf",
+                        "type": "string",
+                        "enum": [
+                          "FILM_LIGHT",
+                          "FILM_STANDARD",
+                          "MUSIC_LIGHT",
+                          "MUSIC_STANDARD",
+                          "NONE",
+                          "SPEECH"
+                        ]
                       },
                       "LfeControl": {
-                        "locationName": "lfeControl"
+                        "locationName": "lfeControl",
+                        "type": "string",
+                        "enum": [
+                          "LFE",
+                          "NO_LFE"
+                        ]
                       },
                       "LfeFilter": {
-                        "locationName": "lfeFilter"
+                        "locationName": "lfeFilter",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "LoRoCenterMixLevel": {
                         "locationName": "loRoCenterMixLevel",
@@ -1799,22 +2031,56 @@
                         "type": "double"
                       },
                       "MetadataControl": {
-                        "locationName": "metadataControl"
+                        "locationName": "metadataControl",
+                        "type": "string",
+                        "enum": [
+                          "FOLLOW_INPUT",
+                          "USE_CONFIGURED"
+                        ]
                       },
                       "PassthroughControl": {
-                        "locationName": "passthroughControl"
+                        "locationName": "passthroughControl",
+                        "type": "string",
+                        "enum": [
+                          "NO_PASSTHROUGH",
+                          "WHEN_POSSIBLE"
+                        ]
                       },
                       "PhaseControl": {
-                        "locationName": "phaseControl"
+                        "locationName": "phaseControl",
+                        "type": "string",
+                        "enum": [
+                          "NO_SHIFT",
+                          "SHIFT_90_DEGREES"
+                        ]
                       },
                       "StereoDownmix": {
-                        "locationName": "stereoDownmix"
+                        "locationName": "stereoDownmix",
+                        "type": "string",
+                        "enum": [
+                          "DPL2",
+                          "LO_RO",
+                          "LT_RT",
+                          "NOT_INDICATED"
+                        ]
                       },
                       "SurroundExMode": {
-                        "locationName": "surroundExMode"
+                        "locationName": "surroundExMode",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED",
+                          "NOT_INDICATED"
+                        ]
                       },
                       "SurroundMode": {
-                        "locationName": "surroundMode"
+                        "locationName": "surroundMode",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED",
+                          "NOT_INDICATED"
+                        ]
                       }
                     }
                   },
@@ -1827,7 +2093,12 @@
                         "type": "double"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode"
+                        "locationName": "codingMode",
+                        "type": "string",
+                        "enum": [
+                          "CODING_MODE_1_0",
+                          "CODING_MODE_2_0"
+                        ]
                       },
                       "SampleRate": {
                         "locationName": "sampleRate",
@@ -1843,10 +2114,16 @@
                 }
               },
               "LanguageCode": {
+                "shape": "S2f",
                 "locationName": "languageCode"
               },
               "LanguageCodeControl": {
-                "locationName": "languageCodeControl"
+                "locationName": "languageCodeControl",
+                "type": "string",
+                "enum": [
+                  "FOLLOW_INPUT",
+                  "USE_CONFIGURED"
+                ]
               },
               "Name": {
                 "locationName": "name"
@@ -1869,11 +2146,13 @@
                             "members": {
                               "Gain": {
                                 "locationName": "gain",
-                                "type": "integer"
+                                "type": "integer",
+                                "min": -60,
+                                "max": 6
                               },
                               "InputChannel": {
-                                "locationName": "inputChannel",
-                                "type": "integer"
+                                "shape": "S2n",
+                                "locationName": "inputChannel"
                               }
                             },
                             "required": [
@@ -1883,8 +2162,8 @@
                           }
                         },
                         "OutputChannel": {
-                          "locationName": "outputChannel",
-                          "type": "integer"
+                          "shape": "Ss",
+                          "locationName": "outputChannel"
                         }
                       },
                       "required": [
@@ -1895,11 +2174,15 @@
                   },
                   "ChannelsIn": {
                     "locationName": "channelsIn",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 1,
+                    "max": 16
                   },
                   "ChannelsOut": {
                     "locationName": "channelsOut",
-                    "type": "integer"
+                    "type": "integer",
+                    "min": 1,
+                    "max": 8
                   }
                 },
                 "required": [
@@ -1925,7 +2208,12 @@
               "locationName": "availBlankingImage"
             },
             "State": {
-              "locationName": "state"
+              "locationName": "state",
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "ENABLED"
+              ]
             }
           }
         },
@@ -1942,14 +2230,24 @@
                   "type": "structure",
                   "members": {
                     "AdAvailOffset": {
-                      "locationName": "adAvailOffset",
-                      "type": "integer"
+                      "shape": "S2v",
+                      "locationName": "adAvailOffset"
                     },
                     "NoRegionalBlackoutFlag": {
-                      "locationName": "noRegionalBlackoutFlag"
+                      "locationName": "noRegionalBlackoutFlag",
+                      "type": "string",
+                      "enum": [
+                        "FOLLOW",
+                        "IGNORE"
+                      ]
                     },
                     "WebDeliveryAllowedFlag": {
-                      "locationName": "webDeliveryAllowedFlag"
+                      "locationName": "webDeliveryAllowedFlag",
+                      "type": "string",
+                      "enum": [
+                        "FOLLOW",
+                        "IGNORE"
+                      ]
                     }
                   }
                 },
@@ -1958,14 +2256,24 @@
                   "type": "structure",
                   "members": {
                     "AdAvailOffset": {
-                      "locationName": "adAvailOffset",
-                      "type": "integer"
+                      "shape": "S2v",
+                      "locationName": "adAvailOffset"
                     },
                     "NoRegionalBlackoutFlag": {
-                      "locationName": "noRegionalBlackoutFlag"
+                      "locationName": "noRegionalBlackoutFlag",
+                      "type": "string",
+                      "enum": [
+                        "FOLLOW",
+                        "IGNORE"
+                      ]
                     },
                     "WebDeliveryAllowedFlag": {
-                      "locationName": "webDeliveryAllowedFlag"
+                      "locationName": "webDeliveryAllowedFlag",
+                      "type": "string",
+                      "enum": [
+                        "FOLLOW",
+                        "IGNORE"
+                      ]
                     }
                   }
                 }
@@ -1982,17 +2290,30 @@
               "locationName": "blackoutSlateImage"
             },
             "NetworkEndBlackout": {
-              "locationName": "networkEndBlackout"
+              "locationName": "networkEndBlackout",
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "ENABLED"
+              ]
             },
             "NetworkEndBlackoutImage": {
               "shape": "Sr",
               "locationName": "networkEndBlackoutImage"
             },
             "NetworkId": {
-              "locationName": "networkId"
+              "locationName": "networkId",
+              "type": "string",
+              "min": 34,
+              "max": 34
             },
             "State": {
-              "locationName": "state"
+              "locationName": "state",
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "ENABLED"
+              ]
             }
           }
         },
@@ -2019,46 +2340,82 @@
                     "type": "structure",
                     "members": {
                       "Alignment": {
-                        "locationName": "alignment"
+                        "locationName": "alignment",
+                        "type": "string",
+                        "enum": [
+                          "CENTERED",
+                          "LEFT",
+                          "SMART"
+                        ]
                       },
                       "BackgroundColor": {
-                        "locationName": "backgroundColor"
+                        "locationName": "backgroundColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "NONE",
+                          "WHITE"
+                        ]
                       },
                       "BackgroundOpacity": {
-                        "locationName": "backgroundOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "backgroundOpacity"
                       },
                       "Font": {
                         "shape": "Sr",
                         "locationName": "font"
                       },
                       "FontColor": {
-                        "locationName": "fontColor"
+                        "locationName": "fontColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "BLUE",
+                          "GREEN",
+                          "RED",
+                          "WHITE",
+                          "YELLOW"
+                        ]
                       },
                       "FontOpacity": {
-                        "locationName": "fontOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "fontOpacity"
                       },
                       "FontResolution": {
-                        "locationName": "fontResolution",
-                        "type": "integer"
+                        "shape": "S3d",
+                        "locationName": "fontResolution"
                       },
                       "FontSize": {
                         "locationName": "fontSize"
                       },
                       "OutlineColor": {
-                        "locationName": "outlineColor"
+                        "locationName": "outlineColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "BLUE",
+                          "GREEN",
+                          "RED",
+                          "WHITE",
+                          "YELLOW"
+                        ]
                       },
                       "OutlineSize": {
-                        "locationName": "outlineSize",
-                        "type": "integer"
+                        "shape": "S3f",
+                        "locationName": "outlineSize"
                       },
                       "ShadowColor": {
-                        "locationName": "shadowColor"
+                        "locationName": "shadowColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "NONE",
+                          "WHITE"
+                        ]
                       },
                       "ShadowOpacity": {
-                        "locationName": "shadowOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "shadowOpacity"
                       },
                       "ShadowXOffset": {
                         "locationName": "shadowXOffset",
@@ -2069,15 +2426,20 @@
                         "type": "integer"
                       },
                       "TeletextGridControl": {
-                        "locationName": "teletextGridControl"
+                        "locationName": "teletextGridControl",
+                        "type": "string",
+                        "enum": [
+                          "FIXED",
+                          "SCALED"
+                        ]
                       },
                       "XPosition": {
-                        "locationName": "xPosition",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "xPosition"
                       },
                       "YPosition": {
-                        "locationName": "yPosition",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "yPosition"
                       }
                     }
                   },
@@ -2086,46 +2448,82 @@
                     "type": "structure",
                     "members": {
                       "Alignment": {
-                        "locationName": "alignment"
+                        "locationName": "alignment",
+                        "type": "string",
+                        "enum": [
+                          "CENTERED",
+                          "LEFT",
+                          "SMART"
+                        ]
                       },
                       "BackgroundColor": {
-                        "locationName": "backgroundColor"
+                        "locationName": "backgroundColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "NONE",
+                          "WHITE"
+                        ]
                       },
                       "BackgroundOpacity": {
-                        "locationName": "backgroundOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "backgroundOpacity"
                       },
                       "Font": {
                         "shape": "Sr",
                         "locationName": "font"
                       },
                       "FontColor": {
-                        "locationName": "fontColor"
+                        "locationName": "fontColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "BLUE",
+                          "GREEN",
+                          "RED",
+                          "WHITE",
+                          "YELLOW"
+                        ]
                       },
                       "FontOpacity": {
-                        "locationName": "fontOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "fontOpacity"
                       },
                       "FontResolution": {
-                        "locationName": "fontResolution",
-                        "type": "integer"
+                        "shape": "S3d",
+                        "locationName": "fontResolution"
                       },
                       "FontSize": {
                         "locationName": "fontSize"
                       },
                       "OutlineColor": {
-                        "locationName": "outlineColor"
+                        "locationName": "outlineColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "BLUE",
+                          "GREEN",
+                          "RED",
+                          "WHITE",
+                          "YELLOW"
+                        ]
                       },
                       "OutlineSize": {
-                        "locationName": "outlineSize",
-                        "type": "integer"
+                        "shape": "S3f",
+                        "locationName": "outlineSize"
                       },
                       "ShadowColor": {
-                        "locationName": "shadowColor"
+                        "locationName": "shadowColor",
+                        "type": "string",
+                        "enum": [
+                          "BLACK",
+                          "NONE",
+                          "WHITE"
+                        ]
                       },
                       "ShadowOpacity": {
-                        "locationName": "shadowOpacity",
-                        "type": "integer"
+                        "shape": "Sl",
+                        "locationName": "shadowOpacity"
                       },
                       "ShadowXOffset": {
                         "locationName": "shadowXOffset",
@@ -2136,15 +2534,20 @@
                         "type": "integer"
                       },
                       "TeletextGridControl": {
-                        "locationName": "teletextGridControl"
+                        "locationName": "teletextGridControl",
+                        "type": "string",
+                        "enum": [
+                          "FIXED",
+                          "SCALED"
+                        ]
                       },
                       "XPosition": {
-                        "locationName": "xPosition",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "xPosition"
                       },
                       "YPosition": {
-                        "locationName": "yPosition",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "yPosition"
                       }
                     }
                   },
@@ -2188,7 +2591,12 @@
                     "type": "structure",
                     "members": {
                       "StyleControl": {
-                        "locationName": "styleControl"
+                        "locationName": "styleControl",
+                        "type": "string",
+                        "enum": [
+                          "PASSTHROUGH",
+                          "USE_CONFIGURED"
+                        ]
                       }
                     }
                   },
@@ -2221,40 +2629,65 @@
           "members": {
             "InitialAudioGain": {
               "locationName": "initialAudioGain",
-              "type": "integer"
+              "type": "integer",
+              "min": -60,
+              "max": 60
             },
             "InputEndAction": {
-              "locationName": "inputEndAction"
+              "locationName": "inputEndAction",
+              "type": "string",
+              "enum": [
+                "NONE",
+                "SWITCH_AND_LOOP_INPUTS"
+              ]
             },
             "InputLossBehavior": {
               "locationName": "inputLossBehavior",
               "type": "structure",
               "members": {
                 "BlackFrameMsec": {
-                  "locationName": "blackFrameMsec",
-                  "type": "integer"
+                  "shape": "S44",
+                  "locationName": "blackFrameMsec"
                 },
                 "InputLossImageColor": {
-                  "locationName": "inputLossImageColor"
+                  "locationName": "inputLossImageColor",
+                  "type": "string",
+                  "min": 6,
+                  "max": 6
                 },
                 "InputLossImageSlate": {
                   "shape": "Sr",
                   "locationName": "inputLossImageSlate"
                 },
                 "InputLossImageType": {
-                  "locationName": "inputLossImageType"
+                  "locationName": "inputLossImageType",
+                  "type": "string",
+                  "enum": [
+                    "COLOR",
+                    "SLATE"
+                  ]
                 },
                 "RepeatFrameMsec": {
-                  "locationName": "repeatFrameMsec",
-                  "type": "integer"
+                  "shape": "S44",
+                  "locationName": "repeatFrameMsec"
                 }
               }
             },
             "OutputTimingSource": {
-              "locationName": "outputTimingSource"
+              "locationName": "outputTimingSource",
+              "type": "string",
+              "enum": [
+                "INPUT_CLOCK",
+                "SYSTEM_CLOCK"
+              ]
             },
             "SupportLowFramerateInputs": {
-              "locationName": "supportLowFramerateInputs"
+              "locationName": "supportLowFramerateInputs",
+              "type": "string",
+              "enum": [
+                "DISABLED",
+                "ENABLED"
+              ]
             }
           }
         },
@@ -2265,7 +2698,9 @@
             "type": "structure",
             "members": {
               "Name": {
-                "locationName": "name"
+                "locationName": "name",
+                "type": "string",
+                "max": 32
               },
               "OutputGroupSettings": {
                 "locationName": "outputGroupSettings",
@@ -2280,8 +2715,8 @@
                         "locationName": "destination"
                       },
                       "RolloverInterval": {
-                        "locationName": "rolloverInterval",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "rolloverInterval"
                       }
                     },
                     "required": [
@@ -2295,7 +2730,14 @@
                       "AdMarkers": {
                         "locationName": "adMarkers",
                         "type": "list",
-                        "member": {}
+                        "member": {
+                          "type": "string",
+                          "enum": [
+                            "ADOBE",
+                            "ELEMENTAL",
+                            "ELEMENTAL_SCTE35"
+                          ]
+                        }
                       },
                       "BaseUrlContent": {
                         "locationName": "baseUrlContent"
@@ -2310,13 +2752,15 @@
                           "type": "structure",
                           "members": {
                             "CaptionChannel": {
-                              "locationName": "captionChannel",
-                              "type": "integer"
+                              "shape": "S4k",
+                              "locationName": "captionChannel"
                             },
                             "LanguageCode": {
+                              "shape": "S2f",
                               "locationName": "languageCode"
                             },
                             "LanguageDescription": {
+                              "shape": "S4l",
                               "locationName": "languageDescription"
                             }
                           },
@@ -2328,15 +2772,32 @@
                         }
                       },
                       "CaptionLanguageSetting": {
-                        "locationName": "captionLanguageSetting"
+                        "locationName": "captionLanguageSetting",
+                        "type": "string",
+                        "enum": [
+                          "INSERT",
+                          "NONE",
+                          "OMIT"
+                        ]
                       },
                       "ClientCache": {
-                        "locationName": "clientCache"
+                        "locationName": "clientCache",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "CodecSpecification": {
-                        "locationName": "codecSpecification"
+                        "locationName": "codecSpecification",
+                        "type": "string",
+                        "enum": [
+                          "RFC_4281",
+                          "RFC_6381"
+                        ]
                       },
                       "ConstantIv": {
+                        "shape": "S4p",
                         "locationName": "constantIv"
                       },
                       "Destination": {
@@ -2344,10 +2805,20 @@
                         "locationName": "destination"
                       },
                       "DirectoryStructure": {
-                        "locationName": "directoryStructure"
+                        "locationName": "directoryStructure",
+                        "type": "string",
+                        "enum": [
+                          "SINGLE_DIRECTORY",
+                          "SUBDIRECTORY_PER_STREAM"
+                        ]
                       },
                       "EncryptionType": {
-                        "locationName": "encryptionType"
+                        "locationName": "encryptionType",
+                        "type": "string",
+                        "enum": [
+                          "AES128",
+                          "SAMPLE_AES"
+                        ]
                       },
                       "HlsCdnSettings": {
                         "locationName": "hlsCdnSettings",
@@ -2358,23 +2829,28 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "locationName": "connectionRetryInterval",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "connectionRetryInterval"
                               },
                               "FilecacheDuration": {
-                                "locationName": "filecacheDuration",
-                                "type": "integer"
+                                "shape": "S4u",
+                                "locationName": "filecacheDuration"
                               },
                               "HttpTransferMode": {
-                                "locationName": "httpTransferMode"
+                                "locationName": "httpTransferMode",
+                                "type": "string",
+                                "enum": [
+                                  "CHUNKED",
+                                  "NON_CHUNKED"
+                                ]
                               },
                               "NumRetries": {
-                                "locationName": "numRetries",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "numRetries"
                               },
                               "RestartDelay": {
-                                "locationName": "restartDelay",
-                                "type": "integer"
+                                "shape": "S2n",
+                                "locationName": "restartDelay"
                               },
                               "Salt": {
                                 "locationName": "salt"
@@ -2389,20 +2865,20 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "locationName": "connectionRetryInterval",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "connectionRetryInterval"
                               },
                               "FilecacheDuration": {
-                                "locationName": "filecacheDuration",
-                                "type": "integer"
+                                "shape": "S4u",
+                                "locationName": "filecacheDuration"
                               },
                               "NumRetries": {
-                                "locationName": "numRetries",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "numRetries"
                               },
                               "RestartDelay": {
-                                "locationName": "restartDelay",
-                                "type": "integer"
+                                "shape": "S2n",
+                                "locationName": "restartDelay"
                               }
                             }
                           },
@@ -2411,23 +2887,27 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "locationName": "connectionRetryInterval",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "connectionRetryInterval"
                               },
                               "FilecacheDuration": {
-                                "locationName": "filecacheDuration",
-                                "type": "integer"
+                                "shape": "S4u",
+                                "locationName": "filecacheDuration"
                               },
                               "MediaStoreStorageClass": {
-                                "locationName": "mediaStoreStorageClass"
+                                "locationName": "mediaStoreStorageClass",
+                                "type": "string",
+                                "enum": [
+                                  "TEMPORAL"
+                                ]
                               },
                               "NumRetries": {
-                                "locationName": "numRetries",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "numRetries"
                               },
                               "RestartDelay": {
-                                "locationName": "restartDelay",
-                                "type": "integer"
+                                "shape": "S2n",
+                                "locationName": "restartDelay"
                               }
                             }
                           },
@@ -2436,23 +2916,28 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "locationName": "connectionRetryInterval",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "connectionRetryInterval"
                               },
                               "FilecacheDuration": {
-                                "locationName": "filecacheDuration",
-                                "type": "integer"
+                                "shape": "S4u",
+                                "locationName": "filecacheDuration"
                               },
                               "HttpTransferMode": {
-                                "locationName": "httpTransferMode"
+                                "locationName": "httpTransferMode",
+                                "type": "string",
+                                "enum": [
+                                  "CHUNKED",
+                                  "NON_CHUNKED"
+                                ]
                               },
                               "NumRetries": {
-                                "locationName": "numRetries",
-                                "type": "integer"
+                                "shape": "Sp",
+                                "locationName": "numRetries"
                               },
                               "RestartDelay": {
-                                "locationName": "restartDelay",
-                                "type": "integer"
+                                "shape": "S2n",
+                                "locationName": "restartDelay"
                               }
                             }
                           }
@@ -2460,20 +2945,36 @@
                       },
                       "IndexNSegments": {
                         "locationName": "indexNSegments",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 3
                       },
                       "InputLossAction": {
-                        "locationName": "inputLossAction"
+                        "locationName": "inputLossAction",
+                        "type": "string",
+                        "enum": [
+                          "EMIT_OUTPUT",
+                          "PAUSE_OUTPUT"
+                        ]
                       },
                       "IvInManifest": {
-                        "locationName": "ivInManifest"
+                        "locationName": "ivInManifest",
+                        "type": "string",
+                        "enum": [
+                          "EXCLUDE",
+                          "INCLUDE"
+                        ]
                       },
                       "IvSource": {
-                        "locationName": "ivSource"
+                        "locationName": "ivSource",
+                        "type": "string",
+                        "enum": [
+                          "EXPLICIT",
+                          "FOLLOWS_SEGMENT_NUMBER"
+                        ]
                       },
                       "KeepSegments": {
-                        "locationName": "keepSegments",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "keepSegments"
                       },
                       "KeyFormat": {
                         "locationName": "keyFormat"
@@ -2494,6 +2995,7 @@
                                 "locationName": "keyProviderServer"
                               },
                               "StaticKeyValue": {
+                                "shape": "S4p",
                                 "locationName": "staticKeyValue"
                               }
                             },
@@ -2504,55 +3006,103 @@
                         }
                       },
                       "ManifestCompression": {
-                        "locationName": "manifestCompression"
+                        "locationName": "manifestCompression",
+                        "type": "string",
+                        "enum": [
+                          "GZIP",
+                          "NONE"
+                        ]
                       },
                       "ManifestDurationFormat": {
-                        "locationName": "manifestDurationFormat"
+                        "locationName": "manifestDurationFormat",
+                        "type": "string",
+                        "enum": [
+                          "FLOATING_POINT",
+                          "INTEGER"
+                        ]
                       },
                       "MinSegmentLength": {
-                        "locationName": "minSegmentLength",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "minSegmentLength"
                       },
                       "Mode": {
-                        "locationName": "mode"
+                        "locationName": "mode",
+                        "type": "string",
+                        "enum": [
+                          "LIVE",
+                          "VOD"
+                        ]
                       },
                       "OutputSelection": {
-                        "locationName": "outputSelection"
+                        "locationName": "outputSelection",
+                        "type": "string",
+                        "enum": [
+                          "MANIFESTS_AND_SEGMENTS",
+                          "SEGMENTS_ONLY"
+                        ]
                       },
                       "ProgramDateTime": {
-                        "locationName": "programDateTime"
+                        "locationName": "programDateTime",
+                        "type": "string",
+                        "enum": [
+                          "EXCLUDE",
+                          "INCLUDE"
+                        ]
                       },
                       "ProgramDateTimePeriod": {
                         "locationName": "programDateTimePeriod",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 0,
+                        "max": 3600
                       },
                       "SegmentLength": {
-                        "locationName": "segmentLength",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "segmentLength"
                       },
                       "SegmentationMode": {
-                        "locationName": "segmentationMode"
+                        "locationName": "segmentationMode",
+                        "type": "string",
+                        "enum": [
+                          "USE_INPUT_SEGMENTATION",
+                          "USE_SEGMENT_DURATION"
+                        ]
                       },
                       "SegmentsPerSubdirectory": {
-                        "locationName": "segmentsPerSubdirectory",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "segmentsPerSubdirectory"
                       },
                       "StreamInfResolution": {
-                        "locationName": "streamInfResolution"
+                        "locationName": "streamInfResolution",
+                        "type": "string",
+                        "enum": [
+                          "EXCLUDE",
+                          "INCLUDE"
+                        ]
                       },
                       "TimedMetadataId3Frame": {
-                        "locationName": "timedMetadataId3Frame"
+                        "locationName": "timedMetadataId3Frame",
+                        "type": "string",
+                        "enum": [
+                          "NONE",
+                          "PRIV",
+                          "TDRL"
+                        ]
                       },
                       "TimedMetadataId3Period": {
-                        "locationName": "timedMetadataId3Period",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "timedMetadataId3Period"
                       },
                       "TimestampDeltaMilliseconds": {
-                        "locationName": "timestampDeltaMilliseconds",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "timestampDeltaMilliseconds"
                       },
                       "TsFileMode": {
-                        "locationName": "tsFileMode"
+                        "locationName": "tsFileMode",
+                        "type": "string",
+                        "enum": [
+                          "SEGMENTED_FILES",
+                          "SINGLE_FILE"
+                        ]
                       }
                     },
                     "required": [
@@ -2567,14 +3117,24 @@
                         "locationName": "acquisitionPointId"
                       },
                       "AudioOnlyTimecodeControl": {
-                        "locationName": "audioOnlyTimecodeControl"
+                        "locationName": "audioOnlyTimecodeControl",
+                        "type": "string",
+                        "enum": [
+                          "PASSTHROUGH",
+                          "USE_CONFIGURED_CLOCK"
+                        ]
                       },
                       "CertificateMode": {
-                        "locationName": "certificateMode"
+                        "locationName": "certificateMode",
+                        "type": "string",
+                        "enum": [
+                          "SELF_SIGNED",
+                          "VERIFY_AUTHENTICITY"
+                        ]
                       },
                       "ConnectionRetryInterval": {
-                        "locationName": "connectionRetryInterval",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "connectionRetryInterval"
                       },
                       "Destination": {
                         "shape": "S4e",
@@ -2584,48 +3144,84 @@
                         "locationName": "eventId"
                       },
                       "EventIdMode": {
-                        "locationName": "eventIdMode"
+                        "locationName": "eventIdMode",
+                        "type": "string",
+                        "enum": [
+                          "NO_EVENT_ID",
+                          "USE_CONFIGURED",
+                          "USE_TIMESTAMP"
+                        ]
                       },
                       "EventStopBehavior": {
-                        "locationName": "eventStopBehavior"
+                        "locationName": "eventStopBehavior",
+                        "type": "string",
+                        "enum": [
+                          "NONE",
+                          "SEND_EOS"
+                        ]
                       },
                       "FilecacheDuration": {
-                        "locationName": "filecacheDuration",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "filecacheDuration"
                       },
                       "FragmentLength": {
-                        "locationName": "fragmentLength",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "fragmentLength"
                       },
                       "InputLossAction": {
-                        "locationName": "inputLossAction"
+                        "locationName": "inputLossAction",
+                        "type": "string",
+                        "enum": [
+                          "EMIT_OUTPUT",
+                          "PAUSE_OUTPUT"
+                        ]
                       },
                       "NumRetries": {
-                        "locationName": "numRetries",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "numRetries"
                       },
                       "RestartDelay": {
-                        "locationName": "restartDelay",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "restartDelay"
                       },
                       "SegmentationMode": {
-                        "locationName": "segmentationMode"
+                        "locationName": "segmentationMode",
+                        "type": "string",
+                        "enum": [
+                          "USE_INPUT_SEGMENTATION",
+                          "USE_SEGMENT_DURATION"
+                        ]
                       },
                       "SendDelayMs": {
-                        "locationName": "sendDelayMs",
-                        "type": "integer"
+                        "shape": "S5o",
+                        "locationName": "sendDelayMs"
                       },
                       "SparseTrackType": {
-                        "locationName": "sparseTrackType"
+                        "locationName": "sparseTrackType",
+                        "type": "string",
+                        "enum": [
+                          "NONE",
+                          "SCTE_35"
+                        ]
                       },
                       "StreamManifestBehavior": {
-                        "locationName": "streamManifestBehavior"
+                        "locationName": "streamManifestBehavior",
+                        "type": "string",
+                        "enum": [
+                          "DO_NOT_SEND",
+                          "SEND"
+                        ]
                       },
                       "TimestampOffset": {
                         "locationName": "timestampOffset"
                       },
                       "TimestampOffsetMode": {
-                        "locationName": "timestampOffsetMode"
+                        "locationName": "timestampOffsetMode",
+                        "type": "string",
+                        "enum": [
+                          "USE_CONFIGURED_OFFSET",
+                          "USE_EVENT_START_DATE"
+                        ]
                       }
                     },
                     "required": [
@@ -2637,21 +3233,38 @@
                     "type": "structure",
                     "members": {
                       "AuthenticationScheme": {
-                        "locationName": "authenticationScheme"
+                        "locationName": "authenticationScheme",
+                        "type": "string",
+                        "enum": [
+                          "AKAMAI",
+                          "COMMON"
+                        ]
                       },
                       "CacheFullBehavior": {
-                        "locationName": "cacheFullBehavior"
+                        "locationName": "cacheFullBehavior",
+                        "type": "string",
+                        "enum": [
+                          "DISCONNECT_IMMEDIATELY",
+                          "WAIT_FOR_SERVER"
+                        ]
                       },
                       "CacheLength": {
                         "locationName": "cacheLength",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 30
                       },
                       "CaptionData": {
-                        "locationName": "captionData"
+                        "locationName": "captionData",
+                        "type": "string",
+                        "enum": [
+                          "ALL",
+                          "FIELD1_608",
+                          "FIELD1_AND_FIELD2_608"
+                        ]
                       },
                       "RestartDelay": {
-                        "locationName": "restartDelay",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "restartDelay"
                       }
                     }
                   },
@@ -2660,14 +3273,26 @@
                     "type": "structure",
                     "members": {
                       "InputLossAction": {
-                        "locationName": "inputLossAction"
+                        "locationName": "inputLossAction",
+                        "type": "string",
+                        "enum": [
+                          "DROP_PROGRAM",
+                          "DROP_TS",
+                          "EMIT_PROGRAM"
+                        ]
                       },
                       "TimedMetadataId3Frame": {
-                        "locationName": "timedMetadataId3Frame"
+                        "locationName": "timedMetadataId3Frame",
+                        "type": "string",
+                        "enum": [
+                          "NONE",
+                          "PRIV",
+                          "TDRL"
+                        ]
                       },
                       "TimedMetadataId3Period": {
-                        "locationName": "timedMetadataId3Period",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "timedMetadataId3Period"
                       }
                     }
                   }
@@ -2688,7 +3313,10 @@
                       "locationName": "captionDescriptionNames"
                     },
                     "OutputName": {
-                      "locationName": "outputName"
+                      "locationName": "outputName",
+                      "type": "string",
+                      "min": 1,
+                      "max": 255
                     },
                     "OutputSettings": {
                       "locationName": "outputSettings",
@@ -2739,7 +3367,14 @@
                                       "locationName": "audioOnlyImage"
                                     },
                                     "AudioTrackType": {
-                                      "locationName": "audioTrackType"
+                                      "locationName": "audioTrackType",
+                                      "type": "string",
+                                      "enum": [
+                                        "ALTERNATE_AUDIO_AUTO_SELECT",
+                                        "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT",
+                                        "ALTERNATE_AUDIO_NOT_AUTO_SELECT",
+                                        "AUDIO_ONLY_VARIANT_STREAM"
+                                      ]
                                     }
                                   }
                                 },
@@ -2755,8 +3390,8 @@
                                       "type": "structure",
                                       "members": {
                                         "AudioFramesPerPes": {
-                                          "locationName": "audioFramesPerPes",
-                                          "type": "integer"
+                                          "shape": "Sp",
+                                          "locationName": "audioFramesPerPes"
                                         },
                                         "AudioPids": {
                                           "locationName": "audioPids"
@@ -2765,45 +3400,60 @@
                                           "locationName": "ecmPid"
                                         },
                                         "PatInterval": {
-                                          "locationName": "patInterval",
-                                          "type": "integer"
+                                          "shape": "S6t",
+                                          "locationName": "patInterval"
                                         },
                                         "PcrControl": {
-                                          "locationName": "pcrControl"
+                                          "locationName": "pcrControl",
+                                          "type": "string",
+                                          "enum": [
+                                            "CONFIGURED_PCR_PERIOD",
+                                            "PCR_EVERY_PES_PACKET"
+                                          ]
                                         },
                                         "PcrPeriod": {
-                                          "locationName": "pcrPeriod",
-                                          "type": "integer"
+                                          "shape": "S6v",
+                                          "locationName": "pcrPeriod"
                                         },
                                         "PcrPid": {
                                           "locationName": "pcrPid"
                                         },
                                         "PmtInterval": {
-                                          "locationName": "pmtInterval",
-                                          "type": "integer"
+                                          "shape": "S6t",
+                                          "locationName": "pmtInterval"
                                         },
                                         "PmtPid": {
                                           "locationName": "pmtPid"
                                         },
                                         "ProgramNum": {
-                                          "locationName": "programNum",
-                                          "type": "integer"
+                                          "shape": "S6w",
+                                          "locationName": "programNum"
                                         },
                                         "Scte35Behavior": {
-                                          "locationName": "scte35Behavior"
+                                          "locationName": "scte35Behavior",
+                                          "type": "string",
+                                          "enum": [
+                                            "NO_PASSTHROUGH",
+                                            "PASSTHROUGH"
+                                          ]
                                         },
                                         "Scte35Pid": {
                                           "locationName": "scte35Pid"
                                         },
                                         "TimedMetadataBehavior": {
-                                          "locationName": "timedMetadataBehavior"
+                                          "locationName": "timedMetadataBehavior",
+                                          "type": "string",
+                                          "enum": [
+                                            "NO_PASSTHROUGH",
+                                            "PASSTHROUGH"
+                                          ]
                                         },
                                         "TimedMetadataPid": {
                                           "locationName": "timedMetadataPid"
                                         },
                                         "TransportStreamId": {
-                                          "locationName": "transportStreamId",
-                                          "type": "integer"
+                                          "shape": "S6w",
+                                          "locationName": "transportStreamId"
                                         },
                                         "VideoPid": {
                                           "locationName": "videoPid"
@@ -2818,6 +3468,7 @@
                               }
                             },
                             "NameModifier": {
+                              "shape": "S4l",
                               "locationName": "nameModifier"
                             },
                             "SegmentModifier": {
@@ -2842,19 +3493,24 @@
                           "type": "structure",
                           "members": {
                             "CertificateMode": {
-                              "locationName": "certificateMode"
+                              "locationName": "certificateMode",
+                              "type": "string",
+                              "enum": [
+                                "SELF_SIGNED",
+                                "VERIFY_AUTHENTICITY"
+                              ]
                             },
                             "ConnectionRetryInterval": {
-                              "locationName": "connectionRetryInterval",
-                              "type": "integer"
+                              "shape": "Sq",
+                              "locationName": "connectionRetryInterval"
                             },
                             "Destination": {
                               "shape": "S4e",
                               "locationName": "destination"
                             },
                             "NumRetries": {
-                              "locationName": "numRetries",
-                              "type": "integer"
+                              "shape": "Sp",
+                              "locationName": "numRetries"
                             }
                           },
                           "required": [
@@ -2866,8 +3522,8 @@
                           "type": "structure",
                           "members": {
                             "BufferMsec": {
-                              "locationName": "bufferMsec",
-                              "type": "integer"
+                              "shape": "S5o",
+                              "locationName": "bufferMsec"
                             },
                             "ContainerSettings": {
                               "locationName": "containerSettings",
@@ -2889,14 +3545,23 @@
                               "members": {
                                 "ColumnDepth": {
                                   "locationName": "columnDepth",
-                                  "type": "integer"
+                                  "type": "integer",
+                                  "min": 4,
+                                  "max": 20
                                 },
                                 "IncludeFec": {
-                                  "locationName": "includeFec"
+                                  "locationName": "includeFec",
+                                  "type": "string",
+                                  "enum": [
+                                    "COLUMN",
+                                    "COLUMN_AND_ROW"
+                                  ]
                                 },
                                 "RowLength": {
                                   "locationName": "rowLength",
-                                  "type": "integer"
+                                  "type": "integer",
+                                  "min": 1,
+                                  "max": 20
                                 }
                               }
                             }
@@ -2929,11 +3594,19 @@
           "type": "structure",
           "members": {
             "Source": {
-              "locationName": "source"
+              "locationName": "source",
+              "type": "string",
+              "enum": [
+                "EMBEDDED",
+                "SYSTEMCLOCK",
+                "ZEROBASED"
+              ]
             },
             "SyncThreshold": {
               "locationName": "syncThreshold",
-              "type": "integer"
+              "type": "integer",
+              "min": 1,
+              "max": 1000000
             }
           },
           "required": [
@@ -2955,37 +3628,86 @@
                     "type": "structure",
                     "members": {
                       "AdaptiveQuantization": {
-                        "locationName": "adaptiveQuantization"
+                        "locationName": "adaptiveQuantization",
+                        "type": "string",
+                        "enum": [
+                          "HIGH",
+                          "HIGHER",
+                          "LOW",
+                          "MAX",
+                          "MEDIUM",
+                          "OFF"
+                        ]
                       },
                       "AfdSignaling": {
-                        "locationName": "afdSignaling"
+                        "locationName": "afdSignaling",
+                        "type": "string",
+                        "enum": [
+                          "AUTO",
+                          "FIXED",
+                          "NONE"
+                        ]
                       },
                       "Bitrate": {
-                        "locationName": "bitrate",
-                        "type": "integer"
+                        "shape": "S7u",
+                        "locationName": "bitrate"
                       },
                       "BufFillPct": {
-                        "locationName": "bufFillPct",
-                        "type": "integer"
+                        "shape": "St",
+                        "locationName": "bufFillPct"
                       },
                       "BufSize": {
-                        "locationName": "bufSize",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "bufSize"
                       },
                       "ColorMetadata": {
-                        "locationName": "colorMetadata"
+                        "locationName": "colorMetadata",
+                        "type": "string",
+                        "enum": [
+                          "IGNORE",
+                          "INSERT"
+                        ]
                       },
                       "EntropyEncoding": {
-                        "locationName": "entropyEncoding"
+                        "locationName": "entropyEncoding",
+                        "type": "string",
+                        "enum": [
+                          "CABAC",
+                          "CAVLC"
+                        ]
                       },
                       "FixedAfd": {
-                        "locationName": "fixedAfd"
+                        "locationName": "fixedAfd",
+                        "type": "string",
+                        "enum": [
+                          "AFD_0000",
+                          "AFD_0010",
+                          "AFD_0011",
+                          "AFD_0100",
+                          "AFD_1000",
+                          "AFD_1001",
+                          "AFD_1010",
+                          "AFD_1011",
+                          "AFD_1101",
+                          "AFD_1110",
+                          "AFD_1111"
+                        ]
                       },
                       "FlickerAq": {
-                        "locationName": "flickerAq"
+                        "locationName": "flickerAq",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "FramerateControl": {
-                        "locationName": "framerateControl"
+                        "locationName": "framerateControl",
+                        "type": "string",
+                        "enum": [
+                          "INITIALIZE_FROM_SOURCE",
+                          "SPECIFIED"
+                        ]
                       },
                       "FramerateDenominator": {
                         "locationName": "framerateDenominator",
@@ -2996,83 +3718,176 @@
                         "type": "integer"
                       },
                       "GopBReference": {
-                        "locationName": "gopBReference"
+                        "locationName": "gopBReference",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "GopClosedCadence": {
-                        "locationName": "gopClosedCadence",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "gopClosedCadence"
                       },
                       "GopNumBFrames": {
-                        "locationName": "gopNumBFrames",
-                        "type": "integer"
+                        "shape": "Ss",
+                        "locationName": "gopNumBFrames"
                       },
                       "GopSize": {
                         "locationName": "gopSize",
                         "type": "double"
                       },
                       "GopSizeUnits": {
-                        "locationName": "gopSizeUnits"
+                        "locationName": "gopSizeUnits",
+                        "type": "string",
+                        "enum": [
+                          "FRAMES",
+                          "SECONDS"
+                        ]
                       },
                       "Level": {
-                        "locationName": "level"
+                        "locationName": "level",
+                        "type": "string",
+                        "enum": [
+                          "H264_LEVEL_1",
+                          "H264_LEVEL_1_1",
+                          "H264_LEVEL_1_2",
+                          "H264_LEVEL_1_3",
+                          "H264_LEVEL_2",
+                          "H264_LEVEL_2_1",
+                          "H264_LEVEL_2_2",
+                          "H264_LEVEL_3",
+                          "H264_LEVEL_3_1",
+                          "H264_LEVEL_3_2",
+                          "H264_LEVEL_4",
+                          "H264_LEVEL_4_1",
+                          "H264_LEVEL_4_2",
+                          "H264_LEVEL_5",
+                          "H264_LEVEL_5_1",
+                          "H264_LEVEL_5_2",
+                          "H264_LEVEL_AUTO"
+                        ]
                       },
                       "LookAheadRateControl": {
-                        "locationName": "lookAheadRateControl"
+                        "locationName": "lookAheadRateControl",
+                        "type": "string",
+                        "enum": [
+                          "HIGH",
+                          "LOW",
+                          "MEDIUM"
+                        ]
                       },
                       "MaxBitrate": {
-                        "locationName": "maxBitrate",
-                        "type": "integer"
+                        "shape": "S7u",
+                        "locationName": "maxBitrate"
                       },
                       "MinIInterval": {
                         "locationName": "minIInterval",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 0,
+                        "max": 30
                       },
                       "NumRefFrames": {
                         "locationName": "numRefFrames",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 1,
+                        "max": 6
                       },
                       "ParControl": {
-                        "locationName": "parControl"
+                        "locationName": "parControl",
+                        "type": "string",
+                        "enum": [
+                          "INITIALIZE_FROM_SOURCE",
+                          "SPECIFIED"
+                        ]
                       },
                       "ParDenominator": {
-                        "locationName": "parDenominator",
-                        "type": "integer"
+                        "shape": "Sq",
+                        "locationName": "parDenominator"
                       },
                       "ParNumerator": {
                         "locationName": "parNumerator",
                         "type": "integer"
                       },
                       "Profile": {
-                        "locationName": "profile"
+                        "locationName": "profile",
+                        "type": "string",
+                        "enum": [
+                          "BASELINE",
+                          "HIGH",
+                          "HIGH_10BIT",
+                          "HIGH_422",
+                          "HIGH_422_10BIT",
+                          "MAIN"
+                        ]
                       },
                       "RateControlMode": {
-                        "locationName": "rateControlMode"
+                        "locationName": "rateControlMode",
+                        "type": "string",
+                        "enum": [
+                          "CBR",
+                          "VBR"
+                        ]
                       },
                       "ScanType": {
-                        "locationName": "scanType"
+                        "locationName": "scanType",
+                        "type": "string",
+                        "enum": [
+                          "INTERLACED",
+                          "PROGRESSIVE"
+                        ]
                       },
                       "SceneChangeDetect": {
-                        "locationName": "sceneChangeDetect"
+                        "locationName": "sceneChangeDetect",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "Slices": {
                         "locationName": "slices",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 1,
+                        "max": 32
                       },
                       "Softness": {
                         "locationName": "softness",
-                        "type": "integer"
+                        "type": "integer",
+                        "min": 0,
+                        "max": 128
                       },
                       "SpatialAq": {
-                        "locationName": "spatialAq"
+                        "locationName": "spatialAq",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "Syntax": {
-                        "locationName": "syntax"
+                        "locationName": "syntax",
+                        "type": "string",
+                        "enum": [
+                          "DEFAULT",
+                          "RP2027"
+                        ]
                       },
                       "TemporalAq": {
-                        "locationName": "temporalAq"
+                        "locationName": "temporalAq",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "ENABLED"
+                        ]
                       },
                       "TimecodeInsertion": {
-                        "locationName": "timecodeInsertion"
+                        "locationName": "timecodeInsertion",
+                        "type": "string",
+                        "enum": [
+                          "DISABLED",
+                          "PIC_TIMING_SEI"
+                        ]
                       }
                     }
                   }
@@ -3086,14 +3901,25 @@
                 "locationName": "name"
               },
               "RespondToAfd": {
-                "locationName": "respondToAfd"
+                "locationName": "respondToAfd",
+                "type": "string",
+                "enum": [
+                  "NONE",
+                  "PASSTHROUGH",
+                  "RESPOND"
+                ]
               },
               "ScalingBehavior": {
-                "locationName": "scalingBehavior"
+                "locationName": "scalingBehavior",
+                "type": "string",
+                "enum": [
+                  "DEFAULT",
+                  "STRETCH_TO_OUTPUT"
+                ]
               },
               "Sharpness": {
-                "locationName": "sharpness",
-                "type": "integer"
+                "shape": "St",
+                "locationName": "sharpness"
               },
               "Width": {
                 "locationName": "width",
@@ -3113,6 +3939,41 @@
         "TimecodeConfig"
       ]
     },
+    "S1t": {
+      "type": "integer",
+      "min": 1,
+      "max": 31
+    },
+    "S2f": {
+      "type": "string",
+      "min": 3,
+      "max": 3
+    },
+    "S2n": {
+      "type": "integer",
+      "min": 0,
+      "max": 15
+    },
+    "S2v": {
+      "type": "integer",
+      "min": -1000,
+      "max": 1000
+    },
+    "S3d": {
+      "type": "integer",
+      "min": 96,
+      "max": 600
+    },
+    "S3f": {
+      "type": "integer",
+      "min": 0,
+      "max": 10
+    },
+    "S44": {
+      "type": "integer",
+      "min": 0,
+      "max": 1000000
+    },
     "S4e": {
       "type": "structure",
       "members": {
@@ -3121,58 +3982,120 @@
         }
       }
     },
+    "S4k": {
+      "type": "integer",
+      "min": 1,
+      "max": 4
+    },
+    "S4l": {
+      "type": "string",
+      "min": 1
+    },
+    "S4p": {
+      "type": "string",
+      "min": 32,
+      "max": 32
+    },
+    "S4u": {
+      "type": "integer",
+      "min": 0,
+      "max": 600
+    },
+    "S5o": {
+      "type": "integer",
+      "min": 0,
+      "max": 10000
+    },
     "S66": {
       "type": "structure",
       "members": {
         "AbsentInputAudioBehavior": {
-          "locationName": "absentInputAudioBehavior"
+          "locationName": "absentInputAudioBehavior",
+          "type": "string",
+          "enum": [
+            "DROP",
+            "ENCODE_SILENCE"
+          ]
         },
         "Arib": {
-          "locationName": "arib"
+          "locationName": "arib",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "ENABLED"
+          ]
         },
         "AribCaptionsPid": {
           "locationName": "aribCaptionsPid"
         },
         "AribCaptionsPidControl": {
-          "locationName": "aribCaptionsPidControl"
+          "locationName": "aribCaptionsPidControl",
+          "type": "string",
+          "enum": [
+            "AUTO",
+            "USE_CONFIGURED"
+          ]
         },
         "AudioBufferModel": {
-          "locationName": "audioBufferModel"
+          "locationName": "audioBufferModel",
+          "type": "string",
+          "enum": [
+            "ATSC",
+            "DVB"
+          ]
         },
         "AudioFramesPerPes": {
-          "locationName": "audioFramesPerPes",
-          "type": "integer"
+          "shape": "Sp",
+          "locationName": "audioFramesPerPes"
         },
         "AudioPids": {
           "locationName": "audioPids"
         },
         "AudioStreamType": {
-          "locationName": "audioStreamType"
+          "locationName": "audioStreamType",
+          "type": "string",
+          "enum": [
+            "ATSC",
+            "DVB"
+          ]
         },
         "Bitrate": {
-          "locationName": "bitrate",
-          "type": "integer"
+          "shape": "Sp",
+          "locationName": "bitrate"
         },
         "BufferModel": {
-          "locationName": "bufferModel"
+          "locationName": "bufferModel",
+          "type": "string",
+          "enum": [
+            "MULTIPLEX",
+            "NONE"
+          ]
         },
         "CcDescriptor": {
-          "locationName": "ccDescriptor"
+          "locationName": "ccDescriptor",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "ENABLED"
+          ]
         },
         "DvbNitSettings": {
           "locationName": "dvbNitSettings",
           "type": "structure",
           "members": {
             "NetworkId": {
-              "locationName": "networkId",
-              "type": "integer"
+              "shape": "S6f",
+              "locationName": "networkId"
             },
             "NetworkName": {
+              "shape": "S6g",
               "locationName": "networkName"
             },
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer"
+              "type": "integer",
+              "min": 25,
+              "max": 10000
             }
           },
           "required": [
@@ -3185,16 +4108,27 @@
           "type": "structure",
           "members": {
             "OutputSdt": {
-              "locationName": "outputSdt"
+              "locationName": "outputSdt",
+              "type": "string",
+              "enum": [
+                "SDT_FOLLOW",
+                "SDT_FOLLOW_IF_PRESENT",
+                "SDT_MANUAL",
+                "SDT_NONE"
+              ]
             },
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer"
+              "type": "integer",
+              "min": 25,
+              "max": 2000
             },
             "ServiceName": {
+              "shape": "S6g",
               "locationName": "serviceName"
             },
             "ServiceProviderName": {
+              "shape": "S6g",
               "locationName": "serviceProviderName"
             }
           }
@@ -3208,7 +4142,9 @@
           "members": {
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer"
+              "type": "integer",
+              "min": 1000,
+              "max": 30000
             }
           }
         },
@@ -3216,23 +4152,43 @@
           "locationName": "dvbTeletextPid"
         },
         "Ebif": {
-          "locationName": "ebif"
+          "locationName": "ebif",
+          "type": "string",
+          "enum": [
+            "NONE",
+            "PASSTHROUGH"
+          ]
         },
         "EbpAudioInterval": {
-          "locationName": "ebpAudioInterval"
+          "locationName": "ebpAudioInterval",
+          "type": "string",
+          "enum": [
+            "VIDEO_AND_FIXED_INTERVALS",
+            "VIDEO_INTERVAL"
+          ]
         },
         "EbpLookaheadMs": {
-          "locationName": "ebpLookaheadMs",
-          "type": "integer"
+          "shape": "S5o",
+          "locationName": "ebpLookaheadMs"
         },
         "EbpPlacement": {
-          "locationName": "ebpPlacement"
+          "locationName": "ebpPlacement",
+          "type": "string",
+          "enum": [
+            "VIDEO_AND_AUDIO_PIDS",
+            "VIDEO_PID"
+          ]
         },
         "EcmPid": {
           "locationName": "ecmPid"
         },
         "EsRateInPes": {
-          "locationName": "esRateInPes"
+          "locationName": "esRateInPes",
+          "type": "string",
+          "enum": [
+            "EXCLUDE",
+            "INCLUDE"
+          ]
         },
         "EtvPlatformPid": {
           "locationName": "etvPlatformPid"
@@ -3245,7 +4201,12 @@
           "type": "double"
         },
         "Klv": {
-          "locationName": "klv"
+          "locationName": "klv",
+          "type": "string",
+          "enum": [
+            "NONE",
+            "PASSTHROUGH"
+          ]
         },
         "KlvDataPids": {
           "locationName": "klvDataPids"
@@ -3255,66 +4216,129 @@
           "type": "double"
         },
         "PatInterval": {
-          "locationName": "patInterval",
-          "type": "integer"
+          "shape": "S6t",
+          "locationName": "patInterval"
         },
         "PcrControl": {
-          "locationName": "pcrControl"
+          "locationName": "pcrControl",
+          "type": "string",
+          "enum": [
+            "CONFIGURED_PCR_PERIOD",
+            "PCR_EVERY_PES_PACKET"
+          ]
         },
         "PcrPeriod": {
-          "locationName": "pcrPeriod",
-          "type": "integer"
+          "shape": "S6v",
+          "locationName": "pcrPeriod"
         },
         "PcrPid": {
           "locationName": "pcrPid"
         },
         "PmtInterval": {
-          "locationName": "pmtInterval",
-          "type": "integer"
+          "shape": "S6t",
+          "locationName": "pmtInterval"
         },
         "PmtPid": {
           "locationName": "pmtPid"
         },
         "ProgramNum": {
-          "locationName": "programNum",
-          "type": "integer"
+          "shape": "S6w",
+          "locationName": "programNum"
         },
         "RateMode": {
-          "locationName": "rateMode"
+          "locationName": "rateMode",
+          "type": "string",
+          "enum": [
+            "CBR",
+            "VBR"
+          ]
         },
         "Scte27Pids": {
           "locationName": "scte27Pids"
         },
         "Scte35Control": {
-          "locationName": "scte35Control"
+          "locationName": "scte35Control",
+          "type": "string",
+          "enum": [
+            "NONE",
+            "PASSTHROUGH"
+          ]
         },
         "Scte35Pid": {
           "locationName": "scte35Pid"
         },
         "SegmentationMarkers": {
-          "locationName": "segmentationMarkers"
+          "locationName": "segmentationMarkers",
+          "type": "string",
+          "enum": [
+            "EBP",
+            "EBP_LEGACY",
+            "NONE",
+            "PSI_SEGSTART",
+            "RAI_ADAPT",
+            "RAI_SEGSTART"
+          ]
         },
         "SegmentationStyle": {
-          "locationName": "segmentationStyle"
+          "locationName": "segmentationStyle",
+          "type": "string",
+          "enum": [
+            "MAINTAIN_CADENCE",
+            "RESET_CADENCE"
+          ]
         },
         "SegmentationTime": {
           "locationName": "segmentationTime",
           "type": "double"
         },
         "TimedMetadataBehavior": {
-          "locationName": "timedMetadataBehavior"
+          "locationName": "timedMetadataBehavior",
+          "type": "string",
+          "enum": [
+            "NO_PASSTHROUGH",
+            "PASSTHROUGH"
+          ]
         },
         "TimedMetadataPid": {
           "locationName": "timedMetadataPid"
         },
         "TransportStreamId": {
-          "locationName": "transportStreamId",
-          "type": "integer"
+          "shape": "S6w",
+          "locationName": "transportStreamId"
         },
         "VideoPid": {
           "locationName": "videoPid"
         }
       }
+    },
+    "S6f": {
+      "type": "integer",
+      "min": 0,
+      "max": 65536
+    },
+    "S6g": {
+      "type": "string",
+      "min": 1,
+      "max": 256
+    },
+    "S6t": {
+      "type": "integer",
+      "min": 0,
+      "max": 1000
+    },
+    "S6v": {
+      "type": "integer",
+      "min": 0,
+      "max": 500
+    },
+    "S6w": {
+      "type": "integer",
+      "min": 0,
+      "max": 65535
+    },
+    "S7u": {
+      "type": "integer",
+      "min": 1000
     },
     "S8j": {
       "type": "list",
@@ -3349,7 +4373,12 @@
                               "locationName": "languageCode"
                             },
                             "LanguageSelectionPolicy": {
-                              "locationName": "languageSelectionPolicy"
+                              "locationName": "languageSelectionPolicy",
+                              "type": "string",
+                              "enum": [
+                                "LOOSE",
+                                "STRICT"
+                              ]
                             }
                           },
                           "required": [
@@ -3361,8 +4390,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "locationName": "pid",
-                              "type": "integer"
+                              "shape": "S8s",
+                              "locationName": "pid"
                             }
                           },
                           "required": [
@@ -3403,8 +4432,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "locationName": "pid",
-                              "type": "integer"
+                              "shape": "Sq",
+                              "locationName": "pid"
                             }
                           }
                         },
@@ -3413,18 +4442,28 @@
                           "type": "structure",
                           "members": {
                             "Convert608To708": {
-                              "locationName": "convert608To708"
+                              "locationName": "convert608To708",
+                              "type": "string",
+                              "enum": [
+                                "DISABLED",
+                                "UPCONVERT"
+                              ]
                             },
                             "Scte20Detection": {
-                              "locationName": "scte20Detection"
+                              "locationName": "scte20Detection",
+                              "type": "string",
+                              "enum": [
+                                "AUTO",
+                                "OFF"
+                              ]
                             },
                             "Source608ChannelNumber": {
-                              "locationName": "source608ChannelNumber",
-                              "type": "integer"
+                              "shape": "S4k",
+                              "locationName": "source608ChannelNumber"
                             },
                             "Source608TrackNumber": {
-                              "locationName": "source608TrackNumber",
-                              "type": "integer"
+                              "shape": "S91",
+                              "locationName": "source608TrackNumber"
                             }
                           }
                         },
@@ -3433,11 +4472,16 @@
                           "type": "structure",
                           "members": {
                             "Convert608To708": {
-                              "locationName": "convert608To708"
+                              "locationName": "convert608To708",
+                              "type": "string",
+                              "enum": [
+                                "DISABLED",
+                                "UPCONVERT"
+                              ]
                             },
                             "Source608ChannelNumber": {
-                              "locationName": "source608ChannelNumber",
-                              "type": "integer"
+                              "shape": "S4k",
+                              "locationName": "source608ChannelNumber"
                             }
                           }
                         },
@@ -3446,8 +4490,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "locationName": "pid",
-                              "type": "integer"
+                              "shape": "Sq",
+                              "locationName": "pid"
                             }
                           }
                         },
@@ -3469,17 +4513,33 @@
                 }
               },
               "DeblockFilter": {
-                "locationName": "deblockFilter"
+                "locationName": "deblockFilter",
+                "type": "string",
+                "enum": [
+                  "DISABLED",
+                  "ENABLED"
+                ]
               },
               "DenoiseFilter": {
-                "locationName": "denoiseFilter"
+                "locationName": "denoiseFilter",
+                "type": "string",
+                "enum": [
+                  "DISABLED",
+                  "ENABLED"
+                ]
               },
               "FilterStrength": {
-                "locationName": "filterStrength",
-                "type": "integer"
+                "shape": "S91",
+                "locationName": "filterStrength"
               },
               "InputFilter": {
-                "locationName": "inputFilter"
+                "locationName": "inputFilter",
+                "type": "string",
+                "enum": [
+                  "AUTO",
+                  "DISABLED",
+                  "FORCED"
+                ]
               },
               "NetworkInputSettings": {
                 "locationName": "networkInputSettings",
@@ -3490,40 +4550,61 @@
                     "type": "structure",
                     "members": {
                       "Bandwidth": {
-                        "locationName": "bandwidth",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "bandwidth"
                       },
                       "BufferSegments": {
-                        "locationName": "bufferSegments",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "bufferSegments"
                       },
                       "Retries": {
-                        "locationName": "retries",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "retries"
                       },
                       "RetryInterval": {
-                        "locationName": "retryInterval",
-                        "type": "integer"
+                        "shape": "Sp",
+                        "locationName": "retryInterval"
                       }
                     }
                   },
                   "ServerValidation": {
-                    "locationName": "serverValidation"
+                    "locationName": "serverValidation",
+                    "type": "string",
+                    "enum": [
+                      "CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME",
+                      "CHECK_CRYPTOGRAPHY_ONLY"
+                    ]
                   }
                 }
               },
               "SourceEndBehavior": {
-                "locationName": "sourceEndBehavior"
+                "locationName": "sourceEndBehavior",
+                "type": "string",
+                "enum": [
+                  "CONTINUE",
+                  "LOOP"
+                ]
               },
               "VideoSelector": {
                 "locationName": "videoSelector",
                 "type": "structure",
                 "members": {
                   "ColorSpace": {
-                    "locationName": "colorSpace"
+                    "locationName": "colorSpace",
+                    "type": "string",
+                    "enum": [
+                      "FOLLOW",
+                      "REC_601",
+                      "REC_709"
+                    ]
                   },
                   "ColorSpaceUsage": {
-                    "locationName": "colorSpaceUsage"
+                    "locationName": "colorSpaceUsage",
+                    "type": "string",
+                    "enum": [
+                      "FALLBACK",
+                      "FORCE"
+                    ]
                   },
                   "SelectorSettings": {
                     "locationName": "selectorSettings",
@@ -3534,8 +4615,8 @@
                         "type": "structure",
                         "members": {
                           "Pid": {
-                            "locationName": "pid",
-                            "type": "integer"
+                            "shape": "S8s",
+                            "locationName": "pid"
                           }
                         }
                       },
@@ -3544,8 +4625,8 @@
                         "type": "structure",
                         "members": {
                           "ProgramId": {
-                            "locationName": "programId",
-                            "type": "integer"
+                            "shape": "S6f",
+                            "locationName": "programId"
                           }
                         }
                       }
@@ -3558,19 +4639,57 @@
         }
       }
     },
+    "S8s": {
+      "type": "integer",
+      "min": 0,
+      "max": 8191
+    },
+    "S91": {
+      "type": "integer",
+      "min": 1,
+      "max": 5
+    },
     "S9j": {
       "type": "structure",
       "members": {
         "Codec": {
-          "locationName": "codec"
+          "locationName": "codec",
+          "type": "string",
+          "enum": [
+            "MPEG2",
+            "AVC",
+            "HEVC"
+          ]
         },
         "MaximumBitrate": {
-          "locationName": "maximumBitrate"
+          "locationName": "maximumBitrate",
+          "type": "string",
+          "enum": [
+            "MAX_10_MBPS",
+            "MAX_20_MBPS",
+            "MAX_50_MBPS"
+          ]
         },
         "Resolution": {
-          "locationName": "resolution"
+          "locationName": "resolution",
+          "type": "string",
+          "enum": [
+            "SD",
+            "HD",
+            "UHD"
+          ]
         }
       }
+    },
+    "S9n": {
+      "type": "string",
+      "enum": [
+        "ERROR",
+        "WARNING",
+        "INFO",
+        "DEBUG",
+        "DISABLED"
+      ]
     },
     "S9p": {
       "type": "structure",
@@ -3602,6 +4721,7 @@
           "locationName": "inputSpecification"
         },
         "LogLevel": {
+          "shape": "S9n",
           "locationName": "logLevel"
         },
         "Name": {
@@ -3615,6 +4735,7 @@
           "locationName": "roleArn"
         },
         "State": {
+          "shape": "S9s",
           "locationName": "state"
         }
       }
@@ -3629,6 +4750,20 @@
           }
         }
       }
+    },
+    "S9s": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "CREATE_FAILED",
+        "IDLE",
+        "STARTING",
+        "RUNNING",
+        "RECOVERING",
+        "STOPPING",
+        "DELETING",
+        "DELETED"
+      ]
     },
     "S9u": {
       "type": "list",
@@ -3657,6 +4792,16 @@
           }
         }
       }
+    },
+    "S9y": {
+      "type": "string",
+      "enum": [
+        "UDP_PUSH",
+        "RTP_PUSH",
+        "RTMP_PUSH",
+        "RTMP_PULL",
+        "URL_PULL"
+      ]
     },
     "Sa0": {
       "type": "structure",
@@ -3687,9 +4832,11 @@
           "locationName": "sources"
         },
         "State": {
+          "shape": "Sa5",
           "locationName": "state"
         },
         "Type": {
+          "shape": "S9y",
           "locationName": "type"
         }
       }
@@ -3728,6 +4875,16 @@
         }
       }
     },
+    "Sa5": {
+      "type": "string",
+      "enum": [
+        "CREATING",
+        "DETACHED",
+        "ATTACHED",
+        "DELETING",
+        "DELETED"
+      ]
+    },
     "Sa7": {
       "type": "list",
       "member": {
@@ -3753,6 +4910,7 @@
           "locationName": "inputs"
         },
         "State": {
+          "shape": "Sab",
           "locationName": "state"
         },
         "WhitelistRules": {
@@ -3760,6 +4918,15 @@
           "locationName": "whitelistRules"
         }
       }
+    },
+    "Sab": {
+      "type": "string",
+      "enum": [
+        "IDLE",
+        "IN_USE",
+        "UPDATING",
+        "DELETED"
+      ]
     },
     "Sac": {
       "type": "list",
@@ -3772,31 +4939,98 @@
         }
       }
     },
+    "Sam": {
+      "type": "string",
+      "enum": [
+        "MONTHS"
+      ]
+    },
+    "San": {
+      "type": "string",
+      "enum": [
+        "NO_UPFRONT"
+      ]
+    },
     "Sao": {
       "type": "structure",
       "members": {
         "Codec": {
-          "locationName": "codec"
+          "locationName": "codec",
+          "type": "string",
+          "enum": [
+            "MPEG2",
+            "AVC",
+            "HEVC",
+            "AUDIO"
+          ]
         },
         "MaximumBitrate": {
-          "locationName": "maximumBitrate"
+          "locationName": "maximumBitrate",
+          "type": "string",
+          "enum": [
+            "MAX_10_MBPS",
+            "MAX_20_MBPS",
+            "MAX_50_MBPS"
+          ]
         },
         "MaximumFramerate": {
-          "locationName": "maximumFramerate"
+          "locationName": "maximumFramerate",
+          "type": "string",
+          "enum": [
+            "MAX_30_FPS",
+            "MAX_60_FPS"
+          ]
         },
         "Resolution": {
-          "locationName": "resolution"
+          "locationName": "resolution",
+          "type": "string",
+          "enum": [
+            "SD",
+            "HD",
+            "UHD"
+          ]
         },
         "ResourceType": {
-          "locationName": "resourceType"
+          "locationName": "resourceType",
+          "type": "string",
+          "enum": [
+            "INPUT",
+            "OUTPUT",
+            "CHANNEL"
+          ]
         },
         "SpecialFeature": {
-          "locationName": "specialFeature"
+          "locationName": "specialFeature",
+          "type": "string",
+          "enum": [
+            "ADVANCED_AUDIO",
+            "AUDIO_NORMALIZATION"
+          ]
         },
         "VideoQuality": {
-          "locationName": "videoQuality"
+          "locationName": "videoQuality",
+          "type": "string",
+          "enum": [
+            "STANDARD",
+            "ENHANCED",
+            "PREMIUM"
+          ]
         }
       }
+    },
+    "Saw": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "EXPIRED",
+        "CANCELED",
+        "DELETED"
+      ]
+    },
+    "Sb8": {
+      "type": "integer",
+      "min": 1,
+      "max": 1000
     },
     "Sbr": {
       "type": "structure",
@@ -3816,6 +5050,7 @@
           "type": "integer"
         },
         "DurationUnits": {
+          "shape": "Sam",
           "locationName": "durationUnits"
         },
         "End": {
@@ -3835,6 +5070,7 @@
           "locationName": "offeringId"
         },
         "OfferingType": {
+          "shape": "San",
           "locationName": "offeringType"
         },
         "Region": {
@@ -3851,6 +5087,7 @@
           "locationName": "start"
         },
         "State": {
+          "shape": "Saw",
           "locationName": "state"
         },
         "UsagePrice": {

--- a/apis/mediapackage-2017-10-12.min.json
+++ b/apis/mediapackage-2017-10-12.min.json
@@ -320,7 +320,7 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer"
+            "shape": "S17"
           },
           "NextToken": {
             "location": "querystring",
@@ -375,7 +375,7 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer"
+            "shape": "S17"
           },
           "NextToken": {
             "location": "querystring",
@@ -714,7 +714,8 @@
           "member": {
             "members": {
               "AdMarkers": {
-                "locationName": "adMarkers"
+                "locationName": "adMarkers",
+                "shape": "Sf"
               },
               "Id": {
                 "locationName": "id"
@@ -727,7 +728,8 @@
                 "locationName": "manifestName"
               },
               "PlaylistType": {
-                "locationName": "playlistType"
+                "locationName": "playlistType",
+                "shape": "Sh"
               },
               "PlaylistWindowSeconds": {
                 "locationName": "playlistWindowSeconds",
@@ -803,6 +805,22 @@
       "member": {},
       "type": "list"
     },
+    "Sf": {
+      "enum": [
+        "NONE",
+        "SCTE35_ENHANCED",
+        "PASSTHROUGH"
+      ],
+      "type": "string"
+    },
+    "Sh": {
+      "enum": [
+        "NONE",
+        "EVENT",
+        "VOD"
+      ],
+      "type": "string"
+    },
     "Si": {
       "members": {
         "MaxVideoBitsPerSecond": {
@@ -814,7 +832,13 @@
           "type": "integer"
         },
         "StreamOrder": {
-          "locationName": "streamOrder"
+          "locationName": "streamOrder",
+          "enum": [
+            "ORIGINAL",
+            "VIDEO_BITRATE_ASCENDING",
+            "VIDEO_BITRATE_DESCENDING"
+          ],
+          "type": "string"
         }
       },
       "type": "structure"
@@ -852,11 +876,21 @@
         },
         "PeriodTriggers": {
           "locationName": "periodTriggers",
-          "member": {},
+          "member": {
+            "enum": [
+              "ADS"
+            ],
+            "type": "string"
+          },
           "type": "list"
         },
         "Profile": {
-          "locationName": "profile"
+          "locationName": "profile",
+          "enum": [
+            "NONE",
+            "HBBTV_1_5"
+          ],
+          "type": "string"
         },
         "SegmentDurationSeconds": {
           "locationName": "segmentDurationSeconds",
@@ -876,7 +910,8 @@
     "Sp": {
       "members": {
         "AdMarkers": {
-          "locationName": "adMarkers"
+          "locationName": "adMarkers",
+          "shape": "Sf"
         },
         "Encryption": {
           "locationName": "encryption",
@@ -885,7 +920,12 @@
               "locationName": "constantInitializationVector"
             },
             "EncryptionMethod": {
-              "locationName": "encryptionMethod"
+              "locationName": "encryptionMethod",
+              "enum": [
+                "AES_128",
+                "SAMPLE_AES"
+              ],
+              "type": "string"
             },
             "KeyRotationIntervalSeconds": {
               "locationName": "keyRotationIntervalSeconds",
@@ -910,7 +950,8 @@
           "type": "boolean"
         },
         "PlaylistType": {
-          "locationName": "playlistType"
+          "locationName": "playlistType",
+          "shape": "Sh"
         },
         "PlaylistWindowSeconds": {
           "locationName": "playlistWindowSeconds",
@@ -976,7 +1017,8 @@
           "member": {
             "members": {
               "AdMarkers": {
-                "locationName": "adMarkers"
+                "locationName": "adMarkers",
+                "shape": "Sf"
               },
               "Id": {
                 "locationName": "id"
@@ -989,7 +1031,8 @@
                 "locationName": "manifestName"
               },
               "PlaylistType": {
-                "locationName": "playlistType"
+                "locationName": "playlistType",
+                "shape": "Sh"
               },
               "PlaylistWindowSeconds": {
                 "locationName": "playlistWindowSeconds",
@@ -1023,6 +1066,11 @@
         }
       },
       "type": "structure"
+    },
+    "S17": {
+      "max": 1000,
+      "min": 1,
+      "type": "integer"
     }
   }
 }

--- a/apis/mediastore-2017-09-01.min.json
+++ b/apis/mediastore-2017-09-01.min.json
@@ -21,7 +21,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -43,7 +45,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -58,7 +62,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -73,7 +79,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -85,7 +93,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -104,7 +114,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -113,7 +125,9 @@
           "Policy"
         ],
         "members": {
-          "Policy": {}
+          "Policy": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -124,7 +138,9 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {}
+          "ContainerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -143,9 +159,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "Sx"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           }
         }
       },
@@ -161,7 +181,9 @@
               "shape": "S4"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -173,8 +195,12 @@
           "Policy"
         ],
         "members": {
-          "ContainerName": {},
-          "Policy": {}
+          "ContainerName": {
+            "shape": "S2"
+          },
+          "Policy": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -190,7 +216,9 @@
           "CorsPolicy"
         ],
         "members": {
-          "ContainerName": {},
+          "ContainerName": {
+            "shape": "S2"
+          },
           "CorsPolicy": {
             "shape": "Sm"
           }
@@ -203,17 +231,49 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "\\w+"
+    },
     "S4": {
       "type": "structure",
       "members": {
-        "Endpoint": {},
+        "Endpoint": {
+          "type": "string",
+          "max": 255,
+          "min": 1
+        },
         "CreationTime": {
           "type": "timestamp"
         },
-        "ARN": {},
-        "Name": {},
-        "Status": {}
+        "ARN": {
+          "type": "string",
+          "max": 1024,
+          "min": 1,
+          "pattern": "arn:aws:mediastore:[a-z]+-[a-z]+-\\d:\\d{12}:container/\\w{1,255}"
+        },
+        "Name": {
+          "shape": "S2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "ACTIVE",
+            "CREATING",
+            "DELETING"
+          ],
+          "max": 16,
+          "min": 1
+        }
       }
+    },
+    "Sj": {
+      "type": "string",
+      "max": 8192,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
     },
     "Sm": {
       "type": "list",
@@ -222,25 +282,60 @@
         "members": {
           "AllowedOrigins": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+            }
           },
           "AllowedMethods": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "PUT",
+                "GET",
+                "DELETE",
+                "HEAD"
+              ]
+            }
           },
           "AllowedHeaders": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "St"
+            },
+            "max": 100,
+            "min": 0
           },
           "MaxAgeSeconds": {
-            "type": "integer"
+            "type": "integer",
+            "max": 2147483647,
+            "min": 0
           },
           "ExposeHeaders": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "St"
+            },
+            "max": 100,
+            "min": 0
           }
         }
-      }
+      },
+      "max": 100,
+      "min": 1
+    },
+    "St": {
+      "type": "string",
+      "max": 8192,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "Sx": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[0-9A-Za-z=/+]+"
     }
   }
 }

--- a/apis/mediastore-data-2017-09-01.min.json
+++ b/apis/mediastore-data-2017-09-01.min.json
@@ -24,6 +24,7 @@
         ],
         "members": {
           "Path": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           }
@@ -46,6 +47,7 @@
         ],
         "members": {
           "Path": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           }
@@ -55,17 +57,19 @@
         "type": "structure",
         "members": {
           "ETag": {
+            "shape": "S6",
             "location": "header",
             "locationName": "ETag"
           },
           "ContentType": {
+            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
           "ContentLength": {
+            "shape": "S8",
             "location": "header",
-            "locationName": "Content-Length",
-            "type": "long"
+            "locationName": "Content-Length"
           },
           "CacheControl": {
             "location": "header",
@@ -91,12 +95,15 @@
         ],
         "members": {
           "Path": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           },
           "Range": {
             "location": "header",
-            "locationName": "Range"
+            "locationName": "Range",
+            "type": "string",
+            "pattern": "^bytes=(?:\\d+\\-\\d*|\\d*\\-\\d+)$"
           }
         }
       },
@@ -115,18 +122,22 @@
           },
           "ContentRange": {
             "location": "header",
-            "locationName": "Content-Range"
+            "locationName": "Content-Range",
+            "type": "string",
+            "pattern": "^bytes=\\d+\\-\\d+/\\d+$"
           },
           "ContentLength": {
+            "shape": "S8",
             "location": "header",
-            "locationName": "Content-Length",
-            "type": "long"
+            "locationName": "Content-Length"
           },
           "ContentType": {
+            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
           "ETag": {
+            "shape": "S6",
             "location": "header",
             "locationName": "ETag"
           },
@@ -152,12 +163,18 @@
         "members": {
           "Path": {
             "location": "querystring",
-            "locationName": "Path"
+            "locationName": "Path",
+            "type": "string",
+            "max": 900,
+            "min": 0,
+            "pattern": "/?(?:[A-Za-z0-9_\\.\\-\\~]+/){0,10}(?:[A-Za-z0-9_\\.\\-\\~]+)?/?"
           },
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer"
+            "type": "integer",
+            "max": 1000,
+            "min": 1
           },
           "NextToken": {
             "location": "querystring",
@@ -173,15 +190,28 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Type": {},
-                "ETag": {},
+                "Name": {
+                  "type": "string",
+                  "pattern": "[A-Za-z0-9_\\.\\-\\~]+"
+                },
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "OBJECT",
+                    "FOLDER"
+                  ]
+                },
+                "ETag": {
+                  "shape": "S6"
+                },
                 "LastModified": {
                   "type": "timestamp"
                 },
-                "ContentType": {},
+                "ContentType": {
+                  "shape": "S7"
+                },
                 "ContentLength": {
-                  "type": "long"
+                  "shape": "S8"
                 }
               }
             }
@@ -206,10 +236,12 @@
             "shape": "Se"
           },
           "Path": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           },
           "ContentType": {
+            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
@@ -218,6 +250,7 @@
             "locationName": "Cache-Control"
           },
           "StorageClass": {
+            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-storage-class"
           }
@@ -227,18 +260,55 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContentSHA256": {},
-          "ETag": {},
-          "StorageClass": {}
+          "ContentSHA256": {
+            "type": "string",
+            "max": 64,
+            "min": 64,
+            "pattern": "[0-9A-Fa-f]{64}"
+          },
+          "ETag": {
+            "shape": "S6"
+          },
+          "StorageClass": {
+            "shape": "Sr"
+          }
         }
       },
       "authtype": "v4-unsigned-body"
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 900,
+      "min": 1,
+      "pattern": "(?:[A-Za-z0-9_\\.\\-\\~]+/){0,10}[A-Za-z0-9_\\.\\-\\~]+"
+    },
+    "S6": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[0-9A-Fa-f]+"
+    },
+    "S7": {
+      "type": "string",
+      "pattern": "^[\\w\\-\\/\\.]{1,255}$"
+    },
+    "S8": {
+      "type": "long",
+      "min": 0
+    },
     "Se": {
       "type": "blob",
       "streaming": true
+    },
+    "Sr": {
+      "type": "string",
+      "enum": [
+        "TEMPORAL"
+      ],
+      "max": 16,
+      "min": 1
     }
   }
 }

--- a/apis/mediatailor-2018-04-23.min.json
+++ b/apis/mediatailor-2018-04-23.min.json
@@ -83,7 +83,9 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer"
+            "type": "integer",
+            "min": 1,
+            "max": 100
           },
           "NextToken": {
             "location": "querystring",

--- a/apis/meteringmarketplace-2016-01-14.min.json
+++ b/apis/meteringmarketplace-2016-01-14.min.json
@@ -24,7 +24,9 @@
           "UsageRecords": {
             "shape": "S2"
           },
-          "ProductCode": {}
+          "ProductCode": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -39,7 +41,14 @@
                   "shape": "S3"
                 },
                 "MeteringRecordId": {},
-                "Status": {}
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Success",
+                    "CustomerNotSubscribed",
+                    "DuplicateRecord"
+                  ]
+                }
               }
             }
           },
@@ -60,13 +69,17 @@
           "DryRun"
         ],
         "members": {
-          "ProductCode": {},
+          "ProductCode": {
+            "shape": "S8"
+          },
           "Timestamp": {
             "type": "timestamp"
           },
-          "UsageDimension": {},
+          "UsageDimension": {
+            "shape": "S6"
+          },
           "UsageQuantity": {
-            "type": "integer"
+            "shape": "S7"
           },
           "DryRun": {
             "type": "boolean"
@@ -87,14 +100,21 @@
           "RegistrationToken"
         ],
         "members": {
-          "RegistrationToken": {}
+          "RegistrationToken": {
+            "type": "string",
+            "pattern": "\\S+"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CustomerIdentifier": {},
-          "ProductCode": {}
+          "CustomerIdentifier": {
+            "shape": "S5"
+          },
+          "ProductCode": {
+            "shape": "S8"
+          }
         }
       }
     }
@@ -104,7 +124,9 @@
       "type": "list",
       "member": {
         "shape": "S3"
-      }
+      },
+      "max": 25,
+      "min": 0
     },
     "S3": {
       "type": "structure",
@@ -118,12 +140,36 @@
         "Timestamp": {
           "type": "timestamp"
         },
-        "CustomerIdentifier": {},
-        "Dimension": {},
+        "CustomerIdentifier": {
+          "shape": "S5"
+        },
+        "Dimension": {
+          "shape": "S6"
+        },
         "Quantity": {
-          "type": "integer"
+          "shape": "S7"
         }
       }
+    },
+    "S5": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S7": {
+      "type": "integer",
+      "max": 1000000,
+      "min": 0
+    },
+    "S8": {
+      "type": "string",
+      "max": 255,
+      "min": 1
     }
   }
 }

--- a/apis/mobile-2017-07-01.min.json
+++ b/apis/mobile-2017-07-01.min.json
@@ -151,6 +151,7 @@
             "locationName": "projectId"
           },
           "platform": {
+            "shape": "Sw",
             "location": "querystring",
             "locationName": "platform"
           }
@@ -293,7 +294,14 @@
         "name": {},
         "projectId": {},
         "region": {},
-        "state": {},
+        "state": {
+          "type": "string",
+          "enum": [
+            "NORMAL",
+            "SYNCING",
+            "IMPORTING"
+          ]
+        },
         "createdDate": {
           "type": "timestamp"
         },
@@ -333,9 +341,23 @@
         "iconUrl": {},
         "availablePlatforms": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "Sw"
+          }
         }
       }
+    },
+    "Sw": {
+      "type": "string",
+      "enum": [
+        "OSX",
+        "WINDOWS",
+        "LINUX",
+        "OBJC",
+        "SWIFT",
+        "ANDROID",
+        "JAVASCRIPT"
+      ]
     }
   }
 }

--- a/apis/mobileanalytics-2014-06-05.min.json
+++ b/apis/mobileanalytics-2014-06-05.min.json
@@ -30,12 +30,16 @@
                 "timestamp"
               ],
               "members": {
-                "eventType": {},
+                "eventType": {
+                  "shape": "S4"
+                },
                 "timestamp": {},
                 "session": {
                   "type": "structure",
                   "members": {
-                    "id": {},
+                    "id": {
+                      "shape": "S4"
+                    },
                     "duration": {
                       "type": "long"
                     },
@@ -43,18 +47,34 @@
                     "stopTimestamp": {}
                   }
                 },
-                "version": {},
+                "version": {
+                  "type": "string",
+                  "min": 1,
+                  "max": 10
+                },
                 "attributes": {
                   "type": "map",
-                  "key": {},
-                  "value": {}
+                  "key": {
+                    "shape": "S4"
+                  },
+                  "value": {
+                    "type": "string",
+                    "min": 0,
+                    "max": 1000
+                  },
+                  "min": 0,
+                  "max": 50
                 },
                 "metrics": {
                   "type": "map",
-                  "key": {},
+                  "key": {
+                    "shape": "S4"
+                  },
                   "value": {
                     "type": "double"
-                  }
+                  },
+                  "min": 0,
+                  "max": 50
                 }
               }
             }
@@ -71,5 +91,11 @@
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S4": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    }
+  }
 }

--- a/apis/monitoring-2010-08-01.min.json
+++ b/apis/monitoring-2010-08-01.min.json
@@ -48,8 +48,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "AlarmName": {},
-          "HistoryItemType": {},
+          "AlarmName": {
+            "shape": "S3"
+          },
+          "HistoryItemType": {
+            "shape": "S9"
+          },
           "StartDate": {
             "type": "timestamp"
           },
@@ -57,9 +61,11 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "type": "integer"
+            "shape": "Sb"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -71,17 +77,31 @@
             "member": {
               "type": "structure",
               "members": {
-                "AlarmName": {},
+                "AlarmName": {
+                  "shape": "S3"
+                },
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "HistoryItemType": {},
-                "HistorySummary": {},
-                "HistoryData": {}
+                "HistoryItemType": {
+                  "shape": "S9"
+                },
+                "HistorySummary": {
+                  "type": "string",
+                  "max": 255,
+                  "min": 1
+                },
+                "HistoryData": {
+                  "type": "string",
+                  "max": 4095,
+                  "min": 1
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -92,13 +112,25 @@
           "AlarmNames": {
             "shape": "S2"
           },
-          "AlarmNamePrefix": {},
-          "StateValue": {},
-          "ActionPrefix": {},
-          "MaxRecords": {
-            "type": "integer"
+          "AlarmNamePrefix": {
+            "type": "string",
+            "max": 255,
+            "min": 1
           },
-          "NextToken": {}
+          "StateValue": {
+            "shape": "Sk"
+          },
+          "ActionPrefix": {
+            "type": "string",
+            "max": 1024,
+            "min": 1
+          },
+          "MaxRecords": {
+            "shape": "Sb"
+          },
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -108,7 +140,9 @@
           "MetricAlarms": {
             "shape": "Sn"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -120,17 +154,27 @@
           "Namespace"
         ],
         "members": {
-          "MetricName": {},
-          "Namespace": {},
-          "Statistic": {},
-          "ExtendedStatistic": {},
+          "MetricName": {
+            "shape": "Sw"
+          },
+          "Namespace": {
+            "shape": "Sx"
+          },
+          "Statistic": {
+            "shape": "Sy"
+          },
+          "ExtendedStatistic": {
+            "shape": "Sz"
+          },
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "Unit": {}
+          "Unit": {
+            "shape": "S15"
+          }
         }
       },
       "output": {
@@ -206,7 +250,9 @@
                 "Id"
               ],
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S1n"
+                },
                 "MetricStat": {
                   "type": "structure",
                   "required": [
@@ -219,13 +265,19 @@
                       "shape": "S1p"
                     },
                     "Period": {
-                      "type": "integer"
+                      "shape": "S14"
                     },
                     "Stat": {},
-                    "Unit": {}
+                    "Unit": {
+                      "shape": "S15"
+                    }
                   }
                 },
-                "Expression": {},
+                "Expression": {
+                  "type": "string",
+                  "max": 1024,
+                  "min": 1
+                },
                 "Label": {},
                 "ReturnData": {
                   "type": "boolean"
@@ -239,8 +291,16 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "NextToken": {},
-          "ScanBy": {},
+          "NextToken": {
+            "shape": "Sc"
+          },
+          "ScanBy": {
+            "type": "string",
+            "enum": [
+              "TimestampDescending",
+              "TimestampAscending"
+            ]
+          },
           "MaxDatapoints": {
             "type": "integer"
           }
@@ -255,7 +315,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S1n"
+                },
                 "Label": {},
                 "Timestamps": {
                   "type": "list",
@@ -269,7 +331,14 @@
                     "type": "double"
                   }
                 },
-                "StatusCode": {},
+                "StatusCode": {
+                  "type": "string",
+                  "enum": [
+                    "Complete",
+                    "InternalError",
+                    "PartialData"
+                  ]
+                },
                 "Messages": {
                   "type": "list",
                   "member": {
@@ -283,7 +352,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -298,8 +369,12 @@
           "Period"
         ],
         "members": {
-          "Namespace": {},
-          "MetricName": {},
+          "Namespace": {
+            "shape": "Sx"
+          },
+          "MetricName": {
+            "shape": "Sw"
+          },
           "Dimensions": {
             "shape": "S10"
           },
@@ -310,17 +385,27 @@
             "type": "timestamp"
           },
           "Period": {
-            "type": "integer"
+            "shape": "S14"
           },
           "Statistics": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sy"
+            },
+            "max": 5,
+            "min": 1
           },
           "ExtendedStatistics": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sz"
+            },
+            "max": 10,
+            "min": 1
           },
-          "Unit": {}
+          "Unit": {
+            "shape": "S15"
+          }
         }
       },
       "output": {
@@ -351,10 +436,14 @@
                 "Maximum": {
                   "type": "double"
                 },
-                "Unit": {},
+                "Unit": {
+                  "shape": "S15"
+                },
                 "ExtendedStatistics": {
                   "type": "map",
-                  "key": {},
+                  "key": {
+                    "shape": "Sz"
+                  },
                   "value": {
                     "type": "double"
                   }
@@ -401,7 +490,9 @@
         "type": "structure",
         "members": {
           "DashboardNamePrefix": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -424,7 +515,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -432,8 +525,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "Namespace": {},
-          "MetricName": {},
+          "Namespace": {
+            "shape": "Sx"
+          },
+          "MetricName": {
+            "shape": "Sw"
+          },
           "Dimensions": {
             "type": "list",
             "member": {
@@ -442,12 +539,19 @@
                 "Name"
               ],
               "members": {
-                "Name": {},
-                "Value": {}
+                "Name": {
+                  "shape": "S12"
+                },
+                "Value": {
+                  "shape": "S13"
+                }
               }
-            }
+            },
+            "max": 10
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -460,7 +564,9 @@
               "shape": "S1p"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sc"
+          }
         },
         "xmlOrder": [
           "Metrics",
@@ -510,8 +616,12 @@
           "ComparisonOperator"
         ],
         "members": {
-          "AlarmName": {},
-          "AlarmDescription": {},
+          "AlarmName": {
+            "shape": "S3"
+          },
+          "AlarmDescription": {
+            "shape": "Sq"
+          },
           "ActionsEnabled": {
             "type": "boolean"
           },
@@ -524,29 +634,45 @@
           "InsufficientDataActions": {
             "shape": "Ss"
           },
-          "MetricName": {},
-          "Namespace": {},
-          "Statistic": {},
-          "ExtendedStatistic": {},
+          "MetricName": {
+            "shape": "Sw"
+          },
+          "Namespace": {
+            "shape": "Sx"
+          },
+          "Statistic": {
+            "shape": "Sy"
+          },
+          "ExtendedStatistic": {
+            "shape": "Sz"
+          },
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "Unit": {},
+          "Unit": {
+            "shape": "S15"
+          },
           "EvaluationPeriods": {
-            "type": "integer"
+            "shape": "S16"
           },
           "DatapointsToAlarm": {
-            "type": "integer"
+            "shape": "S17"
           },
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {},
-          "TreatMissingData": {},
-          "EvaluateLowSampleCountPercentile": {}
+          "ComparisonOperator": {
+            "shape": "S19"
+          },
+          "TreatMissingData": {
+            "shape": "S1a"
+          },
+          "EvaluateLowSampleCountPercentile": {
+            "shape": "S1b"
+          }
         }
       }
     },
@@ -558,7 +684,9 @@
           "MetricData"
         ],
         "members": {
-          "Namespace": {},
+          "Namespace": {
+            "shape": "Sx"
+          },
           "MetricData": {
             "type": "list",
             "member": {
@@ -567,7 +695,9 @@
                 "MetricName"
               ],
               "members": {
-                "MetricName": {},
+                "MetricName": {
+                  "shape": "Sw"
+                },
                 "Dimensions": {
                   "shape": "S10"
                 },
@@ -612,9 +742,12 @@
                     "type": "double"
                   }
                 },
-                "Unit": {},
+                "Unit": {
+                  "shape": "S15"
+                },
                 "StorageResolution": {
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 1
                 }
               }
             }
@@ -631,10 +764,18 @@
           "StateReason"
         ],
         "members": {
-          "AlarmName": {},
-          "StateValue": {},
-          "StateReason": {},
-          "StateReasonData": {}
+          "AlarmName": {
+            "shape": "S3"
+          },
+          "StateValue": {
+            "shape": "Sk"
+          },
+          "StateReason": {
+            "shape": "Su"
+          },
+          "StateReasonData": {
+            "shape": "Sv"
+          }
         }
       }
     }
@@ -642,16 +783,58 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      },
+      "max": 100
+    },
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S9": {
+      "type": "string",
+      "enum": [
+        "ConfigurationUpdate",
+        "StateUpdate",
+        "Action"
+      ]
+    },
+    "Sb": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "Sc": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "OK",
+        "ALARM",
+        "INSUFFICIENT_DATA"
+      ]
     },
     "Sn": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "AlarmName": {},
-          "AlarmArn": {},
-          "AlarmDescription": {},
+          "AlarmName": {
+            "shape": "S3"
+          },
+          "AlarmArn": {
+            "type": "string",
+            "max": 1600,
+            "min": 1
+          },
+          "AlarmDescription": {
+            "shape": "Sq"
+          },
           "AlarmConfigurationUpdatedTimestamp": {
             "type": "timestamp"
           },
@@ -667,35 +850,57 @@
           "InsufficientDataActions": {
             "shape": "Ss"
           },
-          "StateValue": {},
-          "StateReason": {},
-          "StateReasonData": {},
+          "StateValue": {
+            "shape": "Sk"
+          },
+          "StateReason": {
+            "shape": "Su"
+          },
+          "StateReasonData": {
+            "shape": "Sv"
+          },
           "StateUpdatedTimestamp": {
             "type": "timestamp"
           },
-          "MetricName": {},
-          "Namespace": {},
-          "Statistic": {},
-          "ExtendedStatistic": {},
+          "MetricName": {
+            "shape": "Sw"
+          },
+          "Namespace": {
+            "shape": "Sx"
+          },
+          "Statistic": {
+            "shape": "Sy"
+          },
+          "ExtendedStatistic": {
+            "shape": "Sz"
+          },
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "type": "integer"
+            "shape": "S14"
           },
-          "Unit": {},
+          "Unit": {
+            "shape": "S15"
+          },
           "EvaluationPeriods": {
-            "type": "integer"
+            "shape": "S16"
           },
           "DatapointsToAlarm": {
-            "type": "integer"
+            "shape": "S17"
           },
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {},
-          "TreatMissingData": {},
-          "EvaluateLowSampleCountPercentile": {}
+          "ComparisonOperator": {
+            "shape": "S19"
+          },
+          "TreatMissingData": {
+            "shape": "S1a"
+          },
+          "EvaluateLowSampleCountPercentile": {
+            "shape": "S1b"
+          }
         },
         "xmlOrder": [
           "AlarmName",
@@ -726,9 +931,54 @@
         ]
       }
     },
+    "Sq": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
     "Ss": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 1024,
+        "min": 1
+      },
+      "max": 5
+    },
+    "Su": {
+      "type": "string",
+      "max": 1023,
+      "min": 0
+    },
+    "Sv": {
+      "type": "string",
+      "max": 4000,
+      "min": 0
+    },
+    "Sw": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "Sx": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[^:].*"
+    },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "SampleCount",
+        "Average",
+        "Sum",
+        "Minimum",
+        "Maximum"
+      ]
+    },
+    "Sz": {
+      "type": "string",
+      "pattern": "p(\\d{1,2}(\\.\\d{0,2})?|100)"
     },
     "S10": {
       "type": "list",
@@ -739,20 +989,107 @@
           "Value"
         ],
         "members": {
-          "Name": {},
-          "Value": {}
+          "Name": {
+            "shape": "S12"
+          },
+          "Value": {
+            "shape": "S13"
+          }
         },
         "xmlOrder": [
           "Name",
           "Value"
         ]
-      }
+      },
+      "max": 10
+    },
+    "S12": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S13": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S14": {
+      "type": "integer",
+      "min": 1
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "Seconds",
+        "Microseconds",
+        "Milliseconds",
+        "Bytes",
+        "Kilobytes",
+        "Megabytes",
+        "Gigabytes",
+        "Terabytes",
+        "Bits",
+        "Kilobits",
+        "Megabits",
+        "Gigabits",
+        "Terabits",
+        "Percent",
+        "Count",
+        "Bytes/Second",
+        "Kilobytes/Second",
+        "Megabytes/Second",
+        "Gigabytes/Second",
+        "Terabytes/Second",
+        "Bits/Second",
+        "Kilobits/Second",
+        "Megabits/Second",
+        "Gigabits/Second",
+        "Terabits/Second",
+        "Count/Second",
+        "None"
+      ]
+    },
+    "S16": {
+      "type": "integer",
+      "min": 1
+    },
+    "S17": {
+      "type": "integer",
+      "min": 1
+    },
+    "S19": {
+      "type": "string",
+      "enum": [
+        "GreaterThanOrEqualToThreshold",
+        "GreaterThanThreshold",
+        "LessThanThreshold",
+        "LessThanOrEqualToThreshold"
+      ]
+    },
+    "S1a": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S1b": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S1n": {
+      "type": "string",
+      "max": 255,
+      "min": 1
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "Namespace": {},
-        "MetricName": {},
+        "Namespace": {
+          "shape": "Sx"
+        },
+        "MetricName": {
+          "shape": "Sw"
+        },
         "Dimensions": {
           "shape": "S10"
         }

--- a/apis/mq-2017-11-27.min.json
+++ b/apis/mq-2017-11-27.min.json
@@ -35,9 +35,11 @@
             "idempotencyToken": true
           },
           "DeploymentMode": {
+            "shape": "S6",
             "locationName": "deploymentMode"
           },
           "EngineType": {
+            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -112,6 +114,7 @@
         "type": "structure",
         "members": {
           "EngineType": {
+            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -292,6 +295,7 @@
             "locationName": "brokerName"
           },
           "BrokerState": {
+            "shape": "St",
             "locationName": "brokerState"
           },
           "Configurations": {
@@ -320,9 +324,11 @@
             "locationName": "created"
           },
           "DeploymentMode": {
+            "shape": "S6",
             "locationName": "deploymentMode"
           },
           "EngineType": {
+            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -420,6 +426,7 @@
             "locationName": "description"
           },
           "EngineType": {
+            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -530,6 +537,7 @@
                 "locationName": "groups"
               },
               "PendingChange": {
+                "shape": "S10",
                 "locationName": "pendingChange"
               }
             }
@@ -550,9 +558,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -579,6 +587,7 @@
                   "locationName": "brokerName"
                 },
                 "BrokerState": {
+                  "shape": "St",
                   "locationName": "brokerState"
                 },
                 "Created": {
@@ -586,6 +595,7 @@
                   "locationName": "created"
                 },
                 "DeploymentMode": {
+                  "shape": "S6",
                   "locationName": "deploymentMode"
                 },
                 "HostInstanceType": {
@@ -614,9 +624,9 @@
             "locationName": "configuration-id"
           },
           "MaxResults": {
+            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -660,9 +670,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -690,6 +700,7 @@
                   "locationName": "description"
                 },
                 "EngineType": {
+                  "shape": "S7",
                   "locationName": "engineType"
                 },
                 "EngineVersion": {
@@ -732,9 +743,9 @@
             "locationName": "broker-id"
           },
           "MaxResults": {
+            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -753,7 +764,9 @@
           },
           "MaxResults": {
             "locationName": "maxResults",
-            "type": "integer"
+            "type": "integer",
+            "min": 5,
+            "max": 100
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -887,7 +900,13 @@
                   "locationName": "elementName"
                 },
                 "Reason": {
-                  "locationName": "reason"
+                  "locationName": "reason",
+                  "type": "string",
+                  "enum": [
+                    "DISALLOWED_ELEMENT_REMOVED",
+                    "DISALLOWED_ATTRIBUTE_REMOVED",
+                    "INVALID_ATTRIBUTE_VALUE_REMOVED"
+                  ]
                 }
               }
             }
@@ -948,6 +967,19 @@
         }
       }
     },
+    "S6": {
+      "type": "string",
+      "enum": [
+        "SINGLE_INSTANCE",
+        "ACTIVE_STANDBY_MULTI_AZ"
+      ]
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "ACTIVEMQ"
+      ]
+    },
     "S8": {
       "type": "structure",
       "members": {
@@ -965,7 +997,17 @@
       "type": "structure",
       "members": {
         "DayOfWeek": {
-          "locationName": "dayOfWeek"
+          "locationName": "dayOfWeek",
+          "type": "string",
+          "enum": [
+            "MONDAY",
+            "TUESDAY",
+            "WEDNESDAY",
+            "THURSDAY",
+            "FRIDAY",
+            "SATURDAY",
+            "SUNDAY"
+          ]
         },
         "TimeOfDay": {
           "locationName": "timeOfDay"
@@ -999,12 +1041,23 @@
         }
       }
     },
+    "St": {
+      "type": "string",
+      "enum": [
+        "CREATION_IN_PROGRESS",
+        "CREATION_FAILED",
+        "DELETION_IN_PROGRESS",
+        "RUNNING",
+        "REBOOT_IN_PROGRESS"
+      ]
+    },
     "Sy": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "PendingChange": {
+            "shape": "S10",
             "locationName": "pendingChange"
           },
           "Username": {
@@ -1012,6 +1065,19 @@
           }
         }
       }
+    },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "CREATE",
+        "UPDATE",
+        "DELETE"
+      ]
+    },
+    "S19": {
+      "type": "integer",
+      "min": 1,
+      "max": 100
     }
   }
 }

--- a/apis/mturk-requester-2017-01-17.min.json
+++ b/apis/mturk-requester-2017-01-17.min.json
@@ -38,7 +38,9 @@
           "AssignmentId"
         ],
         "members": {
-          "AssignmentId": {},
+          "AssignmentId": {
+            "shape": "S6"
+          },
           "RequesterFeedback": {},
           "OverrideRejection": {
             "type": "boolean"
@@ -59,8 +61,12 @@
           "WorkerId"
         ],
         "members": {
-          "QualificationTypeId": {},
-          "WorkerId": {},
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
+          "WorkerId": {
+            "shape": "Sa"
+          },
           "IntegerValue": {
             "type": "integer"
           },
@@ -82,11 +88,15 @@
           "NumberOfAdditionalAssignments"
         ],
         "members": {
-          "HITId": {},
+          "HITId": {
+            "shape": "S6"
+          },
           "NumberOfAdditionalAssignments": {
             "type": "integer"
           },
-          "UniqueRequestToken": {}
+          "UniqueRequestToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -117,7 +127,9 @@
           "AssignmentDurationInSeconds": {
             "type": "long"
           },
-          "Reward": {},
+          "Reward": {
+            "shape": "Sh"
+          },
           "Title": {},
           "Keywords": {},
           "Description": {},
@@ -126,14 +138,18 @@
           "QualificationRequirements": {
             "shape": "Si"
           },
-          "UniqueRequestToken": {},
+          "UniqueRequestToken": {
+            "shape": "Sd"
+          },
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
           "HITReviewPolicy": {
             "shape": "Sq"
           },
-          "HITLayoutId": {},
+          "HITLayoutId": {
+            "shape": "S6"
+          },
           "HITLayoutParameters": {
             "shape": "Sw"
           }
@@ -164,7 +180,9 @@
           "AssignmentDurationInSeconds": {
             "type": "long"
           },
-          "Reward": {},
+          "Reward": {
+            "shape": "Sh"
+          },
           "Title": {},
           "Keywords": {},
           "Description": {},
@@ -176,7 +194,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "HITTypeId": {}
+          "HITTypeId": {
+            "shape": "S6"
+          }
         }
       },
       "idempotent": true
@@ -189,7 +209,9 @@
           "LifetimeInSeconds"
         ],
         "members": {
-          "HITTypeId": {},
+          "HITTypeId": {
+            "shape": "S6"
+          },
           "MaxAssignments": {
             "type": "integer"
           },
@@ -198,14 +220,18 @@
           },
           "Question": {},
           "RequesterAnnotation": {},
-          "UniqueRequestToken": {},
+          "UniqueRequestToken": {
+            "shape": "Sd"
+          },
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
           "HITReviewPolicy": {
             "shape": "Sq"
           },
-          "HITLayoutId": {},
+          "HITLayoutId": {
+            "shape": "S6"
+          },
           "HITLayoutParameters": {
             "shape": "Sw"
           }
@@ -232,7 +258,9 @@
           "Name": {},
           "Keywords": {},
           "Description": {},
-          "QualificationTypeStatus": {},
+          "QualificationTypeStatus": {
+            "shape": "S18"
+          },
           "RetryDelayInSeconds": {
             "type": "long"
           },
@@ -266,7 +294,9 @@
           "Reason"
         ],
         "members": {
-          "WorkerId": {},
+          "WorkerId": {
+            "shape": "Sa"
+          },
           "Reason": {}
         }
       },
@@ -282,7 +312,9 @@
           "HITId"
         ],
         "members": {
-          "HITId": {}
+          "HITId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -298,7 +330,9 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {}
+          "QualificationTypeId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -314,7 +348,9 @@
           "WorkerId"
         ],
         "members": {
-          "WorkerId": {},
+          "WorkerId": {
+            "shape": "Sa"
+          },
           "Reason": {}
         }
       },
@@ -332,8 +368,12 @@
           "QualificationTypeId"
         ],
         "members": {
-          "WorkerId": {},
-          "QualificationTypeId": {},
+          "WorkerId": {
+            "shape": "Sa"
+          },
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
           "Reason": {}
         }
       },
@@ -350,8 +390,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "AvailableBalance": {},
-          "OnHoldBalance": {}
+          "AvailableBalance": {
+            "shape": "Sh"
+          },
+          "OnHoldBalance": {
+            "shape": "Sh"
+          }
         }
       },
       "idempotent": true
@@ -363,7 +407,9 @@
           "AssignmentId"
         ],
         "members": {
-          "AssignmentId": {}
+          "AssignmentId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -387,7 +433,9 @@
           "QuestionIdentifier"
         ],
         "members": {
-          "AssignmentId": {},
+          "AssignmentId": {
+            "shape": "S6"
+          },
           "QuestionIdentifier": {}
         }
       },
@@ -406,7 +454,9 @@
           "HITId"
         ],
         "members": {
-          "HITId": {}
+          "HITId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -427,8 +477,12 @@
           "WorkerId"
         ],
         "members": {
-          "QualificationTypeId": {},
-          "WorkerId": {}
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
+          "WorkerId": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -448,7 +502,9 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {}
+          "QualificationTypeId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -468,21 +524,29 @@
           "HITId"
         ],
         "members": {
-          "HITId": {},
-          "NextToken": {},
+          "HITId": {
+            "shape": "S6"
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           },
           "AssignmentStatuses": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1q"
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -500,11 +564,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "HITId": {},
-          "AssignmentId": {},
-          "NextToken": {},
+          "HITId": {
+            "shape": "S6"
+          },
+          "AssignmentId": {
+            "shape": "S6"
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
@@ -514,15 +584,23 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "BonusPayments": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "WorkerId": {},
-                "BonusAmount": {},
-                "AssignmentId": {},
+                "WorkerId": {
+                  "shape": "Sa"
+                },
+                "BonusAmount": {
+                  "shape": "Sh"
+                },
+                "AssignmentId": {
+                  "shape": "S6"
+                },
                 "Reason": {},
                 "GrantTime": {
                   "type": "timestamp"
@@ -538,16 +616,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -565,17 +647,23 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {},
-          "NextToken": {},
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -590,10 +678,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "QualificationTypeId": {},
-          "NextToken": {},
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
@@ -603,15 +695,21 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "QualificationRequests": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
                 "QualificationRequestId": {},
-                "QualificationTypeId": {},
-                "WorkerId": {},
+                "QualificationTypeId": {
+                  "shape": "S6"
+                },
+                "WorkerId": {
+                  "shape": "Sa"
+                },
                 "Test": {},
                 "Answer": {},
                 "SubmitTime": {
@@ -638,9 +736,11 @@
           "MustBeOwnedByCaller": {
             "type": "boolean"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
@@ -650,7 +750,9 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "QualificationTypes": {
             "type": "list",
             "member": {
@@ -668,10 +770,18 @@
           "HITId"
         ],
         "members": {
-          "HITId": {},
+          "HITId": {
+            "shape": "S6"
+          },
           "PolicyLevels": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "Assignment",
+                "HIT"
+              ]
+            }
           },
           "RetrieveActions": {
             "type": "boolean"
@@ -679,16 +789,20 @@
           "RetrieveResults": {
             "type": "boolean"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HITId": {},
+          "HITId": {
+            "shape": "S6"
+          },
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
@@ -701,7 +815,9 @@
           "HITReviewReport": {
             "shape": "S2r"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S22"
+          }
         }
       },
       "idempotent": true
@@ -710,18 +826,30 @@
       "input": {
         "type": "structure",
         "members": {
-          "HITTypeId": {},
-          "Status": {},
-          "NextToken": {},
+          "HITTypeId": {
+            "shape": "S6"
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "Reviewable",
+              "Reviewing"
+            ]
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -736,16 +864,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -754,7 +886,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkerId": {},
+                "WorkerId": {
+                  "shape": "Sa"
+                },
                 "Reason": {}
               }
             }
@@ -770,18 +904,26 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {},
-          "Status": {},
-          "NextToken": {},
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
+          "Status": {
+            "shape": "S1y"
+          },
+          "NextToken": {
+            "shape": "S22"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S23"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S22"
+          },
           "NumResults": {
             "type": "integer"
           },
@@ -808,7 +950,9 @@
           "MessageText": {},
           "WorkerIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa"
+            }
           }
         }
       },
@@ -820,9 +964,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "NotifyWorkersFailureCode": {},
+                "NotifyWorkersFailureCode": {
+                  "type": "string",
+                  "enum": [
+                    "SoftFailure",
+                    "HardFailure"
+                  ]
+                },
                 "NotifyWorkersFailureMessage": {},
-                "WorkerId": {}
+                "WorkerId": {
+                  "shape": "Sa"
+                }
               }
             }
           }
@@ -837,7 +989,9 @@
           "RequesterFeedback"
         ],
         "members": {
-          "AssignmentId": {},
+          "AssignmentId": {
+            "shape": "S6"
+          },
           "RequesterFeedback": {}
         }
       },
@@ -873,11 +1027,19 @@
           "Reason"
         ],
         "members": {
-          "WorkerId": {},
-          "BonusAmount": {},
-          "AssignmentId": {},
+          "WorkerId": {
+            "shape": "Sa"
+          },
+          "BonusAmount": {
+            "shape": "Sh"
+          },
+          "AssignmentId": {
+            "shape": "S6"
+          },
           "Reason": {},
-          "UniqueRequestToken": {}
+          "UniqueRequestToken": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -896,7 +1058,9 @@
           "Notification": {
             "shape": "S3k"
           },
-          "TestEventType": {}
+          "TestEventType": {
+            "shape": "S3n"
+          }
         }
       },
       "output": {
@@ -912,7 +1076,9 @@
           "ExpireAt"
         ],
         "members": {
-          "HITId": {},
+          "HITId": {
+            "shape": "S6"
+          },
           "ExpireAt": {
             "type": "timestamp"
           }
@@ -931,7 +1097,9 @@
           "HITId"
         ],
         "members": {
-          "HITId": {},
+          "HITId": {
+            "shape": "S6"
+          },
           "Revert": {
             "type": "boolean"
           }
@@ -951,8 +1119,12 @@
           "HITTypeId"
         ],
         "members": {
-          "HITId": {},
-          "HITTypeId": {}
+          "HITId": {
+            "shape": "S6"
+          },
+          "HITTypeId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -968,7 +1140,9 @@
           "HITTypeId"
         ],
         "members": {
-          "HITTypeId": {},
+          "HITTypeId": {
+            "shape": "S6"
+          },
           "Notification": {
             "shape": "S3k"
           },
@@ -990,9 +1164,13 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {},
+          "QualificationTypeId": {
+            "shape": "S6"
+          },
           "Description": {},
-          "QualificationTypeStatus": {},
+          "QualificationTypeStatus": {
+            "shape": "S18"
+          },
           "Test": {},
           "AnswerKey": {},
           "TestDurationInSeconds": {
@@ -1020,6 +1198,27 @@
     }
   },
   "shapes": {
+    "S6": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[A-Z0-9]+$"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^A[A-Z0-9]+$"
+    },
+    "Sd": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.)?[0-9]{0,2}$"
+    },
     "Si": {
       "type": "list",
       "member": {
@@ -1030,7 +1229,21 @@
         ],
         "members": {
           "QualificationTypeId": {},
-          "Comparator": {},
+          "Comparator": {
+            "type": "string",
+            "enum": [
+              "LessThan",
+              "LessThanOrEqualTo",
+              "GreaterThan",
+              "GreaterThanOrEqualTo",
+              "EqualTo",
+              "NotEqualTo",
+              "Exists",
+              "DoesNotExist",
+              "In",
+              "NotIn"
+            ]
+          },
           "IntegerValues": {
             "type": "list",
             "member": {
@@ -1047,7 +1260,14 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "ActionsGuarded": {}
+          "ActionsGuarded": {
+            "type": "string",
+            "enum": [
+              "Accept",
+              "PreviewAndAccept",
+              "DiscoverPreviewAndAccept"
+            ]
+          }
         }
       }
     },
@@ -1057,9 +1277,18 @@
         "Country"
       ],
       "members": {
-        "Country": {},
-        "Subdivision": {}
+        "Country": {
+          "shape": "So"
+        },
+        "Subdivision": {
+          "shape": "So"
+        }
       }
+    },
+    "So": {
+      "type": "string",
+      "max": 2,
+      "min": 2
     },
     "Sq": {
       "type": "structure",
@@ -1115,10 +1344,18 @@
     "Sz": {
       "type": "structure",
       "members": {
-        "HITId": {},
-        "HITTypeId": {},
-        "HITGroupId": {},
-        "HITLayoutId": {},
+        "HITId": {
+          "shape": "S6"
+        },
+        "HITTypeId": {
+          "shape": "S6"
+        },
+        "HITGroupId": {
+          "shape": "S6"
+        },
+        "HITLayoutId": {
+          "shape": "S6"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
@@ -1126,11 +1363,22 @@
         "Description": {},
         "Question": {},
         "Keywords": {},
-        "HITStatus": {},
+        "HITStatus": {
+          "type": "string",
+          "enum": [
+            "Assignable",
+            "Unassignable",
+            "Reviewable",
+            "Reviewing",
+            "Disposed"
+          ]
+        },
         "MaxAssignments": {
           "type": "integer"
         },
-        "Reward": {},
+        "Reward": {
+          "shape": "Sh"
+        },
         "AutoApprovalDelayInSeconds": {
           "type": "long"
         },
@@ -1144,7 +1392,15 @@
         "QualificationRequirements": {
           "shape": "Si"
         },
-        "HITReviewStatus": {},
+        "HITReviewStatus": {
+          "type": "string",
+          "enum": [
+            "NotReviewed",
+            "MarkedForReview",
+            "ReviewedAppropriate",
+            "ReviewedInappropriate"
+          ]
+        },
         "NumberOfAssignmentsPending": {
           "type": "integer"
         },
@@ -1156,17 +1412,28 @@
         }
       }
     },
+    "S18": {
+      "type": "string",
+      "enum": [
+        "Active",
+        "Inactive"
+      ]
+    },
     "S1a": {
       "type": "structure",
       "members": {
-        "QualificationTypeId": {},
+        "QualificationTypeId": {
+          "shape": "S6"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
         "Name": {},
         "Description": {},
         "Keywords": {},
-        "QualificationTypeStatus": {},
+        "QualificationTypeStatus": {
+          "shape": "S18"
+        },
         "Test": {},
         "TestDurationInSeconds": {
           "type": "long"
@@ -1189,10 +1456,18 @@
     "S1p": {
       "type": "structure",
       "members": {
-        "AssignmentId": {},
-        "WorkerId": {},
-        "HITId": {},
-        "AssignmentStatus": {},
+        "AssignmentId": {
+          "shape": "S6"
+        },
+        "WorkerId": {
+          "shape": "Sa"
+        },
+        "HITId": {
+          "shape": "S6"
+        },
+        "AssignmentStatus": {
+          "shape": "S1q"
+        },
         "AutoApprovalTime": {
           "type": "timestamp"
         },
@@ -1215,11 +1490,23 @@
         "RequesterFeedback": {}
       }
     },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "Submitted",
+        "Approved",
+        "Rejected"
+      ]
+    },
     "S1x": {
       "type": "structure",
       "members": {
-        "QualificationTypeId": {},
-        "WorkerId": {},
+        "QualificationTypeId": {
+          "shape": "S6"
+        },
+        "WorkerId": {
+          "shape": "Sa"
+        },
         "GrantTime": {
           "type": "timestamp"
         },
@@ -1229,8 +1516,27 @@
         "LocaleValue": {
           "shape": "Sn"
         },
-        "Status": {}
+        "Status": {
+          "shape": "S1y"
+        }
       }
+    },
+    "S1y": {
+      "type": "string",
+      "enum": [
+        "Granted",
+        "Revoked"
+      ]
+    },
+    "S22": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S23": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S2d": {
       "type": "list",
@@ -1246,10 +1552,16 @@
           "member": {
             "type": "structure",
             "members": {
-              "ActionId": {},
-              "SubjectId": {},
+              "ActionId": {
+                "shape": "S6"
+              },
+              "SubjectId": {
+                "shape": "S6"
+              },
               "SubjectType": {},
-              "QuestionId": {},
+              "QuestionId": {
+                "shape": "S6"
+              },
               "Key": {},
               "Value": {}
             }
@@ -1260,11 +1572,23 @@
           "member": {
             "type": "structure",
             "members": {
-              "ActionId": {},
+              "ActionId": {
+                "shape": "S6"
+              },
               "ActionName": {},
-              "TargetId": {},
+              "TargetId": {
+                "shape": "S6"
+              },
               "TargetType": {},
-              "Status": {},
+              "Status": {
+                "type": "string",
+                "enum": [
+                  "Intended",
+                  "Succeeded",
+                  "Failed",
+                  "Cancelled"
+                ]
+              },
               "CompleteTime": {
                 "type": "timestamp"
               },
@@ -1285,13 +1609,39 @@
       ],
       "members": {
         "Destination": {},
-        "Transport": {},
+        "Transport": {
+          "type": "string",
+          "enum": [
+            "Email",
+            "SQS",
+            "SNS"
+          ]
+        },
         "Version": {},
         "EventTypes": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S3n"
+          }
         }
       }
+    },
+    "S3n": {
+      "type": "string",
+      "enum": [
+        "AssignmentAccepted",
+        "AssignmentAbandoned",
+        "AssignmentReturned",
+        "AssignmentSubmitted",
+        "AssignmentRejected",
+        "AssignmentApproved",
+        "HITCreated",
+        "HITExpired",
+        "HITReviewable",
+        "HITExtended",
+        "HITDisposed",
+        "Ping"
+      ]
     }
   }
 }

--- a/apis/neptune-2014-10-31.min.json
+++ b/apis/neptune-2014-10-31.min.json
@@ -1062,7 +1062,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S43"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -1096,7 +1098,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S43"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S7"
@@ -2371,7 +2375,13 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {}
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          }
         }
       }
     },
@@ -2418,6 +2428,17 @@
         }
       },
       "wrapper": true
+    },
+    "S43": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot",
+        "db-cluster",
+        "db-cluster-snapshot"
+      ]
     },
     "S4l": {
       "type": "list",

--- a/apis/opsworks-2013-02-18.min.json
+++ b/apis/opsworks-2013-02-18.min.json
@@ -108,7 +108,9 @@
           "CloneAppIds": {
             "shape": "S3"
           },
-          "DefaultRootDeviceType": {},
+          "DefaultRootDeviceType": {
+            "shape": "Sf"
+          },
           "AgentVersion": {}
         }
       },
@@ -135,7 +137,9 @@
           "DataSources": {
             "shape": "Si"
           },
-          "Type": {},
+          "Type": {
+            "shape": "Sk"
+          },
           "AppSource": {
             "shape": "Sd"
           },
@@ -207,7 +211,9 @@
             "shape": "S3"
           },
           "InstanceType": {},
-          "AutoScalingType": {},
+          "AutoScalingType": {
+            "shape": "Sx"
+          },
           "Hostname": {},
           "Os": {},
           "AmiId": {},
@@ -215,8 +221,12 @@
           "AvailabilityZone": {},
           "VirtualizationType": {},
           "SubnetId": {},
-          "Architecture": {},
-          "RootDeviceType": {},
+          "Architecture": {
+            "shape": "Sy"
+          },
+          "RootDeviceType": {
+            "shape": "Sf"
+          },
           "BlockDeviceMappings": {
             "shape": "Sz"
           },
@@ -248,7 +258,9 @@
         ],
         "members": {
           "StackId": {},
-          "Type": {},
+          "Type": {
+            "shape": "S16"
+          },
           "Name": {},
           "Shortname": {},
           "Attributes": {
@@ -337,7 +349,9 @@
             "shape": "Sd"
           },
           "DefaultSshKeyName": {},
-          "DefaultRootDeviceType": {},
+          "DefaultRootDeviceType": {
+            "shape": "Sf"
+          },
           "AgentVersion": {}
         }
       },
@@ -540,7 +554,9 @@
                 "DataSources": {
                   "shape": "Si"
                 },
-                "Type": {},
+                "Type": {
+                  "shape": "Sk"
+                },
                 "AppSource": {
                   "shape": "Sd"
                 },
@@ -769,9 +785,13 @@
               "members": {
                 "AgentVersion": {},
                 "AmiId": {},
-                "Architecture": {},
+                "Architecture": {
+                  "shape": "Sy"
+                },
                 "Arn": {},
-                "AutoScalingType": {},
+                "AutoScalingType": {
+                  "shape": "Sx"
+                },
                 "AvailabilityZone": {},
                 "BlockDeviceMappings": {
                   "shape": "Sz"
@@ -812,7 +832,9 @@
                     "Version": {}
                   }
                 },
-                "RootDeviceType": {},
+                "RootDeviceType": {
+                  "shape": "Sf"
+                },
                 "RootDeviceVolumeId": {},
                 "SecurityGroupIds": {
                   "shape": "S3"
@@ -824,7 +846,13 @@
                 "Status": {},
                 "SubnetId": {},
                 "Tenancy": {},
-                "VirtualizationType": {}
+                "VirtualizationType": {
+                  "type": "string",
+                  "enum": [
+                    "paravirtual",
+                    "hvm"
+                  ]
+                }
               }
             }
           }
@@ -852,7 +880,9 @@
                 "Arn": {},
                 "StackId": {},
                 "LayerId": {},
-                "Type": {},
+                "Type": {
+                  "shape": "S16"
+                },
                 "Name": {},
                 "Shortname": {},
                 "Attributes": {
@@ -1303,7 +1333,9 @@
                 },
                 "DefaultSshKeyName": {},
                 "CreatedAt": {},
-                "DefaultRootDeviceType": {},
+                "DefaultRootDeviceType": {
+                  "shape": "Sf"
+                },
                 "AgentVersion": {}
               }
             }
@@ -1468,7 +1500,9 @@
         "members": {
           "InstanceId": {},
           "ValidForInMinutes": {
-            "type": "integer"
+            "type": "integer",
+            "max": 1440,
+            "min": 60
           }
         }
       },
@@ -1793,7 +1827,9 @@
           "DataSources": {
             "shape": "Si"
           },
-          "Type": {},
+          "Type": {
+            "shape": "Sk"
+          },
           "AppSource": {
             "shape": "Sd"
           },
@@ -1839,12 +1875,16 @@
             "shape": "S3"
           },
           "InstanceType": {},
-          "AutoScalingType": {},
+          "AutoScalingType": {
+            "shape": "Sx"
+          },
           "Hostname": {},
           "Os": {},
           "AmiId": {},
           "SshKeyName": {},
-          "Architecture": {},
+          "Architecture": {
+            "shape": "Sy"
+          },
           "InstallUpdatesOnBoot": {
             "type": "boolean"
           },
@@ -1959,7 +1999,9 @@
             "shape": "Sd"
           },
           "DefaultSshKeyName": {},
-          "DefaultRootDeviceType": {},
+          "DefaultRootDeviceType": {
+            "shape": "Sf"
+          },
           "UseOpsworksSecurityGroups": {
             "type": "boolean"
           },
@@ -2004,7 +2046,12 @@
     },
     "S8": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "Color"
+        ]
+      },
       "value": {}
     },
     "Sa": {
@@ -2026,13 +2073,28 @@
     "Sd": {
       "type": "structure",
       "members": {
-        "Type": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "git",
+            "svn",
+            "archive",
+            "s3"
+          ]
+        },
         "Url": {},
         "Username": {},
         "Password": {},
         "SshKey": {},
         "Revision": {}
       }
+    },
+    "Sf": {
+      "type": "string",
+      "enum": [
+        "ebs",
+        "instance-store"
+      ]
     },
     "Si": {
       "type": "list",
@@ -2044,6 +2106,18 @@
           "DatabaseName": {}
         }
       }
+    },
+    "Sk": {
+      "type": "string",
+      "enum": [
+        "aws-flow-ruby",
+        "java",
+        "rails",
+        "php",
+        "nodejs",
+        "static",
+        "other"
+      ]
     },
     "Sl": {
       "type": "structure",
@@ -2059,7 +2133,15 @@
     },
     "Sm": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "DocumentRoot",
+          "RailsEnv",
+          "AutoBundleOnDeploy",
+          "AwsFlowRubySettings"
+        ]
+      },
       "value": {}
     },
     "So": {
@@ -2085,7 +2167,23 @@
         "Name"
       ],
       "members": {
-        "Name": {},
+        "Name": {
+          "type": "string",
+          "enum": [
+            "install_dependencies",
+            "update_dependencies",
+            "update_custom_cookbooks",
+            "execute_recipes",
+            "configure",
+            "setup",
+            "deploy",
+            "rollback",
+            "start",
+            "stop",
+            "restart",
+            "undeploy"
+          ]
+        },
         "Args": {
           "type": "map",
           "key": {},
@@ -2094,6 +2192,20 @@
           }
         }
       }
+    },
+    "Sx": {
+      "type": "string",
+      "enum": [
+        "load",
+        "timer"
+      ]
+    },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "x86_64",
+        "i386"
+      ]
     },
     "Sz": {
       "type": "list",
@@ -2113,7 +2225,14 @@
               "VolumeSize": {
                 "type": "integer"
               },
-              "VolumeType": {},
+              "VolumeType": {
+                "type": "string",
+                "enum": [
+                  "gp2",
+                  "io1",
+                  "standard"
+                ]
+              },
               "DeleteOnTermination": {
                 "type": "boolean"
               }
@@ -2122,9 +2241,55 @@
         }
       }
     },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "aws-flow-ruby",
+        "ecs-cluster",
+        "java-app",
+        "lb",
+        "web",
+        "php-app",
+        "rails-app",
+        "nodejs-app",
+        "memcached",
+        "db-master",
+        "monitoring-master",
+        "custom"
+      ]
+    },
     "S17": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "EcsClusterArn",
+          "EnableHaproxyStats",
+          "HaproxyStatsUrl",
+          "HaproxyStatsUser",
+          "HaproxyStatsPassword",
+          "HaproxyHealthCheckUrl",
+          "HaproxyHealthCheckMethod",
+          "MysqlRootPassword",
+          "MysqlRootPasswordUbiquitous",
+          "GangliaUrl",
+          "GangliaUser",
+          "GangliaPassword",
+          "MemcachedMemory",
+          "NodejsVersion",
+          "RubyVersion",
+          "RubygemsVersion",
+          "ManageBundler",
+          "BundlerVersion",
+          "RailsStack",
+          "PassengerVersion",
+          "Jvm",
+          "JvmVersion",
+          "JvmOptions",
+          "JavaAppServer",
+          "JavaAppServerVersion"
+        ]
+      },
       "value": {}
     },
     "S19": {
@@ -2140,12 +2305,120 @@
             "members": {
               "LogGroupName": {},
               "DatetimeFormat": {},
-              "TimeZone": {},
+              "TimeZone": {
+                "type": "string",
+                "enum": [
+                  "LOCAL",
+                  "UTC"
+                ]
+              },
               "File": {},
               "FileFingerprintLines": {},
               "MultiLineStartPattern": {},
-              "InitialPosition": {},
-              "Encoding": {},
+              "InitialPosition": {
+                "type": "string",
+                "enum": [
+                  "start_of_file",
+                  "end_of_file"
+                ]
+              },
+              "Encoding": {
+                "type": "string",
+                "enum": [
+                  "ascii",
+                  "big5",
+                  "big5hkscs",
+                  "cp037",
+                  "cp424",
+                  "cp437",
+                  "cp500",
+                  "cp720",
+                  "cp737",
+                  "cp775",
+                  "cp850",
+                  "cp852",
+                  "cp855",
+                  "cp856",
+                  "cp857",
+                  "cp858",
+                  "cp860",
+                  "cp861",
+                  "cp862",
+                  "cp863",
+                  "cp864",
+                  "cp865",
+                  "cp866",
+                  "cp869",
+                  "cp874",
+                  "cp875",
+                  "cp932",
+                  "cp949",
+                  "cp950",
+                  "cp1006",
+                  "cp1026",
+                  "cp1140",
+                  "cp1250",
+                  "cp1251",
+                  "cp1252",
+                  "cp1253",
+                  "cp1254",
+                  "cp1255",
+                  "cp1256",
+                  "cp1257",
+                  "cp1258",
+                  "euc_jp",
+                  "euc_jis_2004",
+                  "euc_jisx0213",
+                  "euc_kr",
+                  "gb2312",
+                  "gbk",
+                  "gb18030",
+                  "hz",
+                  "iso2022_jp",
+                  "iso2022_jp_1",
+                  "iso2022_jp_2",
+                  "iso2022_jp_2004",
+                  "iso2022_jp_3",
+                  "iso2022_jp_ext",
+                  "iso2022_kr",
+                  "latin_1",
+                  "iso8859_2",
+                  "iso8859_3",
+                  "iso8859_4",
+                  "iso8859_5",
+                  "iso8859_6",
+                  "iso8859_7",
+                  "iso8859_8",
+                  "iso8859_9",
+                  "iso8859_10",
+                  "iso8859_13",
+                  "iso8859_14",
+                  "iso8859_15",
+                  "iso8859_16",
+                  "johab",
+                  "koi8_r",
+                  "koi8_u",
+                  "mac_cyrillic",
+                  "mac_greek",
+                  "mac_iceland",
+                  "mac_latin2",
+                  "mac_roman",
+                  "mac_turkish",
+                  "ptcp154",
+                  "shift_jis",
+                  "shift_jis_2004",
+                  "shift_jisx0213",
+                  "utf_32",
+                  "utf_32_be",
+                  "utf_32_le",
+                  "utf_16",
+                  "utf_16_be",
+                  "utf_16_le",
+                  "utf_7",
+                  "utf_8",
+                  "utf_8_sig"
+                ]
+              },
               "BufferDuration": {
                 "type": "integer"
               },
@@ -2233,10 +2506,10 @@
           "type": "integer"
         },
         "ThresholdsWaitTime": {
-          "type": "integer"
+          "shape": "S37"
         },
         "IgnoreMetricsTime": {
-          "type": "integer"
+          "shape": "S37"
         },
         "CpuThreshold": {
           "type": "double"
@@ -2251,6 +2524,11 @@
           "shape": "S3"
         }
       }
+    },
+    "S37": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S4b": {
       "type": "structure",

--- a/apis/opsworkscm-2016-11-01.min.json
+++ b/apis/opsworkscm-2016-11-01.min.json
@@ -23,8 +23,12 @@
           "EngineAttributes"
         ],
         "members": {
-          "ServerName": {},
-          "NodeName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
+          "NodeName": {
+            "shape": "S3"
+          },
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -44,7 +48,9 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
           "Description": {}
         }
       },
@@ -80,22 +86,37 @@
             "shape": "S4"
           },
           "BackupRetentionCount": {
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           },
-          "ServerName": {},
-          "InstanceProfileArn": {},
+          "ServerName": {
+            "shape": "S2"
+          },
+          "InstanceProfileArn": {
+            "type": "string",
+            "pattern": "arn:aws:iam::[0-9]{12}:instance-profile/.*"
+          },
           "InstanceType": {},
           "KeyPair": {},
-          "PreferredMaintenanceWindow": {},
-          "PreferredBackupWindow": {},
+          "PreferredMaintenanceWindow": {
+            "shape": "Sh"
+          },
+          "PreferredBackupWindow": {
+            "shape": "Sh"
+          },
           "SecurityGroupIds": {
             "shape": "Sj"
           },
-          "ServiceRoleArn": {},
+          "ServiceRoleArn": {
+            "type": "string",
+            "pattern": "arn:aws:iam::[0-9]{12}:role/.*"
+          },
           "SubnetIds": {
             "shape": "Sj"
           },
-          "BackupId": {}
+          "BackupId": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -114,7 +135,9 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {}
+          "BackupId": {
+            "shape": "Se"
+          }
         }
       },
       "output": {
@@ -129,7 +152,9 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {}
+          "ServerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -167,11 +192,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "BackupId": {},
-          "ServerName": {},
+          "BackupId": {
+            "shape": "Se"
+          },
+          "ServerName": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           }
         }
       },
@@ -195,10 +224,12 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           }
         }
       },
@@ -232,13 +263,22 @@
         ],
         "members": {
           "NodeAssociationStatusToken": {},
-          "ServerName": {}
+          "ServerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NodeAssociationStatus": {},
+          "NodeAssociationStatus": {
+            "type": "string",
+            "enum": [
+              "SUCCESS",
+              "FAILED",
+              "IN_PROGRESS"
+            ]
+          },
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -249,10 +289,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "ServerName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           }
         }
       },
@@ -277,8 +319,12 @@
           "NodeName"
         ],
         "members": {
-          "ServerName": {},
-          "NodeName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
+          "NodeName": {
+            "shape": "S3"
+          },
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -299,8 +345,12 @@
           "ServerName"
         ],
         "members": {
-          "BackupId": {},
-          "ServerName": {},
+          "BackupId": {
+            "shape": "Se"
+          },
+          "ServerName": {
+            "shape": "S2"
+          },
           "InstanceType": {},
           "KeyPair": {}
         }
@@ -317,7 +367,9 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -345,9 +397,15 @@
           "BackupRetentionCount": {
             "type": "integer"
           },
-          "ServerName": {},
-          "PreferredMaintenanceWindow": {},
-          "PreferredBackupWindow": {}
+          "ServerName": {
+            "shape": "S2"
+          },
+          "PreferredMaintenanceWindow": {
+            "shape": "Sh"
+          },
+          "PreferredBackupWindow": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -367,8 +425,15 @@
           "AttributeName"
         ],
         "members": {
-          "ServerName": {},
-          "AttributeName": {},
+          "ServerName": {
+            "shape": "S2"
+          },
+          "AttributeName": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "[A-Z][A-Z0-9_]*"
+          },
           "AttributeValue": {}
         }
       },
@@ -383,6 +448,16 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 40,
+      "min": 1,
+      "pattern": "[a-zA-Z][a-zA-Z0-9\\-]*"
+    },
+    "S3": {
+      "type": "string",
+      "pattern": "^[\\-\\p{Alnum}_:.]+$"
+    },
     "S4": {
       "type": "list",
       "member": {
@@ -400,8 +475,16 @@
       "type": "structure",
       "members": {
         "BackupArn": {},
-        "BackupId": {},
-        "BackupType": {},
+        "BackupId": {
+          "shape": "Se"
+        },
+        "BackupType": {
+          "type": "string",
+          "enum": [
+            "AUTOMATED",
+            "MANUAL"
+          ]
+        },
         "CreatedAt": {
           "type": "timestamp"
         },
@@ -412,8 +495,12 @@
         "InstanceProfileArn": {},
         "InstanceType": {},
         "KeyPair": {},
-        "PreferredBackupWindow": {},
-        "PreferredMaintenanceWindow": {},
+        "PreferredBackupWindow": {
+          "shape": "Sh"
+        },
+        "PreferredMaintenanceWindow": {
+          "shape": "Sh"
+        },
         "S3DataSize": {
           "deprecated": true,
           "type": "integer"
@@ -425,9 +512,19 @@
         "SecurityGroupIds": {
           "shape": "Sj"
         },
-        "ServerName": {},
+        "ServerName": {
+          "shape": "S2"
+        },
         "ServiceRoleArn": {},
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "IN_PROGRESS",
+            "OK",
+            "FAILED",
+            "DELETING"
+          ]
+        },
         "StatusDescription": {},
         "SubnetIds": {
           "shape": "Sj"
@@ -435,6 +532,14 @@
         "ToolsVersion": {},
         "UserArn": {}
       }
+    },
+    "Se": {
+      "type": "string",
+      "max": 79
+    },
+    "Sh": {
+      "type": "string",
+      "pattern": "^((Mon|Tue|Wed|Thu|Fri|Sat|Sun):)?([0-1][0-9]|2[0-3]):[0-5][0-9]$"
     },
     "Sj": {
       "type": "list",
@@ -467,20 +572,51 @@
         "InstanceProfileArn": {},
         "InstanceType": {},
         "KeyPair": {},
-        "MaintenanceStatus": {},
-        "PreferredMaintenanceWindow": {},
-        "PreferredBackupWindow": {},
+        "MaintenanceStatus": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILED"
+          ]
+        },
+        "PreferredMaintenanceWindow": {
+          "shape": "Sh"
+        },
+        "PreferredBackupWindow": {
+          "shape": "Sh"
+        },
         "SecurityGroupIds": {
           "shape": "Sj"
         },
         "ServiceRoleArn": {},
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "BACKING_UP",
+            "CONNECTION_LOST",
+            "CREATING",
+            "DELETING",
+            "MODIFYING",
+            "FAILED",
+            "HEALTHY",
+            "RUNNING",
+            "RESTORING",
+            "SETUP",
+            "UNDER_MAINTENANCE",
+            "UNHEALTHY",
+            "TERMINATED"
+          ]
+        },
         "StatusReason": {},
         "SubnetIds": {
           "shape": "Sj"
         },
         "ServerArn": {}
       }
+    },
+    "S15": {
+      "type": "integer",
+      "min": 1
     }
   }
 }

--- a/apis/organizations-2016-11-28.min.json
+++ b/apis/organizations-2016-11-28.min.json
@@ -20,7 +20,9 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {}
+          "HandshakeId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -40,8 +42,12 @@
           "TargetId"
         ],
         "members": {
-          "PolicyId": {},
-          "TargetId": {}
+          "PolicyId": {
+            "shape": "Si"
+          },
+          "TargetId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -52,7 +58,9 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {}
+          "HandshakeId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -78,8 +86,17 @@
           "AccountName": {
             "shape": "So"
           },
-          "RoleName": {},
-          "IamUserAccessToBilling": {}
+          "RoleName": {
+            "type": "string",
+            "pattern": "[\\w+=,.@-]{1,64}"
+          },
+          "IamUserAccessToBilling": {
+            "type": "string",
+            "enum": [
+              "ALLOW",
+              "DENY"
+            ]
+          }
         }
       },
       "output": {
@@ -95,7 +112,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "FeatureSet": {}
+          "FeatureSet": {
+            "shape": "Sy"
+          }
         }
       },
       "output": {
@@ -115,8 +134,12 @@
           "Name"
         ],
         "members": {
-          "ParentId": {},
-          "Name": {}
+          "ParentId": {
+            "shape": "S19"
+          },
+          "Name": {
+            "shape": "S1a"
+          }
         }
       },
       "output": {
@@ -138,10 +161,18 @@
           "Type"
         ],
         "members": {
-          "Content": {},
-          "Description": {},
-          "Name": {},
-          "Type": {}
+          "Content": {
+            "shape": "S1g"
+          },
+          "Description": {
+            "shape": "S1h"
+          },
+          "Name": {
+            "shape": "S1i"
+          },
+          "Type": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -160,7 +191,9 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {}
+          "HandshakeId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -180,7 +213,9 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {}
+          "OrganizationalUnitId": {
+            "shape": "S1d"
+          }
         }
       }
     },
@@ -191,7 +226,9 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {}
+          "PolicyId": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -202,7 +239,9 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {}
+          "AccountId": {
+            "shape": "Sv"
+          }
         }
       },
       "output": {
@@ -221,7 +260,9 @@
           "CreateAccountRequestId"
         ],
         "members": {
-          "CreateAccountRequestId": {}
+          "CreateAccountRequestId": {
+            "shape": "St"
+          }
         }
       },
       "output": {
@@ -240,7 +281,9 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {}
+          "HandshakeId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -269,7 +312,9 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {}
+          "OrganizationalUnitId": {
+            "shape": "S1d"
+          }
         }
       },
       "output": {
@@ -288,7 +333,9 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {}
+          "PolicyId": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -308,8 +355,12 @@
           "TargetId"
         ],
         "members": {
-          "PolicyId": {},
-          "TargetId": {}
+          "PolicyId": {
+            "shape": "Si"
+          },
+          "TargetId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -320,7 +371,9 @@
           "ServicePrincipal"
         ],
         "members": {
-          "ServicePrincipal": {}
+          "ServicePrincipal": {
+            "shape": "S28"
+          }
         }
       }
     },
@@ -332,8 +385,12 @@
           "PolicyType"
         ],
         "members": {
-          "RootId": {},
-          "PolicyType": {}
+          "RootId": {
+            "shape": "S2a"
+          },
+          "PolicyType": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -352,7 +409,9 @@
           "ServicePrincipal"
         ],
         "members": {
-          "ServicePrincipal": {}
+          "ServicePrincipal": {
+            "shape": "S28"
+          }
         }
       }
     },
@@ -378,8 +437,12 @@
           "PolicyType"
         ],
         "members": {
-          "RootId": {},
-          "PolicyType": {}
+          "RootId": {
+            "shape": "S2a"
+          },
+          "PolicyType": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -403,6 +466,7 @@
           },
           "Notes": {
             "type": "string",
+            "max": 1024,
             "sensitive": true
           }
         }
@@ -423,7 +487,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -435,7 +499,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ServicePrincipal": {},
+                "ServicePrincipal": {
+                  "shape": "S28"
+                },
                 "DateEnabled": {
                   "type": "timestamp"
                 }
@@ -452,7 +518,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -473,10 +539,12 @@
           "ParentId"
         ],
         "members": {
-          "ParentId": {},
+          "ParentId": {
+            "shape": "S19"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -498,11 +566,15 @@
           "ChildType"
         ],
         "members": {
-          "ParentId": {},
-          "ChildType": {},
+          "ParentId": {
+            "shape": "S19"
+          },
+          "ChildType": {
+            "shape": "S2z"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -514,8 +586,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Type": {}
+                "Id": {
+                  "shape": "S33"
+                },
+                "Type": {
+                  "shape": "S2z"
+                }
               }
             }
           },
@@ -529,11 +605,13 @@
         "members": {
           "States": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Su"
+            }
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -559,7 +637,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -582,7 +660,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -603,10 +681,12 @@
           "ParentId"
         ],
         "members": {
-          "ParentId": {},
+          "ParentId": {
+            "shape": "S19"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -630,10 +710,12 @@
           "ChildId"
         ],
         "members": {
-          "ChildId": {},
+          "ChildId": {
+            "shape": "S33"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -645,8 +727,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Type": {}
+                "Id": {
+                  "shape": "S19"
+                },
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "ROOT",
+                    "ORGANIZATIONAL_UNIT"
+                  ]
+                }
               }
             }
           },
@@ -661,10 +751,12 @@
           "Filter"
         ],
         "members": {
-          "Filter": {},
+          "Filter": {
+            "shape": "S16"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -686,11 +778,15 @@
           "Filter"
         ],
         "members": {
-          "TargetId": {},
-          "Filter": {},
+          "TargetId": {
+            "shape": "Sj"
+          },
+          "Filter": {
+            "shape": "S16"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -710,7 +806,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -734,10 +830,12 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {},
+          "PolicyId": {
+            "shape": "Si"
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2p"
           }
         }
       },
@@ -749,10 +847,26 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {},
-                "Arn": {},
-                "Name": {},
-                "Type": {}
+                "TargetId": {
+                  "shape": "Sj"
+                },
+                "Arn": {
+                  "type": "string",
+                  "pattern": "^arn:aws:organizations::.+:.+"
+                },
+                "Name": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "ACCOUNT",
+                    "ORGANIZATIONAL_UNIT",
+                    "ROOT"
+                  ]
+                }
               }
             }
           },
@@ -769,9 +883,15 @@
           "DestinationParentId"
         ],
         "members": {
-          "AccountId": {},
-          "SourceParentId": {},
-          "DestinationParentId": {}
+          "AccountId": {
+            "shape": "Sv"
+          },
+          "SourceParentId": {
+            "shape": "S19"
+          },
+          "DestinationParentId": {
+            "shape": "S19"
+          }
         }
       }
     },
@@ -782,7 +902,9 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {}
+          "AccountId": {
+            "shape": "Sv"
+          }
         }
       }
     },
@@ -793,8 +915,12 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {},
-          "Name": {}
+          "OrganizationalUnitId": {
+            "shape": "S1d"
+          },
+          "Name": {
+            "shape": "S1a"
+          }
         }
       },
       "output": {
@@ -813,10 +939,18 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {},
-          "Name": {},
-          "Description": {},
-          "Content": {}
+          "PolicyId": {
+            "shape": "Si"
+          },
+          "Name": {
+            "shape": "S1i"
+          },
+          "Description": {
+            "shape": "S1h"
+          },
+          "Content": {
+            "shape": "S1g"
+          }
         }
       },
       "output": {
@@ -830,25 +964,46 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "^h-[0-9a-z]{8,32}$"
+    },
     "S4": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
+        "Id": {
+          "shape": "S2"
+        },
+        "Arn": {
+          "type": "string",
+          "pattern": "^arn:aws:organizations::\\d{12}:handshake\\/o-[a-z0-9]{10,32}\\/[a-z_]{1,32}\\/h-[0-9a-z]{8,32}"
+        },
         "Parties": {
           "type": "list",
           "member": {
             "shape": "S7"
           }
         },
-        "State": {},
+        "State": {
+          "type": "string",
+          "enum": [
+            "REQUESTED",
+            "OPEN",
+            "CANCELED",
+            "ACCEPTED",
+            "DECLINED",
+            "EXPIRED"
+          ]
+        },
         "RequestedTimestamp": {
           "type": "timestamp"
         },
         "ExpirationTimestamp": {
           "type": "timestamp"
         },
-        "Action": {},
+        "Action": {
+          "shape": "Sc"
+        },
         "Resources": {
           "shape": "Sd"
         }
@@ -863,10 +1018,28 @@
       "members": {
         "Id": {
           "type": "string",
+          "max": 64,
+          "min": 1,
           "sensitive": true
         },
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT",
+            "ORGANIZATION",
+            "EMAIL"
+          ]
+        }
       }
+    },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "INVITE",
+        "ENABLE_ALL_FEATURES",
+        "APPROVE_ALL_FEATURES",
+        "ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE"
+      ]
     },
     "Sd": {
       "type": "list",
@@ -877,47 +1050,124 @@
             "type": "string",
             "sensitive": true
           },
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "ACCOUNT",
+              "ORGANIZATION",
+              "ORGANIZATION_FEATURE_SET",
+              "EMAIL",
+              "MASTER_EMAIL",
+              "MASTER_NAME",
+              "NOTES",
+              "PARENT_HANDSHAKE"
+            ]
+          },
           "Resources": {
             "shape": "Sd"
           }
         }
       }
     },
+    "Si": {
+      "type": "string",
+      "pattern": "^p-[0-9a-zA-Z_]{8,128}$"
+    },
+    "Sj": {
+      "type": "string",
+      "pattern": "^(r-[0-9a-z]{4,32})|(\\d{12})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
+    },
     "Sn": {
       "type": "string",
+      "max": 64,
+      "min": 6,
+      "pattern": "[^\\s@]+@[^\\s@]+\\.[^\\s@]+",
       "sensitive": true
     },
     "So": {
       "type": "string",
+      "max": 50,
+      "min": 1,
+      "pattern": "[\\u0020-\\u007E]+",
       "sensitive": true
     },
     "Ss": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "St"
+        },
         "AccountName": {
           "shape": "So"
         },
-        "State": {},
+        "State": {
+          "shape": "Su"
+        },
         "RequestedTimestamp": {
           "type": "timestamp"
         },
         "CompletedTimestamp": {
           "type": "timestamp"
         },
-        "AccountId": {},
-        "FailureReason": {}
+        "AccountId": {
+          "shape": "Sv"
+        },
+        "FailureReason": {
+          "type": "string",
+          "enum": [
+            "ACCOUNT_LIMIT_EXCEEDED",
+            "EMAIL_ALREADY_EXISTS",
+            "INVALID_ADDRESS",
+            "INVALID_EMAIL",
+            "CONCURRENT_ACCOUNT_MODIFICATION",
+            "INTERNAL_FAILURE"
+          ]
+        }
       }
+    },
+    "St": {
+      "type": "string",
+      "pattern": "^car-[a-z0-9]{8,32}$"
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "Sv": {
+      "type": "string",
+      "pattern": "^\\d{12}$"
+    },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "ALL",
+        "CONSOLIDATED_BILLING"
+      ]
     },
     "S10": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
-        "FeatureSet": {},
-        "MasterAccountArn": {},
-        "MasterAccountId": {},
+        "Id": {
+          "type": "string",
+          "pattern": "^o-[a-z0-9]{10,32}$"
+        },
+        "Arn": {
+          "type": "string",
+          "pattern": "^arn:aws:organizations::\\d{12}:organization\\/o-[a-z0-9]{10,32}"
+        },
+        "FeatureSet": {
+          "shape": "Sy"
+        },
+        "MasterAccountArn": {
+          "shape": "S13"
+        },
+        "MasterAccountId": {
+          "shape": "Sv"
+        },
         "MasterAccountEmail": {
           "shape": "Sn"
         },
@@ -926,23 +1176,76 @@
         }
       }
     },
+    "S13": {
+      "type": "string",
+      "pattern": "^arn:aws:organizations::\\d{12}:account\\/o-[a-z0-9]{10,32}\\/\\d{12}"
+    },
     "S14": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Type": {},
-          "Status": {}
+          "Type": {
+            "shape": "S16"
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "ENABLED",
+              "PENDING_ENABLE",
+              "PENDING_DISABLE"
+            ]
+          }
         }
       }
+    },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "SERVICE_CONTROL_POLICY"
+      ]
+    },
+    "S19": {
+      "type": "string",
+      "pattern": "^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
+    },
+    "S1a": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S1c": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
-        "Name": {}
+        "Id": {
+          "shape": "S1d"
+        },
+        "Arn": {
+          "type": "string",
+          "pattern": "^arn:aws:organizations::\\d{12}:ou\\/o-[a-z0-9]{10,32}\\/ou-[0-9a-z]{4,32}-[0-9a-z]{8,32}"
+        },
+        "Name": {
+          "shape": "S1a"
+        }
       }
+    },
+    "S1d": {
+      "type": "string",
+      "pattern": "^ou-[0-9a-z]{4,32}-[a-z0-9]{8,32}$"
+    },
+    "S1g": {
+      "type": "string",
+      "max": 1000000,
+      "min": 1
+    },
+    "S1h": {
+      "type": "string",
+      "max": 512
+    },
+    "S1i": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S1k": {
       "type": "structure",
@@ -950,17 +1253,30 @@
         "PolicySummary": {
           "shape": "S1l"
         },
-        "Content": {}
+        "Content": {
+          "shape": "S1g"
+        }
       }
     },
     "S1l": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
-        "Name": {},
-        "Description": {},
-        "Type": {},
+        "Id": {
+          "shape": "Si"
+        },
+        "Arn": {
+          "type": "string",
+          "pattern": "^(arn:aws:organizations::\\d{12}:policy\\/o-[a-z0-9]{10,32}\\/[0-9a-z_]+\\/p-[0-9a-z]{10,32})|(arn:aws:organizations::aws:policy\\/[0-9a-z_]+\\/p-[0-9a-zA-Z_]{10,128})"
+        },
+        "Name": {
+          "shape": "S1i"
+        },
+        "Description": {
+          "shape": "S1h"
+        },
+        "Type": {
+          "shape": "S16"
+        },
         "AwsManaged": {
           "type": "boolean"
         }
@@ -969,31 +1285,71 @@
     "S1u": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
+        "Id": {
+          "shape": "Sv"
+        },
+        "Arn": {
+          "shape": "S13"
+        },
         "Email": {
           "shape": "Sn"
         },
         "Name": {
           "shape": "So"
         },
-        "Status": {},
-        "JoinedMethod": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "ACTIVE",
+            "SUSPENDED"
+          ]
+        },
+        "JoinedMethod": {
+          "type": "string",
+          "enum": [
+            "INVITED",
+            "CREATED"
+          ]
+        },
         "JoinedTimestamp": {
           "type": "timestamp"
         }
       }
     },
+    "S28": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+=,.@-]*"
+    },
+    "S2a": {
+      "type": "string",
+      "pattern": "^r-[0-9a-z]{4,32}$"
+    },
     "S2c": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
-        "Name": {},
+        "Id": {
+          "shape": "S2a"
+        },
+        "Arn": {
+          "type": "string",
+          "pattern": "^arn:aws:organizations::\\d{12}:root\\/o-[a-z0-9]{10,32}\\/r-[0-9a-z]{4,32}"
+        },
+        "Name": {
+          "type": "string",
+          "max": 128,
+          "min": 1
+        },
         "PolicyTypes": {
           "shape": "S14"
         }
       }
+    },
+    "S2p": {
+      "type": "integer",
+      "max": 20,
+      "min": 1
     },
     "S2v": {
       "type": "list",
@@ -1001,11 +1357,26 @@
         "shape": "S1u"
       }
     },
+    "S2z": {
+      "type": "string",
+      "enum": [
+        "ACCOUNT",
+        "ORGANIZATIONAL_UNIT"
+      ]
+    },
+    "S33": {
+      "type": "string",
+      "pattern": "^(\\d{12})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
+    },
     "S39": {
       "type": "structure",
       "members": {
-        "ActionType": {},
-        "ParentHandshakeId": {}
+        "ActionType": {
+          "shape": "Sc"
+        },
+        "ParentHandshakeId": {
+          "shape": "S2"
+        }
       }
     },
     "S3b": {

--- a/apis/pi-2018-02-27.min.json
+++ b/apis/pi-2018-02-27.min.json
@@ -26,7 +26,9 @@
           "GroupBy"
         ],
         "members": {
-          "ServiceType": {},
+          "ServiceType": {
+            "shape": "S2"
+          },
           "Identifier": {},
           "StartTime": {
             "type": "timestamp"
@@ -48,7 +50,7 @@
             "shape": "S9"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa"
           },
           "NextToken": {}
         }
@@ -111,7 +113,9 @@
           "EndTime"
         ],
         "members": {
-          "ServiceType": {},
+          "ServiceType": {
+            "shape": "S2"
+          },
           "Identifier": {},
           "MetricQueries": {
             "type": "list",
@@ -129,7 +133,9 @@
                   "shape": "S9"
                 }
               }
-            }
+            },
+            "max": 15,
+            "min": 1
           },
           "StartTime": {
             "type": "timestamp"
@@ -141,7 +147,7 @@
             "type": "integer"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa"
           },
           "NextToken": {}
         }
@@ -200,6 +206,12 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "enum": [
+        "RDS"
+      ]
+    },
     "S6": {
       "type": "structure",
       "required": [
@@ -209,10 +221,14 @@
         "Group": {},
         "Dimensions": {
           "type": "list",
-          "member": {}
+          "member": {},
+          "max": 10,
+          "min": 1
         },
         "Limit": {
-          "type": "integer"
+          "type": "integer",
+          "max": 10,
+          "min": 1
         }
       }
     },
@@ -220,6 +236,11 @@
       "type": "map",
       "key": {},
       "value": {}
+    },
+    "Sa": {
+      "type": "integer",
+      "max": 20,
+      "min": 0
     },
     "Se": {
       "type": "map",

--- a/apis/pinpoint-2016-12-01.min.json
+++ b/apis/pinpoint-2016-12-01.min.json
@@ -143,7 +143,9 @@
                 "type": "boolean"
               },
               "ExternalId": {},
-              "Format": {},
+              "Format": {
+                "shape": "S13"
+              },
               "RegisterEndpoints": {
                 "type": "boolean"
               },
@@ -1995,7 +1997,9 @@
                         "Attributes": {
                           "shape": "S2w"
                         },
-                        "ChannelType": {},
+                        "ChannelType": {
+                          "shape": "S2x"
+                        },
                         "Demographic": {
                           "shape": "S2y"
                         },
@@ -2181,7 +2185,9 @@
                   "type": "structure",
                   "members": {
                     "BodyOverride": {},
-                    "ChannelType": {},
+                    "ChannelType": {
+                      "shape": "S2x"
+                    },
                     "Context": {
                       "shape": "S62"
                     },
@@ -2230,7 +2236,9 @@
                 "value": {
                   "type": "structure",
                   "members": {
-                    "DeliveryStatus": {},
+                    "DeliveryStatus": {
+                      "shape": "S6x"
+                    },
                     "MessageId": {},
                     "StatusCode": {
                       "type": "integer"
@@ -2755,7 +2763,9 @@
               "Attributes": {
                 "shape": "S2w"
               },
-              "ChannelType": {},
+              "ChannelType": {
+                "shape": "S2x"
+              },
               "Demographic": {
                 "shape": "S2y"
               },
@@ -2820,7 +2830,9 @@
                     "Attributes": {
                       "shape": "S2w"
                     },
-                    "ChannelType": {},
+                    "ChannelType": {
+                      "shape": "S2x"
+                    },
                     "Demographic": {
                       "shape": "S2y"
                     },
@@ -3085,7 +3097,9 @@
           "type": "structure",
           "members": {
             "Body": {},
-            "MessageType": {},
+            "MessageType": {
+              "shape": "Sh"
+            },
             "SenderId": {}
           }
         }
@@ -3094,7 +3108,9 @@
     "Sb": {
       "type": "structure",
       "members": {
-        "Action": {},
+        "Action": {
+          "shape": "Sc"
+        },
         "Body": {},
         "ImageIconUrl": {},
         "ImageSmallIconUrl": {},
@@ -3113,11 +3129,35 @@
       },
       "required": []
     },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "OPEN_APP",
+        "DEEP_LINK",
+        "URL"
+      ]
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "TRANSACTIONAL",
+        "PROMOTIONAL"
+      ]
+    },
     "Si": {
       "type": "structure",
       "members": {
         "EndTime": {},
-        "Frequency": {},
+        "Frequency": {
+          "type": "string",
+          "enum": [
+            "ONCE",
+            "HOURLY",
+            "DAILY",
+            "WEEKLY",
+            "MONTHLY"
+          ]
+        },
         "IsLocalTime": {
           "type": "boolean"
         },
@@ -3140,7 +3180,13 @@
       "type": "structure",
       "members": {
         "LambdaFunctionName": {},
-        "Mode": {},
+        "Mode": {
+          "type": "string",
+          "enum": [
+            "DELIVERY",
+            "FILTER"
+          ]
+        },
         "WebUrl": {}
       }
     },
@@ -3233,7 +3279,17 @@
     "Ss": {
       "type": "structure",
       "members": {
-        "CampaignStatus": {}
+        "CampaignStatus": {
+          "type": "string",
+          "enum": [
+            "SCHEDULED",
+            "EXECUTING",
+            "PENDING_NEXT_RUN",
+            "COMPLETED",
+            "PAUSED",
+            "DELETED"
+          ]
+        }
       }
     },
     "Sx": {
@@ -3264,7 +3320,9 @@
           "shape": "Sz"
         },
         "Id": {},
-        "JobStatus": {},
+        "JobStatus": {
+          "shape": "S10"
+        },
         "TotalFailures": {
           "type": "integer"
         },
@@ -3282,6 +3340,25 @@
       "type": "list",
       "member": {}
     },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "CREATED",
+        "INITIALIZING",
+        "PROCESSING",
+        "COMPLETING",
+        "COMPLETED",
+        "FAILING",
+        "FAILED"
+      ]
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "CSV",
+        "JSON"
+      ]
+    },
     "S15": {
       "type": "structure",
       "members": {
@@ -3298,7 +3375,9 @@
               "type": "boolean"
             },
             "ExternalId": {},
-            "Format": {},
+            "Format": {
+              "shape": "S13"
+            },
             "RegisterEndpoints": {
               "type": "boolean"
             },
@@ -3316,7 +3395,9 @@
           "shape": "Sz"
         },
         "Id": {},
-        "JobStatus": {},
+        "JobStatus": {
+          "shape": "S10"
+        },
         "TotalFailures": {
           "type": "integer"
         },
@@ -3355,8 +3436,22 @@
             "Recency": {
               "type": "structure",
               "members": {
-                "Duration": {},
-                "RecencyType": {}
+                "Duration": {
+                  "type": "string",
+                  "enum": [
+                    "HR_24",
+                    "DAY_7",
+                    "DAY_14",
+                    "DAY_30"
+                  ]
+                },
+                "RecencyType": {
+                  "type": "string",
+                  "enum": [
+                    "ACTIVE",
+                    "INACTIVE"
+                  ]
+                }
               },
               "required": []
             }
@@ -3438,7 +3533,13 @@
       "value": {
         "type": "structure",
         "members": {
-          "AttributeType": {},
+          "AttributeType": {
+            "type": "string",
+            "enum": [
+              "INCLUSIVE",
+              "EXCLUSIVE"
+            ]
+          },
           "Values": {
             "shape": "Sz"
           }
@@ -3449,7 +3550,13 @@
     "S1i": {
       "type": "structure",
       "members": {
-        "DimensionType": {},
+        "DimensionType": {
+          "type": "string",
+          "enum": [
+            "INCLUSIVE",
+            "EXCLUSIVE"
+          ]
+        },
         "Values": {
           "shape": "Sz"
         }
@@ -3482,13 +3589,34 @@
                   }
                 }
               },
-              "SourceType": {},
-              "Type": {}
+              "SourceType": {
+                "type": "string",
+                "enum": [
+                  "ALL",
+                  "ANY",
+                  "NONE"
+                ]
+              },
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "ALL",
+                  "ANY",
+                  "NONE"
+                ]
+              }
             },
             "required": []
           }
         },
-        "Include": {}
+        "Include": {
+          "type": "string",
+          "enum": [
+            "ALL",
+            "ANY",
+            "NONE"
+          ]
+        }
       },
       "required": []
     },
@@ -3512,7 +3640,9 @@
               }
             },
             "ExternalId": {},
-            "Format": {},
+            "Format": {
+              "shape": "S13"
+            },
             "RoleArn": {},
             "S3Url": {},
             "Size": {
@@ -3526,7 +3656,13 @@
         "SegmentGroups": {
           "shape": "S1q"
         },
-        "SegmentType": {},
+        "SegmentType": {
+          "type": "string",
+          "enum": [
+            "DIMENSIONAL",
+            "IMPORT"
+          ]
+        },
         "Version": {
           "type": "integer"
         }
@@ -3732,7 +3868,9 @@
         "Attributes": {
           "shape": "S2w"
         },
-        "ChannelType": {},
+        "ChannelType": {
+          "shape": "S2x"
+        },
         "CohortId": {},
         "CreationDate": {},
         "Demographic": {
@@ -3760,6 +3898,21 @@
       "value": {
         "shape": "Sz"
       }
+    },
+    "S2x": {
+      "type": "string",
+      "enum": [
+        "GCM",
+        "APNS",
+        "APNS_SANDBOX",
+        "APNS_VOIP",
+        "APNS_VOIP_SANDBOX",
+        "ADM",
+        "SMS",
+        "EMAIL",
+        "BAIDU",
+        "CUSTOM"
+      ]
     },
     "S2y": {
       "type": "structure",
@@ -3984,7 +4137,9 @@
         "ADMMessage": {
           "type": "structure",
           "members": {
-            "Action": {},
+            "Action": {
+              "shape": "Sc"
+            },
             "Body": {},
             "ConsolidationKey": {},
             "Data": {
@@ -4011,7 +4166,9 @@
         "APNSMessage": {
           "type": "structure",
           "members": {
-            "Action": {},
+            "Action": {
+              "shape": "Sc"
+            },
             "Badge": {
               "type": "integer"
             },
@@ -4043,7 +4200,9 @@
         "BaiduMessage": {
           "type": "structure",
           "members": {
-            "Action": {},
+            "Action": {
+              "shape": "Sc"
+            },
             "Body": {},
             "Data": {
               "shape": "S62"
@@ -4079,7 +4238,9 @@
         "DefaultPushNotificationMessage": {
           "type": "structure",
           "members": {
-            "Action": {},
+            "Action": {
+              "shape": "Sc"
+            },
             "Body": {},
             "Data": {
               "shape": "S62"
@@ -4097,7 +4258,9 @@
         "GCMMessage": {
           "type": "structure",
           "members": {
-            "Action": {},
+            "Action": {
+              "shape": "Sc"
+            },
             "Body": {},
             "CollapseKey": {},
             "Data": {
@@ -4129,7 +4292,9 @@
           "members": {
             "Body": {},
             "Keyword": {},
-            "MessageType": {},
+            "MessageType": {
+              "shape": "Sh"
+            },
             "OriginationNumber": {},
             "SenderId": {},
             "Substitutions": {
@@ -4147,7 +4312,9 @@
         "type": "structure",
         "members": {
           "Address": {},
-          "DeliveryStatus": {},
+          "DeliveryStatus": {
+            "shape": "S6x"
+          },
           "MessageId": {},
           "StatusCode": {
             "type": "integer"
@@ -4157,6 +4324,18 @@
         },
         "required": []
       }
+    },
+    "S6x": {
+      "type": "string",
+      "enum": [
+        "SUCCESSFUL",
+        "THROTTLED",
+        "TEMPORARY_FAILURE",
+        "PERMANENT_FAILURE",
+        "UNKNOWN_FAILURE",
+        "OPT_OUT",
+        "DUPLICATE"
+      ]
     },
     "S7y": {
       "type": "structure",

--- a/apis/polly-2016-06-10.min.json
+++ b/apis/polly-2016-06-10.min.json
@@ -44,6 +44,7 @@
         "type": "structure",
         "members": {
           "LanguageCode": {
+            "shape": "S5",
             "location": "querystring",
             "locationName": "LanguageCode"
           },
@@ -66,14 +67,26 @@
             "member": {
               "type": "structure",
               "members": {
-                "Gender": {},
-                "Id": {},
-                "LanguageCode": {},
+                "Gender": {
+                  "type": "string",
+                  "enum": [
+                    "Female",
+                    "Male"
+                  ]
+                },
+                "Id": {
+                  "shape": "Sc"
+                },
+                "LanguageCode": {
+                  "shape": "S5"
+                },
                 "LanguageName": {},
                 "Name": {},
                 "AdditionalLanguageCodes": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S5"
+                  }
                 }
               }
             }
@@ -132,6 +145,7 @@
         ],
         "members": {
           "TaskId": {
+            "shape": "Sr",
             "location": "uri",
             "locationName": "TaskId"
           }
@@ -194,13 +208,16 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer"
+            "type": "integer",
+            "max": 100,
+            "min": 1
           },
           "NextToken": {
             "location": "querystring",
             "locationName": "NextToken"
           },
           "Status": {
+            "shape": "Su",
             "location": "querystring",
             "locationName": "Status"
           }
@@ -262,18 +279,34 @@
           "LexiconNames": {
             "shape": "S10"
           },
-          "OutputFormat": {},
-          "OutputS3BucketName": {},
-          "OutputS3KeyPrefix": {},
+          "OutputFormat": {
+            "shape": "S11"
+          },
+          "OutputS3BucketName": {
+            "type": "string",
+            "pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+          },
+          "OutputS3KeyPrefix": {
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z\\/\\!\\-_\\.\\*\\'\\(\\)]{0,800}$"
+          },
           "SampleRate": {},
-          "SnsTopicArn": {},
+          "SnsTopicArn": {
+            "shape": "Sz"
+          },
           "SpeechMarkTypes": {
             "shape": "S13"
           },
           "Text": {},
-          "TextType": {},
-          "VoiceId": {},
-          "LanguageCode": {}
+          "TextType": {
+            "shape": "S15"
+          },
+          "VoiceId": {
+            "shape": "Sc"
+          },
+          "LanguageCode": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -301,15 +334,23 @@
           "LexiconNames": {
             "shape": "S10"
           },
-          "OutputFormat": {},
+          "OutputFormat": {
+            "shape": "S11"
+          },
           "SampleRate": {},
           "SpeechMarkTypes": {
             "shape": "S13"
           },
           "Text": {},
-          "TextType": {},
-          "VoiceId": {},
-          "LanguageCode": {}
+          "TextType": {
+            "shape": "S15"
+          },
+          "VoiceId": {
+            "shape": "Sc"
+          },
+          "LanguageCode": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -336,13 +377,107 @@
   "shapes": {
     "S2": {
       "type": "string",
+      "pattern": "[0-9A-Za-z]{1,20}",
       "sensitive": true
+    },
+    "S5": {
+      "type": "string",
+      "enum": [
+        "cmn-CN",
+        "cy-GB",
+        "da-DK",
+        "de-DE",
+        "en-AU",
+        "en-GB",
+        "en-GB-WLS",
+        "en-IN",
+        "en-US",
+        "es-ES",
+        "es-US",
+        "fr-CA",
+        "fr-FR",
+        "is-IS",
+        "it-IT",
+        "ja-JP",
+        "hi-IN",
+        "ko-KR",
+        "nb-NO",
+        "nl-NL",
+        "pl-PL",
+        "pt-BR",
+        "pt-PT",
+        "ro-RO",
+        "ru-RU",
+        "sv-SE",
+        "tr-TR"
+      ]
+    },
+    "Sc": {
+      "type": "string",
+      "enum": [
+        "Geraint",
+        "Gwyneth",
+        "Mads",
+        "Naja",
+        "Hans",
+        "Marlene",
+        "Nicole",
+        "Russell",
+        "Amy",
+        "Brian",
+        "Emma",
+        "Raveena",
+        "Ivy",
+        "Joanna",
+        "Joey",
+        "Justin",
+        "Kendra",
+        "Kimberly",
+        "Matthew",
+        "Salli",
+        "Conchita",
+        "Enrique",
+        "Miguel",
+        "Penelope",
+        "Chantal",
+        "Celine",
+        "Lea",
+        "Mathieu",
+        "Dora",
+        "Karl",
+        "Carla",
+        "Giorgio",
+        "Mizuki",
+        "Liv",
+        "Lotte",
+        "Ruben",
+        "Ewa",
+        "Jacek",
+        "Jan",
+        "Maja",
+        "Ricardo",
+        "Vitoria",
+        "Cristiano",
+        "Ines",
+        "Carmen",
+        "Maxim",
+        "Tatyana",
+        "Astrid",
+        "Filiz",
+        "Vicki",
+        "Takumi",
+        "Seoyeon",
+        "Aditi",
+        "Zhiyu"
+      ]
     },
     "Sk": {
       "type": "structure",
       "members": {
         "Alphabet": {},
-        "LanguageCode": {},
+        "LanguageCode": {
+          "shape": "S5"
+        },
         "LastModified": {
           "type": "timestamp"
         },
@@ -355,11 +490,20 @@
         }
       }
     },
+    "Sr": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
     "St": {
       "type": "structure",
       "members": {
-        "TaskId": {},
-        "TaskStatus": {},
+        "TaskId": {
+          "shape": "Sr"
+        },
+        "TaskStatus": {
+          "shape": "Su"
+        },
         "TaskStatusReason": {},
         "OutputUri": {},
         "CreationTime": {
@@ -368,29 +512,78 @@
         "RequestCharacters": {
           "type": "integer"
         },
-        "SnsTopicArn": {},
+        "SnsTopicArn": {
+          "shape": "Sz"
+        },
         "LexiconNames": {
           "shape": "S10"
         },
-        "OutputFormat": {},
+        "OutputFormat": {
+          "shape": "S11"
+        },
         "SampleRate": {},
         "SpeechMarkTypes": {
           "shape": "S13"
         },
-        "TextType": {},
-        "VoiceId": {},
-        "LanguageCode": {}
+        "TextType": {
+          "shape": "S15"
+        },
+        "VoiceId": {
+          "shape": "Sc"
+        },
+        "LanguageCode": {
+          "shape": "S5"
+        }
       }
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "scheduled",
+        "inProgress",
+        "completed",
+        "failed"
+      ]
+    },
+    "Sz": {
+      "type": "string",
+      "pattern": "^arn:aws(-(cn|iso(-b)?|us-gov))?:sns:.*:\\w{12}:.+$"
     },
     "S10": {
       "type": "list",
       "member": {
         "shape": "S2"
-      }
+      },
+      "max": 5
+    },
+    "S11": {
+      "type": "string",
+      "enum": [
+        "json",
+        "mp3",
+        "ogg_vorbis",
+        "pcm"
+      ]
     },
     "S13": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "sentence",
+          "ssml",
+          "viseme",
+          "word"
+        ]
+      },
+      "max": 4
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "ssml",
+        "text"
+      ]
     }
   }
 }

--- a/apis/pricing-2017-10-15.min.json
+++ b/apis/pricing-2017-10-15.min.json
@@ -22,7 +22,7 @@
           "FormatVersion": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S3"
           }
         }
       },
@@ -59,7 +59,7 @@
           "AttributeName": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S3"
           }
         }
       },
@@ -94,7 +94,12 @@
                 "Value"
               ],
               "members": {
-                "Type": {},
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "TERM_MATCH"
+                  ]
+                },
                 "Field": {},
                 "Value": {}
               }
@@ -103,7 +108,7 @@
           "FormatVersion": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S3"
           }
         }
       },
@@ -122,5 +127,11 @@
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S3": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    }
+  }
 }

--- a/apis/rds-2013-01-10.min.json
+++ b/apis/rds-2013-01-10.min.json
@@ -758,7 +758,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S32"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -789,7 +791,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S32"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -1835,9 +1839,24 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {}
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          }
         }
       }
+    },
+    "S32": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot"
+      ]
     },
     "S3m": {
       "type": "structure",

--- a/apis/rds-2013-02-12.min.json
+++ b/apis/rds-2013-02-12.min.json
@@ -803,7 +803,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S3a"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -834,7 +836,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S3a"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -1967,9 +1971,24 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {}
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          }
         }
       }
+    },
+    "S3a": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot"
+      ]
     },
     "S3w": {
       "type": "structure",

--- a/apis/rds-2013-09-09.min.json
+++ b/apis/rds-2013-09-09.min.json
@@ -864,7 +864,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S3f"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -898,7 +900,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S3f"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -2103,9 +2107,24 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {}
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          }
         }
       }
+    },
+    "S3f": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot"
+      ]
     },
     "S41": {
       "type": "structure",

--- a/apis/rds-2014-09-01.min.json
+++ b/apis/rds-2014-09-01.min.json
@@ -922,7 +922,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S3j"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -956,7 +958,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S3j"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -2176,9 +2180,24 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {}
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          }
         }
       }
+    },
+    "S3j": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot"
+      ]
     },
     "S45": {
       "type": "structure",

--- a/apis/rds-2014-10-31.min.json
+++ b/apis/rds-2014-10-31.min.json
@@ -1622,7 +1622,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S5v"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -1656,7 +1658,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S5v"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S7"
@@ -4128,7 +4132,13 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {},
+          "ApplyMethod": {
+            "type": "string",
+            "enum": [
+              "immediate",
+              "pending-reboot"
+            ]
+          },
           "SupportedEngineModes": {
             "shape": "S45"
           }
@@ -4203,6 +4213,17 @@
         }
       },
       "wrapper": true
+    },
+    "S5v": {
+      "type": "string",
+      "enum": [
+        "db-instance",
+        "db-parameter-group",
+        "db-security-group",
+        "db-snapshot",
+        "db-cluster",
+        "db-cluster-snapshot"
+      ]
     },
     "S6k": {
       "type": "list",

--- a/apis/redshift-2012-12-01.min.json
+++ b/apis/redshift-2012-12-01.min.json
@@ -976,7 +976,9 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {},
+          "SourceType": {
+            "shape": "S47"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -1004,7 +1006,9 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {},
+                "SourceType": {
+                  "shape": "S47"
+                },
                 "Message": {},
                 "EventCategories": {
                   "shape": "S23"
@@ -1965,7 +1969,9 @@
         "RecurringCharges": {
           "shape": "S8"
         },
-        "ReservedNodeOfferingType": {}
+        "ReservedNodeOfferingType": {
+          "shape": "Sa"
+        }
       },
       "wrapper": true
     },
@@ -1982,6 +1988,13 @@
         },
         "wrapper": true
       }
+    },
+    "Sa": {
+      "type": "string",
+      "enum": [
+        "Regular",
+        "Upgradable"
+      ]
     },
     "Sd": {
       "type": "structure",
@@ -2490,13 +2503,28 @@
           "Source": {},
           "DataType": {},
           "AllowedValues": {},
-          "ApplyType": {},
+          "ApplyType": {
+            "type": "string",
+            "enum": [
+              "static",
+              "dynamic"
+            ]
+          },
           "IsModifiable": {
             "type": "boolean"
           },
           "MinimumEngineVersion": {}
         }
       }
+    },
+    "S47": {
+      "type": "string",
+      "enum": [
+        "cluster",
+        "cluster-parameter-group",
+        "cluster-security-group",
+        "cluster-snapshot"
+      ]
     },
     "S4i": {
       "type": "structure",
@@ -2537,7 +2565,9 @@
           "RecurringCharges": {
             "shape": "S8"
           },
-          "ReservedNodeOfferingType": {}
+          "ReservedNodeOfferingType": {
+            "shape": "Sa"
+          }
         },
         "wrapper": true
       }
@@ -2546,7 +2576,16 @@
       "type": "structure",
       "members": {
         "TableRestoreRequestId": {},
-        "Status": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "IN_PROGRESS",
+            "SUCCEEDED",
+            "FAILED",
+            "CANCELED"
+          ]
+        },
         "Message": {},
         "RequestTime": {
           "type": "timestamp"

--- a/apis/rekognition-2016-06-27.min.json
+++ b/apis/rekognition-2016-06-27.min.json
@@ -27,7 +27,7 @@
             "shape": "S2"
           },
           "SimilarityThreshold": {
-            "type": "float"
+            "shape": "S8"
           }
         }
       },
@@ -41,7 +41,7 @@
                 "shape": "Sb"
               },
               "Confidence": {
-                "type": "float"
+                "shape": "S8"
               }
             }
           },
@@ -51,7 +51,7 @@
               "type": "structure",
               "members": {
                 "Similarity": {
-                  "type": "float"
+                  "shape": "S8"
                 },
                 "Face": {
                   "shape": "Sf"
@@ -65,8 +65,12 @@
               "shape": "Sf"
             }
           },
-          "SourceImageOrientationCorrection": {},
-          "TargetImageOrientationCorrection": {}
+          "SourceImageOrientationCorrection": {
+            "shape": "Sn"
+          },
+          "TargetImageOrientationCorrection": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -77,14 +81,16 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {}
+          "CollectionId": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "StatusCode": {
-            "type": "integer"
+            "shape": "Sr"
           },
           "CollectionArn": {},
           "FaceModelVersion": {}
@@ -108,17 +114,23 @@
           "Output": {
             "shape": "Sx"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S10"
+          },
           "Settings": {
             "shape": "S11"
           },
-          "RoleArn": {}
+          "RoleArn": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamProcessorArn": {}
+          "StreamProcessorArn": {
+            "shape": "S15"
+          }
         }
       }
     },
@@ -129,14 +141,16 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {}
+          "CollectionId": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "StatusCode": {
-            "type": "integer"
+            "shape": "Sr"
           }
         }
       }
@@ -149,7 +163,9 @@
           "FaceIds"
         ],
         "members": {
-          "CollectionId": {},
+          "CollectionId": {
+            "shape": "Sp"
+          },
           "FaceIds": {
             "shape": "S19"
           }
@@ -171,7 +187,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S10"
+          }
         }
       },
       "output": {
@@ -186,14 +204,16 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {}
+          "CollectionId": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "FaceCount": {
-            "type": "long"
+            "shape": "S1g"
           },
           "FaceModelVersion": {},
           "CollectionARN": {},
@@ -210,15 +230,23 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S10"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "StreamProcessorArn": {},
-          "Status": {},
+          "Name": {
+            "shape": "S10"
+          },
+          "StreamProcessorArn": {
+            "shape": "S15"
+          },
+          "Status": {
+            "shape": "S1k"
+          },
           "StatusMessage": {},
           "CreationTimestamp": {
             "type": "timestamp"
@@ -232,7 +260,9 @@
           "Output": {
             "shape": "Sx"
           },
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S13"
+          },
           "Settings": {
             "shape": "S11"
           }
@@ -263,7 +293,9 @@
               "shape": "S1q"
             }
           },
-          "OrientationCorrection": {}
+          "OrientationCorrection": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -278,10 +310,10 @@
             "shape": "S2"
           },
           "MaxLabels": {
-            "type": "integer"
+            "shape": "Sr"
           },
           "MinConfidence": {
-            "type": "float"
+            "shape": "S8"
           }
         }
       },
@@ -294,7 +326,9 @@
               "shape": "S28"
             }
           },
-          "OrientationCorrection": {}
+          "OrientationCorrection": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -309,7 +343,7 @@
             "shape": "S2"
           },
           "MinConfidence": {
-            "type": "float"
+            "shape": "S8"
           }
         }
       },
@@ -346,15 +380,21 @@
               "type": "structure",
               "members": {
                 "DetectedText": {},
-                "Type": {},
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "LINE",
+                    "WORD"
+                  ]
+                },
                 "Id": {
-                  "type": "integer"
+                  "shape": "Sr"
                 },
                 "ParentId": {
-                  "type": "integer"
+                  "shape": "Sr"
                 },
                 "Confidence": {
-                  "type": "float"
+                  "shape": "S8"
                 },
                 "Geometry": {
                   "type": "structure",
@@ -391,7 +431,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "S2m"
+          }
         }
       },
       "output": {
@@ -411,23 +453,37 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {},
-          "SortBy": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "ID",
+              "TIMESTAMP"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "Celebrities": {
             "type": "list",
             "member": {
@@ -443,9 +499,11 @@
                       "shape": "S2o"
                     },
                     "Name": {},
-                    "Id": {},
+                    "Id": {
+                      "shape": "S2m"
+                    },
                     "Confidence": {
-                      "type": "float"
+                      "shape": "S8"
                     },
                     "BoundingBox": {
                       "shape": "Sb"
@@ -468,18 +526,30 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {},
-          "SortBy": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "NAME",
+              "TIMESTAMP"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
@@ -498,7 +568,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S2t"
+          }
         }
       }
     },
@@ -509,22 +581,30 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "Faces": {
             "type": "list",
             "member": {
@@ -549,20 +629,34 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {},
-          "SortBy": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "INDEX",
+              "TIMESTAMP"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "VideoMetadata": {
             "shape": "S2y"
           },
@@ -593,23 +687,37 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {},
-          "SortBy": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "NAME",
+              "TIMESTAMP"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "Labels": {
             "type": "list",
             "member": {
@@ -634,23 +742,37 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "MaxResults": {
-            "type": "integer"
+          "JobId": {
+            "shape": "S2r"
           },
-          "NextToken": {},
-          "SortBy": {}
+          "MaxResults": {
+            "shape": "S2s"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "INDEX",
+              "TIMESTAMP"
+            ]
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {},
+          "JobStatus": {
+            "shape": "S2w"
+          },
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "Persons": {
             "type": "list",
             "member": {
@@ -676,18 +798,29 @@
           "Image"
         ],
         "members": {
-          "CollectionId": {},
+          "CollectionId": {
+            "shape": "Sp"
+          },
           "Image": {
             "shape": "S2"
           },
-          "ExternalImageId": {},
+          "ExternalImageId": {
+            "shape": "S3n"
+          },
           "DetectionAttributes": {
             "shape": "S1m"
           },
           "MaxFaces": {
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           },
-          "QualityFilter": {}
+          "QualityFilter": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "AUTO"
+            ]
+          }
         }
       },
       "output": {
@@ -707,7 +840,9 @@
               }
             }
           },
-          "OrientationCorrection": {},
+          "OrientationCorrection": {
+            "shape": "Sn"
+          },
           "FaceModelVersion": {},
           "UnindexedFaces": {
             "type": "list",
@@ -716,7 +851,17 @@
               "members": {
                 "Reasons": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "enum": [
+                      "EXCEEDS_MAX_FACES",
+                      "EXTREME_POSE",
+                      "LOW_BRIGHTNESS",
+                      "LOW_SHARPNESS",
+                      "LOW_CONFIDENCE",
+                      "SMALL_BOUNDING_BOX"
+                    ]
+                  }
                 },
                 "FaceDetail": {
                   "shape": "S1q"
@@ -731,9 +876,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S49"
           }
         }
       },
@@ -742,9 +889,13 @@
         "members": {
           "CollectionIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sp"
+            }
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "FaceModelVersions": {
             "type": "list",
             "member": {}
@@ -759,10 +910,14 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {},
-          "NextToken": {},
+          "CollectionId": {
+            "shape": "Sp"
+          },
+          "NextToken": {
+            "shape": "S2t"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S49"
           }
         }
       },
@@ -784,23 +939,31 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S2s"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S2t"
+          },
           "StreamProcessors": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Status": {}
+                "Name": {
+                  "shape": "S10"
+                },
+                "Status": {
+                  "shape": "S1k"
+                }
               }
             }
           }
@@ -831,12 +994,14 @@
                   "shape": "S2o"
                 },
                 "Name": {},
-                "Id": {},
+                "Id": {
+                  "shape": "S2m"
+                },
                 "Face": {
                   "shape": "Sf"
                 },
                 "MatchConfidence": {
-                  "type": "float"
+                  "shape": "S8"
                 }
               }
             }
@@ -847,7 +1012,9 @@
               "shape": "Sf"
             }
           },
-          "OrientationCorrection": {}
+          "OrientationCorrection": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -859,20 +1026,26 @@
           "FaceId"
         ],
         "members": {
-          "CollectionId": {},
-          "FaceId": {},
+          "CollectionId": {
+            "shape": "Sp"
+          },
+          "FaceId": {
+            "shape": "S1a"
+          },
           "MaxFaces": {
-            "type": "integer"
+            "shape": "S4q"
           },
           "FaceMatchThreshold": {
-            "type": "float"
+            "shape": "S8"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SearchedFaceId": {},
+          "SearchedFaceId": {
+            "shape": "S1a"
+          },
           "FaceMatches": {
             "shape": "S3j"
           },
@@ -888,15 +1061,17 @@
           "Image"
         ],
         "members": {
-          "CollectionId": {},
+          "CollectionId": {
+            "shape": "Sp"
+          },
           "Image": {
             "shape": "S2"
           },
           "MaxFaces": {
-            "type": "integer"
+            "shape": "S4q"
           },
           "FaceMatchThreshold": {
-            "type": "float"
+            "shape": "S8"
           }
         }
       },
@@ -907,7 +1082,7 @@
             "shape": "Sb"
           },
           "SearchedFaceConfidence": {
-            "type": "float"
+            "shape": "S8"
           },
           "FaceMatches": {
             "shape": "S3j"
@@ -926,17 +1101,23 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S4w"
+          },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {}
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -952,19 +1133,25 @@
             "shape": "S4v"
           },
           "MinConfidence": {
-            "type": "float"
+            "shape": "S8"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S4w"
+          },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {}
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -979,18 +1166,30 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S4w"
+          },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "FaceAttributes": {},
-          "JobTag": {}
+          "FaceAttributes": {
+            "type": "string",
+            "enum": [
+              "DEFAULT",
+              "ALL"
+            ]
+          },
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -1006,21 +1205,29 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {},
-          "FaceMatchThreshold": {
-            "type": "float"
+          "ClientRequestToken": {
+            "shape": "S4w"
           },
-          "CollectionId": {},
+          "FaceMatchThreshold": {
+            "shape": "S8"
+          },
+          "CollectionId": {
+            "shape": "Sp"
+          },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {}
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -1035,20 +1242,26 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S4w"
+          },
           "MinConfidence": {
-            "type": "float"
+            "shape": "S8"
           },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {}
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -1063,17 +1276,23 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {},
+          "ClientRequestToken": {
+            "shape": "S4w"
+          },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {}
+          "JobTag": {
+            "shape": "S4z"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S2r"
+          }
         }
       },
       "idempotent": true
@@ -1085,7 +1304,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S10"
+          }
         }
       },
       "output": {
@@ -1100,7 +1321,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S10"
+          }
         }
       },
       "output": {
@@ -1114,7 +1337,9 @@
       "type": "structure",
       "members": {
         "Bytes": {
-          "type": "blob"
+          "type": "blob",
+          "max": 5242880,
+          "min": 1
         },
         "S3Object": {
           "shape": "S4"
@@ -1124,10 +1349,28 @@
     "S4": {
       "type": "structure",
       "members": {
-        "Bucket": {},
-        "Name": {},
-        "Version": {}
+        "Bucket": {
+          "type": "string",
+          "max": 255,
+          "min": 3,
+          "pattern": "[0-9A-Za-z\\.\\-_]*"
+        },
+        "Name": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        },
+        "Version": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        }
       }
+    },
+    "S8": {
+      "type": "float",
+      "max": 100,
+      "min": 0
     },
     "Sb": {
       "type": "structure",
@@ -1153,7 +1396,7 @@
           "shape": "Sb"
         },
         "Confidence": {
-          "type": "float"
+          "shape": "S8"
         },
         "Landmarks": {
           "shape": "Sg"
@@ -1171,7 +1414,36 @@
       "member": {
         "type": "structure",
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "eyeLeft",
+              "eyeRight",
+              "nose",
+              "mouthLeft",
+              "mouthRight",
+              "leftEyeBrowLeft",
+              "leftEyeBrowRight",
+              "leftEyeBrowUp",
+              "rightEyeBrowLeft",
+              "rightEyeBrowRight",
+              "rightEyeBrowUp",
+              "leftEyeLeft",
+              "leftEyeRight",
+              "leftEyeUp",
+              "leftEyeDown",
+              "rightEyeLeft",
+              "rightEyeRight",
+              "rightEyeUp",
+              "rightEyeDown",
+              "noseLeft",
+              "noseRight",
+              "mouthUp",
+              "mouthDown",
+              "leftPupil",
+              "rightPupil"
+            ]
+          },
           "X": {
             "type": "float"
           },
@@ -1185,15 +1457,20 @@
       "type": "structure",
       "members": {
         "Roll": {
-          "type": "float"
+          "shape": "Sk"
         },
         "Yaw": {
-          "type": "float"
+          "shape": "Sk"
         },
         "Pitch": {
-          "type": "float"
+          "shape": "Sk"
         }
       }
+    },
+    "Sk": {
+      "type": "float",
+      "max": 180,
+      "min": -180
     },
     "Sl": {
       "type": "structure",
@@ -1206,13 +1483,35 @@
         }
       }
     },
+    "Sn": {
+      "type": "string",
+      "enum": [
+        "ROTATE_0",
+        "ROTATE_90",
+        "ROTATE_180",
+        "ROTATE_270"
+      ]
+    },
+    "Sp": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.\\-]+"
+    },
+    "Sr": {
+      "type": "integer",
+      "min": 0
+    },
     "Su": {
       "type": "structure",
       "members": {
         "KinesisVideoStream": {
           "type": "structure",
           "members": {
-            "Arn": {}
+            "Arn": {
+              "type": "string",
+              "pattern": "(^arn:([a-z\\d-]+):kinesisvideo:([a-z\\d-]+):\\d{12}:.+$)"
+            }
           }
         }
       }
@@ -1223,10 +1522,19 @@
         "KinesisDataStream": {
           "type": "structure",
           "members": {
-            "Arn": {}
+            "Arn": {
+              "type": "string",
+              "pattern": "(^arn:([a-z\\d-]+):kinesis:([a-z\\d-]+):\\d{12}:.+$)"
+            }
           }
         }
       }
+    },
+    "S10": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.\\-]+"
     },
     "S11": {
       "type": "structure",
@@ -1234,21 +1542,59 @@
         "FaceSearch": {
           "type": "structure",
           "members": {
-            "CollectionId": {},
+            "CollectionId": {
+              "shape": "Sp"
+            },
             "FaceMatchThreshold": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         }
       }
     },
+    "S13": {
+      "type": "string",
+      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
+    "S15": {
+      "type": "string",
+      "pattern": "(^arn:[a-z\\d-]+:rekognition:[a-z\\d-]+:\\d{12}:streamprocessor\\/.+$)"
+    },
     "S19": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1a"
+      },
+      "max": 4096,
+      "min": 1
+    },
+    "S1a": {
+      "type": "string",
+      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "S1g": {
+      "type": "long",
+      "min": 0
+    },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "STOPPED",
+        "STARTING",
+        "RUNNING",
+        "FAILED",
+        "STOPPING"
+      ]
     },
     "S1m": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "DEFAULT",
+          "ALL"
+        ]
+      }
     },
     "S1q": {
       "type": "structure",
@@ -1260,10 +1606,10 @@
           "type": "structure",
           "members": {
             "Low": {
-              "type": "integer"
+              "shape": "Sr"
             },
             "High": {
-              "type": "integer"
+              "shape": "Sr"
             }
           }
         },
@@ -1274,7 +1620,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1285,7 +1631,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1296,16 +1642,22 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
         "Gender": {
           "type": "structure",
           "members": {
-            "Value": {},
+            "Value": {
+              "type": "string",
+              "enum": [
+                "Male",
+                "Female"
+              ]
+            },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1316,7 +1668,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1327,7 +1679,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1338,7 +1690,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1349,7 +1701,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "type": "float"
+              "shape": "S8"
             }
           }
         },
@@ -1358,9 +1710,21 @@
           "member": {
             "type": "structure",
             "members": {
-              "Type": {},
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "HAPPY",
+                  "SAD",
+                  "ANGRY",
+                  "CONFUSED",
+                  "DISGUSTED",
+                  "SURPRISED",
+                  "CALM",
+                  "UNKNOWN"
+                ]
+              },
               "Confidence": {
-                "type": "float"
+                "shape": "S8"
               }
             }
           }
@@ -1375,7 +1739,7 @@
           "shape": "Sl"
         },
         "Confidence": {
-          "type": "float"
+          "shape": "S8"
         }
       }
     },
@@ -1384,7 +1748,7 @@
       "members": {
         "Name": {},
         "Confidence": {
-          "type": "float"
+          "shape": "S8"
         }
       }
     },
@@ -1392,32 +1756,58 @@
       "type": "structure",
       "members": {
         "Confidence": {
-          "type": "float"
+          "shape": "S8"
         },
         "Name": {},
         "ParentName": {}
       }
     },
+    "S2m": {
+      "type": "string",
+      "pattern": "[0-9A-Za-z]*"
+    },
     "S2o": {
       "type": "list",
       "member": {}
+    },
+    "S2r": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9-_]+$"
+    },
+    "S2s": {
+      "type": "integer",
+      "min": 1
+    },
+    "S2t": {
+      "type": "string",
+      "max": 255
+    },
+    "S2w": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "SUCCEEDED",
+        "FAILED"
+      ]
     },
     "S2y": {
       "type": "structure",
       "members": {
         "Codec": {},
         "DurationMillis": {
-          "type": "long"
+          "shape": "S1g"
         },
         "Format": {},
         "FrameRate": {
           "type": "float"
         },
         "FrameHeight": {
-          "type": "long"
+          "shape": "S1g"
         },
         "FrameWidth": {
-          "type": "long"
+          "shape": "S1g"
         }
       }
     },
@@ -1441,7 +1831,7 @@
         "type": "structure",
         "members": {
           "Similarity": {
-            "type": "float"
+            "shape": "S8"
           },
           "Face": {
             "shape": "S3l"
@@ -1452,16 +1842,39 @@
     "S3l": {
       "type": "structure",
       "members": {
-        "FaceId": {},
+        "FaceId": {
+          "shape": "S1a"
+        },
         "BoundingBox": {
           "shape": "Sb"
         },
-        "ImageId": {},
-        "ExternalImageId": {},
+        "ImageId": {
+          "type": "string",
+          "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+        },
+        "ExternalImageId": {
+          "shape": "S3n"
+        },
         "Confidence": {
-          "type": "float"
+          "shape": "S8"
         }
       }
+    },
+    "S3n": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.\\-:]+"
+    },
+    "S49": {
+      "type": "integer",
+      "max": 4096,
+      "min": 0
+    },
+    "S4q": {
+      "type": "integer",
+      "max": 4096,
+      "min": 1
     },
     "S4v": {
       "type": "structure",
@@ -1471,6 +1884,12 @@
         }
       }
     },
+    "S4w": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9-_]+$"
+    },
     "S4x": {
       "type": "structure",
       "required": [
@@ -1478,9 +1897,20 @@
         "RoleArn"
       ],
       "members": {
-        "SNSTopicArn": {},
-        "RoleArn": {}
+        "SNSTopicArn": {
+          "type": "string",
+          "pattern": "(^arn:aws:sns:.*:\\w{12}:.+$)"
+        },
+        "RoleArn": {
+          "shape": "S13"
+        }
       }
+    },
+    "S4z": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_.\\-:]+"
     }
   }
 }

--- a/apis/resource-groups-2017-11-27.min.json
+++ b/apis/resource-groups-2017-11-27.min.json
@@ -23,8 +23,12 @@
           "ResourceQuery"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
+          "Name": {
+            "shape": "S2"
+          },
+          "Description": {
+            "shape": "S3"
+          },
           "ResourceQuery": {
             "shape": "S4"
           },
@@ -60,6 +64,7 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -86,6 +91,7 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -112,6 +118,7 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -138,6 +145,7 @@
         ],
         "members": {
           "Arn": {
+            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           }
@@ -146,7 +154,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {},
+          "Arn": {
+            "shape": "Sc"
+          },
           "Tags": {
             "shape": "S7"
           }
@@ -164,6 +174,7 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
@@ -176,18 +187,30 @@
                 "Values"
               ],
               "members": {
-                "Name": {},
+                "Name": {
+                  "type": "string",
+                  "enum": [
+                    "resource-type"
+                  ]
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 128,
+                    "min": 1,
+                    "pattern": "AWS::[a-zA-Z0-9]+::[a-zA-Z0-9]+"
+                  },
+                  "max": 5,
+                  "min": 1
                 }
               }
             }
           },
           "MaxResults": {
+            "shape": "Ss",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -213,9 +236,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
+            "shape": "Ss",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "NextToken": {
             "location": "querystring",
@@ -250,7 +273,7 @@
             "shape": "S4"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Ss"
           },
           "NextToken": {}
         }
@@ -278,6 +301,7 @@
         ],
         "members": {
           "Arn": {
+            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           },
@@ -289,7 +313,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {},
+          "Arn": {
+            "shape": "Sc"
+          },
           "Tags": {
             "shape": "S7"
           }
@@ -309,6 +335,7 @@
         ],
         "members": {
           "Arn": {
+            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           },
@@ -320,7 +347,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {},
+          "Arn": {
+            "shape": "Sc"
+          },
           "Keys": {
             "shape": "S17"
           }
@@ -339,10 +368,13 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
-          "Description": {}
+          "Description": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -367,6 +399,7 @@
         ],
         "members": {
           "GroupName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
@@ -386,6 +419,17 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9_\\.-]+"
+    },
+    "S3": {
+      "type": "string",
+      "max": 512,
+      "pattern": "[\\sa-zA-Z0-9_\\.-]*"
+    },
     "S4": {
       "type": "structure",
       "required": [
@@ -393,14 +437,35 @@
         "Query"
       ],
       "members": {
-        "Type": {},
-        "Query": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "TAG_FILTERS_1_0"
+          ]
+        },
+        "Query": {
+          "type": "string",
+          "max": 2048
+        }
       }
     },
     "S7": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S8"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "min": 0,
+        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
+    },
+    "S8": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "Sb": {
       "type": "structure",
@@ -409,10 +474,20 @@
         "Name"
       ],
       "members": {
-        "GroupArn": {},
-        "Name": {},
-        "Description": {}
+        "GroupArn": {
+          "shape": "Sc"
+        },
+        "Name": {
+          "shape": "S2"
+        },
+        "Description": {
+          "shape": "S3"
+        }
       }
+    },
+    "Sc": {
+      "type": "string",
+      "pattern": "arn:aws:resource-groups:[a-z]{2}-[a-z]+-\\d{1}:[0-9]{12}:group/[a-zA-Z0-9_\\.-]{1,128}"
     },
     "Sj": {
       "type": "structure",
@@ -421,25 +496,40 @@
         "ResourceQuery"
       ],
       "members": {
-        "GroupName": {},
+        "GroupName": {
+          "shape": "S2"
+        },
         "ResourceQuery": {
           "shape": "S4"
         }
       }
+    },
+    "Ss": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
     },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceArn": {},
-          "ResourceType": {}
+          "ResourceArn": {
+            "type": "string",
+            "pattern": "arn:aws:[a-z0-9\\-]*:([a-z]{2}-[a-z]+-\\d{1})?:([0-9]{12})?:.+"
+          },
+          "ResourceType": {
+            "type": "string",
+            "pattern": "AWS::[a-zA-Z0-9]+::\\w+"
+          }
         }
       }
     },
     "S17": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S8"
+      }
     }
   }
 }

--- a/apis/resourcegroupstaggingapi-2017-01-26.min.json
+++ b/apis/resourcegroupstaggingapi-2017-01-26.min.json
@@ -16,19 +16,29 @@
       "input": {
         "type": "structure",
         "members": {
-          "PaginationToken": {},
+          "PaginationToken": {
+            "shape": "S2"
+          },
           "TagFilters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
+                "Key": {
+                  "shape": "S5"
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S7"
+                  },
+                  "max": 20,
+                  "min": 0
                 }
               }
-            }
+            },
+            "max": 50,
+            "min": 0
           },
           "ResourcesPerPage": {
             "type": "integer"
@@ -38,20 +48,28 @@
           },
           "ResourceTypeFilters": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 256,
+              "min": 0
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {},
+          "PaginationToken": {
+            "shape": "S2"
+          },
           "ResourceTagMappingList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "ResourceARN": {},
+                "ResourceARN": {
+                  "shape": "Sf"
+                },
                 "Tags": {
                   "type": "list",
                   "member": {
@@ -61,8 +79,12 @@
                       "Value"
                     ],
                     "members": {
-                      "Key": {},
-                      "Value": {}
+                      "Key": {
+                        "shape": "S5"
+                      },
+                      "Value": {
+                        "shape": "S7"
+                      }
                     }
                   }
                 }
@@ -76,16 +98,22 @@
       "input": {
         "type": "structure",
         "members": {
-          "PaginationToken": {}
+          "PaginationToken": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {},
+          "PaginationToken": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            }
           }
         }
       }
@@ -97,17 +125,25 @@
           "Key"
         ],
         "members": {
-          "PaginationToken": {},
-          "Key": {}
+          "PaginationToken": {
+            "shape": "S2"
+          },
+          "Key": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {},
+          "PaginationToken": {
+            "shape": "S2"
+          },
           "TagValues": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S7"
+            }
           }
         }
       }
@@ -125,8 +161,14 @@
           },
           "Tags": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S5"
+            },
+            "value": {
+              "shape": "S7"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -152,7 +194,11 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -167,20 +213,52 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "Sf": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
     "Sp": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sf"
+      },
+      "max": 20,
+      "min": 1
     },
     "Ss": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Sf"
+      },
       "value": {
         "type": "structure",
         "members": {
           "StatusCode": {
             "type": "integer"
           },
-          "ErrorCode": {},
+          "ErrorCode": {
+            "type": "string",
+            "enum": [
+              "InternalServiceException",
+              "InvalidParameterException"
+            ]
+          },
           "ErrorMessage": {}
         }
       }

--- a/apis/route53-2013-04-01.min.json
+++ b/apis/route53-2013-04-01.min.json
@@ -28,6 +28,7 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -65,6 +66,7 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -74,7 +76,9 @@
               "Changes"
             ],
             "members": {
-              "Comment": {},
+              "Comment": {
+                "shape": "Sb"
+              },
               "Changes": {
                 "type": "list",
                 "member": {
@@ -85,12 +89,20 @@
                     "ResourceRecordSet"
                   ],
                   "members": {
-                    "Action": {},
+                    "Action": {
+                      "type": "string",
+                      "enum": [
+                        "CREATE",
+                        "DELETE",
+                        "UPSERT"
+                      ]
+                    },
                     "ResourceRecordSet": {
                       "shape": "Sh"
                     }
                   }
-                }
+                },
+                "min": 1
               }
             }
           }
@@ -124,10 +136,12 @@
         ],
         "members": {
           "ResourceType": {
+            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceId": {
+            "shape": "S14",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -137,8 +151,11 @@
           "RemoveTagKeys": {
             "type": "list",
             "member": {
+              "shape": "S17",
               "locationName": "Key"
-            }
+            },
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -163,7 +180,9 @@
           "HealthCheckConfig"
         ],
         "members": {
-          "CallerReference": {},
+          "CallerReference": {
+            "shape": "S1c"
+          },
           "HealthCheckConfig": {
             "shape": "S1d"
           }
@@ -180,6 +199,7 @@
             "shape": "S1y"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -202,15 +222,21 @@
           "CallerReference"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "Si"
+          },
           "VPC": {
             "shape": "S3"
           },
-          "CallerReference": {},
+          "CallerReference": {
+            "shape": "S2f"
+          },
           "HostedZoneConfig": {
             "shape": "S2g"
           },
-          "DelegationSetId": {}
+          "DelegationSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -235,6 +261,7 @@
             "shape": "S3"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -257,7 +284,9 @@
           "CloudWatchLogsLogGroupArn"
         ],
         "members": {
-          "HostedZoneId": {},
+          "HostedZoneId": {
+            "shape": "S2"
+          },
           "CloudWatchLogsLogGroupArn": {}
         }
       },
@@ -272,6 +301,7 @@
             "shape": "S2q"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -293,8 +323,12 @@
           "CallerReference"
         ],
         "members": {
-          "CallerReference": {},
-          "HostedZoneId": {}
+          "CallerReference": {
+            "shape": "S2f"
+          },
+          "HostedZoneId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -308,6 +342,7 @@
             "shape": "S2l"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -330,9 +365,15 @@
           "Document"
         ],
         "members": {
-          "Name": {},
-          "Document": {},
-          "Comment": {}
+          "Name": {
+            "shape": "S2v"
+          },
+          "Document": {
+            "shape": "S2w"
+          },
+          "Comment": {
+            "shape": "S2x"
+          }
         }
       },
       "output": {
@@ -346,6 +387,7 @@
             "shape": "S2z"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -371,14 +413,20 @@
           "TrafficPolicyVersion"
         ],
         "members": {
-          "HostedZoneId": {},
-          "Name": {},
-          "TTL": {
-            "type": "long"
+          "HostedZoneId": {
+            "shape": "S2"
           },
-          "TrafficPolicyId": {},
+          "Name": {
+            "shape": "Si"
+          },
+          "TTL": {
+            "shape": "St"
+          },
+          "TrafficPolicyId": {
+            "shape": "S30"
+          },
           "TrafficPolicyVersion": {
-            "type": "integer"
+            "shape": "S31"
           }
         }
       },
@@ -393,6 +441,7 @@
             "shape": "S34"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -416,11 +465,16 @@
         ],
         "members": {
           "Id": {
+            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
-          "Document": {},
-          "Comment": {}
+          "Document": {
+            "shape": "S2w"
+          },
+          "Comment": {
+            "shape": "S2x"
+          }
         }
       },
       "output": {
@@ -434,6 +488,7 @@
             "shape": "S2z"
           },
           "Location": {
+            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -456,6 +511,7 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -471,7 +527,9 @@
           "VPC"
         ],
         "members": {
-          "HostedZoneId": {},
+          "HostedZoneId": {
+            "shape": "S2"
+          },
           "VPC": {
             "shape": "S3"
           }
@@ -490,6 +548,7 @@
         ],
         "members": {
           "HealthCheckId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -512,6 +571,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -541,6 +601,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2r",
             "location": "uri",
             "locationName": "Id"
           }
@@ -563,6 +624,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -586,13 +648,14 @@
         ],
         "members": {
           "Id": {
+            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
+            "shape": "S31",
             "location": "uri",
-            "locationName": "Version",
-            "type": "integer"
+            "locationName": "Version"
           }
         }
       },
@@ -613,6 +676,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           }
@@ -639,6 +703,7 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -668,6 +733,7 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -701,6 +767,7 @@
         ],
         "members": {
           "Type": {
+            "shape": "S3t",
             "location": "uri",
             "locationName": "Type"
           }
@@ -720,14 +787,16 @@
               "Value"
             ],
             "members": {
-              "Type": {},
+              "Type": {
+                "shape": "S3t"
+              },
               "Value": {
-                "type": "long"
+                "shape": "S3w"
               }
             }
           },
           "Count": {
-            "type": "long"
+            "shape": "S3x"
           }
         }
       }
@@ -744,6 +813,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -792,14 +862,17 @@
         "type": "structure",
         "members": {
           "ContinentCode": {
+            "shape": "So",
             "location": "querystring",
             "locationName": "continentcode"
           },
           "CountryCode": {
+            "shape": "Sp",
             "location": "querystring",
             "locationName": "countrycode"
           },
           "SubdivisionCode": {
+            "shape": "Sq",
             "location": "querystring",
             "locationName": "subdivisioncode"
           }
@@ -829,6 +902,7 @@
         ],
         "members": {
           "HealthCheckId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -879,6 +953,7 @@
         ],
         "members": {
           "HealthCheckId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -908,6 +983,7 @@
         ],
         "members": {
           "HealthCheckId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -937,6 +1013,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -994,10 +1071,12 @@
         ],
         "members": {
           "Type": {
+            "shape": "S4u",
             "location": "uri",
             "locationName": "Type"
           },
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1017,14 +1096,16 @@
               "Value"
             ],
             "members": {
-              "Type": {},
+              "Type": {
+                "shape": "S4u"
+              },
               "Value": {
-                "type": "long"
+                "shape": "S3w"
               }
             }
           },
           "Count": {
-            "type": "long"
+            "shape": "S3x"
           }
         }
       }
@@ -1041,6 +1122,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2r",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1070,6 +1152,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1100,10 +1183,12 @@
         ],
         "members": {
           "Type": {
+            "shape": "S52",
             "location": "uri",
             "locationName": "Type"
           },
           "DelegationSetId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1123,14 +1208,16 @@
               "Value"
             ],
             "members": {
-              "Type": {},
+              "Type": {
+                "shape": "S52"
+              },
               "Value": {
-                "type": "long"
+                "shape": "S3w"
               }
             }
           },
           "Count": {
-            "type": "long"
+            "shape": "S3x"
           }
         }
       }
@@ -1148,13 +1235,14 @@
         ],
         "members": {
           "Id": {
+            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
+            "shape": "S31",
             "location": "uri",
-            "locationName": "Version",
-            "type": "integer"
+            "locationName": "Version"
           }
         }
       },
@@ -1182,6 +1270,7 @@
         ],
         "members": {
           "Id": {
+            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1229,14 +1318,17 @@
         "type": "structure",
         "members": {
           "StartContinentCode": {
+            "shape": "So",
             "location": "querystring",
             "locationName": "startcontinentcode"
           },
           "StartCountryCode": {
+            "shape": "Sp",
             "location": "querystring",
             "locationName": "startcountrycode"
           },
           "StartSubdivisionCode": {
+            "shape": "Sq",
             "location": "querystring",
             "locationName": "startsubdivisioncode"
           },
@@ -1264,9 +1356,15 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextContinentCode": {},
-          "NextCountryCode": {},
-          "NextSubdivisionCode": {},
+          "NextContinentCode": {
+            "shape": "So"
+          },
+          "NextCountryCode": {
+            "shape": "Sp"
+          },
+          "NextSubdivisionCode": {
+            "shape": "Sq"
+          },
           "MaxItems": {}
         }
       }
@@ -1280,6 +1378,7 @@
         "type": "structure",
         "members": {
           "Marker": {
+            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1305,11 +1404,15 @@
               "locationName": "HealthCheck"
             }
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S5i"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S5i"
+          },
           "MaxItems": {}
         }
       }
@@ -1323,6 +1426,7 @@
         "type": "structure",
         "members": {
           "Marker": {
+            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1331,6 +1435,7 @@
             "locationName": "maxitems"
           },
           "DelegationSetId": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "delegationsetid"
           }
@@ -1348,11 +1453,15 @@
           "HostedZones": {
             "shape": "S5n"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S5i"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S5i"
+          },
           "MaxItems": {}
         }
       }
@@ -1366,10 +1475,12 @@
         "type": "structure",
         "members": {
           "DNSName": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "dnsname"
           },
           "HostedZoneId": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
@@ -1390,13 +1501,21 @@
           "HostedZones": {
             "shape": "S5n"
           },
-          "DNSName": {},
-          "HostedZoneId": {},
+          "DNSName": {
+            "shape": "Si"
+          },
+          "HostedZoneId": {
+            "shape": "S2"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextDNSName": {},
-          "NextHostedZoneId": {},
+          "NextDNSName": {
+            "shape": "Si"
+          },
+          "NextHostedZoneId": {
+            "shape": "S2"
+          },
           "MaxItems": {}
         }
       }
@@ -1410,10 +1529,12 @@
         "type": "structure",
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "NextToken": {
+            "shape": "S5r",
             "location": "querystring",
             "locationName": "nexttoken"
           },
@@ -1436,7 +1557,9 @@
               "locationName": "QueryLoggingConfig"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5r"
+          }
         }
       }
     },
@@ -1452,18 +1575,22 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
           "StartRecordName": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "name"
           },
           "StartRecordType": {
+            "shape": "Sj",
             "location": "querystring",
             "locationName": "type"
           },
           "StartRecordIdentifier": {
+            "shape": "Sk",
             "location": "querystring",
             "locationName": "identifier"
           },
@@ -1491,9 +1618,15 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextRecordName": {},
-          "NextRecordType": {},
-          "NextRecordIdentifier": {},
+          "NextRecordName": {
+            "shape": "Si"
+          },
+          "NextRecordType": {
+            "shape": "Sj"
+          },
+          "NextRecordIdentifier": {
+            "shape": "Sk"
+          },
           "MaxItems": {}
         }
       }
@@ -1507,6 +1640,7 @@
         "type": "structure",
         "members": {
           "Marker": {
+            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1532,11 +1666,15 @@
               "locationName": "DelegationSet"
             }
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S5i"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S5i"
+          },
           "MaxItems": {}
         }
       }
@@ -1554,10 +1692,12 @@
         ],
         "members": {
           "ResourceType": {
+            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceId": {
+            "shape": "S14",
             "location": "uri",
             "locationName": "ResourceId"
           }
@@ -1591,14 +1731,18 @@
         ],
         "members": {
           "ResourceType": {
+            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceIds": {
             "type": "list",
             "member": {
+              "shape": "S14",
               "locationName": "ResourceId"
-            }
+            },
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -1627,6 +1771,7 @@
         "type": "structure",
         "members": {
           "TrafficPolicyIdMarker": {
+            "shape": "S30",
             "location": "querystring",
             "locationName": "trafficpolicyid"
           },
@@ -1658,14 +1803,20 @@
                 "TrafficPolicyCount"
               ],
               "members": {
-                "Id": {},
-                "Name": {},
-                "Type": {},
+                "Id": {
+                  "shape": "S30"
+                },
+                "Name": {
+                  "shape": "S2v"
+                },
+                "Type": {
+                  "shape": "Sj"
+                },
                 "LatestVersion": {
-                  "type": "integer"
+                  "shape": "S31"
                 },
                 "TrafficPolicyCount": {
-                  "type": "integer"
+                  "shape": "S31"
                 }
               }
             }
@@ -1673,7 +1824,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "TrafficPolicyIdMarker": {},
+          "TrafficPolicyIdMarker": {
+            "shape": "S30"
+          },
           "MaxItems": {}
         }
       }
@@ -1687,14 +1840,17 @@
         "type": "structure",
         "members": {
           "HostedZoneIdMarker": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1715,9 +1871,15 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "HostedZoneIdMarker": {},
-          "TrafficPolicyInstanceNameMarker": {},
-          "TrafficPolicyInstanceTypeMarker": {},
+          "HostedZoneIdMarker": {
+            "shape": "S2"
+          },
+          "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si"
+          },
+          "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
@@ -1737,14 +1899,17 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "id"
           },
           "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1765,8 +1930,12 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "TrafficPolicyInstanceNameMarker": {},
-          "TrafficPolicyInstanceTypeMarker": {},
+          "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si"
+          },
+          "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
@@ -1787,23 +1956,27 @@
         ],
         "members": {
           "TrafficPolicyId": {
+            "shape": "S30",
             "location": "querystring",
             "locationName": "id"
           },
           "TrafficPolicyVersion": {
+            "shape": "S31",
             "location": "querystring",
-            "locationName": "version",
-            "type": "integer"
+            "locationName": "version"
           },
           "HostedZoneIdMarker": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1824,9 +1997,15 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "HostedZoneIdMarker": {},
-          "TrafficPolicyInstanceNameMarker": {},
-          "TrafficPolicyInstanceTypeMarker": {},
+          "HostedZoneIdMarker": {
+            "shape": "S2"
+          },
+          "TrafficPolicyInstanceNameMarker": {
+            "shape": "Si"
+          },
+          "TrafficPolicyInstanceTypeMarker": {
+            "shape": "Sj"
+          },
           "IsTruncated": {
             "type": "boolean"
           },
@@ -1846,10 +2025,12 @@
         ],
         "members": {
           "Id": {
+            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "TrafficPolicyVersionMarker": {
+            "shape": "S6k",
             "location": "querystring",
             "locationName": "trafficpolicyversion"
           },
@@ -1878,7 +2059,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "TrafficPolicyVersionMarker": {},
+          "TrafficPolicyVersionMarker": {
+            "shape": "S6k"
+          },
           "MaxItems": {}
         }
       }
@@ -1895,10 +2078,12 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
           "NextToken": {
+            "shape": "S5r",
             "location": "querystring",
             "locationName": "nexttoken"
           },
@@ -1915,8 +2100,12 @@
           "VPCs"
         ],
         "members": {
-          "HostedZoneId": {},
-          "NextToken": {},
+          "HostedZoneId": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S5r"
+          },
           "VPCs": {
             "shape": "S4p"
           }
@@ -1937,28 +2126,36 @@
         ],
         "members": {
           "HostedZoneId": {
+            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "RecordName": {
+            "shape": "Si",
             "location": "querystring",
             "locationName": "recordname"
           },
           "RecordType": {
+            "shape": "Sj",
             "location": "querystring",
             "locationName": "recordtype"
           },
           "ResolverIP": {
+            "shape": "S1e",
             "location": "querystring",
             "locationName": "resolverip"
           },
           "EDNS0ClientSubnetIP": {
+            "shape": "S1e",
             "location": "querystring",
             "locationName": "edns0clientsubnetip"
           },
           "EDNS0ClientSubnetMask": {
             "location": "querystring",
-            "locationName": "edns0clientsubnetmask"
+            "locationName": "edns0clientsubnetmask",
+            "type": "string",
+            "max": 3,
+            "min": 0
           }
         }
       },
@@ -1973,13 +2170,24 @@
           "Protocol"
         ],
         "members": {
-          "Nameserver": {},
-          "RecordName": {},
-          "RecordType": {},
+          "Nameserver": {
+            "type": "string",
+            "max": 255,
+            "min": 0
+          },
+          "RecordName": {
+            "shape": "Si"
+          },
+          "RecordType": {
+            "shape": "Sj"
+          },
           "RecordData": {
             "type": "list",
             "member": {
-              "locationName": "RecordDataEntry"
+              "locationName": "RecordDataEntry",
+              "type": "string",
+              "max": 512,
+              "min": 0
             }
           },
           "ResponseCode": {},
@@ -2002,27 +2210,36 @@
         ],
         "members": {
           "HealthCheckId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           },
           "HealthCheckVersion": {
-            "type": "long"
+            "shape": "S21"
           },
-          "IPAddress": {},
+          "IPAddress": {
+            "shape": "S1e"
+          },
           "Port": {
-            "type": "integer"
+            "shape": "S1f"
           },
-          "ResourcePath": {},
-          "FullyQualifiedDomainName": {},
-          "SearchString": {},
+          "ResourcePath": {
+            "shape": "S1h"
+          },
+          "FullyQualifiedDomainName": {
+            "shape": "S1i"
+          },
+          "SearchString": {
+            "shape": "S1j"
+          },
           "FailureThreshold": {
-            "type": "integer"
+            "shape": "S1l"
           },
           "Inverted": {
             "type": "boolean"
           },
           "HealthThreshold": {
-            "type": "integer"
+            "shape": "S1o"
           },
           "ChildHealthChecks": {
             "shape": "S1p"
@@ -2036,12 +2253,24 @@
           "AlarmIdentifier": {
             "shape": "S1t"
           },
-          "InsufficientDataHealthStatus": {},
+          "InsufficientDataHealthStatus": {
+            "shape": "S1w"
+          },
           "ResetElements": {
             "type": "list",
             "member": {
-              "locationName": "ResettableElementName"
-            }
+              "locationName": "ResettableElementName",
+              "type": "string",
+              "enum": [
+                "FullyQualifiedDomainName",
+                "Regions",
+                "ResourcePath",
+                "ChildHealthChecks"
+              ],
+              "max": 64,
+              "min": 1
+            },
+            "max": 64
           }
         }
       },
@@ -2072,10 +2301,13 @@
         ],
         "members": {
           "Id": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Comment": {}
+          "Comment": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -2107,15 +2339,18 @@
         ],
         "members": {
           "Id": {
+            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
+            "shape": "S31",
             "location": "uri",
-            "locationName": "Version",
-            "type": "integer"
+            "locationName": "Version"
           },
-          "Comment": {}
+          "Comment": {
+            "shape": "S2x"
+          }
         }
       },
       "output": {
@@ -2148,15 +2383,18 @@
         ],
         "members": {
           "Id": {
+            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           },
           "TTL": {
-            "type": "long"
+            "shape": "St"
           },
-          "TrafficPolicyId": {},
+          "TrafficPolicyId": {
+            "shape": "S30"
+          },
           "TrafficPolicyVersion": {
-            "type": "integer"
+            "shape": "S31"
           }
         }
       },
@@ -2174,11 +2412,41 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 32
+    },
     "S3": {
       "type": "structure",
       "members": {
-        "VPCRegion": {},
-        "VPCId": {}
+        "VPCRegion": {
+          "type": "string",
+          "enum": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "eu-central-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-south-1",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "sa-east-1",
+            "ca-central-1",
+            "cn-north-1"
+          ],
+          "max": 64,
+          "min": 1
+        },
+        "VPCId": {
+          "type": "string",
+          "max": 1024
+        }
       }
     },
     "S8": {
@@ -2189,13 +2457,27 @@
         "SubmittedAt"
       ],
       "members": {
-        "Id": {},
-        "Status": {},
+        "Id": {
+          "shape": "S2"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "INSYNC"
+          ]
+        },
         "SubmittedAt": {
           "type": "timestamp"
         },
-        "Comment": {}
+        "Comment": {
+          "shape": "Sb"
+        }
       }
+    },
+    "Sb": {
+      "type": "string",
+      "max": 256
     },
     "Sh": {
       "type": "structure",
@@ -2204,27 +2486,71 @@
         "Type"
       ],
       "members": {
-        "Name": {},
-        "Type": {},
-        "SetIdentifier": {},
-        "Weight": {
-          "type": "long"
+        "Name": {
+          "shape": "Si"
         },
-        "Region": {},
+        "Type": {
+          "shape": "Sj"
+        },
+        "SetIdentifier": {
+          "shape": "Sk"
+        },
+        "Weight": {
+          "type": "long",
+          "max": 255,
+          "min": 0
+        },
+        "Region": {
+          "type": "string",
+          "enum": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "ca-central-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "eu-central-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "sa-east-1",
+            "cn-north-1",
+            "cn-northwest-1",
+            "ap-south-1"
+          ],
+          "max": 64,
+          "min": 1
+        },
         "GeoLocation": {
           "type": "structure",
           "members": {
-            "ContinentCode": {},
-            "CountryCode": {},
-            "SubdivisionCode": {}
+            "ContinentCode": {
+              "shape": "So"
+            },
+            "CountryCode": {
+              "shape": "Sp"
+            },
+            "SubdivisionCode": {
+              "shape": "Sq"
+            }
           }
         },
-        "Failover": {},
+        "Failover": {
+          "type": "string",
+          "enum": [
+            "PRIMARY",
+            "SECONDARY"
+          ]
+        },
         "MultiValueAnswer": {
           "type": "boolean"
         },
         "TTL": {
-          "type": "long"
+          "shape": "St"
         },
         "ResourceRecords": {
           "type": "list",
@@ -2235,9 +2561,13 @@
               "Value"
             ],
             "members": {
-              "Value": {}
+              "Value": {
+                "type": "string",
+                "max": 4000
+              }
             }
-          }
+          },
+          "min": 1
         },
         "AliasTarget": {
           "type": "structure",
@@ -2247,16 +2577,90 @@
             "EvaluateTargetHealth"
           ],
           "members": {
-            "HostedZoneId": {},
-            "DNSName": {},
+            "HostedZoneId": {
+              "shape": "S2"
+            },
+            "DNSName": {
+              "shape": "Si"
+            },
             "EvaluateTargetHealth": {
               "type": "boolean"
             }
           }
         },
-        "HealthCheckId": {},
-        "TrafficPolicyInstanceId": {}
+        "HealthCheckId": {
+          "shape": "Sz"
+        },
+        "TrafficPolicyInstanceId": {
+          "shape": "S10"
+        }
       }
+    },
+    "Si": {
+      "type": "string",
+      "max": 1024
+    },
+    "Sj": {
+      "type": "string",
+      "enum": [
+        "SOA",
+        "A",
+        "TXT",
+        "NS",
+        "CNAME",
+        "MX",
+        "NAPTR",
+        "PTR",
+        "SRV",
+        "SPF",
+        "AAAA",
+        "CAA"
+      ]
+    },
+    "Sk": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "So": {
+      "type": "string",
+      "max": 2,
+      "min": 2
+    },
+    "Sp": {
+      "type": "string",
+      "max": 2,
+      "min": 1
+    },
+    "Sq": {
+      "type": "string",
+      "max": 3,
+      "min": 1
+    },
+    "St": {
+      "type": "long",
+      "max": 2147483647,
+      "min": 0
+    },
+    "Sz": {
+      "type": "string",
+      "max": 64
+    },
+    "S10": {
+      "type": "string",
+      "max": 36,
+      "min": 1
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "healthcheck",
+        "hostedzone"
+      ]
+    },
+    "S14": {
+      "type": "string",
+      "max": 64
     },
     "S15": {
       "type": "list",
@@ -2264,10 +2668,26 @@
         "locationName": "Tag",
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S17"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256
+          }
         }
-      }
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S17": {
+      "type": "string",
+      "max": 128
+    },
+    "S1c": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "S1d": {
       "type": "structure",
@@ -2275,19 +2695,40 @@
         "Type"
       ],
       "members": {
-        "IPAddress": {},
-        "Port": {
-          "type": "integer"
+        "IPAddress": {
+          "shape": "S1e"
         },
-        "Type": {},
-        "ResourcePath": {},
-        "FullyQualifiedDomainName": {},
-        "SearchString": {},
+        "Port": {
+          "shape": "S1f"
+        },
+        "Type": {
+          "type": "string",
+          "enum": [
+            "HTTP",
+            "HTTPS",
+            "HTTP_STR_MATCH",
+            "HTTPS_STR_MATCH",
+            "TCP",
+            "CALCULATED",
+            "CLOUDWATCH_METRIC"
+          ]
+        },
+        "ResourcePath": {
+          "shape": "S1h"
+        },
+        "FullyQualifiedDomainName": {
+          "shape": "S1i"
+        },
+        "SearchString": {
+          "shape": "S1j"
+        },
         "RequestInterval": {
-          "type": "integer"
+          "type": "integer",
+          "max": 30,
+          "min": 10
         },
         "FailureThreshold": {
-          "type": "integer"
+          "shape": "S1l"
         },
         "MeasureLatency": {
           "type": "boolean"
@@ -2296,7 +2737,7 @@
           "type": "boolean"
         },
         "HealthThreshold": {
-          "type": "integer"
+          "shape": "S1o"
         },
         "ChildHealthChecks": {
           "shape": "S1p"
@@ -2310,20 +2751,74 @@
         "AlarmIdentifier": {
           "shape": "S1t"
         },
-        "InsufficientDataHealthStatus": {}
+        "InsufficientDataHealthStatus": {
+          "shape": "S1w"
+        }
       }
+    },
+    "S1e": {
+      "type": "string",
+      "max": 45,
+      "pattern": "(^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$|^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)"
+    },
+    "S1f": {
+      "type": "integer",
+      "max": 65535,
+      "min": 1
+    },
+    "S1h": {
+      "type": "string",
+      "max": 255
+    },
+    "S1i": {
+      "type": "string",
+      "max": 255
+    },
+    "S1j": {
+      "type": "string",
+      "max": 255
+    },
+    "S1l": {
+      "type": "integer",
+      "max": 10,
+      "min": 1
+    },
+    "S1o": {
+      "type": "integer",
+      "max": 256,
+      "min": 0
     },
     "S1p": {
       "type": "list",
       "member": {
+        "shape": "Sz",
         "locationName": "ChildHealthCheck"
-      }
+      },
+      "max": 256
     },
     "S1r": {
       "type": "list",
       "member": {
+        "shape": "S1s",
         "locationName": "Region"
-      }
+      },
+      "max": 64,
+      "min": 3
+    },
+    "S1s": {
+      "type": "string",
+      "enum": [
+        "us-east-1",
+        "us-west-1",
+        "us-west-2",
+        "eu-west-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "sa-east-1"
+      ],
+      "max": 64,
+      "min": 1
     },
     "S1t": {
       "type": "structure",
@@ -2332,9 +2827,43 @@
         "Name"
       ],
       "members": {
-        "Region": {},
-        "Name": {}
+        "Region": {
+          "type": "string",
+          "enum": [
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2",
+            "ca-central-1",
+            "eu-central-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-northeast-3",
+            "sa-east-1"
+          ],
+          "max": 64,
+          "min": 1
+        },
+        "Name": {
+          "type": "string",
+          "max": 256,
+          "min": 1
+        }
       }
+    },
+    "S1w": {
+      "type": "string",
+      "enum": [
+        "Healthy",
+        "Unhealthy",
+        "LastKnownStatus"
+      ]
     },
     "S1y": {
       "type": "structure",
@@ -2345,8 +2874,12 @@
         "HealthCheckVersion"
       ],
       "members": {
-        "Id": {},
-        "CallerReference": {},
+        "Id": {
+          "shape": "Sz"
+        },
+        "CallerReference": {
+          "shape": "S1c"
+        },
         "LinkedService": {
           "shape": "S1z"
         },
@@ -2354,7 +2887,7 @@
           "shape": "S1d"
         },
         "HealthCheckVersion": {
-          "type": "long"
+          "shape": "S21"
         },
         "CloudWatchAlarmConfiguration": {
           "type": "structure",
@@ -2369,18 +2902,45 @@
           ],
           "members": {
             "EvaluationPeriods": {
-              "type": "integer"
+              "type": "integer",
+              "min": 1
             },
             "Threshold": {
               "type": "double"
             },
-            "ComparisonOperator": {},
-            "Period": {
-              "type": "integer"
+            "ComparisonOperator": {
+              "type": "string",
+              "enum": [
+                "GreaterThanOrEqualToThreshold",
+                "GreaterThanThreshold",
+                "LessThanThreshold",
+                "LessThanOrEqualToThreshold"
+              ]
             },
-            "MetricName": {},
-            "Namespace": {},
-            "Statistic": {},
+            "Period": {
+              "type": "integer",
+              "min": 60
+            },
+            "MetricName": {
+              "type": "string",
+              "max": 255,
+              "min": 1
+            },
+            "Namespace": {
+              "type": "string",
+              "max": 255,
+              "min": 1
+            },
+            "Statistic": {
+              "type": "string",
+              "enum": [
+                "Average",
+                "Sum",
+                "SampleCount",
+                "Maximum",
+                "Minimum"
+              ]
+            },
             "Dimensions": {
               "type": "list",
               "member": {
@@ -2391,10 +2951,15 @@
                   "Value"
                 ],
                 "members": {
-                  "Name": {},
-                  "Value": {}
+                  "Name": {
+                    "shape": "S2c"
+                  },
+                  "Value": {
+                    "shape": "S2c"
+                  }
                 }
-              }
+              },
+              "max": 10
             }
           }
         }
@@ -2403,14 +2968,39 @@
     "S1z": {
       "type": "structure",
       "members": {
-        "ServicePrincipal": {},
-        "Description": {}
+        "ServicePrincipal": {
+          "type": "string",
+          "max": 128
+        },
+        "Description": {
+          "shape": "Sb"
+        }
       }
+    },
+    "S21": {
+      "type": "long",
+      "min": 1
+    },
+    "S2c": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S2d": {
+      "type": "string",
+      "max": 1024
+    },
+    "S2f": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S2g": {
       "type": "structure",
       "members": {
-        "Comment": {},
+        "Comment": {
+          "shape": "Sb"
+        },
         "PrivateZone": {
           "type": "boolean"
         }
@@ -2424,9 +3014,15 @@
         "CallerReference"
       ],
       "members": {
-        "Id": {},
-        "Name": {},
-        "CallerReference": {},
+        "Id": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "Si"
+        },
+        "CallerReference": {
+          "shape": "S2f"
+        },
         "Config": {
           "shape": "S2g"
         },
@@ -2444,13 +3040,19 @@
         "NameServers"
       ],
       "members": {
-        "Id": {},
-        "CallerReference": {},
+        "Id": {
+          "shape": "S2"
+        },
+        "CallerReference": {
+          "shape": "S2f"
+        },
         "NameServers": {
           "type": "list",
           "member": {
+            "shape": "Si",
             "locationName": "NameServer"
-          }
+          },
+          "min": 1
         }
       }
     },
@@ -2462,10 +3064,31 @@
         "CloudWatchLogsLogGroupArn"
       ],
       "members": {
-        "Id": {},
-        "HostedZoneId": {},
+        "Id": {
+          "shape": "S2r"
+        },
+        "HostedZoneId": {
+          "shape": "S2"
+        },
         "CloudWatchLogsLogGroupArn": {}
       }
+    },
+    "S2r": {
+      "type": "string",
+      "max": 36,
+      "min": 1
+    },
+    "S2v": {
+      "type": "string",
+      "max": 512
+    },
+    "S2w": {
+      "type": "string",
+      "max": 102400
+    },
+    "S2x": {
+      "type": "string",
+      "max": 1024
     },
     "S2z": {
       "type": "structure",
@@ -2477,15 +3100,35 @@
         "Document"
       ],
       "members": {
-        "Id": {},
-        "Version": {
-          "type": "integer"
+        "Id": {
+          "shape": "S30"
         },
-        "Name": {},
-        "Type": {},
-        "Document": {},
-        "Comment": {}
+        "Version": {
+          "shape": "S31"
+        },
+        "Name": {
+          "shape": "S2v"
+        },
+        "Type": {
+          "shape": "Sj"
+        },
+        "Document": {
+          "shape": "S2w"
+        },
+        "Comment": {
+          "shape": "S2x"
+        }
       }
+    },
+    "S30": {
+      "type": "string",
+      "max": 36,
+      "min": 1
+    },
+    "S31": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
     },
     "S34": {
       "type": "structure",
@@ -2501,30 +3144,79 @@
         "TrafficPolicyType"
       ],
       "members": {
-        "Id": {},
-        "HostedZoneId": {},
-        "Name": {},
+        "Id": {
+          "shape": "S10"
+        },
+        "HostedZoneId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "Si"
+        },
         "TTL": {
-          "type": "long"
+          "shape": "St"
         },
         "State": {},
-        "Message": {},
-        "TrafficPolicyId": {},
-        "TrafficPolicyVersion": {
-          "type": "integer"
+        "Message": {
+          "type": "string",
+          "max": 1024
         },
-        "TrafficPolicyType": {}
+        "TrafficPolicyId": {
+          "shape": "S30"
+        },
+        "TrafficPolicyVersion": {
+          "shape": "S31"
+        },
+        "TrafficPolicyType": {
+          "shape": "Sj"
+        }
       }
+    },
+    "S3t": {
+      "type": "string",
+      "enum": [
+        "MAX_HEALTH_CHECKS_BY_OWNER",
+        "MAX_HOSTED_ZONES_BY_OWNER",
+        "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER",
+        "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER",
+        "MAX_TRAFFIC_POLICIES_BY_OWNER"
+      ]
+    },
+    "S3w": {
+      "type": "long",
+      "min": 1
+    },
+    "S3x": {
+      "type": "long",
+      "min": 0
     },
     "S46": {
       "type": "structure",
       "members": {
-        "ContinentCode": {},
-        "ContinentName": {},
-        "CountryCode": {},
-        "CountryName": {},
-        "SubdivisionCode": {},
-        "SubdivisionName": {}
+        "ContinentCode": {
+          "shape": "So"
+        },
+        "ContinentName": {
+          "type": "string",
+          "max": 32,
+          "min": 1
+        },
+        "CountryCode": {
+          "shape": "Sp"
+        },
+        "CountryName": {
+          "type": "string",
+          "max": 64,
+          "min": 1
+        },
+        "SubdivisionCode": {
+          "shape": "Sq"
+        },
+        "SubdivisionName": {
+          "type": "string",
+          "max": 64,
+          "min": 1
+        }
       }
     },
     "S4h": {
@@ -2533,8 +3225,12 @@
         "locationName": "HealthCheckObservation",
         "type": "structure",
         "members": {
-          "Region": {},
-          "IPAddress": {},
+          "Region": {
+            "shape": "S1s"
+          },
+          "IPAddress": {
+            "shape": "S1e"
+          },
           "StatusReport": {
             "type": "structure",
             "members": {
@@ -2552,7 +3248,25 @@
       "member": {
         "shape": "S3",
         "locationName": "VPC"
-      }
+      },
+      "min": 1
+    },
+    "S4u": {
+      "type": "string",
+      "enum": [
+        "MAX_RRSETS_BY_ZONE",
+        "MAX_VPCS_ASSOCIATED_BY_ZONE"
+      ]
+    },
+    "S52": {
+      "type": "string",
+      "enum": [
+        "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
+      ]
+    },
+    "S5i": {
+      "type": "string",
+      "max": 64
     },
     "S5n": {
       "type": "list",
@@ -2561,11 +3275,19 @@
         "locationName": "HostedZone"
       }
     },
+    "S5r": {
+      "type": "string",
+      "max": 256
+    },
     "S63": {
       "type": "structure",
       "members": {
-        "ResourceType": {},
-        "ResourceId": {},
+        "ResourceType": {
+          "shape": "S13"
+        },
+        "ResourceId": {
+          "shape": "S14"
+        },
         "Tags": {
           "shape": "S15"
         }
@@ -2577,6 +3299,10 @@
         "shape": "S34",
         "locationName": "TrafficPolicyInstance"
       }
+    },
+    "S6k": {
+      "type": "string",
+      "max": 4
     }
   }
 }

--- a/apis/route53domains-2014-05-15.min.json
+++ b/apis/route53domains-2014-05-15.min.json
@@ -19,8 +19,12 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
-          "IdnLangCode": {}
+          "DomainName": {
+            "shape": "S2"
+          },
+          "IdnLangCode": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -29,7 +33,19 @@
           "Availability"
         ],
         "members": {
-          "Availability": {}
+          "Availability": {
+            "type": "string",
+            "enum": [
+              "AVAILABLE",
+              "AVAILABLE_RESERVED",
+              "AVAILABLE_PREORDER",
+              "UNAVAILABLE",
+              "UNAVAILABLE_PREMIUM",
+              "UNAVAILABLE_RESTRICTED",
+              "RESERVED",
+              "DONT_KNOW"
+            ]
+          }
         }
       }
     },
@@ -40,7 +56,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AuthCode": {
             "shape": "S7"
           }
@@ -55,7 +73,14 @@
           "Transferability": {
             "type": "structure",
             "members": {
-              "Transferable": {}
+              "Transferable": {
+                "type": "string",
+                "enum": [
+                  "TRANSFERABLE",
+                  "UNTRANSFERABLE",
+                  "DONT_KNOW"
+                ]
+              }
             }
           }
         }
@@ -69,7 +94,9 @@
           "TagsToDelete"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "TagsToDelete": {
             "type": "list",
             "member": {}
@@ -88,7 +115,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -103,7 +132,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -112,7 +143,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -123,7 +156,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -138,7 +173,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -147,7 +184,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -155,14 +194,25 @@
       "input": {
         "type": "structure",
         "members": {
-          "domainName": {}
+          "domainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "domainName": {},
-          "status": {}
+          "domainName": {
+            "shape": "S2"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "DONE",
+              "EXPIRED"
+            ]
+          }
         }
       }
     },
@@ -173,7 +223,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -186,7 +238,9 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "Nameservers": {
             "shape": "St"
           },
@@ -214,8 +268,12 @@
           "RegistrarName": {},
           "WhoIsServer": {},
           "RegistrarUrl": {},
-          "AbuseContactEmail": {},
-          "AbuseContactPhone": {},
+          "AbuseContactEmail": {
+            "shape": "S18"
+          },
+          "AbuseContactPhone": {
+            "shape": "S17"
+          },
           "RegistryDomainId": {},
           "CreationDate": {
             "type": "timestamp"
@@ -244,7 +302,9 @@
           "OnlyAvailable"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "SuggestionCount": {
             "type": "integer"
           },
@@ -261,7 +321,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {},
+                "DomainName": {
+                  "shape": "S2"
+                },
                 "Availability": {}
               }
             }
@@ -276,17 +338,27 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {},
-          "Status": {},
+          "OperationId": {
+            "shape": "Sj"
+          },
+          "Status": {
+            "shape": "S1u"
+          },
           "Message": {},
-          "DomainName": {},
-          "Type": {},
+          "DomainName": {
+            "shape": "S2"
+          },
+          "Type": {
+            "shape": "S1w"
+          },
           "SubmittedDate": {
             "type": "timestamp"
           }
@@ -297,9 +369,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {},
+          "Marker": {
+            "shape": "S1y"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S1z"
           }
         }
       },
@@ -317,7 +391,9 @@
                 "DomainName"
               ],
               "members": {
-                "DomainName": {},
+                "DomainName": {
+                  "shape": "S2"
+                },
                 "AutoRenew": {
                   "type": "boolean"
                 },
@@ -330,7 +406,9 @@
               }
             }
           },
-          "NextPageMarker": {}
+          "NextPageMarker": {
+            "shape": "S1y"
+          }
         }
       }
     },
@@ -341,9 +419,11 @@
           "SubmittedSince": {
             "type": "timestamp"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S1y"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S1z"
           }
         }
       },
@@ -364,16 +444,24 @@
                 "SubmittedDate"
               ],
               "members": {
-                "OperationId": {},
-                "Status": {},
-                "Type": {},
+                "OperationId": {
+                  "shape": "Sj"
+                },
+                "Status": {
+                  "shape": "S1u"
+                },
+                "Type": {
+                  "shape": "S1w"
+                },
                 "SubmittedDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextPageMarker": {}
+          "NextPageMarker": {
+            "shape": "S1y"
+          }
         }
       }
     },
@@ -384,7 +472,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -410,10 +500,14 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {},
-          "IdnLangCode": {},
+          "DomainName": {
+            "shape": "S2"
+          },
+          "IdnLangCode": {
+            "shape": "S3"
+          },
           "DurationInYears": {
-            "type": "integer"
+            "shape": "S2d"
           },
           "AutoRenew": {
             "type": "boolean"
@@ -444,7 +538,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -456,9 +552,11 @@
           "CurrentExpiryYear"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "DurationInYears": {
-            "type": "integer"
+            "shape": "S2d"
           },
           "CurrentExpiryYear": {
             "type": "integer"
@@ -471,7 +569,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -479,14 +579,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "domainName": {}
+          "domainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "domainName": {},
-          "emailAddress": {},
+          "domainName": {
+            "shape": "S2"
+          },
+          "emailAddress": {
+            "shape": "S18"
+          },
           "isAlreadyVerified": {
             "type": "boolean"
           }
@@ -500,7 +606,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {}
+          "DomainName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -526,10 +634,14 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {},
-          "IdnLangCode": {},
+          "DomainName": {
+            "shape": "S2"
+          },
+          "IdnLangCode": {
+            "shape": "S3"
+          },
           "DurationInYears": {
-            "type": "integer"
+            "shape": "S2d"
           },
           "Nameservers": {
             "shape": "St"
@@ -566,7 +678,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -577,7 +691,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AdminContact": {
             "shape": "Sz"
           },
@@ -595,7 +711,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -606,7 +724,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "AdminPrivacy": {
             "type": "boolean"
           },
@@ -624,7 +744,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -636,7 +758,9 @@
           "Nameservers"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "FIAuthKey": {
             "deprecated": true
           },
@@ -651,7 +775,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -662,7 +788,9 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {},
+          "DomainName": {
+            "shape": "S2"
+          },
           "TagsToUpdate": {
             "shape": "S29"
           }
@@ -683,23 +811,31 @@
           "End": {
             "type": "timestamp"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S1y"
+          },
           "MaxItems": {
-            "type": "integer"
+            "shape": "S1z"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextPageMarker": {},
+          "NextPageMarker": {
+            "shape": "S1y"
+          },
           "BillingRecords": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {},
-                "Operation": {},
+                "DomainName": {
+                  "shape": "S2"
+                },
+                "Operation": {
+                  "shape": "S1w"
+                },
                 "InvoiceId": {},
                 "BillDate": {
                   "type": "timestamp"
@@ -715,9 +851,22 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 255
+    },
+    "S3": {
+      "type": "string",
+      "max": 3
+    },
     "S7": {
       "type": "string",
+      "max": 1024,
       "sensitive": true
+    },
+    "Sj": {
+      "type": "string",
+      "max": 255
     },
     "St": {
       "type": "list",
@@ -727,10 +876,17 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "type": "string",
+            "max": 255,
+            "pattern": "[a-zA-Z0-9_\\-.]*"
+          },
           "GlueIps": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 45
+            }
           }
         }
       }
@@ -738,19 +894,286 @@
     "Sz": {
       "type": "structure",
       "members": {
-        "FirstName": {},
-        "LastName": {},
-        "ContactType": {},
-        "OrganizationName": {},
-        "AddressLine1": {},
-        "AddressLine2": {},
-        "City": {},
-        "State": {},
-        "CountryCode": {},
-        "ZipCode": {},
-        "PhoneNumber": {},
-        "Email": {},
-        "Fax": {},
+        "FirstName": {
+          "shape": "S10"
+        },
+        "LastName": {
+          "shape": "S10"
+        },
+        "ContactType": {
+          "type": "string",
+          "enum": [
+            "PERSON",
+            "COMPANY",
+            "ASSOCIATION",
+            "PUBLIC_BODY",
+            "RESELLER"
+          ]
+        },
+        "OrganizationName": {
+          "shape": "S10"
+        },
+        "AddressLine1": {
+          "shape": "S12"
+        },
+        "AddressLine2": {
+          "shape": "S12"
+        },
+        "City": {
+          "type": "string",
+          "max": 255
+        },
+        "State": {
+          "type": "string",
+          "max": 255
+        },
+        "CountryCode": {
+          "type": "string",
+          "enum": [
+            "AD",
+            "AE",
+            "AF",
+            "AG",
+            "AI",
+            "AL",
+            "AM",
+            "AN",
+            "AO",
+            "AQ",
+            "AR",
+            "AS",
+            "AT",
+            "AU",
+            "AW",
+            "AZ",
+            "BA",
+            "BB",
+            "BD",
+            "BE",
+            "BF",
+            "BG",
+            "BH",
+            "BI",
+            "BJ",
+            "BL",
+            "BM",
+            "BN",
+            "BO",
+            "BR",
+            "BS",
+            "BT",
+            "BW",
+            "BY",
+            "BZ",
+            "CA",
+            "CC",
+            "CD",
+            "CF",
+            "CG",
+            "CH",
+            "CI",
+            "CK",
+            "CL",
+            "CM",
+            "CN",
+            "CO",
+            "CR",
+            "CU",
+            "CV",
+            "CX",
+            "CY",
+            "CZ",
+            "DE",
+            "DJ",
+            "DK",
+            "DM",
+            "DO",
+            "DZ",
+            "EC",
+            "EE",
+            "EG",
+            "ER",
+            "ES",
+            "ET",
+            "FI",
+            "FJ",
+            "FK",
+            "FM",
+            "FO",
+            "FR",
+            "GA",
+            "GB",
+            "GD",
+            "GE",
+            "GH",
+            "GI",
+            "GL",
+            "GM",
+            "GN",
+            "GQ",
+            "GR",
+            "GT",
+            "GU",
+            "GW",
+            "GY",
+            "HK",
+            "HN",
+            "HR",
+            "HT",
+            "HU",
+            "ID",
+            "IE",
+            "IL",
+            "IM",
+            "IN",
+            "IQ",
+            "IR",
+            "IS",
+            "IT",
+            "JM",
+            "JO",
+            "JP",
+            "KE",
+            "KG",
+            "KH",
+            "KI",
+            "KM",
+            "KN",
+            "KP",
+            "KR",
+            "KW",
+            "KY",
+            "KZ",
+            "LA",
+            "LB",
+            "LC",
+            "LI",
+            "LK",
+            "LR",
+            "LS",
+            "LT",
+            "LU",
+            "LV",
+            "LY",
+            "MA",
+            "MC",
+            "MD",
+            "ME",
+            "MF",
+            "MG",
+            "MH",
+            "MK",
+            "ML",
+            "MM",
+            "MN",
+            "MO",
+            "MP",
+            "MR",
+            "MS",
+            "MT",
+            "MU",
+            "MV",
+            "MW",
+            "MX",
+            "MY",
+            "MZ",
+            "NA",
+            "NC",
+            "NE",
+            "NG",
+            "NI",
+            "NL",
+            "NO",
+            "NP",
+            "NR",
+            "NU",
+            "NZ",
+            "OM",
+            "PA",
+            "PE",
+            "PF",
+            "PG",
+            "PH",
+            "PK",
+            "PL",
+            "PM",
+            "PN",
+            "PR",
+            "PT",
+            "PW",
+            "PY",
+            "QA",
+            "RO",
+            "RS",
+            "RU",
+            "RW",
+            "SA",
+            "SB",
+            "SC",
+            "SD",
+            "SE",
+            "SG",
+            "SH",
+            "SI",
+            "SK",
+            "SL",
+            "SM",
+            "SN",
+            "SO",
+            "SR",
+            "ST",
+            "SV",
+            "SY",
+            "SZ",
+            "TC",
+            "TD",
+            "TG",
+            "TH",
+            "TJ",
+            "TK",
+            "TL",
+            "TM",
+            "TN",
+            "TO",
+            "TR",
+            "TT",
+            "TV",
+            "TW",
+            "TZ",
+            "UA",
+            "UG",
+            "US",
+            "UY",
+            "UZ",
+            "VA",
+            "VC",
+            "VE",
+            "VG",
+            "VI",
+            "VN",
+            "VU",
+            "WF",
+            "WS",
+            "YE",
+            "YT",
+            "ZA",
+            "ZM",
+            "ZW"
+          ]
+        },
+        "ZipCode": {
+          "type": "string",
+          "max": 255
+        },
+        "PhoneNumber": {
+          "shape": "S17"
+        },
+        "Email": {
+          "shape": "S18"
+        },
+        "Fax": {
+          "shape": "S17"
+        },
         "ExtraParams": {
           "type": "list",
           "member": {
@@ -760,13 +1183,101 @@
               "Value"
             ],
             "members": {
-              "Name": {},
-              "Value": {}
+              "Name": {
+                "type": "string",
+                "enum": [
+                  "DUNS_NUMBER",
+                  "BRAND_NUMBER",
+                  "BIRTH_DEPARTMENT",
+                  "BIRTH_DATE_IN_YYYY_MM_DD",
+                  "BIRTH_COUNTRY",
+                  "BIRTH_CITY",
+                  "DOCUMENT_NUMBER",
+                  "AU_ID_NUMBER",
+                  "AU_ID_TYPE",
+                  "CA_LEGAL_TYPE",
+                  "CA_BUSINESS_ENTITY_TYPE",
+                  "ES_IDENTIFICATION",
+                  "ES_IDENTIFICATION_TYPE",
+                  "ES_LEGAL_FORM",
+                  "FI_BUSINESS_NUMBER",
+                  "FI_ID_NUMBER",
+                  "FI_NATIONALITY",
+                  "FI_ORGANIZATION_TYPE",
+                  "IT_PIN",
+                  "IT_REGISTRANT_ENTITY_TYPE",
+                  "RU_PASSPORT_DATA",
+                  "SE_ID_NUMBER",
+                  "SG_ID_NUMBER",
+                  "VAT_NUMBER",
+                  "UK_CONTACT_TYPE",
+                  "UK_COMPANY_NUMBER"
+                ]
+              },
+              "Value": {
+                "type": "string",
+                "max": 2048
+              }
             }
           }
         }
       },
       "sensitive": true
+    },
+    "S10": {
+      "type": "string",
+      "max": 255
+    },
+    "S12": {
+      "type": "string",
+      "max": 255
+    },
+    "S17": {
+      "type": "string",
+      "max": 30
+    },
+    "S18": {
+      "type": "string",
+      "max": 254
+    },
+    "S1u": {
+      "type": "string",
+      "enum": [
+        "SUBMITTED",
+        "IN_PROGRESS",
+        "ERROR",
+        "SUCCESSFUL",
+        "FAILED"
+      ]
+    },
+    "S1w": {
+      "type": "string",
+      "enum": [
+        "REGISTER_DOMAIN",
+        "DELETE_DOMAIN",
+        "TRANSFER_IN_DOMAIN",
+        "UPDATE_DOMAIN_CONTACT",
+        "UPDATE_NAMESERVER",
+        "CHANGE_PRIVACY_PROTECTION",
+        "DOMAIN_LOCK",
+        "ENABLE_AUTORENEW",
+        "DISABLE_AUTORENEW",
+        "ADD_DNSSEC",
+        "REMOVE_DNSSEC",
+        "EXPIRE_DOMAIN",
+        "TRANSFER_OUT_DOMAIN",
+        "CHANGE_DOMAIN_OWNER",
+        "RENEW_DOMAIN",
+        "PUSH_DOMAIN"
+      ]
+    },
+    "S1y": {
+      "type": "string",
+      "max": 4096
+    },
+    "S1z": {
+      "type": "integer",
+      "max": 100
     },
     "S29": {
       "type": "list",
@@ -777,6 +1288,11 @@
           "Value": {}
         }
       }
+    },
+    "S2d": {
+      "type": "integer",
+      "max": 10,
+      "min": 1
     }
   }
 }

--- a/apis/runtime.lex-2016-11-28.min.json
+++ b/apis/runtime.lex-2016-11-28.min.json
@@ -35,6 +35,7 @@
             "locationName": "botAlias"
           },
           "userId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "userId"
           },
@@ -91,10 +92,12 @@
             "locationName": "x-amz-lex-message"
           },
           "messageFormat": {
+            "shape": "Sd",
             "location": "header",
             "locationName": "x-amz-lex-message-format"
           },
           "dialogState": {
+            "shape": "Se",
             "location": "header",
             "locationName": "x-amz-lex-dialog-state"
           },
@@ -136,6 +139,7 @@
             "locationName": "botAlias"
           },
           "userId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "userId"
           },
@@ -163,23 +167,40 @@
           "message": {
             "shape": "Sc"
           },
-          "messageFormat": {},
-          "dialogState": {},
+          "messageFormat": {
+            "shape": "Sd"
+          },
+          "dialogState": {
+            "shape": "Se"
+          },
           "slotToElicit": {},
           "responseCard": {
             "type": "structure",
             "members": {
               "version": {},
-              "contentType": {},
+              "contentType": {
+                "type": "string",
+                "enum": [
+                  "application/vnd.amazonaws.card.generic"
+                ]
+              },
               "genericAttachments": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "title": {},
-                    "subTitle": {},
-                    "attachmentLinkUrl": {},
-                    "imageUrl": {},
+                    "title": {
+                      "shape": "Sm"
+                    },
+                    "subTitle": {
+                      "shape": "Sm"
+                    },
+                    "attachmentLinkUrl": {
+                      "shape": "Sn"
+                    },
+                    "imageUrl": {
+                      "shape": "Sn"
+                    },
                     "buttons": {
                       "type": "list",
                       "member": {
@@ -189,13 +210,25 @@
                           "value"
                         ],
                         "members": {
-                          "text": {},
-                          "value": {}
+                          "text": {
+                            "type": "string",
+                            "max": 15,
+                            "min": 1
+                          },
+                          "value": {
+                            "type": "string",
+                            "max": 1000,
+                            "min": 1
+                          }
                         }
-                      }
+                      },
+                      "max": 5,
+                      "min": 0
                     }
                   }
-                }
+                },
+                "max": 10,
+                "min": 0
               }
             }
           }
@@ -204,6 +237,12 @@
     }
   },
   "shapes": {
+    "S4": {
+      "type": "string",
+      "max": 100,
+      "min": 2,
+      "pattern": "[0-9a-zA-Z._:-]+"
+    },
     "S5": {
       "type": "string",
       "sensitive": true
@@ -214,13 +253,45 @@
     },
     "Sc": {
       "type": "string",
+      "max": 1024,
+      "min": 1,
       "sensitive": true
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "PlainText",
+        "CustomPayload",
+        "SSML",
+        "Composite"
+      ]
+    },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "ElicitIntent",
+        "ConfirmIntent",
+        "ElicitSlot",
+        "Fulfilled",
+        "ReadyForFulfillment",
+        "Failed"
+      ]
     },
     "Sg": {
       "type": "map",
       "key": {},
       "value": {},
       "sensitive": true
+    },
+    "Sm": {
+      "type": "string",
+      "max": 80,
+      "min": 1
+    },
+    "Sn": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
     }
   }
 }

--- a/apis/runtime.sagemaker-2017-05-13.min.json
+++ b/apis/runtime.sagemaker-2017-05-13.min.json
@@ -25,16 +25,21 @@
         "members": {
           "EndpointName": {
             "location": "uri",
-            "locationName": "EndpointName"
+            "locationName": "EndpointName",
+            "type": "string",
+            "max": 63,
+            "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
           },
           "Body": {
             "shape": "S3"
           },
           "ContentType": {
+            "shape": "S4",
             "location": "header",
             "locationName": "Content-Type"
           },
           "Accept": {
+            "shape": "S4",
             "location": "header",
             "locationName": "Accept"
           },
@@ -56,10 +61,12 @@
             "shape": "S3"
           },
           "ContentType": {
+            "shape": "S4",
             "location": "header",
             "locationName": "Content-Type"
           },
           "InvokedProductionVariant": {
+            "shape": "S4",
             "location": "header",
             "locationName": "x-Amzn-Invoked-Production-Variant"
           },
@@ -76,10 +83,16 @@
   "shapes": {
     "S3": {
       "type": "blob",
+      "max": 5242880,
       "sensitive": true
+    },
+    "S4": {
+      "type": "string",
+      "max": 1024
     },
     "S5": {
       "type": "string",
+      "max": 1024,
       "sensitive": true
     }
   }

--- a/apis/s3-2006-03-01.min.json
+++ b/apis/s3-2006-03-01.min.json
@@ -31,6 +31,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -39,6 +40,7 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -48,6 +50,7 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -71,6 +74,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -102,6 +106,7 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -113,13 +118,16 @@
         "members": {
           "Location": {},
           "Bucket": {},
-          "Key": {},
+          "Key": {
+            "shape": "S3"
+          },
           "Expiration": {
             "location": "header",
             "locationName": "x-amz-expiration"
           },
           "ETag": {},
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -133,6 +141,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -153,6 +162,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -181,6 +191,7 @@
             "locationName": "Content-Type"
           },
           "CopySource": {
+            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-copy-source"
           },
@@ -224,6 +235,7 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -234,17 +246,29 @@
           },
           "MetadataDirective": {
             "location": "header",
-            "locationName": "x-amz-metadata-directive"
+            "locationName": "x-amz-metadata-directive",
+            "type": "string",
+            "enum": [
+              "COPY",
+              "REPLACE"
+            ]
           },
           "TaggingDirective": {
             "location": "header",
-            "locationName": "x-amz-tagging-directive"
+            "locationName": "x-amz-tagging-directive",
+            "type": "string",
+            "enum": [
+              "COPY",
+              "REPLACE"
+            ]
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -284,6 +308,7 @@
             "locationName": "x-amz-copy-source-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -318,6 +343,7 @@
             "locationName": "x-amz-version-id"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -335,6 +361,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -355,6 +382,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "S1k",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -369,7 +397,9 @@
             },
             "type": "structure",
             "members": {
-              "LocationConstraint": {}
+              "LocationConstraint": {
+                "shape": "S1m"
+              }
             }
           },
           "GrantFullControl": {
@@ -418,6 +448,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -467,6 +498,7 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -476,10 +508,12 @@
             "locationName": "x-amz-meta-"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -506,6 +540,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -530,9 +565,12 @@
           "Bucket": {
             "locationName": "Bucket"
           },
-          "Key": {},
+          "Key": {
+            "shape": "S3"
+          },
           "UploadId": {},
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -550,6 +588,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -787,6 +826,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -799,6 +839,7 @@
             "locationName": "versionId"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -817,6 +858,7 @@
             "locationName": "x-amz-version-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -840,6 +882,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -893,7 +936,9 @@
                     "Key"
                   ],
                   "members": {
-                    "Key": {},
+                    "Key": {
+                      "shape": "S3"
+                    },
                     "VersionId": {}
                   }
                 },
@@ -909,6 +954,7 @@
             "locationName": "x-amz-mfa"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -923,7 +969,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
+                "Key": {
+                  "shape": "S3"
+                },
                 "VersionId": {},
                 "DeleteMarker": {
                   "type": "boolean"
@@ -934,6 +982,7 @@
             "flattened": true
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
@@ -943,7 +992,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
+                "Key": {
+                  "shape": "S3"
+                },
                 "VersionId": {},
                 "Code": {},
                 "Message": {}
@@ -975,7 +1026,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Status": {}
+          "Status": {
+            "shape": "S2s"
+          }
         }
       }
     },
@@ -1202,7 +1255,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "LocationConstraint": {}
+          "LocationConstraint": {
+            "shape": "S1m"
+          }
         }
       }
     },
@@ -1361,7 +1416,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Payer": {}
+          "Payer": {
+            "shape": "S71"
+          }
         }
       }
     },
@@ -1414,9 +1471,16 @@
       "output": {
         "type": "structure",
         "members": {
-          "Status": {},
+          "Status": {
+            "shape": "S76"
+          },
           "MFADelete": {
-            "locationName": "MfaDelete"
+            "locationName": "MfaDelete",
+            "type": "string",
+            "enum": [
+              "Enabled",
+              "Disabled"
+            ]
           }
         }
       }
@@ -1491,6 +1555,7 @@
             "type": "timestamp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1541,6 +1606,7 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -1632,6 +1698,7 @@
             "locationName": "x-amz-website-redirect-location"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -1654,14 +1721,17 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "StorageClass": {
+            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
           "ReplicationStatus": {
+            "shape": "S88",
             "location": "header",
             "locationName": "x-amz-replication-status"
           },
@@ -1696,6 +1766,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1704,6 +1775,7 @@
             "locationName": "versionId"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -1720,6 +1792,7 @@
             "locationName": "AccessControlList"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -1743,6 +1816,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1785,10 +1859,12 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -1802,6 +1878,7 @@
             "type": "blob"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -1862,6 +1939,7 @@
             "type": "timestamp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1887,6 +1965,7 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -1970,6 +2049,7 @@
             "locationName": "x-amz-website-redirect-location"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -1992,14 +2072,17 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "StorageClass": {
+            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
           "ReplicationStatus": {
+            "shape": "S88",
             "location": "header",
             "locationName": "x-amz-replication-status"
           },
@@ -2178,6 +2261,7 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
+            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2223,11 +2307,15 @@
               "type": "structure",
               "members": {
                 "UploadId": {},
-                "Key": {},
+                "Key": {
+                  "shape": "S3"
+                },
                 "Initiated": {
                   "type": "timestamp"
                 },
-                "StorageClass": {},
+                "StorageClass": {
+                  "shape": "S16"
+                },
                 "Owner": {
                   "shape": "S2v"
                 },
@@ -2241,7 +2329,9 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {}
+          "EncodingType": {
+            "shape": "S92"
+          }
         }
       }
     },
@@ -2265,6 +2355,7 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
+            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2307,8 +2398,15 @@
                 "Size": {
                   "type": "integer"
                 },
-                "StorageClass": {},
-                "Key": {},
+                "StorageClass": {
+                  "type": "string",
+                  "enum": [
+                    "STANDARD"
+                  ]
+                },
+                "Key": {
+                  "shape": "S3"
+                },
                 "VersionId": {},
                 "IsLatest": {
                   "type": "boolean"
@@ -2332,7 +2430,9 @@
                 "Owner": {
                   "shape": "S2v"
                 },
-                "Key": {},
+                "Key": {
+                  "shape": "S3"
+                },
                 "VersionId": {},
                 "IsLatest": {
                   "type": "boolean"
@@ -2353,7 +2453,9 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {}
+          "EncodingType": {
+            "shape": "S92"
+          }
         }
       },
       "alias": "GetBucketObjectVersions"
@@ -2378,6 +2480,7 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
+            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2395,6 +2498,7 @@
             "locationName": "prefix"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2420,7 +2524,9 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {}
+          "EncodingType": {
+            "shape": "S92"
+          }
         }
       },
       "alias": "GetBucket"
@@ -2445,6 +2551,7 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
+            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2471,6 +2578,7 @@
             "locationName": "start-after"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2494,7 +2602,9 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {},
+          "EncodingType": {
+            "shape": "S92"
+          },
           "KeyCount": {
             "type": "integer"
           },
@@ -2522,6 +2632,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -2540,6 +2651,7 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2558,7 +2670,9 @@
             "locationName": "x-amz-abort-rule-id"
           },
           "Bucket": {},
-          "Key": {},
+          "Key": {
+            "shape": "S3"
+          },
           "UploadId": {},
           "PartNumberMarker": {
             "type": "integer"
@@ -2598,8 +2712,11 @@
           "Owner": {
             "shape": "S2v"
           },
-          "StorageClass": {},
+          "StorageClass": {
+            "shape": "S16"
+          },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -2629,7 +2746,9 @@
             },
             "type": "structure",
             "members": {
-              "Status": {}
+              "Status": {
+                "shape": "S2s"
+              }
             }
           }
         },
@@ -2648,6 +2767,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "S1k",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3118,7 +3238,9 @@
               "Payer"
             ],
             "members": {
-              "Payer": {}
+              "Payer": {
+                "shape": "S71"
+              }
             }
           }
         },
@@ -3188,9 +3310,16 @@
             "type": "structure",
             "members": {
               "MFADelete": {
-                "locationName": "MfaDelete"
+                "locationName": "MfaDelete",
+                "type": "string",
+                "enum": [
+                  "Enabled",
+                  "Disabled"
+                ]
               },
-              "Status": {}
+              "Status": {
+                "shape": "S76"
+              }
             }
           }
         },
@@ -3255,6 +3384,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3317,6 +3447,7 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3326,10 +3457,12 @@
             "locationName": "x-amz-meta-"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
+            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -3356,6 +3489,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -3378,6 +3512,7 @@
             "locationName": "ETag"
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -3399,6 +3534,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -3418,6 +3554,7 @@
         ],
         "members": {
           "ACL": {
+            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3457,10 +3594,12 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -3475,6 +3614,7 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -3499,6 +3639,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3546,6 +3687,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3569,11 +3711,20 @@
                   "Tier"
                 ],
                 "members": {
-                  "Tier": {}
+                  "Tier": {
+                    "shape": "Sbe"
+                  }
                 }
               },
-              "Type": {},
-              "Tier": {},
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "SELECT"
+                ]
+              },
+              "Tier": {
+                "shape": "Sbe"
+              },
               "Description": {},
               "SelectParameters": {
                 "type": "structure",
@@ -3587,7 +3738,9 @@
                   "InputSerialization": {
                     "shape": "Sbi"
                   },
-                  "ExpressionType": {},
+                  "ExpressionType": {
+                    "shape": "Sbv"
+                  },
                   "Expression": {},
                   "OutputSerialization": {
                     "shape": "Sbx"
@@ -3612,14 +3765,18 @@
                           "EncryptionType"
                         ],
                         "members": {
-                          "EncryptionType": {},
+                          "EncryptionType": {
+                            "shape": "Sh"
+                          },
                           "KMSKeyId": {
                             "shape": "Sj"
                           },
                           "KMSContext": {}
                         }
                       },
-                      "CannedACL": {},
+                      "CannedACL": {
+                        "shape": "Sl"
+                      },
                       "AccessControlList": {
                         "shape": "S2y"
                       },
@@ -3637,7 +3794,9 @@
                           }
                         }
                       },
-                      "StorageClass": {}
+                      "StorageClass": {
+                        "shape": "S16"
+                      }
                     }
                   }
                 }
@@ -3645,6 +3804,7 @@
             }
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -3655,6 +3815,7 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
@@ -3690,6 +3851,7 @@
             "locationName": "Bucket"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3707,7 +3869,9 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "Expression": {},
-          "ExpressionType": {},
+          "ExpressionType": {
+            "shape": "Sbv"
+          },
           "RequestProgress": {
             "type": "structure",
             "members": {
@@ -3831,6 +3995,7 @@
             "locationName": "Content-MD5"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3857,6 +4022,7 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -3867,6 +4033,7 @@
         "type": "structure",
         "members": {
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -3888,6 +4055,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -3914,6 +4082,7 @@
             "locationName": "Bucket"
           },
           "CopySource": {
+            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-copy-source"
           },
@@ -3940,6 +4109,7 @@
             "locationName": "x-amz-copy-source-range"
           },
           "Key": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3979,6 +4149,7 @@
             "locationName": "x-amz-copy-source-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
+            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -4001,6 +4172,7 @@
             }
           },
           "ServerSideEncryption": {
+            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -4018,6 +4190,7 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
+            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -4027,14 +4200,62 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "min": 1
+    },
+    "S5": {
+      "type": "string",
+      "enum": [
+        "requester"
+      ]
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "requester"
+      ]
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "AES256",
+        "aws:kms"
+      ]
+    },
     "Sj": {
       "type": "string",
       "sensitive": true
+    },
+    "Sl": {
+      "type": "string",
+      "enum": [
+        "private",
+        "public-read",
+        "public-read-write",
+        "authenticated-read",
+        "aws-exec-read",
+        "bucket-owner-read",
+        "bucket-owner-full-control"
+      ]
+    },
+    "Sr": {
+      "type": "string",
+      "pattern": "\\/.+\\/.+"
     },
     "S11": {
       "type": "map",
       "key": {},
       "value": {}
+    },
+    "S16": {
+      "type": "string",
+      "enum": [
+        "STANDARD",
+        "REDUCED_REDUNDANCY",
+        "STANDARD_IA",
+        "ONEZONE_IA"
+      ]
     },
     "S19": {
       "type": "blob",
@@ -4043,6 +4264,38 @@
     "S1c": {
       "type": "blob",
       "sensitive": true
+    },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "private",
+        "public-read",
+        "public-read-write",
+        "authenticated-read"
+      ]
+    },
+    "S1m": {
+      "type": "string",
+      "enum": [
+        "EU",
+        "eu-west-1",
+        "us-west-1",
+        "us-west-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ap-northeast-1",
+        "sa-east-1",
+        "cn-north-1",
+        "eu-central-1"
+      ]
+    },
+    "S2s": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Suspended"
+      ]
     },
     "S2v": {
       "type": "structure",
@@ -4060,7 +4313,16 @@
           "Grantee": {
             "shape": "S30"
           },
-          "Permission": {}
+          "Permission": {
+            "type": "string",
+            "enum": [
+              "FULL_CONTROL",
+              "WRITE",
+              "WRITE_ACP",
+              "READ",
+              "READ_ACP"
+            ]
+          }
         }
       }
     },
@@ -4075,7 +4337,13 @@
         "ID": {},
         "Type": {
           "locationName": "xsi:type",
-          "xmlAttribute": true
+          "xmlAttribute": true,
+          "type": "string",
+          "enum": [
+            "CanonicalUser",
+            "AmazonCustomerByEmail",
+            "Group"
+          ]
         },
         "URI": {}
       },
@@ -4122,7 +4390,12 @@
                 "Destination"
               ],
               "members": {
-                "OutputSchemaVersion": {},
+                "OutputSchemaVersion": {
+                  "type": "string",
+                  "enum": [
+                    "V_1"
+                  ]
+                },
                 "Destination": {
                   "type": "structure",
                   "required": [
@@ -4136,7 +4409,12 @@
                         "Bucket"
                       ],
                       "members": {
-                        "Format": {},
+                        "Format": {
+                          "type": "string",
+                          "enum": [
+                            "CSV"
+                          ]
+                        },
                         "BucketAccountId": {},
                         "Bucket": {},
                         "Prefix": {}
@@ -4157,7 +4435,9 @@
         "Value"
       ],
       "members": {
-        "Key": {},
+        "Key": {
+          "shape": "S3"
+        },
         "Value": {}
       }
     },
@@ -4226,7 +4506,9 @@
                   "SSEAlgorithm"
                 ],
                 "members": {
-                  "SSEAlgorithm": {},
+                  "SSEAlgorithm": {
+                    "shape": "Sh"
+                  },
                   "KMSMasterKeyID": {
                     "shape": "Sj"
                   }
@@ -4263,7 +4545,13 @@
               "members": {
                 "AccountId": {},
                 "Bucket": {},
-                "Format": {},
+                "Format": {
+                  "type": "string",
+                  "enum": [
+                    "CSV",
+                    "ORC"
+                  ]
+                },
                 "Prefix": {},
                 "Encryption": {
                   "type": "structure",
@@ -4304,11 +4592,27 @@
           }
         },
         "Id": {},
-        "IncludedObjectVersions": {},
+        "IncludedObjectVersions": {
+          "type": "string",
+          "enum": [
+            "All",
+            "Current"
+          ]
+        },
         "OptionalFields": {
           "type": "list",
           "member": {
-            "locationName": "Field"
+            "locationName": "Field",
+            "type": "string",
+            "enum": [
+              "Size",
+              "LastModifiedDate",
+              "StorageClass",
+              "ETag",
+              "IsMultipartUploaded",
+              "ReplicationStatus",
+              "EncryptionStatus"
+            ]
           }
         },
         "Schedule": {
@@ -4317,7 +4621,13 @@
             "Frequency"
           ],
           "members": {
-            "Frequency": {}
+            "Frequency": {
+              "type": "string",
+              "enum": [
+                "Daily",
+                "Weekly"
+              ]
+            }
           }
         }
       }
@@ -4336,7 +4646,9 @@
           },
           "ID": {},
           "Prefix": {},
-          "Status": {},
+          "Status": {
+            "shape": "S4s"
+          },
           "Transition": {
             "shape": "S4t"
           },
@@ -4371,6 +4683,13 @@
       "type": "timestamp",
       "timestampFormat": "iso8601"
     },
+    "S4s": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ]
+    },
     "S4t": {
       "type": "structure",
       "members": {
@@ -4380,8 +4699,18 @@
         "Days": {
           "type": "integer"
         },
-        "StorageClass": {}
+        "StorageClass": {
+          "shape": "S4u"
+        }
       }
+    },
+    "S4u": {
+      "type": "string",
+      "enum": [
+        "GLACIER",
+        "STANDARD_IA",
+        "ONEZONE_IA"
+      ]
     },
     "S4v": {
       "type": "structure",
@@ -4389,7 +4718,9 @@
         "NoncurrentDays": {
           "type": "integer"
         },
-        "StorageClass": {}
+        "StorageClass": {
+          "shape": "S4u"
+        }
       }
     },
     "S4w": {
@@ -4443,7 +4774,9 @@
               }
             }
           },
-          "Status": {},
+          "Status": {
+            "shape": "S4s"
+          },
           "Transitions": {
             "locationName": "Transition",
             "type": "list",
@@ -4487,7 +4820,14 @@
               "Grantee": {
                 "shape": "S30"
               },
-              "Permission": {}
+              "Permission": {
+                "type": "string",
+                "enum": [
+                  "FULL_CONTROL",
+                  "READ",
+                  "WRITE"
+                ]
+              }
             }
           }
         },
@@ -4547,6 +4887,7 @@
               "locationName": "Event"
             },
             "Event": {
+              "shape": "S5r",
               "deprecated": true
             },
             "Topic": {}
@@ -4557,6 +4898,7 @@
           "members": {
             "Id": {},
             "Event": {
+              "shape": "S5r",
               "deprecated": true
             },
             "Events": {
@@ -4571,6 +4913,7 @@
           "members": {
             "Id": {},
             "Event": {
+              "shape": "S5r",
               "deprecated": true
             },
             "Events": {
@@ -4585,8 +4928,24 @@
     },
     "S5q": {
       "type": "list",
-      "member": {},
+      "member": {
+        "shape": "S5r"
+      },
       "flattened": true
+    },
+    "S5r": {
+      "type": "string",
+      "enum": [
+        "s3:ReducedRedundancyLostObject",
+        "s3:ObjectCreated:*",
+        "s3:ObjectCreated:Put",
+        "s3:ObjectCreated:Post",
+        "s3:ObjectCreated:Copy",
+        "s3:ObjectCreated:CompleteMultipartUpload",
+        "s3:ObjectRemoved:*",
+        "s3:ObjectRemoved:Delete",
+        "s3:ObjectRemoved:DeleteMarkerCreated"
+      ]
     },
     "S5y": {
       "type": "structure",
@@ -4681,7 +5040,13 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "Name": {},
+                  "Name": {
+                    "type": "string",
+                    "enum": [
+                      "prefix",
+                      "suffix"
+                    ]
+                  },
                   "Value": {}
                 }
               },
@@ -4736,7 +5101,13 @@
                   }
                 }
               },
-              "Status": {},
+              "Status": {
+                "type": "string",
+                "enum": [
+                  "Enabled",
+                  "Disabled"
+                ]
+              },
               "SourceSelectionCriteria": {
                 "type": "structure",
                 "members": {
@@ -4746,7 +5117,13 @@
                       "Status"
                     ],
                     "members": {
-                      "Status": {}
+                      "Status": {
+                        "type": "string",
+                        "enum": [
+                          "Enabled",
+                          "Disabled"
+                        ]
+                      }
                     }
                   }
                 }
@@ -4759,14 +5136,21 @@
                 "members": {
                   "Bucket": {},
                   "Account": {},
-                  "StorageClass": {},
+                  "StorageClass": {
+                    "shape": "S16"
+                  },
                   "AccessControlTranslation": {
                     "type": "structure",
                     "required": [
                       "Owner"
                     ],
                     "members": {
-                      "Owner": {}
+                      "Owner": {
+                        "type": "string",
+                        "enum": [
+                          "Destination"
+                        ]
+                      }
                     }
                   },
                   "EncryptionConfiguration": {
@@ -4780,7 +5164,13 @@
               "DeleteMarkerReplication": {
                 "type": "structure",
                 "members": {
-                  "Status": {}
+                  "Status": {
+                    "type": "string",
+                    "enum": [
+                      "Enabled",
+                      "Disabled"
+                    ]
+                  }
                 }
               }
             }
@@ -4789,6 +5179,20 @@
         }
       }
     },
+    "S71": {
+      "type": "string",
+      "enum": [
+        "Requester",
+        "BucketOwner"
+      ]
+    },
+    "S76": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Suspended"
+      ]
+    },
     "S7a": {
       "type": "structure",
       "required": [
@@ -4796,8 +5200,17 @@
       ],
       "members": {
         "HostName": {},
-        "Protocol": {}
+        "Protocol": {
+          "shape": "S7c"
+        }
       }
+    },
+    "S7c": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ]
     },
     "S7d": {
       "type": "structure",
@@ -4814,7 +5227,9 @@
         "Key"
       ],
       "members": {
-        "Key": {}
+        "Key": {
+          "shape": "S3"
+        }
       }
     },
     "S7g": {
@@ -4838,13 +5253,30 @@
             "members": {
               "HostName": {},
               "HttpRedirectCode": {},
-              "Protocol": {},
+              "Protocol": {
+                "shape": "S7c"
+              },
               "ReplaceKeyPrefixWith": {},
               "ReplaceKeyWith": {}
             }
           }
         }
       }
+    },
+    "S88": {
+      "type": "string",
+      "enum": [
+        "COMPLETE",
+        "PENDING",
+        "FAILED",
+        "REPLICA"
+      ]
+    },
+    "S92": {
+      "type": "string",
+      "enum": [
+        "url"
+      ]
     },
     "S9c": {
       "type": "structure",
@@ -4868,7 +5300,9 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "shape": "S3"
+          },
           "LastModified": {
             "type": "timestamp"
           },
@@ -4876,7 +5310,16 @@
           "Size": {
             "type": "integer"
           },
-          "StorageClass": {},
+          "StorageClass": {
+            "type": "string",
+            "enum": [
+              "STANDARD",
+              "REDUCED_REDUNDANCY",
+              "GLACIER",
+              "STANDARD_IA",
+              "ONEZONE_IA"
+            ]
+          },
           "Owner": {
             "shape": "S2v"
           }
@@ -4907,13 +5350,28 @@
         }
       }
     },
+    "Sbe": {
+      "type": "string",
+      "enum": [
+        "Standard",
+        "Bulk",
+        "Expedited"
+      ]
+    },
     "Sbi": {
       "type": "structure",
       "members": {
         "CSV": {
           "type": "structure",
           "members": {
-            "FileHeaderInfo": {},
+            "FileHeaderInfo": {
+              "type": "string",
+              "enum": [
+                "USE",
+                "IGNORE",
+                "NONE"
+              ]
+            },
             "Comments": {},
             "QuoteEscapeCharacter": {},
             "RecordDelimiter": {},
@@ -4924,11 +5382,24 @@
             }
           }
         },
-        "CompressionType": {},
+        "CompressionType": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "GZIP",
+            "BZIP2"
+          ]
+        },
         "JSON": {
           "type": "structure",
           "members": {
-            "Type": {}
+            "Type": {
+              "type": "string",
+              "enum": [
+                "DOCUMENT",
+                "LINES"
+              ]
+            }
           }
         },
         "Parquet": {
@@ -4937,13 +5408,25 @@
         }
       }
     },
+    "Sbv": {
+      "type": "string",
+      "enum": [
+        "SQL"
+      ]
+    },
     "Sbx": {
       "type": "structure",
       "members": {
         "CSV": {
           "type": "structure",
           "members": {
-            "QuoteFields": {},
+            "QuoteFields": {
+              "type": "string",
+              "enum": [
+                "ALWAYS",
+                "ASNEEDED"
+              ]
+            },
             "QuoteEscapeCharacter": {},
             "RecordDelimiter": {},
             "FieldDelimiter": {},

--- a/apis/sagemaker-2017-07-24.min.json
+++ b/apis/sagemaker-2017-07-24.min.json
@@ -22,7 +22,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "S3"
           }
@@ -45,8 +47,12 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointName": {},
-          "EndpointConfigName": {},
+          "EndpointName": {
+            "shape": "S9"
+          },
+          "EndpointConfigName": {
+            "shape": "Sa"
+          },
           "Tags": {
             "shape": "S3"
           }
@@ -58,7 +64,9 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {}
+          "EndpointArn": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -70,14 +78,18 @@
           "ProductionVariants"
         ],
         "members": {
-          "EndpointConfigName": {},
+          "EndpointConfigName": {
+            "shape": "Sa"
+          },
           "ProductionVariants": {
             "shape": "Se"
           },
           "Tags": {
             "shape": "S3"
           },
-          "KmsKeyId": {}
+          "KmsKeyId": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -86,7 +98,9 @@
           "EndpointConfigArn"
         ],
         "members": {
-          "EndpointConfigArn": {}
+          "EndpointConfigArn": {
+            "shape": "Sn"
+          }
         }
       }
     },
@@ -99,7 +113,9 @@
           "TrainingJobDefinition"
         ],
         "members": {
-          "HyperParameterTuningJobName": {},
+          "HyperParameterTuningJobName": {
+            "shape": "Sp"
+          },
           "HyperParameterTuningJobConfig": {
             "shape": "Sq"
           },
@@ -117,7 +133,9 @@
           "HyperParameterTuningJobArn"
         ],
         "members": {
-          "HyperParameterTuningJobArn": {}
+          "HyperParameterTuningJobArn": {
+            "shape": "S25"
+          }
         }
       }
     },
@@ -130,11 +148,15 @@
           "ExecutionRoleArn"
         ],
         "members": {
-          "ModelName": {},
+          "ModelName": {
+            "shape": "Sh"
+          },
           "PrimaryContainer": {
             "shape": "S27"
           },
-          "ExecutionRoleArn": {},
+          "ExecutionRoleArn": {
+            "shape": "S1g"
+          },
           "Tags": {
             "shape": "S3"
           },
@@ -149,7 +171,9 @@
           "ModelArn"
         ],
         "members": {
-          "ModelArn": {}
+          "ModelArn": {
+            "shape": "S2f"
+          }
         }
       }
     },
@@ -162,25 +186,41 @@
           "RoleArn"
         ],
         "members": {
-          "NotebookInstanceName": {},
-          "InstanceType": {},
-          "SubnetId": {},
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          },
+          "InstanceType": {
+            "shape": "S2i"
+          },
+          "SubnetId": {
+            "shape": "S1w"
+          },
           "SecurityGroupIds": {
             "shape": "S2j"
           },
-          "RoleArn": {},
-          "KmsKeyId": {},
+          "RoleArn": {
+            "shape": "S1g"
+          },
+          "KmsKeyId": {
+            "shape": "Sl"
+          },
           "Tags": {
             "shape": "S3"
           },
-          "LifecycleConfigName": {},
-          "DirectInternetAccess": {}
+          "LifecycleConfigName": {
+            "shape": "S2k"
+          },
+          "DirectInternetAccess": {
+            "shape": "S2l"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceArn": {}
+          "NotebookInstanceArn": {
+            "shape": "S2n"
+          }
         }
       }
     },
@@ -191,7 +231,9 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {},
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          },
           "OnCreate": {
             "shape": "S2p"
           },
@@ -203,7 +245,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceLifecycleConfigArn": {}
+          "NotebookInstanceLifecycleConfigArn": {
+            "shape": "S2t"
+          }
         }
       }
     },
@@ -214,9 +258,13 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {},
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          },
           "SessionExpirationDurationInSeconds": {
-            "type": "integer"
+            "type": "integer",
+            "max": 43200,
+            "min": 1800
           }
         }
       },
@@ -240,14 +288,18 @@
           "StoppingCondition"
         ],
         "members": {
-          "TrainingJobName": {},
+          "TrainingJobName": {
+            "shape": "S2z"
+          },
           "HyperParameters": {
             "shape": "S19"
           },
           "AlgorithmSpecification": {
             "shape": "S30"
           },
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S1g"
+          },
           "InputDataConfig": {
             "shape": "S1h"
           },
@@ -274,7 +326,9 @@
           "TrainingJobArn"
         ],
         "members": {
-          "TrainingJobArn": {}
+          "TrainingJobArn": {
+            "shape": "S32"
+          }
         }
       }
     },
@@ -289,15 +343,21 @@
           "TransformResources"
         ],
         "members": {
-          "TransformJobName": {},
-          "ModelName": {},
+          "TransformJobName": {
+            "shape": "S34"
+          },
+          "ModelName": {
+            "shape": "Sh"
+          },
           "MaxConcurrentTransforms": {
-            "type": "integer"
+            "shape": "S35"
           },
           "MaxPayloadInMB": {
-            "type": "integer"
+            "shape": "S36"
           },
-          "BatchStrategy": {},
+          "BatchStrategy": {
+            "shape": "S37"
+          },
           "Environment": {
             "shape": "S38"
           },
@@ -321,7 +381,9 @@
           "TransformJobArn"
         ],
         "members": {
-          "TransformJobArn": {}
+          "TransformJobArn": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -332,7 +394,9 @@
           "EndpointName"
         ],
         "members": {
-          "EndpointName": {}
+          "EndpointName": {
+            "shape": "S9"
+          }
         }
       }
     },
@@ -343,7 +407,9 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointConfigName": {}
+          "EndpointConfigName": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -354,7 +420,9 @@
           "ModelName"
         ],
         "members": {
-          "ModelName": {}
+          "ModelName": {
+            "shape": "Sh"
+          }
         }
       }
     },
@@ -365,7 +433,9 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {}
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          }
         }
       }
     },
@@ -376,7 +446,9 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {}
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          }
         }
       }
     },
@@ -388,10 +460,16 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {},
+          "ResourceArn": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S5"
+            },
+            "max": 50,
+            "min": 1
           }
         }
       },
@@ -407,7 +485,9 @@
           "EndpointName"
         ],
         "members": {
-          "EndpointName": {}
+          "EndpointName": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -421,9 +501,15 @@
           "LastModifiedTime"
         ],
         "members": {
-          "EndpointName": {},
-          "EndpointArn": {},
-          "EndpointConfigName": {},
+          "EndpointName": {
+            "shape": "S9"
+          },
+          "EndpointArn": {
+            "shape": "Sc"
+          },
+          "EndpointConfigName": {
+            "shape": "Sa"
+          },
           "ProductionVariants": {
             "type": "list",
             "member": {
@@ -432,14 +518,20 @@
                 "VariantName"
               ],
               "members": {
-                "VariantName": {},
+                "VariantName": {
+                  "shape": "Sg"
+                },
                 "DeployedImages": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "SpecifiedImage": {},
-                      "ResolvedImage": {},
+                      "SpecifiedImage": {
+                        "shape": "S29"
+                      },
+                      "ResolvedImage": {
+                        "shape": "S29"
+                      },
                       "ResolutionTime": {
                         "type": "timestamp"
                       }
@@ -447,22 +539,27 @@
                   }
                 },
                 "CurrentWeight": {
-                  "type": "float"
+                  "shape": "Sk"
                 },
                 "DesiredWeight": {
-                  "type": "float"
+                  "shape": "Sk"
                 },
                 "CurrentInstanceCount": {
-                  "type": "integer"
+                  "shape": "Si"
                 },
                 "DesiredInstanceCount": {
-                  "type": "integer"
+                  "shape": "Si"
                 }
               }
-            }
+            },
+            "min": 1
           },
-          "EndpointStatus": {},
-          "FailureReason": {},
+          "EndpointStatus": {
+            "shape": "S42"
+          },
+          "FailureReason": {
+            "shape": "S43"
+          },
           "CreationTime": {
             "type": "timestamp"
           },
@@ -479,7 +576,9 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointConfigName": {}
+          "EndpointConfigName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -491,12 +590,18 @@
           "CreationTime"
         ],
         "members": {
-          "EndpointConfigName": {},
-          "EndpointConfigArn": {},
+          "EndpointConfigName": {
+            "shape": "Sa"
+          },
+          "EndpointConfigArn": {
+            "shape": "Sn"
+          },
           "ProductionVariants": {
             "shape": "Se"
           },
-          "KmsKeyId": {},
+          "KmsKeyId": {
+            "shape": "Sl"
+          },
           "CreationTime": {
             "type": "timestamp"
           }
@@ -510,7 +615,9 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {}
+          "HyperParameterTuningJobName": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
@@ -526,15 +633,21 @@
           "ObjectiveStatusCounters"
         ],
         "members": {
-          "HyperParameterTuningJobName": {},
-          "HyperParameterTuningJobArn": {},
+          "HyperParameterTuningJobName": {
+            "shape": "Sp"
+          },
+          "HyperParameterTuningJobArn": {
+            "shape": "S25"
+          },
           "HyperParameterTuningJobConfig": {
             "shape": "Sq"
           },
           "TrainingJobDefinition": {
             "shape": "S18"
           },
-          "HyperParameterTuningJobStatus": {},
+          "HyperParameterTuningJobStatus": {
+            "shape": "S48"
+          },
           "CreationTime": {
             "type": "timestamp"
           },
@@ -553,7 +666,9 @@
           "BestTrainingJob": {
             "shape": "S4d"
           },
-          "FailureReason": {}
+          "FailureReason": {
+            "shape": "S43"
+          }
         }
       }
     },
@@ -564,7 +679,9 @@
           "ModelName"
         ],
         "members": {
-          "ModelName": {}
+          "ModelName": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -577,18 +694,24 @@
           "ModelArn"
         ],
         "members": {
-          "ModelName": {},
+          "ModelName": {
+            "shape": "Sh"
+          },
           "PrimaryContainer": {
             "shape": "S27"
           },
-          "ExecutionRoleArn": {},
+          "ExecutionRoleArn": {
+            "shape": "S1g"
+          },
           "VpcConfig": {
             "shape": "S1s"
           },
           "CreationTime": {
             "type": "timestamp"
           },
-          "ModelArn": {}
+          "ModelArn": {
+            "shape": "S2f"
+          }
         }
       }
     },
@@ -599,24 +722,42 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {}
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceArn": {},
-          "NotebookInstanceName": {},
-          "NotebookInstanceStatus": {},
-          "FailureReason": {},
+          "NotebookInstanceArn": {
+            "shape": "S2n"
+          },
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          },
+          "NotebookInstanceStatus": {
+            "shape": "S4m"
+          },
+          "FailureReason": {
+            "shape": "S43"
+          },
           "Url": {},
-          "InstanceType": {},
-          "SubnetId": {},
+          "InstanceType": {
+            "shape": "S2i"
+          },
+          "SubnetId": {
+            "shape": "S1w"
+          },
           "SecurityGroups": {
             "shape": "S2j"
           },
-          "RoleArn": {},
-          "KmsKeyId": {},
+          "RoleArn": {
+            "shape": "S1g"
+          },
+          "KmsKeyId": {
+            "shape": "Sl"
+          },
           "NetworkInterfaceId": {},
           "LastModifiedTime": {
             "type": "timestamp"
@@ -624,8 +765,12 @@
           "CreationTime": {
             "type": "timestamp"
           },
-          "NotebookInstanceLifecycleConfigName": {},
-          "DirectInternetAccess": {}
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          },
+          "DirectInternetAccess": {
+            "shape": "S2l"
+          }
         }
       }
     },
@@ -636,14 +781,20 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {}
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceLifecycleConfigArn": {},
-          "NotebookInstanceLifecycleConfigName": {},
+          "NotebookInstanceLifecycleConfigArn": {
+            "shape": "S2t"
+          },
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          },
           "OnCreate": {
             "shape": "S2p"
           },
@@ -666,7 +817,9 @@
           "TrainingJobName"
         ],
         "members": {
-          "TrainingJobName": {}
+          "TrainingJobName": {
+            "shape": "S2z"
+          }
         }
       },
       "output": {
@@ -684,28 +837,44 @@
           "CreationTime"
         ],
         "members": {
-          "TrainingJobName": {},
-          "TrainingJobArn": {},
-          "TuningJobArn": {},
+          "TrainingJobName": {
+            "shape": "S2z"
+          },
+          "TrainingJobArn": {
+            "shape": "S32"
+          },
+          "TuningJobArn": {
+            "shape": "S25"
+          },
           "ModelArtifacts": {
             "type": "structure",
             "required": [
               "S3ModelArtifacts"
             ],
             "members": {
-              "S3ModelArtifacts": {}
+              "S3ModelArtifacts": {
+                "shape": "S1n"
+              }
             }
           },
-          "TrainingJobStatus": {},
-          "SecondaryStatus": {},
-          "FailureReason": {},
+          "TrainingJobStatus": {
+            "shape": "S4e"
+          },
+          "SecondaryStatus": {
+            "shape": "S4v"
+          },
+          "FailureReason": {
+            "shape": "S43"
+          },
           "HyperParameters": {
             "shape": "S19"
           },
           "AlgorithmSpecification": {
             "shape": "S30"
           },
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S1g"
+          },
           "InputDataConfig": {
             "shape": "S1h"
           },
@@ -742,7 +911,9 @@
                 "StartTime"
               ],
               "members": {
-                "Status": {},
+                "Status": {
+                  "shape": "S4v"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -763,7 +934,9 @@
           "TransformJobName"
         ],
         "members": {
-          "TransformJobName": {}
+          "TransformJobName": {
+            "shape": "S34"
+          }
         }
       },
       "output": {
@@ -778,18 +951,30 @@
           "CreationTime"
         ],
         "members": {
-          "TransformJobName": {},
-          "TransformJobArn": {},
-          "TransformJobStatus": {},
-          "FailureReason": {},
-          "ModelName": {},
+          "TransformJobName": {
+            "shape": "S34"
+          },
+          "TransformJobArn": {
+            "shape": "S3m"
+          },
+          "TransformJobStatus": {
+            "shape": "S51"
+          },
+          "FailureReason": {
+            "shape": "S43"
+          },
+          "ModelName": {
+            "shape": "Sh"
+          },
           "MaxConcurrentTransforms": {
-            "type": "integer"
+            "shape": "S35"
           },
           "MaxPayloadInMB": {
-            "type": "integer"
+            "shape": "S36"
           },
-          "BatchStrategy": {},
+          "BatchStrategy": {
+            "shape": "S37"
+          },
           "Environment": {
             "shape": "S38"
           },
@@ -818,13 +1003,26 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {},
-          "SortOrder": {},
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime"
+            ]
           },
-          "NameContains": {},
+          "SortOrder": {
+            "shape": "S54"
+          },
+          "NextToken": {
+            "shape": "S55"
+          },
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "NameContains": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9-]+"
+          },
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -849,15 +1047,21 @@
                 "CreationTime"
               ],
               "members": {
-                "EndpointConfigName": {},
-                "EndpointConfigArn": {},
+                "EndpointConfigName": {
+                  "shape": "Sa"
+                },
+                "EndpointConfigArn": {
+                  "shape": "Sn"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S55"
+          }
         }
       }
     },
@@ -865,13 +1069,27 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {},
-          "SortOrder": {},
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime",
+              "Status"
+            ]
           },
-          "NameContains": {},
+          "SortOrder": {
+            "shape": "S54"
+          },
+          "NextToken": {
+            "shape": "S55"
+          },
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "NameContains": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9-]+"
+          },
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -884,7 +1102,9 @@
           "LastModifiedTimeAfter": {
             "type": "timestamp"
           },
-          "StatusEquals": {}
+          "StatusEquals": {
+            "shape": "S42"
+          }
         }
       },
       "output": {
@@ -905,19 +1125,27 @@
                 "EndpointStatus"
               ],
               "members": {
-                "EndpointName": {},
-                "EndpointArn": {},
+                "EndpointName": {
+                  "shape": "S9"
+                },
+                "EndpointArn": {
+                  "shape": "Sc"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "EndpointStatus": {}
+                "EndpointStatus": {
+                  "shape": "S42"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S55"
+          }
         }
       }
     },
@@ -925,13 +1153,26 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "S5i"
           },
-          "SortBy": {},
-          "SortOrder": {},
-          "NameContains": {},
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "Status",
+              "CreationTime"
+            ]
+          },
+          "SortOrder": {
+            "shape": "S5k"
+          },
+          "NameContains": {
+            "shape": "S5l"
+          },
           "CreationTimeAfter": {
             "type": "timestamp"
           },
@@ -944,7 +1185,9 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "StatusEquals": {}
+          "StatusEquals": {
+            "shape": "S48"
+          }
         }
       },
       "output": {
@@ -967,10 +1210,18 @@
                 "ObjectiveStatusCounters"
               ],
               "members": {
-                "HyperParameterTuningJobName": {},
-                "HyperParameterTuningJobArn": {},
-                "HyperParameterTuningJobStatus": {},
-                "Strategy": {},
+                "HyperParameterTuningJobName": {
+                  "shape": "Sp"
+                },
+                "HyperParameterTuningJobArn": {
+                  "shape": "S25"
+                },
+                "HyperParameterTuningJobStatus": {
+                  "shape": "S48"
+                },
+                "Strategy": {
+                  "shape": "Sr"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -992,7 +1243,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5i"
+          }
         }
       }
     },
@@ -1000,13 +1253,26 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {},
-          "SortOrder": {},
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime"
+            ]
           },
-          "NameContains": {},
+          "SortOrder": {
+            "shape": "S54"
+          },
+          "NextToken": {
+            "shape": "S55"
+          },
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "NameContains": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9-]+"
+          },
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1031,15 +1297,21 @@
                 "CreationTime"
               ],
               "members": {
-                "ModelName": {},
-                "ModelArn": {},
+                "ModelName": {
+                  "shape": "Sh"
+                },
+                "ModelArn": {
+                  "shape": "S2f"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S55"
+          }
         }
       }
     },
@@ -1047,13 +1319,31 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "S5i"
           },
-          "SortBy": {},
-          "SortOrder": {},
-          "NameContains": {},
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime",
+              "LastModifiedTime"
+            ]
+          },
+          "SortOrder": {
+            "type": "string",
+            "enum": [
+              "Ascending",
+              "Descending"
+            ]
+          },
+          "NameContains": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9-]+"
+          },
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1071,7 +1361,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S5i"
+          },
           "NotebookInstanceLifecycleConfigs": {
             "type": "list",
             "member": {
@@ -1081,8 +1373,12 @@
                 "NotebookInstanceLifecycleConfigArn"
               ],
               "members": {
-                "NotebookInstanceLifecycleConfigName": {},
-                "NotebookInstanceLifecycleConfigArn": {},
+                "NotebookInstanceLifecycleConfigName": {
+                  "shape": "S2k"
+                },
+                "NotebookInstanceLifecycleConfigArn": {
+                  "shape": "S2t"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1099,13 +1395,31 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "S5i"
           },
-          "SortBy": {},
-          "SortOrder": {},
-          "NameContains": {},
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime",
+              "Status"
+            ]
+          },
+          "SortOrder": {
+            "type": "string",
+            "enum": [
+              "Ascending",
+              "Descending"
+            ]
+          },
+          "NameContains": {
+            "type": "string",
+            "pattern": "[a-zA-Z0-9-]+"
+          },
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1118,14 +1432,20 @@
           "LastModifiedTimeAfter": {
             "type": "timestamp"
           },
-          "StatusEquals": {},
-          "NotebookInstanceLifecycleConfigNameContains": {}
+          "StatusEquals": {
+            "shape": "S4m"
+          },
+          "NotebookInstanceLifecycleConfigNameContains": {
+            "shape": "S2k"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S5i"
+          },
           "NotebookInstances": {
             "type": "list",
             "member": {
@@ -1135,18 +1455,28 @@
                 "NotebookInstanceArn"
               ],
               "members": {
-                "NotebookInstanceName": {},
-                "NotebookInstanceArn": {},
-                "NotebookInstanceStatus": {},
+                "NotebookInstanceName": {
+                  "shape": "S2h"
+                },
+                "NotebookInstanceArn": {
+                  "shape": "S2n"
+                },
+                "NotebookInstanceStatus": {
+                  "shape": "S4m"
+                },
                 "Url": {},
-                "InstanceType": {},
+                "InstanceType": {
+                  "shape": "S2i"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "NotebookInstanceLifecycleConfigName": {}
+                "NotebookInstanceLifecycleConfigName": {
+                  "shape": "S2k"
+                }
               }
             }
           }
@@ -1160,10 +1490,15 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {},
-          "NextToken": {},
+          "ResourceArn": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S5i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "min": 50
           }
         }
       },
@@ -1173,7 +1508,9 @@
           "Tags": {
             "shape": "S3"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5i"
+          }
         }
       }
     },
@@ -1181,9 +1518,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S5i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S56"
           },
           "CreationTimeAfter": {
             "type": "timestamp"
@@ -1197,10 +1536,18 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "NameContains": {},
-          "StatusEquals": {},
-          "SortBy": {},
-          "SortOrder": {}
+          "NameContains": {
+            "shape": "S5l"
+          },
+          "StatusEquals": {
+            "shape": "S4e"
+          },
+          "SortBy": {
+            "shape": "S6d"
+          },
+          "SortOrder": {
+            "shape": "S5k"
+          }
         }
       },
       "output": {
@@ -1220,8 +1567,12 @@
                 "TrainingJobStatus"
               ],
               "members": {
-                "TrainingJobName": {},
-                "TrainingJobArn": {},
+                "TrainingJobName": {
+                  "shape": "S2z"
+                },
+                "TrainingJobArn": {
+                  "shape": "S32"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1231,11 +1582,15 @@
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "TrainingJobStatus": {}
+                "TrainingJobStatus": {
+                  "shape": "S4e"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5i"
+          }
         }
       }
     },
@@ -1246,14 +1601,30 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {},
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "HyperParameterTuningJobName": {
+            "shape": "Sp"
           },
-          "StatusEquals": {},
-          "SortBy": {},
-          "SortOrder": {}
+          "NextToken": {
+            "shape": "S5i"
+          },
+          "MaxResults": {
+            "shape": "S56"
+          },
+          "StatusEquals": {
+            "shape": "S4e"
+          },
+          "SortBy": {
+            "type": "string",
+            "enum": [
+              "Name",
+              "CreationTime",
+              "Status",
+              "FinalObjectiveMetricValue"
+            ]
+          },
+          "SortOrder": {
+            "shape": "S5k"
+          }
         }
       },
       "output": {
@@ -1268,7 +1639,9 @@
               "shape": "S4d"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5i"
+          }
         }
       }
     },
@@ -1288,13 +1661,23 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "NameContains": {},
-          "StatusEquals": {},
-          "SortBy": {},
-          "SortOrder": {},
-          "NextToken": {},
+          "NameContains": {
+            "shape": "S5l"
+          },
+          "StatusEquals": {
+            "shape": "S51"
+          },
+          "SortBy": {
+            "shape": "S6d"
+          },
+          "SortOrder": {
+            "shape": "S5k"
+          },
+          "NextToken": {
+            "shape": "S5i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S56"
           }
         }
       },
@@ -1315,8 +1698,12 @@
                 "TransformJobStatus"
               ],
               "members": {
-                "TransformJobName": {},
-                "TransformJobArn": {},
+                "TransformJobName": {
+                  "shape": "S34"
+                },
+                "TransformJobArn": {
+                  "shape": "S3m"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1326,12 +1713,18 @@
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "TransformJobStatus": {},
-                "FailureReason": {}
+                "TransformJobStatus": {
+                  "shape": "S51"
+                },
+                "FailureReason": {
+                  "shape": "S43"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S5i"
+          }
         }
       }
     },
@@ -1342,7 +1735,9 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {}
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          }
         }
       }
     },
@@ -1353,7 +1748,9 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {}
+          "HyperParameterTuningJobName": {
+            "shape": "Sp"
+          }
         }
       }
     },
@@ -1364,7 +1761,9 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {}
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          }
         }
       }
     },
@@ -1375,7 +1774,9 @@
           "TrainingJobName"
         ],
         "members": {
-          "TrainingJobName": {}
+          "TrainingJobName": {
+            "shape": "S2z"
+          }
         }
       }
     },
@@ -1386,7 +1787,9 @@
           "TransformJobName"
         ],
         "members": {
-          "TransformJobName": {}
+          "TransformJobName": {
+            "shape": "S34"
+          }
         }
       }
     },
@@ -1398,8 +1801,12 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointName": {},
-          "EndpointConfigName": {}
+          "EndpointName": {
+            "shape": "S9"
+          },
+          "EndpointConfigName": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -1408,7 +1815,9 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {}
+          "EndpointArn": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -1420,7 +1829,9 @@
           "DesiredWeightsAndCapacities"
         ],
         "members": {
-          "EndpointName": {},
+          "EndpointName": {
+            "shape": "S9"
+          },
           "DesiredWeightsAndCapacities": {
             "type": "list",
             "member": {
@@ -1429,15 +1840,18 @@
                 "VariantName"
               ],
               "members": {
-                "VariantName": {},
+                "VariantName": {
+                  "shape": "Sg"
+                },
                 "DesiredWeight": {
-                  "type": "float"
+                  "shape": "Sk"
                 },
                 "DesiredInstanceCount": {
-                  "type": "integer"
+                  "shape": "Si"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
@@ -1447,7 +1861,9 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {}
+          "EndpointArn": {
+            "shape": "Sc"
+          }
         }
       }
     },
@@ -1458,10 +1874,18 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {},
-          "InstanceType": {},
-          "RoleArn": {},
-          "LifecycleConfigName": {},
+          "NotebookInstanceName": {
+            "shape": "S2h"
+          },
+          "InstanceType": {
+            "shape": "S2i"
+          },
+          "RoleArn": {
+            "shape": "S1g"
+          },
+          "LifecycleConfigName": {
+            "shape": "S2k"
+          },
           "DisassociateLifecycleConfig": {
             "type": "boolean"
           }
@@ -1479,7 +1903,9 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {},
+          "NotebookInstanceLifecycleConfigName": {
+            "shape": "S2k"
+          },
           "OnCreate": {
             "shape": "S2p"
           },
@@ -1495,6 +1921,10 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 256
+    },
     "S3": {
       "type": "list",
       "member": {
@@ -1504,10 +1934,40 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S5"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
-      }
+      },
+      "max": 50,
+      "min": 0
+    },
+    "S5": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^((?!aws:)[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "S9": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "Sc": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
     },
     "Se": {
       "type": "list",
@@ -1520,17 +1980,91 @@
           "InstanceType"
         ],
         "members": {
-          "VariantName": {},
-          "ModelName": {},
-          "InitialInstanceCount": {
-            "type": "integer"
+          "VariantName": {
+            "shape": "Sg"
           },
-          "InstanceType": {},
+          "ModelName": {
+            "shape": "Sh"
+          },
+          "InitialInstanceCount": {
+            "shape": "Si"
+          },
+          "InstanceType": {
+            "type": "string",
+            "enum": [
+              "ml.t2.medium",
+              "ml.t2.large",
+              "ml.t2.xlarge",
+              "ml.t2.2xlarge",
+              "ml.m4.xlarge",
+              "ml.m4.2xlarge",
+              "ml.m4.4xlarge",
+              "ml.m4.10xlarge",
+              "ml.m4.16xlarge",
+              "ml.m5.large",
+              "ml.m5.xlarge",
+              "ml.m5.2xlarge",
+              "ml.m5.4xlarge",
+              "ml.m5.12xlarge",
+              "ml.m5.24xlarge",
+              "ml.c4.large",
+              "ml.c4.xlarge",
+              "ml.c4.2xlarge",
+              "ml.c4.4xlarge",
+              "ml.c4.8xlarge",
+              "ml.p2.xlarge",
+              "ml.p2.8xlarge",
+              "ml.p2.16xlarge",
+              "ml.p3.2xlarge",
+              "ml.p3.8xlarge",
+              "ml.p3.16xlarge",
+              "ml.c5.large",
+              "ml.c5.xlarge",
+              "ml.c5.2xlarge",
+              "ml.c5.4xlarge",
+              "ml.c5.9xlarge",
+              "ml.c5.18xlarge"
+            ]
+          },
           "InitialVariantWeight": {
-            "type": "float"
+            "shape": "Sk"
           }
         }
-      }
+      },
+      "min": 1
+    },
+    "Sg": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "Sh": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "Si": {
+      "type": "integer",
+      "min": 1
+    },
+    "Sk": {
+      "type": "float",
+      "min": 0
+    },
+    "Sl": {
+      "type": "string",
+      "max": 2048
+    },
+    "Sn": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "Sp": {
+      "type": "string",
+      "max": 32,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
     },
     "Sq": {
       "type": "structure",
@@ -1541,7 +2075,9 @@
         "ParameterRanges"
       ],
       "members": {
-        "Strategy": {},
+        "Strategy": {
+          "shape": "Sr"
+        },
         "HyperParameterTuningJobObjective": {
           "type": "structure",
           "required": [
@@ -1549,8 +2085,12 @@
             "MetricName"
           ],
           "members": {
-            "Type": {},
-            "MetricName": {}
+            "Type": {
+              "shape": "St"
+            },
+            "MetricName": {
+              "shape": "Su"
+            }
           }
         },
         "ResourceLimits": {
@@ -1569,11 +2109,19 @@
                   "MaxValue"
                 ],
                 "members": {
-                  "Name": {},
-                  "MinValue": {},
-                  "MaxValue": {}
+                  "Name": {
+                    "shape": "S11"
+                  },
+                  "MinValue": {
+                    "shape": "S12"
+                  },
+                  "MaxValue": {
+                    "shape": "S12"
+                  }
                 }
-              }
+              },
+              "max": 20,
+              "min": 0
             },
             "ContinuousParameterRanges": {
               "type": "list",
@@ -1585,11 +2133,19 @@
                   "MaxValue"
                 ],
                 "members": {
-                  "Name": {},
-                  "MinValue": {},
-                  "MaxValue": {}
+                  "Name": {
+                    "shape": "S11"
+                  },
+                  "MinValue": {
+                    "shape": "S12"
+                  },
+                  "MaxValue": {
+                    "shape": "S12"
+                  }
                 }
-              }
+              },
+              "max": 20,
+              "min": 0
             },
             "CategoricalParameterRanges": {
               "type": "list",
@@ -1600,17 +2156,43 @@
                   "Values"
                 ],
                 "members": {
-                  "Name": {},
+                  "Name": {
+                    "shape": "S11"
+                  },
                   "Values": {
                     "type": "list",
-                    "member": {}
+                    "member": {
+                      "shape": "S12"
+                    },
+                    "max": 20,
+                    "min": 1
                   }
                 }
-              }
+              },
+              "max": 20,
+              "min": 0
             }
           }
         }
       }
+    },
+    "Sr": {
+      "type": "string",
+      "enum": [
+        "Bayesian"
+      ]
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "Maximize",
+        "Minimize"
+      ]
+    },
+    "Su": {
+      "type": "string",
+      "max": 255,
+      "min": 1
     },
     "Sv": {
       "type": "structure",
@@ -1620,12 +2202,22 @@
       ],
       "members": {
         "MaxNumberOfTrainingJobs": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "MaxParallelTrainingJobs": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         }
       }
+    },
+    "S11": {
+      "type": "string",
+      "max": 256
+    },
+    "S12": {
+      "type": "string",
+      "max": 256
     },
     "S18": {
       "type": "structure",
@@ -1648,8 +2240,12 @@
             "TrainingInputMode"
           ],
           "members": {
-            "TrainingImage": {},
-            "TrainingInputMode": {},
+            "TrainingImage": {
+              "shape": "S1b"
+            },
+            "TrainingInputMode": {
+              "shape": "S1c"
+            },
             "MetricDefinitions": {
               "type": "list",
               "member": {
@@ -1659,14 +2255,24 @@
                   "Regex"
                 ],
                 "members": {
-                  "Name": {},
-                  "Regex": {}
+                  "Name": {
+                    "shape": "Su"
+                  },
+                  "Regex": {
+                    "type": "string",
+                    "max": 500,
+                    "min": 1
+                  }
                 }
-              }
+              },
+              "max": 20,
+              "min": 0
             }
           }
         },
-        "RoleArn": {},
+        "RoleArn": {
+          "shape": "S1g"
+        },
         "InputDataConfig": {
           "shape": "S1h"
         },
@@ -1686,8 +2292,31 @@
     },
     "S19": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S11"
+      },
+      "value": {
+        "shape": "S12"
+      },
+      "max": 100,
+      "min": 0
+    },
+    "S1b": {
+      "type": "string",
+      "max": 255
+    },
+    "S1c": {
+      "type": "string",
+      "enum": [
+        "Pipe",
+        "File"
+      ]
+    },
+    "S1g": {
+      "type": "string",
+      "max": 2048,
+      "min": 20,
+      "pattern": "^arn:aws[a-z\\-]*:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
     },
     "S1h": {
       "type": "list",
@@ -1698,7 +2327,12 @@
           "DataSource"
         ],
         "members": {
-          "ChannelName": {},
+          "ChannelName": {
+            "type": "string",
+            "max": 64,
+            "min": 1,
+            "pattern": "[A-Za-z0-9\\.\\-_]+"
+          },
           "DataSource": {
             "type": "structure",
             "required": [
@@ -1712,18 +2346,63 @@
                   "S3Uri"
                 ],
                 "members": {
-                  "S3DataType": {},
-                  "S3Uri": {},
-                  "S3DataDistributionType": {}
+                  "S3DataType": {
+                    "shape": "S1m"
+                  },
+                  "S3Uri": {
+                    "shape": "S1n"
+                  },
+                  "S3DataDistributionType": {
+                    "type": "string",
+                    "enum": [
+                      "FullyReplicated",
+                      "ShardedByS3Key"
+                    ]
+                  }
                 }
               }
             }
           },
-          "ContentType": {},
-          "CompressionType": {},
-          "RecordWrapperType": {}
+          "ContentType": {
+            "shape": "S1p"
+          },
+          "CompressionType": {
+            "shape": "S1q"
+          },
+          "RecordWrapperType": {
+            "type": "string",
+            "enum": [
+              "None",
+              "RecordIO"
+            ]
+          }
         }
-      }
+      },
+      "max": 8,
+      "min": 1
+    },
+    "S1m": {
+      "type": "string",
+      "enum": [
+        "ManifestFile",
+        "S3Prefix"
+      ]
+    },
+    "S1n": {
+      "type": "string",
+      "max": 1024,
+      "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+    },
+    "S1p": {
+      "type": "string",
+      "max": 256
+    },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Gzip"
+      ]
     },
     "S1s": {
       "type": "structure",
@@ -1734,13 +2413,29 @@
       "members": {
         "SecurityGroupIds": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S1u"
+          },
+          "max": 5,
+          "min": 1
         },
         "Subnets": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S1w"
+          },
+          "max": 16,
+          "min": 1
         }
       }
+    },
+    "S1u": {
+      "type": "string",
+      "max": 32
+    },
+    "S1w": {
+      "type": "string",
+      "max": 32
     },
     "S1x": {
       "type": "structure",
@@ -1748,8 +2443,12 @@
         "S3OutputPath"
       ],
       "members": {
-        "KmsKeyId": {},
-        "S3OutputPath": {}
+        "KmsKeyId": {
+          "shape": "Sl"
+        },
+        "S3OutputPath": {
+          "shape": "S1n"
+        }
       }
     },
     "S1y": {
@@ -1760,23 +2459,63 @@
         "VolumeSizeInGB"
       ],
       "members": {
-        "InstanceType": {},
+        "InstanceType": {
+          "type": "string",
+          "enum": [
+            "ml.m4.xlarge",
+            "ml.m4.2xlarge",
+            "ml.m4.4xlarge",
+            "ml.m4.10xlarge",
+            "ml.m4.16xlarge",
+            "ml.m5.large",
+            "ml.m5.xlarge",
+            "ml.m5.2xlarge",
+            "ml.m5.4xlarge",
+            "ml.m5.12xlarge",
+            "ml.m5.24xlarge",
+            "ml.c4.xlarge",
+            "ml.c4.2xlarge",
+            "ml.c4.4xlarge",
+            "ml.c4.8xlarge",
+            "ml.p2.xlarge",
+            "ml.p2.8xlarge",
+            "ml.p2.16xlarge",
+            "ml.p3.2xlarge",
+            "ml.p3.8xlarge",
+            "ml.p3.16xlarge",
+            "ml.c5.xlarge",
+            "ml.c5.2xlarge",
+            "ml.c5.4xlarge",
+            "ml.c5.9xlarge",
+            "ml.c5.18xlarge"
+          ]
+        },
         "InstanceCount": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "VolumeSizeInGB": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
-        "VolumeKmsKeyId": {}
+        "VolumeKmsKeyId": {
+          "shape": "Sl"
+        }
       }
     },
     "S22": {
       "type": "structure",
       "members": {
         "MaxRuntimeInSeconds": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         }
       }
+    },
+    "S25": {
+      "type": "string",
+      "max": 256,
+      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:hyper-parameter-tuning-job/.*"
     },
     "S27": {
       "type": "structure",
@@ -1784,28 +2523,115 @@
         "Image"
       ],
       "members": {
-        "ContainerHostname": {},
-        "Image": {},
-        "ModelDataUrl": {},
+        "ContainerHostname": {
+          "type": "string",
+          "max": 63,
+          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+        },
+        "Image": {
+          "shape": "S29"
+        },
+        "ModelDataUrl": {
+          "type": "string",
+          "max": 1024,
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        },
         "Environment": {
           "type": "map",
-          "key": {},
-          "value": {}
+          "key": {
+            "type": "string",
+            "max": 1024,
+            "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
+          },
+          "value": {
+            "type": "string",
+            "max": 1024
+          },
+          "max": 16
         }
       }
     },
+    "S29": {
+      "type": "string",
+      "max": 255,
+      "pattern": "[\\S]+"
+    },
+    "S2f": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S2h": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "S2i": {
+      "type": "string",
+      "enum": [
+        "ml.t2.medium",
+        "ml.t2.large",
+        "ml.t2.xlarge",
+        "ml.t2.2xlarge",
+        "ml.m4.xlarge",
+        "ml.m4.2xlarge",
+        "ml.m4.4xlarge",
+        "ml.m4.10xlarge",
+        "ml.m4.16xlarge",
+        "ml.p2.xlarge",
+        "ml.p2.8xlarge",
+        "ml.p2.16xlarge",
+        "ml.p3.2xlarge",
+        "ml.p3.8xlarge",
+        "ml.p3.16xlarge"
+      ]
+    },
     "S2j": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1u"
+      },
+      "max": 5
+    },
+    "S2k": {
+      "type": "string",
+      "max": 63,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "S2l": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ]
+    },
+    "S2n": {
+      "type": "string",
+      "max": 256
     },
     "S2p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Content": {}
+          "Content": {
+            "type": "string",
+            "max": 16384,
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 1
+    },
+    "S2t": {
+      "type": "string",
+      "max": 256
+    },
+    "S2z": {
+      "type": "string",
+      "max": 63,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
     },
     "S30": {
       "type": "structure",
@@ -1814,14 +2640,52 @@
         "TrainingInputMode"
       ],
       "members": {
-        "TrainingImage": {},
-        "TrainingInputMode": {}
+        "TrainingImage": {
+          "shape": "S1b"
+        },
+        "TrainingInputMode": {
+          "shape": "S1c"
+        }
       }
+    },
+    "S32": {
+      "type": "string",
+      "max": 256,
+      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:training-job/.*"
+    },
+    "S34": {
+      "type": "string",
+      "max": 63,
+      "min": 1,
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+    },
+    "S35": {
+      "type": "integer",
+      "min": 0
+    },
+    "S36": {
+      "type": "integer",
+      "min": 0
+    },
+    "S37": {
+      "type": "string",
+      "enum": [
+        "MultiRecord",
+        "SingleRecord"
+      ]
     },
     "S38": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 1024,
+        "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
+      },
+      "value": {
+        "type": "string",
+        "max": 10240
+      },
+      "max": 16
     },
     "S3b": {
       "type": "structure",
@@ -1842,15 +2706,30 @@
                 "S3Uri"
               ],
               "members": {
-                "S3DataType": {},
-                "S3Uri": {}
+                "S3DataType": {
+                  "shape": "S1m"
+                },
+                "S3Uri": {
+                  "shape": "S1n"
+                }
               }
             }
           }
         },
-        "ContentType": {},
-        "CompressionType": {},
-        "SplitType": {}
+        "ContentType": {
+          "shape": "S1p"
+        },
+        "CompressionType": {
+          "shape": "S1q"
+        },
+        "SplitType": {
+          "type": "string",
+          "enum": [
+            "None",
+            "Line",
+            "RecordIO"
+          ]
+        }
       }
     },
     "S3f": {
@@ -1859,10 +2738,23 @@
         "S3OutputPath"
       ],
       "members": {
-        "S3OutputPath": {},
-        "Accept": {},
-        "AssembleWith": {},
-        "KmsKeyId": {}
+        "S3OutputPath": {
+          "shape": "S1n"
+        },
+        "Accept": {
+          "type": "string",
+          "max": 256
+        },
+        "AssembleWith": {
+          "type": "string",
+          "enum": [
+            "None",
+            "Line"
+          ]
+        },
+        "KmsKeyId": {
+          "shape": "Sl"
+        }
       }
     },
     "S3i": {
@@ -1872,46 +2764,119 @@
         "InstanceCount"
       ],
       "members": {
-        "InstanceType": {},
-        "InstanceCount": {
-          "type": "integer"
+        "InstanceType": {
+          "type": "string",
+          "enum": [
+            "ml.m4.xlarge",
+            "ml.m4.2xlarge",
+            "ml.m4.4xlarge",
+            "ml.m4.10xlarge",
+            "ml.m4.16xlarge",
+            "ml.c4.xlarge",
+            "ml.c4.2xlarge",
+            "ml.c4.4xlarge",
+            "ml.c4.8xlarge",
+            "ml.p2.xlarge",
+            "ml.p2.8xlarge",
+            "ml.p2.16xlarge",
+            "ml.p3.2xlarge",
+            "ml.p3.8xlarge",
+            "ml.p3.16xlarge",
+            "ml.c5.xlarge",
+            "ml.c5.2xlarge",
+            "ml.c5.4xlarge",
+            "ml.c5.9xlarge",
+            "ml.c5.18xlarge",
+            "ml.m5.large",
+            "ml.m5.xlarge",
+            "ml.m5.2xlarge",
+            "ml.m5.4xlarge",
+            "ml.m5.12xlarge",
+            "ml.m5.24xlarge"
+          ]
         },
-        "VolumeKmsKeyId": {}
+        "InstanceCount": {
+          "type": "integer",
+          "min": 1
+        },
+        "VolumeKmsKeyId": {
+          "shape": "Sl"
+        }
       }
+    },
+    "S3m": {
+      "type": "string",
+      "max": 256,
+      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:transform-job/.*"
+    },
+    "S42": {
+      "type": "string",
+      "enum": [
+        "OutOfService",
+        "Creating",
+        "Updating",
+        "SystemUpdating",
+        "RollingBack",
+        "InService",
+        "Deleting",
+        "Failed"
+      ]
+    },
+    "S43": {
+      "type": "string",
+      "max": 1024
+    },
+    "S48": {
+      "type": "string",
+      "enum": [
+        "Completed",
+        "InProgress",
+        "Failed",
+        "Stopped",
+        "Stopping"
+      ]
     },
     "S49": {
       "type": "structure",
       "members": {
         "Completed": {
-          "type": "integer"
+          "shape": "S4a"
         },
         "InProgress": {
-          "type": "integer"
+          "shape": "S4a"
         },
         "RetryableError": {
-          "type": "integer"
+          "shape": "S4a"
         },
         "NonRetryableError": {
-          "type": "integer"
+          "shape": "S4a"
         },
         "Stopped": {
-          "type": "integer"
+          "shape": "S4a"
         }
       }
+    },
+    "S4a": {
+      "type": "integer",
+      "min": 0
     },
     "S4b": {
       "type": "structure",
       "members": {
         "Succeeded": {
-          "type": "integer"
+          "shape": "S4c"
         },
         "Pending": {
-          "type": "integer"
+          "shape": "S4c"
         },
         "Failed": {
-          "type": "integer"
+          "shape": "S4c"
         }
       }
+    },
+    "S4c": {
+      "type": "integer",
+      "min": 0
     },
     "S4d": {
       "type": "structure",
@@ -1923,8 +2888,12 @@
         "TunedHyperParameters"
       ],
       "members": {
-        "TrainingJobName": {},
-        "TrainingJobArn": {},
+        "TrainingJobName": {
+          "shape": "S2z"
+        },
+        "TrainingJobArn": {
+          "shape": "S32"
+        },
         "CreationTime": {
           "type": "timestamp"
         },
@@ -1934,11 +2903,15 @@
         "TrainingEndTime": {
           "type": "timestamp"
         },
-        "TrainingJobStatus": {},
+        "TrainingJobStatus": {
+          "shape": "S4e"
+        },
         "TunedHyperParameters": {
           "shape": "S19"
         },
-        "FailureReason": {},
+        "FailureReason": {
+          "shape": "S43"
+        },
         "FinalHyperParameterTuningJobObjectiveMetric": {
           "type": "structure",
           "required": [
@@ -1946,15 +2919,115 @@
             "Value"
           ],
           "members": {
-            "Type": {},
-            "MetricName": {},
+            "Type": {
+              "shape": "St"
+            },
+            "MetricName": {
+              "shape": "Su"
+            },
             "Value": {
               "type": "float"
             }
           }
         },
-        "ObjectiveStatus": {}
+        "ObjectiveStatus": {
+          "type": "string",
+          "enum": [
+            "Succeeded",
+            "Pending",
+            "Failed"
+          ]
+        }
       }
+    },
+    "S4e": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Completed",
+        "Failed",
+        "Stopping",
+        "Stopped"
+      ]
+    },
+    "S4m": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "InService",
+        "Stopping",
+        "Stopped",
+        "Failed",
+        "Deleting",
+        "Updating"
+      ]
+    },
+    "S4v": {
+      "type": "string",
+      "enum": [
+        "Starting",
+        "LaunchingMLInstances",
+        "PreparingTrainingStack",
+        "Downloading",
+        "DownloadingTrainingImage",
+        "Training",
+        "Uploading",
+        "Stopping",
+        "Stopped",
+        "MaxRuntimeExceeded",
+        "Completed",
+        "Failed"
+      ]
+    },
+    "S51": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Completed",
+        "Failed",
+        "Stopping",
+        "Stopped"
+      ]
+    },
+    "S54": {
+      "type": "string",
+      "enum": [
+        "Ascending",
+        "Descending"
+      ]
+    },
+    "S55": {
+      "type": "string",
+      "max": 8192
+    },
+    "S56": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "S5i": {
+      "type": "string",
+      "max": 8192
+    },
+    "S5k": {
+      "type": "string",
+      "enum": [
+        "Ascending",
+        "Descending"
+      ]
+    },
+    "S5l": {
+      "type": "string",
+      "max": 63,
+      "pattern": "[a-zA-Z0-9\\-]+"
+    },
+    "S6d": {
+      "type": "string",
+      "enum": [
+        "Name",
+        "CreationTime",
+        "Status"
+      ]
     }
   }
 }

--- a/apis/secretsmanager-2017-10-17.min.json
+++ b/apis/secretsmanager-2017-10-17.min.json
@@ -20,15 +20,23 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {}
+          "SecretId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -39,12 +47,19 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S8"
+          },
           "ClientRequestToken": {
+            "shape": "S9",
             "idempotencyToken": true
           },
-          "Description": {},
-          "KmsKeyId": {},
+          "Description": {
+            "shape": "Sa"
+          },
+          "KmsKeyId": {
+            "shape": "Sb"
+          },
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -59,9 +74,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -72,14 +93,20 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {}
+          "SecretId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -90,7 +117,9 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "RecoveryWindowInDays": {
             "type": "long"
           },
@@ -102,8 +131,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
           "DeletionDate": {
             "type": "timestamp"
           }
@@ -117,20 +150,32 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {}
+          "SecretId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "Description": {},
-          "KmsKeyId": {},
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "Description": {
+            "shape": "Sa"
+          },
+          "KmsKeyId": {
+            "shape": "Sb"
+          },
           "RotationEnabled": {
             "type": "boolean"
           },
-          "RotationLambdaARN": {},
+          "RotationLambdaARN": {
+            "shape": "St"
+          },
           "RotationRules": {
             "shape": "Su"
           },
@@ -160,9 +205,15 @@
         "type": "structure",
         "members": {
           "PasswordLength": {
-            "type": "long"
+            "type": "long",
+            "max": 4096,
+            "min": 1
           },
-          "ExcludeCharacters": {},
+          "ExcludeCharacters": {
+            "type": "string",
+            "max": 4096,
+            "min": 0
+          },
           "ExcludeNumbers": {
             "type": "boolean"
           },
@@ -186,7 +237,11 @@
       "output": {
         "type": "structure",
         "members": {
-          "RandomPassword": {}
+          "RandomPassword": {
+            "type": "string",
+            "max": 4096,
+            "min": 0
+          }
         }
       }
     },
@@ -197,15 +252,23 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {}
+          "SecretId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "ResourcePolicy": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S8"
+          },
+          "ResourcePolicy": {
+            "shape": "S1g"
+          }
         }
       }
     },
@@ -216,17 +279,29 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
-          "VersionId": {},
-          "VersionStage": {}
+          "SecretId": {
+            "shape": "S2"
+          },
+          "VersionId": {
+            "shape": "S6"
+          },
+          "VersionStage": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {},
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          },
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -249,11 +324,15 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
-          "MaxResults": {
-            "type": "integer"
+          "SecretId": {
+            "shape": "S2"
           },
-          "NextToken": {},
+          "MaxResults": {
+            "shape": "S1l"
+          },
+          "NextToken": {
+            "shape": "S1m"
+          },
           "IncludeDeprecated": {
             "type": "boolean"
           }
@@ -267,7 +346,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "VersionId": {},
+                "VersionId": {
+                  "shape": "S6"
+                },
                 "VersionStages": {
                   "shape": "S11"
                 },
@@ -280,9 +361,15 @@
               }
             }
           },
-          "NextToken": {},
-          "ARN": {},
-          "Name": {}
+          "NextToken": {
+            "shape": "S1m"
+          },
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -291,9 +378,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1l"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
@@ -304,14 +393,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "ARN": {},
-                "Name": {},
-                "Description": {},
-                "KmsKeyId": {},
+                "ARN": {
+                  "shape": "S4"
+                },
+                "Name": {
+                  "shape": "S5"
+                },
+                "Description": {
+                  "shape": "Sa"
+                },
+                "KmsKeyId": {
+                  "shape": "Sb"
+                },
                 "RotationEnabled": {
                   "type": "boolean"
                 },
-                "RotationLambdaARN": {},
+                "RotationLambdaARN": {
+                  "shape": "St"
+                },
                 "RotationRules": {
                   "shape": "Su"
                 },
@@ -336,7 +435,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1m"
+          }
         }
       }
     },
@@ -348,15 +449,23 @@
           "ResourcePolicy"
         ],
         "members": {
-          "SecretId": {},
-          "ResourcePolicy": {}
+          "SecretId": {
+            "shape": "S2"
+          },
+          "ResourcePolicy": {
+            "shape": "S1g"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S8"
+          }
         }
       }
     },
@@ -367,8 +476,11 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "ClientRequestToken": {
+            "shape": "S9",
             "idempotencyToken": true
           },
           "SecretBinary": {
@@ -385,9 +497,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {},
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          },
           "VersionStages": {
             "shape": "S11"
           }
@@ -401,14 +519,20 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {}
+          "SecretId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -419,11 +543,16 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "ClientRequestToken": {
+            "shape": "S9",
             "idempotencyToken": true
           },
-          "RotationLambdaARN": {},
+          "RotationLambdaARN": {
+            "shape": "St"
+          },
           "RotationRules": {
             "shape": "Su"
           }
@@ -432,9 +561,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -446,7 +581,9 @@
           "Tags"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "Tags": {
             "shape": "Se"
           }
@@ -461,10 +598,14 @@
           "TagKeys"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sg"
+            }
           }
         }
       }
@@ -476,12 +617,19 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {},
+          "SecretId": {
+            "shape": "S2"
+          },
           "ClientRequestToken": {
+            "shape": "S9",
             "idempotencyToken": true
           },
-          "Description": {},
-          "KmsKeyId": {},
+          "Description": {
+            "shape": "Sa"
+          },
+          "KmsKeyId": {
+            "shape": "Sb"
+          },
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -493,9 +641,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {},
-          "VersionId": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          },
+          "VersionId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -507,28 +661,83 @@
           "VersionStage"
         ],
         "members": {
-          "SecretId": {},
-          "VersionStage": {},
-          "RemoveFromVersionId": {},
-          "MoveToVersionId": {}
+          "SecretId": {
+            "shape": "S2"
+          },
+          "VersionStage": {
+            "shape": "S12"
+          },
+          "RemoveFromVersionId": {
+            "shape": "S6"
+          },
+          "MoveToVersionId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {},
-          "Name": {}
+          "ARN": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "S5"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S4": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S5": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 64,
+      "min": 32
+    },
+    "S8": {
+      "type": "string",
+      "max": 512,
+      "min": 1
+    },
+    "S9": {
+      "type": "string",
+      "max": 64,
+      "min": 32
+    },
+    "Sa": {
+      "type": "string",
+      "max": 2048
+    },
+    "Sb": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
+    },
     "Sc": {
       "type": "blob",
+      "max": 4096,
+      "min": 0,
       "sensitive": true
     },
     "Sd": {
       "type": "string",
+      "max": 4096,
+      "min": 0,
       "sensitive": true
     },
     "Se": {
@@ -536,29 +745,73 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Sg"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 0
+          }
         }
       }
+    },
+    "Sg": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "St": {
+      "type": "string",
+      "max": 2048,
+      "min": 0
     },
     "Su": {
       "type": "structure",
       "members": {
         "AutomaticallyAfterDays": {
-          "type": "long"
+          "type": "long",
+          "max": 1000,
+          "min": 1
         }
       }
     },
     "S10": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S6"
+      },
       "value": {
         "shape": "S11"
       }
     },
     "S11": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S12"
+      },
+      "max": 20,
+      "min": 1
+    },
+    "S12": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S1g": {
+      "type": "string",
+      "max": 4096,
+      "min": 1
+    },
+    "S1l": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "S1m": {
+      "type": "string",
+      "max": 4096,
+      "min": 1
     }
   }
 }

--- a/apis/serverlessrepo-2017-09-08.min.json
+++ b/apis/serverlessrepo-2017-09-08.min.json
@@ -352,9 +352,9 @@
             "locationName": "applicationId"
           },
           "MaxItems": {
+            "shape": "So",
             "location": "querystring",
-            "locationName": "maxItems",
-            "type": "integer"
+            "locationName": "maxItems"
           },
           "NextToken": {
             "location": "querystring",
@@ -410,9 +410,9 @@
         "type": "structure",
         "members": {
           "MaxItems": {
+            "shape": "So",
             "location": "querystring",
-            "locationName": "maxItems",
-            "type": "integer"
+            "locationName": "maxItems"
           },
           "NextToken": {
             "location": "querystring",
@@ -697,6 +697,11 @@
           "Actions"
         ]
       }
+    },
+    "So": {
+      "type": "integer",
+      "min": 1,
+      "max": 100
     }
   }
 }

--- a/apis/servicecatalog-2015-12-10.min.json
+++ b/apis/servicecatalog-2015-12-10.min.json
@@ -20,7 +20,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {}
+          "PortfolioId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -38,9 +40,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "PrincipalARN": {},
-          "PrincipalType": {}
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "PrincipalARN": {
+            "shape": "S6"
+          },
+          "PrincipalType": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -57,9 +65,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "PortfolioId": {},
-          "SourcePortfolioId": {}
+          "ProductId": {
+            "shape": "S3"
+          },
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "SourcePortfolioId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -76,7 +90,9 @@
         ],
         "members": {
           "ResourceId": {},
-          "TagOptionId": {}
+          "TagOptionId": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -93,22 +109,42 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "SourceProductArn": {},
-          "TargetProductId": {},
-          "TargetProductName": {},
+          "SourceProductArn": {
+            "type": "string",
+            "max": 1224,
+            "min": 1,
+            "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
+          },
+          "TargetProductId": {
+            "shape": "S3"
+          },
+          "TargetProductName": {
+            "shape": "Sh"
+          },
           "SourceProvisioningArtifactIdentifiers": {
             "type": "list",
             "member": {
               "type": "map",
-              "key": {},
+              "key": {
+                "type": "string",
+                "enum": [
+                  "Id"
+                ]
+              },
               "value": {}
             }
           },
           "CopyOptions": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "enum": [
+                "CopyTags"
+              ]
+            }
           },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -116,7 +152,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "CopyProductToken": {}
+          "CopyProductToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -132,12 +170,21 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "ProductId": {},
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "ProductId": {
+            "shape": "S3"
+          },
           "Parameters": {},
-          "Type": {},
-          "Description": {},
+          "Type": {
+            "shape": "Ss"
+          },
+          "Description": {
+            "shape": "St"
+          },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -149,7 +196,9 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -163,13 +212,20 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "DisplayName": {},
-          "Description": {},
-          "ProviderName": {},
+          "DisplayName": {
+            "shape": "Sz"
+          },
+          "Description": {
+            "shape": "S10"
+          },
+          "ProviderName": {
+            "shape": "S11"
+          },
           "Tags": {
             "shape": "S12"
           },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -195,8 +251,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "AccountId": {}
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "AccountId": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
@@ -216,14 +276,30 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Name": {},
-          "Owner": {},
-          "Description": {},
-          "Distributor": {},
-          "SupportDescription": {},
-          "SupportEmail": {},
-          "SupportUrl": {},
-          "ProductType": {},
+          "Name": {
+            "shape": "Sh"
+          },
+          "Owner": {
+            "shape": "S1e"
+          },
+          "Description": {
+            "shape": "S1f"
+          },
+          "Distributor": {
+            "shape": "S1e"
+          },
+          "SupportDescription": {
+            "shape": "S1g"
+          },
+          "SupportEmail": {
+            "shape": "S1h"
+          },
+          "SupportUrl": {
+            "shape": "S1i"
+          },
+          "ProductType": {
+            "shape": "S1j"
+          },
           "Tags": {
             "shape": "S12"
           },
@@ -231,6 +307,7 @@
             "shape": "S1k"
           },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -264,18 +341,29 @@
         "members": {
           "AcceptLanguage": {},
           "PlanName": {},
-          "PlanType": {},
+          "PlanType": {
+            "shape": "S21"
+          },
           "NotificationArns": {
             "shape": "S22"
           },
-          "PathId": {},
-          "ProductId": {},
-          "ProvisionedProductName": {},
-          "ProvisioningArtifactId": {},
+          "PathId": {
+            "shape": "S3"
+          },
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisionedProductName": {
+            "shape": "S24"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
           "ProvisioningParameters": {
             "shape": "S25"
           },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           },
           "Tags": {
@@ -287,10 +375,18 @@
         "type": "structure",
         "members": {
           "PlanName": {},
-          "PlanId": {},
-          "ProvisionProductId": {},
-          "ProvisionedProductName": {},
-          "ProvisioningArtifactId": {}
+          "PlanId": {
+            "shape": "S3"
+          },
+          "ProvisionProductId": {
+            "shape": "S3"
+          },
+          "ProvisionedProductName": {
+            "shape": "S24"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -304,11 +400,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
+          "ProductId": {
+            "shape": "S3"
+          },
           "Parameters": {
             "shape": "S1k"
           },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -322,7 +421,9 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -334,8 +435,12 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S2e"
+          },
+          "Value": {
+            "shape": "S2f"
+          }
         }
       },
       "output": {
@@ -355,7 +460,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -371,7 +478,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -388,8 +497,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "AccountId": {}
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "AccountId": {
+            "shape": "Sw"
+          }
         }
       },
       "output": {
@@ -405,7 +518,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -421,7 +536,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {},
+          "PlanId": {
+            "shape": "S3"
+          },
           "IgnoreErrors": {
             "type": "boolean"
           }
@@ -441,8 +558,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "ProvisioningArtifactId": {}
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -457,7 +578,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -473,7 +596,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -483,7 +608,9 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -495,14 +622,25 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "CopyProductToken": {}
+          "CopyProductToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CopyProductStatus": {},
-          "TargetProductId": {},
+          "CopyProductStatus": {
+            "type": "string",
+            "enum": [
+              "SUCCEEDED",
+              "IN_PROGRESS",
+              "FAILED"
+            ]
+          },
+          "TargetProductId": {
+            "shape": "S3"
+          },
           "StatusDetail": {}
         }
       }
@@ -515,7 +653,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -541,7 +681,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -564,7 +706,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -578,7 +722,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S3"
+                },
                 "Name": {},
                 "Description": {},
                 "CreatedTime": {
@@ -607,7 +753,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -630,7 +778,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -659,11 +809,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {},
-          "PageSize": {
-            "type": "integer"
+          "PlanId": {
+            "shape": "S3"
           },
-          "PageToken": {}
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -675,15 +829,39 @@
               "CreatedTime": {
                 "type": "timestamp"
               },
-              "PathId": {},
-              "ProductId": {},
+              "PathId": {
+                "shape": "S3"
+              },
+              "ProductId": {
+                "shape": "S3"
+              },
               "PlanName": {},
-              "PlanId": {},
-              "ProvisionProductId": {},
-              "ProvisionProductName": {},
-              "PlanType": {},
-              "ProvisioningArtifactId": {},
-              "Status": {},
+              "PlanId": {
+                "shape": "S3"
+              },
+              "ProvisionProductId": {
+                "shape": "S3"
+              },
+              "ProvisionProductName": {
+                "shape": "S24"
+              },
+              "PlanType": {
+                "shape": "S21"
+              },
+              "ProvisioningArtifactId": {
+                "shape": "S3"
+              },
+              "Status": {
+                "type": "string",
+                "enum": [
+                  "CREATE_IN_PROGRESS",
+                  "CREATE_SUCCESS",
+                  "CREATE_FAILED",
+                  "EXECUTE_IN_PROGRESS",
+                  "EXECUTE_SUCCESS",
+                  "EXECUTE_FAILED"
+                ]
+              },
               "UpdatedTime": {
                 "type": "timestamp"
               },
@@ -696,7 +874,10 @@
               "Tags": {
                 "shape": "S1a"
               },
-              "StatusMessage": {}
+              "StatusMessage": {
+                "type": "string",
+                "pattern": "[\\u0009\\u000a\\u000d\\u0020-\\uD7FF\\uE000-\\uFFFD]*"
+              }
             }
           },
           "ResourceChanges": {
@@ -704,14 +885,34 @@
             "member": {
               "type": "structure",
               "members": {
-                "Action": {},
+                "Action": {
+                  "type": "string",
+                  "enum": [
+                    "ADD",
+                    "MODIFY",
+                    "REMOVE"
+                  ]
+                },
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {},
-                "Replacement": {},
+                "ResourceType": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1
+                },
+                "Replacement": {
+                  "type": "string",
+                  "enum": [
+                    "TRUE",
+                    "FALSE",
+                    "CONDITIONAL"
+                  ]
+                },
                 "Scope": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S4a"
+                  }
                 },
                 "Details": {
                   "type": "list",
@@ -721,12 +922,27 @@
                       "Target": {
                         "type": "structure",
                         "members": {
-                          "Attribute": {},
+                          "Attribute": {
+                            "shape": "S4a"
+                          },
                           "Name": {},
-                          "RequiresRecreation": {}
+                          "RequiresRecreation": {
+                            "type": "string",
+                            "enum": [
+                              "NEVER",
+                              "CONDITIONALLY",
+                              "ALWAYS"
+                            ]
+                          }
                         }
                       },
-                      "Evaluation": {},
+                      "Evaluation": {
+                        "type": "string",
+                        "enum": [
+                          "STATIC",
+                          "DYNAMIC"
+                        ]
+                      },
                       "CausingEntity": {}
                     }
                   }
@@ -734,7 +950,9 @@
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -747,8 +965,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProvisioningArtifactId": {},
-          "ProductId": {},
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
+          "ProductId": {
+            "shape": "S3"
+          },
           "Verbose": {
             "type": "boolean"
           }
@@ -763,7 +985,9 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -776,9 +1000,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "ProvisioningArtifactId": {},
-          "PathId": {}
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
+          "PathId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -789,7 +1019,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ParameterKey": {},
+                "ParameterKey": {
+                  "shape": "S27"
+                },
                 "DefaultValue": {},
                 "ParameterType": {},
                 "IsNoEcho": {
@@ -826,10 +1058,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
+                "Key": {
+                  "shape": "S2e"
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S2f"
+                  }
                 }
               }
             }
@@ -845,10 +1081,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {},
-          "PageToken": {},
+          "Id": {
+            "shape": "S3"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           }
         }
       },
@@ -869,7 +1109,9 @@
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -880,7 +1122,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -901,8 +1145,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "PrincipalARN": {}
+          "PortfolioId": {
+            "shape": "S3"
+          },
+          "PrincipalARN": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -919,8 +1167,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "PortfolioId": {}
+          "ProductId": {
+            "shape": "S3"
+          },
+          "PortfolioId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -937,7 +1189,9 @@
         ],
         "members": {
           "ResourceId": {},
-          "TagOptionId": {}
+          "TagOptionId": {
+            "shape": "Sd"
+          }
         }
       },
       "output": {
@@ -954,8 +1208,11 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {},
+          "PlanId": {
+            "shape": "S3"
+          },
           "IdempotencyToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -974,11 +1231,19 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PageToken": {},
-          "PageSize": {
-            "type": "integer"
+          "PageToken": {
+            "shape": "S3w"
           },
-          "PortfolioShareType": {}
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PortfolioShareType": {
+            "type": "string",
+            "enum": [
+              "IMPORTED",
+              "AWS_SERVICECATALOG"
+            ]
+          }
         }
       },
       "output": {
@@ -987,7 +1252,9 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -999,12 +1266,18 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "ProductId": {},
-          "PageSize": {
-            "type": "integer"
+          "PortfolioId": {
+            "shape": "S3"
           },
-          "PageToken": {}
+          "ProductId": {
+            "shape": "S3"
+          },
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1016,7 +1289,9 @@
               "shape": "Sv"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1028,11 +1303,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "PageSize": {
-            "type": "integer"
+          "ProductId": {
+            "shape": "S3"
           },
-          "PageToken": {}
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1043,7 +1322,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S3"
+                },
                 "ConstraintSummaries": {
                   "shape": "S4w"
                 },
@@ -1054,7 +1335,9 @@
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1066,7 +1349,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {}
+          "PortfolioId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1074,9 +1359,13 @@
         "members": {
           "AccountIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sw"
+            }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1085,9 +1374,11 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PageToken": {},
+          "PageToken": {
+            "shape": "S3w"
+          },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           }
         }
       },
@@ -1097,7 +1388,9 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1109,10 +1402,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "PageToken": {},
+          "ProductId": {
+            "shape": "S3"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           }
         }
       },
@@ -1122,7 +1419,9 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1134,11 +1433,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
-          "PageSize": {
-            "type": "integer"
+          "PortfolioId": {
+            "shape": "S3"
           },
-          "PageToken": {}
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1149,12 +1452,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "PrincipalARN": {},
-                "PrincipalType": {}
+                "PrincipalARN": {
+                  "shape": "S6"
+                },
+                "PrincipalType": {
+                  "shape": "S7"
+                }
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1163,11 +1472,15 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "ProvisionProductId": {},
-          "PageSize": {
-            "type": "integer"
+          "ProvisionProductId": {
+            "shape": "S3"
           },
-          "PageToken": {},
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          },
           "AccessLevelFilter": {
             "shape": "S6k"
           }
@@ -1182,15 +1495,27 @@
               "type": "structure",
               "members": {
                 "PlanName": {},
-                "PlanId": {},
-                "ProvisionProductId": {},
-                "ProvisionProductName": {},
-                "PlanType": {},
-                "ProvisioningArtifactId": {}
+                "PlanId": {
+                  "shape": "S3"
+                },
+                "ProvisionProductId": {
+                  "shape": "S3"
+                },
+                "ProvisionProductName": {
+                  "shape": "S24"
+                },
+                "PlanType": {
+                  "shape": "S21"
+                },
+                "ProvisioningArtifactId": {
+                  "shape": "S3"
+                }
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1202,7 +1527,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {}
+          "ProductId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1214,7 +1541,9 @@
               "shape": "S1x"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1234,9 +1563,11 @@
             }
           },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1248,7 +1579,9 @@
               "shape": "S57"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1259,12 +1592,16 @@
           "TagOptionId"
         ],
         "members": {
-          "TagOptionId": {},
+          "TagOptionId": {
+            "shape": "Sd"
+          },
           "ResourceType": {},
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1285,7 +1622,9 @@
               }
             }
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1296,17 +1635,23 @@
           "Filters": {
             "type": "structure",
             "members": {
-              "Key": {},
-              "Value": {},
+              "Key": {
+                "shape": "S2e"
+              },
+              "Value": {
+                "shape": "S2f"
+              },
               "Active": {
                 "type": "boolean"
               }
             }
           },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1315,7 +1660,9 @@
           "TagOptionDetails": {
             "shape": "S36"
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1330,17 +1677,29 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "ProvisioningArtifactId": {},
-          "PathId": {},
-          "ProvisionedProductName": {},
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
+          "PathId": {
+            "shape": "S3"
+          },
+          "ProvisionedProductName": {
+            "shape": "S24"
+          },
           "ProvisioningParameters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
-                "Value": {}
+                "Key": {
+                  "shape": "S27"
+                },
+                "Value": {
+                  "shape": "S28"
+                }
               }
             }
           },
@@ -1351,6 +1710,7 @@
             "shape": "S22"
           },
           "ProvisionToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -1372,7 +1732,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {}
+          "PortfolioId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1389,9 +1751,11 @@
             "shape": "S6k"
           },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           },
-          "PageToken": {}
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1403,7 +1767,9 @@
               "shape": "S3k"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1416,11 +1782,17 @@
             "shape": "S7m"
           },
           "PageSize": {
-            "type": "integer"
+            "shape": "S3v"
           },
-          "SortBy": {},
-          "SortOrder": {},
-          "PageToken": {}
+          "SortBy": {
+            "shape": "S7q"
+          },
+          "SortOrder": {
+            "shape": "S7r"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1448,7 +1820,9 @@
               }
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1457,17 +1831,30 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {},
+          "PortfolioId": {
+            "shape": "S3"
+          },
           "Filters": {
             "shape": "S7m"
           },
-          "SortBy": {},
-          "SortOrder": {},
-          "PageToken": {},
-          "PageSize": {
-            "type": "integer"
+          "SortBy": {
+            "shape": "S7q"
           },
-          "ProductSource": {}
+          "SortOrder": {
+            "shape": "S7r"
+          },
+          "PageToken": {
+            "shape": "S3w"
+          },
+          "PageSize": {
+            "shape": "S3v"
+          },
+          "ProductSource": {
+            "type": "string",
+            "enum": [
+              "ACCOUNT"
+            ]
+          }
         }
       },
       "output": {
@@ -1479,7 +1866,9 @@
               "shape": "S1s"
             }
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1493,18 +1882,29 @@
           },
           "Filters": {
             "type": "map",
-            "key": {},
+            "key": {
+              "type": "string",
+              "enum": [
+                "SearchQuery"
+              ]
+            },
             "value": {
               "type": "list",
               "member": {}
             }
           },
           "SortBy": {},
-          "SortOrder": {},
-          "PageSize": {
-            "type": "integer"
+          "SortOrder": {
+            "shape": "S7r"
           },
-          "PageToken": {}
+          "PageSize": {
+            "type": "integer",
+            "max": 100,
+            "min": 0
+          },
+          "PageToken": {
+            "shape": "S3w"
+          }
         }
       },
       "output": {
@@ -1515,23 +1915,39 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Arn": {},
+                "Name": {
+                  "shape": "S3l"
+                },
+                "Arn": {
+                  "shape": "S3l"
+                },
                 "Type": {},
-                "Id": {},
-                "Status": {},
+                "Id": {
+                  "shape": "S3"
+                },
+                "Status": {
+                  "shape": "S3o"
+                },
                 "StatusMessage": {},
                 "CreatedTime": {
                   "type": "timestamp"
                 },
-                "IdempotencyToken": {},
-                "LastRecordId": {},
+                "IdempotencyToken": {
+                  "shape": "So"
+                },
+                "LastRecordId": {
+                  "shape": "S3"
+                },
                 "Tags": {
                   "shape": "S1a"
                 },
                 "PhysicalId": {},
-                "ProductId": {},
-                "ProvisioningArtifactId": {},
+                "ProductId": {
+                  "shape": "S3"
+                },
+                "ProvisioningArtifactId": {
+                  "shape": "S3"
+                },
                 "UserArn": {},
                 "UserArnSession": {}
               }
@@ -1540,7 +1956,9 @@
           "TotalResultsCount": {
             "type": "integer"
           },
-          "NextPageToken": {}
+          "NextPageToken": {
+            "shape": "S3w"
+          }
         }
       }
     },
@@ -1551,9 +1969,14 @@
           "TerminateToken"
         ],
         "members": {
-          "ProvisionedProductName": {},
-          "ProvisionedProductId": {},
+          "ProvisionedProductName": {
+            "shape": "S3l"
+          },
+          "ProvisionedProductId": {
+            "shape": "S3"
+          },
           "TerminateToken": {
+            "shape": "So",
             "idempotencyToken": true
           },
           "IgnoreErrors": {
@@ -1579,8 +2002,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {},
-          "Description": {}
+          "Id": {
+            "shape": "S3"
+          },
+          "Description": {
+            "shape": "St"
+          }
         }
       },
       "output": {
@@ -1590,7 +2017,9 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -1602,10 +2031,18 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {},
-          "DisplayName": {},
-          "Description": {},
-          "ProviderName": {},
+          "Id": {
+            "shape": "S3"
+          },
+          "DisplayName": {
+            "shape": "Sz"
+          },
+          "Description": {
+            "shape": "S10"
+          },
+          "ProviderName": {
+            "shape": "S11"
+          },
           "AddTags": {
             "shape": "S12"
           },
@@ -1634,14 +2071,30 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {},
-          "Name": {},
-          "Owner": {},
-          "Description": {},
-          "Distributor": {},
-          "SupportDescription": {},
-          "SupportEmail": {},
-          "SupportUrl": {},
+          "Id": {
+            "shape": "S3"
+          },
+          "Name": {
+            "shape": "Sh"
+          },
+          "Owner": {
+            "shape": "S1e"
+          },
+          "Description": {
+            "shape": "S1f"
+          },
+          "Distributor": {
+            "shape": "S1e"
+          },
+          "SupportDescription": {
+            "shape": "S1g"
+          },
+          "SupportEmail": {
+            "shape": "S1h"
+          },
+          "SupportUrl": {
+            "shape": "S1i"
+          },
           "AddTags": {
             "shape": "S12"
           },
@@ -1670,15 +2123,26 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProvisionedProductName": {},
-          "ProvisionedProductId": {},
-          "ProductId": {},
-          "ProvisioningArtifactId": {},
-          "PathId": {},
+          "ProvisionedProductName": {
+            "shape": "S3l"
+          },
+          "ProvisionedProductId": {
+            "shape": "S3"
+          },
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
+          "PathId": {
+            "shape": "S3"
+          },
           "ProvisioningParameters": {
             "shape": "S25"
           },
           "UpdateToken": {
+            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -1701,8 +2165,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {},
-          "ProvisioningArtifactId": {},
+          "ProductId": {
+            "shape": "S3"
+          },
+          "ProvisioningArtifactId": {
+            "shape": "S3"
+          },
           "Name": {},
           "Description": {},
           "Active": {
@@ -1719,7 +2187,9 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {}
+          "Status": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -1730,8 +2200,12 @@
           "Id"
         ],
         "members": {
-          "Id": {},
-          "Value": {},
+          "Id": {
+            "shape": "Sd"
+          },
+          "Value": {
+            "shape": "S2f"
+          },
           "Active": {
             "type": "boolean"
           }
@@ -1748,20 +2222,95 @@
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 1000,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "IAM"
+      ]
+    },
+    "Sd": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 8191
+    },
+    "So": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
+    },
+    "Ss": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "St": {
+      "type": "string",
+      "max": 2000
+    },
     "Sv": {
       "type": "structure",
       "members": {
-        "ConstraintId": {},
-        "Type": {},
-        "Description": {},
-        "Owner": {}
+        "ConstraintId": {
+          "shape": "S3"
+        },
+        "Type": {
+          "shape": "Ss"
+        },
+        "Description": {
+          "shape": "St"
+        },
+        "Owner": {
+          "shape": "Sw"
+        }
       }
+    },
+    "Sw": {
+      "type": "string",
+      "pattern": "^[0-9]{12}$"
+    },
+    "Sx": {
+      "type": "string",
+      "enum": [
+        "AVAILABLE",
+        "CREATING",
+        "FAILED"
+      ]
+    },
+    "Sz": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S10": {
+      "type": "string",
+      "max": 2000
+    },
+    "S11": {
+      "type": "string",
+      "max": 50,
+      "min": 1
     },
     "S12": {
       "type": "list",
       "member": {
         "shape": "S13"
-      }
+      },
+      "max": 20
     },
     "S13": {
       "type": "structure",
@@ -1770,28 +2319,85 @@
         "Value"
       ],
       "members": {
-        "Key": {},
-        "Value": {}
+        "Key": {
+          "shape": "S14"
+        },
+        "Value": {
+          "type": "string",
+          "max": 256,
+          "min": 1,
+          "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+        }
       }
+    },
+    "S14": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S17": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "ARN": {},
-        "DisplayName": {},
-        "Description": {},
+        "Id": {
+          "shape": "S3"
+        },
+        "ARN": {
+          "shape": "S18"
+        },
+        "DisplayName": {
+          "shape": "Sz"
+        },
+        "Description": {
+          "shape": "S10"
+        },
         "CreatedTime": {
           "type": "timestamp"
         },
-        "ProviderName": {}
+        "ProviderName": {
+          "shape": "S11"
+        }
       }
+    },
+    "S18": {
+      "type": "string",
+      "max": 150,
+      "min": 1
     },
     "S1a": {
       "type": "list",
       "member": {
         "shape": "S13"
-      }
+      },
+      "max": 50
+    },
+    "S1e": {
+      "type": "string",
+      "max": 8191
+    },
+    "S1f": {
+      "type": "string",
+      "max": 8191
+    },
+    "S1g": {
+      "type": "string",
+      "max": 8191
+    },
+    "S1h": {
+      "type": "string",
+      "max": 254
+    },
+    "S1i": {
+      "type": "string",
+      "max": 2083
+    },
+    "S1j": {
+      "type": "string",
+      "enum": [
+        "CLOUD_FORMATION_TEMPLATE",
+        "MARKETPLACE"
+      ],
+      "max": 8191
     },
     "S1k": {
       "type": "structure",
@@ -1804,13 +2410,25 @@
         "Info": {
           "shape": "S1n"
         },
-        "Type": {}
+        "Type": {
+          "shape": "S1q"
+        }
       }
     },
     "S1n": {
       "type": "map",
       "key": {},
-      "value": {}
+      "value": {},
+      "max": 100,
+      "min": 1
+    },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "CLOUD_FORMATION_TEMPLATE",
+        "MARKETPLACE_AMI",
+        "MARKETPLACE_CAR"
+      ]
     },
     "S1s": {
       "type": "structure",
@@ -1818,8 +2436,12 @@
         "ProductViewSummary": {
           "shape": "S1t"
         },
-        "Status": {},
-        "ProductARN": {},
+        "Status": {
+          "shape": "Sx"
+        },
+        "ProductARN": {
+          "shape": "S18"
+        },
         "CreatedTime": {
           "type": "timestamp"
         }
@@ -1828,28 +2450,50 @@
     "S1t": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "ProductId": {},
-        "Name": {},
-        "Owner": {},
-        "ShortDescription": {},
-        "Type": {},
+        "Id": {
+          "shape": "S3"
+        },
+        "ProductId": {
+          "shape": "S3"
+        },
+        "Name": {
+          "shape": "Sh"
+        },
+        "Owner": {
+          "shape": "S1e"
+        },
+        "ShortDescription": {
+          "shape": "S1f"
+        },
+        "Type": {
+          "shape": "S1j"
+        },
         "Distributor": {},
         "HasDefaultPath": {
           "type": "boolean"
         },
-        "SupportEmail": {},
-        "SupportDescription": {},
-        "SupportUrl": {}
+        "SupportEmail": {
+          "shape": "S1h"
+        },
+        "SupportDescription": {
+          "shape": "S1g"
+        },
+        "SupportUrl": {
+          "shape": "S1i"
+        }
       }
     },
     "S1x": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S3"
+        },
         "Name": {},
         "Description": {},
-        "Type": {},
+        "Type": {
+          "shape": "S1q"
+        },
         "CreatedTime": {
           "type": "timestamp"
         },
@@ -1858,32 +2502,81 @@
         }
       }
     },
+    "S21": {
+      "type": "string",
+      "enum": [
+        "CLOUDFORMATION"
+      ]
+    },
     "S22": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 1224,
+        "min": 1,
+        "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
+      },
+      "max": 5
+    },
+    "S24": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9._-]*"
     },
     "S25": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
-          "Value": {},
+          "Key": {
+            "shape": "S27"
+          },
+          "Value": {
+            "shape": "S28"
+          },
           "UsePreviousValue": {
             "type": "boolean"
           }
         }
       }
     },
+    "S27": {
+      "type": "string",
+      "max": 1000,
+      "min": 1
+    },
+    "S28": {
+      "type": "string",
+      "max": 4096
+    },
+    "S2e": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "S2f": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
     "S2h": {
       "type": "structure",
       "members": {
-        "Key": {},
-        "Value": {},
+        "Key": {
+          "shape": "S2e"
+        },
+        "Value": {
+          "shape": "S2f"
+        },
         "Active": {
           "type": "boolean"
         },
-        "Id": {}
+        "Id": {
+          "shape": "Sd"
+        }
       }
     },
     "S36": {
@@ -1897,7 +2590,9 @@
       "member": {
         "type": "structure",
         "members": {
-          "Id": {},
+          "Id": {
+            "shape": "S3"
+          },
           "Name": {},
           "Description": {},
           "CreatedTime": {
@@ -1909,35 +2604,96 @@
     "S3k": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Arn": {},
+        "Name": {
+          "shape": "S3l"
+        },
+        "Arn": {
+          "shape": "S3l"
+        },
         "Type": {},
         "Id": {},
-        "Status": {},
+        "Status": {
+          "shape": "S3o"
+        },
         "StatusMessage": {},
         "CreatedTime": {
           "type": "timestamp"
         },
-        "IdempotencyToken": {},
+        "IdempotencyToken": {
+          "shape": "So"
+        },
         "LastRecordId": {}
       }
+    },
+    "S3l": {
+      "type": "string",
+      "max": 1224,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}|arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
+    },
+    "S3o": {
+      "type": "string",
+      "enum": [
+        "AVAILABLE",
+        "UNDER_CHANGE",
+        "TAINTED",
+        "ERROR",
+        "PLAN_IN_PROGRESS"
+      ]
+    },
+    "S3v": {
+      "type": "integer",
+      "max": 20,
+      "min": 0
+    },
+    "S3w": {
+      "type": "string",
+      "pattern": "[\\u0009\\u000a\\u000d\\u0020-\\uD7FF\\uE000-\\uFFFD]*"
+    },
+    "S4a": {
+      "type": "string",
+      "enum": [
+        "PROPERTIES",
+        "METADATA",
+        "CREATIONPOLICY",
+        "UPDATEPOLICY",
+        "DELETIONPOLICY",
+        "TAGS"
+      ]
     },
     "S4w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Type": {},
-          "Description": {}
+          "Type": {
+            "shape": "Ss"
+          },
+          "Description": {
+            "shape": "St"
+          }
         }
       }
     },
     "S57": {
       "type": "structure",
       "members": {
-        "RecordId": {},
-        "ProvisionedProductName": {},
-        "Status": {},
+        "RecordId": {
+          "shape": "S3"
+        },
+        "ProvisionedProductName": {
+          "shape": "S24"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "CREATED",
+            "IN_PROGRESS",
+            "IN_PROGRESS_IN_ERROR",
+            "SUCCEEDED",
+            "FAILED"
+          ]
+        },
         "CreatedTime": {
           "type": "timestamp"
         },
@@ -1946,10 +2702,18 @@
         },
         "ProvisionedProductType": {},
         "RecordType": {},
-        "ProvisionedProductId": {},
-        "ProductId": {},
-        "ProvisioningArtifactId": {},
-        "PathId": {},
+        "ProvisionedProductId": {
+          "shape": "S3"
+        },
+        "ProductId": {
+          "shape": "S3"
+        },
+        "ProvisioningArtifactId": {
+          "shape": "S3"
+        },
+        "PathId": {
+          "shape": "S3"
+        },
         "RecordErrors": {
           "type": "list",
           "member": {
@@ -1965,10 +2729,21 @@
           "member": {
             "type": "structure",
             "members": {
-              "Key": {},
-              "Value": {}
+              "Key": {
+                "type": "string",
+                "max": 128,
+                "min": 1,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+              },
+              "Value": {
+                "type": "string",
+                "max": 256,
+                "min": 1,
+                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
+              }
             }
-          }
+          },
+          "max": 50
         }
       }
     },
@@ -1981,21 +2756,53 @@
     "S6k": {
       "type": "structure",
       "members": {
-        "Key": {},
+        "Key": {
+          "type": "string",
+          "enum": [
+            "Account",
+            "Role",
+            "User"
+          ]
+        },
         "Value": {}
       }
     },
     "S7m": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "enum": [
+          "FullTextSearch",
+          "Owner",
+          "ProductType",
+          "SourceProductId"
+        ]
+      },
       "value": {
         "type": "list",
         "member": {}
       }
     },
+    "S7q": {
+      "type": "string",
+      "enum": [
+        "Title",
+        "VersionCount",
+        "CreationDate"
+      ]
+    },
+    "S7r": {
+      "type": "string",
+      "enum": [
+        "ASCENDING",
+        "DESCENDING"
+      ]
+    },
     "S8n": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S14"
+      }
     }
   }
 }

--- a/apis/servicediscovery-2017-03-14.min.json
+++ b/apis/servicediscovery-2017-03-14.min.json
@@ -21,18 +21,27 @@
           "Vpc"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "CreatorRequestId": {
+            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {},
-          "Vpc": {}
+          "Description": {
+            "shape": "S4"
+          },
+          "Vpc": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -43,17 +52,24 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "CreatorRequestId": {
+            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {}
+          "Description": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -65,11 +81,16 @@
           "DnsConfig"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "Sa"
+          },
           "CreatorRequestId": {
+            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {},
+          "Description": {
+            "shape": "S4"
+          },
           "DnsConfig": {
             "shape": "Sb"
           },
@@ -97,13 +118,17 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -114,7 +139,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -130,14 +157,20 @@
           "InstanceId"
         ],
         "members": {
-          "ServiceId": {},
-          "InstanceId": {}
+          "ServiceId": {
+            "shape": "S3"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -149,8 +182,12 @@
           "InstanceId"
         ],
         "members": {
-          "ServiceId": {},
-          "InstanceId": {}
+          "ServiceId": {
+            "shape": "S3"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -162,8 +199,12 @@
               "Id"
             ],
             "members": {
-              "Id": {},
-              "CreatorRequestId": {},
+              "Id": {
+                "shape": "S3"
+              },
+              "CreatorRequestId": {
+                "shape": "S3"
+              },
               "Attributes": {
                 "shape": "S10"
               }
@@ -179,15 +220,22 @@
           "ServiceId"
         ],
         "members": {
-          "ServiceId": {},
+          "ServiceId": {
+            "shape": "S3"
+          },
           "Instances": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            },
+            "min": 1
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       },
       "output": {
@@ -195,10 +243,21 @@
         "members": {
           "Status": {
             "type": "map",
-            "key": {},
-            "value": {}
+            "key": {
+              "shape": "S3"
+            },
+            "value": {
+              "type": "string",
+              "enum": [
+                "HEALTHY",
+                "UNHEALTHY",
+                "UNKNOWN"
+              ]
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -209,7 +268,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -218,11 +279,21 @@
           "Namespace": {
             "type": "structure",
             "members": {
-              "Id": {},
-              "Arn": {},
-              "Name": {},
-              "Type": {},
-              "Description": {},
+              "Id": {
+                "shape": "S3"
+              },
+              "Arn": {
+                "shape": "So"
+              },
+              "Name": {
+                "shape": "S2"
+              },
+              "Type": {
+                "shape": "S1d"
+              },
+              "Description": {
+                "shape": "S4"
+              },
               "ServiceCount": {
                 "type": "integer"
               },
@@ -232,7 +303,9 @@
                   "DnsProperties": {
                     "type": "structure",
                     "members": {
-                      "HostedZoneId": {}
+                      "HostedZoneId": {
+                        "shape": "S3"
+                      }
                     }
                   }
                 }
@@ -240,7 +313,9 @@
               "CreateDate": {
                 "type": "timestamp"
               },
-              "CreatorRequestId": {}
+              "CreatorRequestId": {
+                "shape": "S3"
+              }
             }
           }
         }
@@ -253,7 +328,9 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -262,9 +339,22 @@
           "Operation": {
             "type": "structure",
             "members": {
-              "Id": {},
-              "Type": {},
-              "Status": {},
+              "Id": {
+                "shape": "S6"
+              },
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "CREATE_NAMESPACE",
+                  "DELETE_NAMESPACE",
+                  "UPDATE_SERVICE",
+                  "REGISTER_INSTANCE",
+                  "DEREGISTER_INSTANCE"
+                ]
+              },
+              "Status": {
+                "shape": "S1k"
+              },
               "ErrorMessage": {},
               "ErrorCode": {},
               "CreateDate": {
@@ -275,8 +365,17 @@
               },
               "Targets": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "NAMESPACE",
+                    "SERVICE",
+                    "INSTANCE"
+                  ]
+                },
+                "value": {
+                  "shape": "S3"
+                }
               }
             }
           }
@@ -290,7 +389,9 @@
           "Id"
         ],
         "members": {
-          "Id": {}
+          "Id": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -309,10 +410,14 @@
           "ServiceId"
         ],
         "members": {
-          "ServiceId": {},
-          "NextToken": {},
+          "ServiceId": {
+            "shape": "S3"
+          },
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           }
         }
       },
@@ -324,14 +429,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S3"
+                },
                 "Attributes": {
                   "shape": "S10"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -339,9 +448,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           },
           "Filters": {
             "type": "list",
@@ -352,11 +463,18 @@
                 "Values"
               ],
               "members": {
-                "Name": {},
+                "Name": {
+                  "type": "string",
+                  "enum": [
+                    "TYPE"
+                  ]
+                },
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {}
+                "Condition": {
+                  "shape": "S21"
+                }
               }
             }
           }
@@ -370,14 +488,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Arn": {},
-                "Name": {},
-                "Type": {}
+                "Id": {
+                  "shape": "S3"
+                },
+                "Arn": {
+                  "shape": "So"
+                },
+                "Name": {
+                  "shape": "S2"
+                },
+                "Type": {
+                  "shape": "S1d"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -385,9 +513,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           },
           "Filters": {
             "type": "list",
@@ -398,11 +528,22 @@
                 "Values"
               ],
               "members": {
-                "Name": {},
+                "Name": {
+                  "type": "string",
+                  "enum": [
+                    "NAMESPACE_ID",
+                    "SERVICE_ID",
+                    "STATUS",
+                    "TYPE",
+                    "UPDATE_DATE"
+                  ]
+                },
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {}
+                "Condition": {
+                  "shape": "S21"
+                }
               }
             }
           }
@@ -416,12 +557,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Status": {}
+                "Id": {
+                  "shape": "S6"
+                },
+                "Status": {
+                  "shape": "S1k"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -429,9 +576,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S16"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S15"
           },
           "Filters": {
             "type": "list",
@@ -442,11 +591,18 @@
                 "Values"
               ],
               "members": {
-                "Name": {},
+                "Name": {
+                  "type": "string",
+                  "enum": [
+                    "NAMESPACE_ID"
+                  ]
+                },
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {}
+                "Condition": {
+                  "shape": "S21"
+                }
               }
             }
           }
@@ -460,17 +616,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Arn": {},
-                "Name": {},
-                "Description": {},
+                "Id": {
+                  "shape": "S3"
+                },
+                "Arn": {
+                  "shape": "So"
+                },
+                "Name": {
+                  "shape": "Sa"
+                },
+                "Description": {
+                  "shape": "S4"
+                },
                 "InstanceCount": {
                   "type": "integer"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S16"
+          }
         }
       }
     },
@@ -483,9 +649,14 @@
           "Attributes"
         ],
         "members": {
-          "ServiceId": {},
-          "InstanceId": {},
+          "ServiceId": {
+            "shape": "S3"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          },
           "CreatorRequestId": {
+            "shape": "S3",
             "idempotencyToken": true
           },
           "Attributes": {
@@ -496,7 +667,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     },
@@ -509,9 +682,19 @@
           "Status"
         ],
         "members": {
-          "ServiceId": {},
-          "InstanceId": {},
-          "Status": {}
+          "ServiceId": {
+            "shape": "S3"
+          },
+          "InstanceId": {
+            "shape": "S3"
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "HEALTHY",
+              "UNHEALTHY"
+            ]
+          }
         }
       }
     },
@@ -523,14 +706,18 @@
           "Service"
         ],
         "members": {
-          "Id": {},
+          "Id": {
+            "shape": "S3"
+          },
           "Service": {
             "type": "structure",
             "required": [
               "DnsConfig"
             ],
             "members": {
-              "Description": {},
+              "Description": {
+                "shape": "S4"
+              },
               "DnsConfig": {
                 "type": "structure",
                 "required": [
@@ -552,12 +739,34 @@
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {}
+          "OperationId": {
+            "shape": "S6"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 1024
+    },
+    "S3": {
+      "type": "string",
+      "max": 64
+    },
+    "S4": {
+      "type": "string",
+      "max": 1024
+    },
+    "S6": {
+      "type": "string",
+      "max": 255
+    },
+    "Sa": {
+      "type": "string",
+      "pattern": "((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(\\.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^\\.$)"
+    },
     "Sb": {
       "type": "structure",
       "required": [
@@ -565,8 +774,16 @@
         "DnsRecords"
       ],
       "members": {
-        "NamespaceId": {},
-        "RoutingPolicy": {},
+        "NamespaceId": {
+          "shape": "S3"
+        },
+        "RoutingPolicy": {
+          "type": "string",
+          "enum": [
+            "MULTIVALUE",
+            "WEIGHTED"
+          ]
+        },
         "DnsRecords": {
           "shape": "Sd"
         }
@@ -581,9 +798,19 @@
           "TTL"
         ],
         "members": {
-          "Type": {},
+          "Type": {
+            "type": "string",
+            "enum": [
+              "SRV",
+              "A",
+              "AAAA",
+              "CNAME"
+            ]
+          },
           "TTL": {
-            "type": "long"
+            "type": "long",
+            "max": 2147483647,
+            "min": 0
           }
         }
       }
@@ -591,28 +818,51 @@
     "Sh": {
       "type": "structure",
       "members": {
-        "Type": {},
-        "ResourcePath": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "HTTP",
+            "HTTPS",
+            "TCP"
+          ]
+        },
+        "ResourcePath": {
+          "type": "string",
+          "max": 255
+        },
         "FailureThreshold": {
-          "type": "integer"
+          "shape": "Sk"
         }
       }
+    },
+    "Sk": {
+      "type": "integer",
+      "max": 10,
+      "min": 1
     },
     "Sl": {
       "type": "structure",
       "members": {
         "FailureThreshold": {
-          "type": "integer"
+          "shape": "Sk"
         }
       }
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Arn": {},
-        "Name": {},
-        "Description": {},
+        "Id": {
+          "shape": "S3"
+        },
+        "Arn": {
+          "shape": "So"
+        },
+        "Name": {
+          "shape": "Sa"
+        },
+        "Description": {
+          "shape": "S4"
+        },
         "InstanceCount": {
           "type": "integer"
         },
@@ -628,17 +878,66 @@
         "CreateDate": {
           "type": "timestamp"
         },
-        "CreatorRequestId": {}
+        "CreatorRequestId": {
+          "shape": "S3"
+        }
       }
+    },
+    "So": {
+      "type": "string",
+      "max": 255
     },
     "S10": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 255
+      },
+      "value": {
+        "type": "string",
+        "max": 255
+      }
+    },
+    "S15": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "S16": {
+      "type": "string",
+      "max": 4096
+    },
+    "S1d": {
+      "type": "string",
+      "enum": [
+        "DNS_PUBLIC",
+        "DNS_PRIVATE"
+      ]
+    },
+    "S1k": {
+      "type": "string",
+      "enum": [
+        "SUBMITTED",
+        "PENDING",
+        "SUCCESS",
+        "FAIL"
+      ]
     },
     "S1z": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      }
+    },
+    "S21": {
+      "type": "string",
+      "enum": [
+        "EQ",
+        "IN",
+        "BETWEEN"
+      ]
     }
   }
 }

--- a/apis/shield-2016-06-02.min.json
+++ b/apis/shield-2016-06-02.min.json
@@ -20,7 +20,9 @@
           "LogBucket"
         ],
         "members": {
-          "LogBucket": {}
+          "LogBucket": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -35,7 +37,9 @@
           "RoleArn"
         ],
         "members": {
-          "RoleArn": {}
+          "RoleArn": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -51,14 +55,20 @@
           "ResourceArn"
         ],
         "members": {
-          "Name": {},
-          "ResourceArn": {}
+          "Name": {
+            "shape": "S8"
+          },
+          "ResourceArn": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ProtectionId": {}
+          "ProtectionId": {
+            "shape": "Sb"
+          }
         }
       }
     },
@@ -79,7 +89,9 @@
           "ProtectionId"
         ],
         "members": {
-          "ProtectionId": {}
+          "ProtectionId": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -107,7 +119,9 @@
           "AttackId"
         ],
         "members": {
-          "AttackId": {}
+          "AttackId": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
@@ -116,14 +130,24 @@
           "Attack": {
             "type": "structure",
             "members": {
-              "AttackId": {},
-              "ResourceArn": {},
+              "AttackId": {
+                "shape": "Sj"
+              },
+              "ResourceArn": {
+                "shape": "S9"
+              },
               "SubResources": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Type": {},
+                    "Type": {
+                      "type": "string",
+                      "enum": [
+                        "IP",
+                        "URL"
+                      ]
+                    },
                     "Id": {},
                     "AttackVectors": {
                       "type": "list",
@@ -160,8 +184,24 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "AttackLayer": {},
-                    "AttackPropertyIdentifier": {},
+                    "AttackLayer": {
+                      "type": "string",
+                      "enum": [
+                        "NETWORK",
+                        "APPLICATION"
+                      ]
+                    },
+                    "AttackPropertyIdentifier": {
+                      "type": "string",
+                      "enum": [
+                        "DESTINATION_URL",
+                        "REFERRER",
+                        "SOURCE_ASN",
+                        "SOURCE_COUNTRY",
+                        "SOURCE_IP_ADDRESS",
+                        "SOURCE_USER_AGENT"
+                      ]
+                    },
                     "TopContributors": {
                       "type": "list",
                       "member": {
@@ -174,7 +214,15 @@
                         }
                       }
                     },
-                    "Unit": {},
+                    "Unit": {
+                      "type": "string",
+                      "enum": [
+                        "BITS",
+                        "BYTES",
+                        "PACKETS",
+                        "REQUESTS"
+                      ]
+                    },
                     "Total": {
                       "type": "long"
                     }
@@ -203,10 +251,16 @@
       "output": {
         "type": "structure",
         "members": {
-          "RoleArn": {},
+          "RoleArn": {
+            "shape": "S5"
+          },
           "LogBucketList": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            },
+            "max": 10,
+            "min": 0
           }
         }
       }
@@ -232,7 +286,9 @@
           "ProtectionId"
         ],
         "members": {
-          "ProtectionId": {}
+          "ProtectionId": {
+            "shape": "Sb"
+          }
         }
       },
       "output": {
@@ -262,9 +318,12 @@
                 "type": "timestamp"
               },
               "TimeCommitmentInSeconds": {
-                "type": "long"
+                "type": "long",
+                "min": 0
               },
-              "AutoRenew": {},
+              "AutoRenew": {
+                "shape": "S1n"
+              },
               "Limits": {
                 "type": "list",
                 "member": {
@@ -289,7 +348,9 @@
           "LogBucket"
         ],
         "members": {
-          "LogBucket": {}
+          "LogBucket": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -318,7 +379,13 @@
           "SubscriptionState"
         ],
         "members": {
-          "SubscriptionState": {}
+          "SubscriptionState": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "INACTIVE"
+            ]
+          }
         }
       }
     },
@@ -328,7 +395,9 @@
         "members": {
           "ResourceArns": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S9"
+            }
           },
           "StartTime": {
             "shape": "S1z"
@@ -336,9 +405,11 @@
           "EndTime": {
             "shape": "S1z"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S20"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S21"
           }
         }
       },
@@ -373,7 +444,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S20"
+          }
         }
       }
     },
@@ -381,9 +454,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S20"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S21"
           }
         }
       },
@@ -396,7 +471,9 @@
               "shape": "S1h"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S20"
+          }
         }
       }
     },
@@ -418,7 +495,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoRenew": {}
+          "AutoRenew": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
@@ -428,6 +507,39 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 63,
+      "min": 3,
+      "pattern": "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$"
+    },
+    "S5": {
+      "type": "string",
+      "max": 96,
+      "pattern": "^arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
+    },
+    "S8": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[ a-zA-Z0-9_\\\\.\\\\-]*"
+    },
+    "S9": {
+      "type": "string",
+      "min": 1
+    },
+    "Sb": {
+      "type": "string",
+      "max": 36,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\\\-]*"
+    },
+    "Sj": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9\\\\-]*"
+    },
     "Ss": {
       "type": "list",
       "member": {
@@ -458,17 +570,35 @@
           "EmailAddress"
         ],
         "members": {
-          "EmailAddress": {}
+          "EmailAddress": {
+            "type": "string",
+            "pattern": "^\\S+@\\S+\\.\\S+$"
+          }
         }
-      }
+      },
+      "max": 10,
+      "min": 0
     },
     "S1h": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Name": {},
-        "ResourceArn": {}
+        "Id": {
+          "shape": "Sb"
+        },
+        "Name": {
+          "shape": "S8"
+        },
+        "ResourceArn": {
+          "shape": "S9"
+        }
       }
+    },
+    "S1n": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED"
+      ]
     },
     "S1z": {
       "type": "structure",
@@ -480,6 +610,15 @@
           "type": "timestamp"
         }
       }
+    },
+    "S20": {
+      "type": "string",
+      "min": 1
+    },
+    "S21": {
+      "type": "integer",
+      "max": 10000,
+      "min": 0
     }
   }
 }

--- a/apis/signer-2017-08-25.min.json
+++ b/apis/signer-2017-08-25.min.json
@@ -25,6 +25,7 @@
         ],
         "members": {
           "profileName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           }
@@ -59,7 +60,9 @@
             "shape": "Sb"
           },
           "platformId": {},
-          "profileName": {},
+          "profileName": {
+            "shape": "S2"
+          },
           "overrides": {
             "shape": "Se"
           },
@@ -73,7 +76,9 @@
             "type": "timestamp"
           },
           "requestedBy": {},
-          "status": {},
+          "status": {
+            "shape": "So"
+          },
           "statusReason": {},
           "signedObject": {
             "shape": "Sq"
@@ -105,7 +110,9 @@
           "displayName": {},
           "partner": {},
           "target": {},
-          "category": {},
+          "category": {
+            "shape": "Sx"
+          },
           "signingConfiguration": {
             "shape": "Sy"
           },
@@ -130,6 +137,7 @@
         ],
         "members": {
           "profileName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           }
@@ -138,7 +146,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "profileName": {},
+          "profileName": {
+            "shape": "S2"
+          },
           "signingMaterial": {
             "shape": "Sb"
           },
@@ -149,7 +159,9 @@
           "signingParameters": {
             "shape": "Si"
           },
-          "status": {}
+          "status": {
+            "shape": "S19"
+          }
         }
       }
     },
@@ -162,6 +174,7 @@
         "type": "structure",
         "members": {
           "status": {
+            "shape": "So",
             "location": "querystring",
             "locationName": "status"
           },
@@ -174,9 +187,9 @@
             "locationName": "requestedBy"
           },
           "maxResults": {
+            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -205,7 +218,9 @@
                 "createdAt": {
                   "type": "timestamp"
                 },
-                "status": {}
+                "status": {
+                  "shape": "So"
+                }
               }
             }
           },
@@ -234,9 +249,9 @@
             "locationName": "target"
           },
           "maxResults": {
+            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -256,7 +271,9 @@
                 "displayName": {},
                 "partner": {},
                 "target": {},
-                "category": {},
+                "category": {
+                  "shape": "Sx"
+                },
                 "signingConfiguration": {
                   "shape": "Sy"
                 },
@@ -287,9 +304,9 @@
             "type": "boolean"
           },
           "maxResults": {
+            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults",
-            "type": "integer"
+            "locationName": "maxResults"
           },
           "nextToken": {
             "location": "querystring",
@@ -305,7 +322,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "profileName": {},
+                "profileName": {
+                  "shape": "S2"
+                },
                 "signingMaterial": {
                   "shape": "Sb"
                 },
@@ -313,7 +332,9 @@
                 "signingParameters": {
                   "shape": "Si"
                 },
-                "status": {}
+                "status": {
+                  "shape": "S19"
+                }
               }
             }
           },
@@ -335,6 +356,7 @@
         ],
         "members": {
           "profileName": {
+            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           },
@@ -384,7 +406,9 @@
               }
             }
           },
-          "profileName": {},
+          "profileName": {
+            "shape": "S2"
+          },
           "clientRequestToken": {
             "idempotencyToken": true
           }
@@ -399,6 +423,12 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 20,
+      "min": 2,
+      "pattern": "^[a-zA-Z0-9_]{2,}"
+    },
     "S6": {
       "type": "structure",
       "members": {
@@ -432,16 +462,42 @@
         "signingConfiguration": {
           "type": "structure",
           "members": {
-            "encryptionAlgorithm": {},
-            "hashAlgorithm": {}
+            "encryptionAlgorithm": {
+              "shape": "Sg"
+            },
+            "hashAlgorithm": {
+              "shape": "Sh"
+            }
           }
         }
       }
+    },
+    "Sg": {
+      "type": "string",
+      "enum": [
+        "RSA",
+        "ECDSA"
+      ]
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "SHA1",
+        "SHA256"
+      ]
     },
     "Si": {
       "type": "map",
       "key": {},
       "value": {}
+    },
+    "So": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Failed",
+        "Succeeded"
+      ]
     },
     "Sq": {
       "type": "structure",
@@ -454,6 +510,12 @@
           }
         }
       }
+    },
+    "Sx": {
+      "type": "string",
+      "enum": [
+        "AWSIoT"
+      ]
     },
     "Sy": {
       "type": "structure",
@@ -471,9 +533,13 @@
           "members": {
             "allowedValues": {
               "type": "list",
-              "member": {}
+              "member": {
+                "shape": "Sg"
+              }
             },
-            "defaultValue": {}
+            "defaultValue": {
+              "shape": "Sg"
+            }
           }
         },
         "hashAlgorithmOptions": {
@@ -485,9 +551,13 @@
           "members": {
             "allowedValues": {
               "type": "list",
-              "member": {}
+              "member": {
+                "shape": "Sh"
+              }
             },
-            "defaultValue": {}
+            "defaultValue": {
+              "shape": "Sh"
+            }
           }
         }
       }
@@ -501,10 +571,32 @@
       "members": {
         "supportedFormats": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S15"
+          }
         },
-        "defaultFormat": {}
+        "defaultFormat": {
+          "shape": "S15"
+        }
       }
+    },
+    "S15": {
+      "type": "string",
+      "enum": [
+        "JSON"
+      ]
+    },
+    "S19": {
+      "type": "string",
+      "enum": [
+        "Active",
+        "Canceled"
+      ]
+    },
+    "S1b": {
+      "type": "integer",
+      "max": 25,
+      "min": 1
     }
   }
 }

--- a/apis/sms-2016-10-24.min.json
+++ b/apis/sms-2016-10-24.min.json
@@ -29,7 +29,9 @@
           "frequency": {
             "type": "integer"
           },
-          "licenseType": {},
+          "licenseType": {
+            "shape": "S5"
+          },
           "roleName": {},
           "description": {}
         }
@@ -102,15 +104,27 @@
               "members": {
                 "connectorId": {},
                 "version": {},
-                "status": {},
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "HEALTHY",
+                    "UNHEALTHY"
+                  ]
+                },
                 "capabilityList": {
                   "type": "list",
                   "member": {
-                    "locationName": "item"
+                    "locationName": "item",
+                    "type": "string",
+                    "enum": [
+                      "VSPHERE"
+                    ]
                   }
                 },
                 "vmManagerName": {},
-                "vmManagerType": {},
+                "vmManagerType": {
+                  "shape": "Ss"
+                },
                 "vmManagerId": {},
                 "ipAddress": {},
                 "macAddress": {},
@@ -192,7 +206,16 @@
           "lastModifiedOn": {
             "type": "timestamp"
           },
-          "serverCatalogStatus": {},
+          "serverCatalogStatus": {
+            "type": "string",
+            "enum": [
+              "NOT_IMPORTED",
+              "IMPORTING",
+              "AVAILABLE",
+              "DELETED",
+              "EXPIRED"
+            ]
+          },
           "serverList": {
             "type": "list",
             "member": {
@@ -200,7 +223,9 @@
               "type": "structure",
               "members": {
                 "serverId": {},
-                "serverType": {},
+                "serverType": {
+                  "shape": "S10"
+                },
                 "vmServer": {
                   "shape": "S11"
                 },
@@ -257,7 +282,9 @@
           "nextReplicationRunStartTime": {
             "type": "timestamp"
           },
-          "licenseType": {},
+          "licenseType": {
+            "shape": "S5"
+          },
           "roleName": {},
           "description": {}
         }
@@ -269,12 +296,27 @@
     }
   },
   "shapes": {
+    "S5": {
+      "type": "string",
+      "enum": [
+        "AWS",
+        "BYOL"
+      ]
+    },
+    "Ss": {
+      "type": "string",
+      "enum": [
+        "VSPHERE"
+      ]
+    },
     "Sz": {
       "type": "structure",
       "members": {
         "replicationJobId": {},
         "serverId": {},
-        "serverType": {},
+        "serverType": {
+          "shape": "S10"
+        },
         "vmServer": {
           "shape": "S11"
         },
@@ -287,16 +329,33 @@
         "nextReplicationRunStartTime": {
           "type": "timestamp"
         },
-        "licenseType": {},
+        "licenseType": {
+          "shape": "S5"
+        },
         "roleName": {},
         "latestAmiId": {},
-        "state": {},
+        "state": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "ACTIVE",
+            "FAILED",
+            "DELETING",
+            "DELETED"
+          ]
+        },
         "statusMessage": {},
         "description": {},
         "replicationRunList": {
           "shape": "S19"
         }
       }
+    },
+    "S10": {
+      "type": "string",
+      "enum": [
+        "VIRTUAL_MACHINE"
+      ]
     },
     "S11": {
       "type": "structure",
@@ -310,7 +369,9 @@
         },
         "vmName": {},
         "vmManagerName": {},
-        "vmManagerType": {},
+        "vmManagerType": {
+          "shape": "Ss"
+        },
         "vmPath": {}
       }
     },
@@ -321,8 +382,25 @@
         "type": "structure",
         "members": {
           "replicationRunId": {},
-          "state": {},
-          "type": {},
+          "state": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "MISSED",
+              "ACTIVE",
+              "FAILED",
+              "COMPLETED",
+              "DELETING",
+              "DELETED"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "ON_DEMAND",
+              "AUTOMATIC"
+            ]
+          },
           "statusMessage": {},
           "amiId": {},
           "scheduledStartTime": {

--- a/apis/snowball-2016-06-30.min.json
+++ b/apis/snowball-2016-06-30.min.json
@@ -20,7 +20,9 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {}
+          "ClusterId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -35,7 +37,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -58,7 +62,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "AddressId": {}
+          "AddressId": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -73,26 +79,44 @@
           "ShippingOption"
         ],
         "members": {
-          "JobType": {},
+          "JobType": {
+            "shape": "Se"
+          },
           "Resources": {
             "shape": "Sf"
           },
-          "Description": {},
-          "AddressId": {},
-          "KmsKeyARN": {},
-          "RoleARN": {},
-          "SnowballType": {},
-          "ShippingOption": {},
+          "Description": {
+            "shape": "Sa"
+          },
+          "AddressId": {
+            "shape": "S9"
+          },
+          "KmsKeyARN": {
+            "shape": "Sr"
+          },
+          "RoleARN": {
+            "shape": "Ss"
+          },
+          "SnowballType": {
+            "shape": "St"
+          },
+          "ShippingOption": {
+            "shape": "Su"
+          },
           "Notification": {
             "shape": "Sv"
           },
-          "ForwardingAddressId": {}
+          "ForwardingAddressId": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClusterId": {}
+          "ClusterId": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -100,28 +124,50 @@
       "input": {
         "type": "structure",
         "members": {
-          "JobType": {},
+          "JobType": {
+            "shape": "Se"
+          },
           "Resources": {
             "shape": "Sf"
           },
-          "Description": {},
-          "AddressId": {},
-          "KmsKeyARN": {},
-          "RoleARN": {},
-          "SnowballCapacityPreference": {},
-          "ShippingOption": {},
+          "Description": {
+            "shape": "Sa"
+          },
+          "AddressId": {
+            "shape": "S9"
+          },
+          "KmsKeyARN": {
+            "shape": "Sr"
+          },
+          "RoleARN": {
+            "shape": "Ss"
+          },
+          "SnowballCapacityPreference": {
+            "shape": "S11"
+          },
+          "ShippingOption": {
+            "shape": "Su"
+          },
           "Notification": {
             "shape": "Sv"
           },
-          "ClusterId": {},
-          "SnowballType": {},
-          "ForwardingAddressId": {}
+          "ClusterId": {
+            "shape": "S2"
+          },
+          "SnowballType": {
+            "shape": "St"
+          },
+          "ForwardingAddressId": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S5"
+          }
         }
       }
     },
@@ -132,7 +178,9 @@
           "AddressId"
         ],
         "members": {
-          "AddressId": {}
+          "AddressId": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -149,9 +197,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S16"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -163,7 +213,9 @@
               "shape": "S8"
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -174,7 +226,9 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {}
+          "ClusterId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -183,25 +237,45 @@
           "ClusterMetadata": {
             "type": "structure",
             "members": {
-              "ClusterId": {},
-              "Description": {},
-              "KmsKeyARN": {},
-              "RoleARN": {},
-              "ClusterState": {},
-              "JobType": {},
-              "SnowballType": {},
+              "ClusterId": {
+                "shape": "Sa"
+              },
+              "Description": {
+                "shape": "Sa"
+              },
+              "KmsKeyARN": {
+                "shape": "Sr"
+              },
+              "RoleARN": {
+                "shape": "Ss"
+              },
+              "ClusterState": {
+                "shape": "S1c"
+              },
+              "JobType": {
+                "shape": "Se"
+              },
+              "SnowballType": {
+                "shape": "St"
+              },
               "CreationDate": {
                 "type": "timestamp"
               },
               "Resources": {
                 "shape": "Sf"
               },
-              "AddressId": {},
-              "ShippingOption": {},
+              "AddressId": {
+                "shape": "S9"
+              },
+              "ShippingOption": {
+                "shape": "Su"
+              },
               "Notification": {
                 "shape": "Sv"
               },
-              "ForwardingAddressId": {}
+              "ForwardingAddressId": {
+                "shape": "S9"
+              }
             }
           }
         }
@@ -214,7 +288,9 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
@@ -239,13 +315,17 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ManifestURI": {}
+          "ManifestURI": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -256,13 +336,17 @@
           "JobId"
         ],
         "members": {
-          "JobId": {}
+          "JobId": {
+            "shape": "S5"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UnlockCode": {}
+          "UnlockCode": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -290,11 +374,15 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {},
-          "MaxResults": {
-            "type": "integer"
+          "ClusterId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "MaxResults": {
+            "shape": "S16"
+          },
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -303,7 +391,9 @@
           "JobListEntries": {
             "shape": "S1w"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -312,9 +402,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S16"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -325,16 +417,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "ClusterId": {},
-                "ClusterState": {},
+                "ClusterId": {
+                  "shape": "Sa"
+                },
+                "ClusterState": {
+                  "shape": "S1c"
+                },
                 "CreationDate": {
                   "type": "timestamp"
                 },
-                "Description": {}
+                "Description": {
+                  "shape": "Sa"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -343,9 +443,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S16"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -356,12 +458,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "AmiId": {},
-                "Name": {}
+                "AmiId": {
+                  "shape": "Sa"
+                },
+                "Name": {
+                  "shape": "Sa"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -370,9 +478,11 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S16"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
@@ -381,7 +491,9 @@
           "JobListEntries": {
             "shape": "S1w"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -392,18 +504,30 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {},
-          "RoleARN": {},
-          "Description": {},
+          "ClusterId": {
+            "shape": "S2"
+          },
+          "RoleARN": {
+            "shape": "Ss"
+          },
+          "Description": {
+            "shape": "Sa"
+          },
           "Resources": {
             "shape": "Sf"
           },
-          "AddressId": {},
-          "ShippingOption": {},
+          "AddressId": {
+            "shape": "S9"
+          },
+          "ShippingOption": {
+            "shape": "Su"
+          },
           "Notification": {
             "shape": "Sv"
           },
-          "ForwardingAddressId": {}
+          "ForwardingAddressId": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -418,19 +542,33 @@
           "JobId"
         ],
         "members": {
-          "JobId": {},
-          "RoleARN": {},
+          "JobId": {
+            "shape": "S5"
+          },
+          "RoleARN": {
+            "shape": "Ss"
+          },
           "Notification": {
             "shape": "Sv"
           },
           "Resources": {
             "shape": "Sf"
           },
-          "AddressId": {},
-          "ShippingOption": {},
-          "Description": {},
-          "SnowballCapacityPreference": {},
-          "ForwardingAddressId": {}
+          "AddressId": {
+            "shape": "S9"
+          },
+          "ShippingOption": {
+            "shape": "Su"
+          },
+          "Description": {
+            "shape": "Sa"
+          },
+          "SnowballCapacityPreference": {
+            "shape": "S11"
+          },
+          "ForwardingAddressId": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -440,26 +578,82 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 39,
+      "min": 39,
+      "pattern": "CID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "S5": {
+      "type": "string",
+      "max": 39,
+      "min": 39,
+      "pattern": "(M|J)ID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
     "S8": {
       "type": "structure",
       "members": {
-        "AddressId": {},
-        "Name": {},
-        "Company": {},
-        "Street1": {},
-        "Street2": {},
-        "Street3": {},
-        "City": {},
-        "StateOrProvince": {},
-        "PrefectureOrDistrict": {},
-        "Landmark": {},
-        "Country": {},
-        "PostalCode": {},
-        "PhoneNumber": {},
+        "AddressId": {
+          "shape": "S9"
+        },
+        "Name": {
+          "shape": "Sa"
+        },
+        "Company": {
+          "shape": "Sa"
+        },
+        "Street1": {
+          "shape": "Sa"
+        },
+        "Street2": {
+          "shape": "Sa"
+        },
+        "Street3": {
+          "shape": "Sa"
+        },
+        "City": {
+          "shape": "Sa"
+        },
+        "StateOrProvince": {
+          "shape": "Sa"
+        },
+        "PrefectureOrDistrict": {
+          "shape": "Sa"
+        },
+        "Landmark": {
+          "shape": "Sa"
+        },
+        "Country": {
+          "shape": "Sa"
+        },
+        "PostalCode": {
+          "shape": "Sa"
+        },
+        "PhoneNumber": {
+          "shape": "Sa"
+        },
         "IsRestricted": {
           "type": "boolean"
         }
       }
+    },
+    "S9": {
+      "type": "string",
+      "max": 40,
+      "min": 40,
+      "pattern": "ADID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    },
+    "Sa": {
+      "type": "string",
+      "min": 1
+    },
+    "Se": {
+      "type": "string",
+      "enum": [
+        "IMPORT",
+        "EXPORT",
+        "LOCAL_USE"
+      ]
     },
     "Sf": {
       "type": "structure",
@@ -469,12 +663,18 @@
           "member": {
             "type": "structure",
             "members": {
-              "BucketArn": {},
+              "BucketArn": {
+                "shape": "Si"
+              },
               "KeyRange": {
                 "type": "structure",
                 "members": {
-                  "BeginMarker": {},
-                  "EndMarker": {}
+                  "BeginMarker": {
+                    "shape": "Sa"
+                  },
+                  "EndMarker": {
+                    "shape": "Sa"
+                  }
                 }
               }
             }
@@ -485,13 +685,17 @@
           "member": {
             "type": "structure",
             "members": {
-              "LambdaArn": {},
+              "LambdaArn": {
+                "shape": "Si"
+              },
               "EventTriggers": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "EventResourceARN": {}
+                    "EventResourceARN": {
+                      "shape": "Si"
+                    }
                   }
                 }
               }
@@ -506,47 +710,150 @@
               "AmiId"
             ],
             "members": {
-              "AmiId": {},
-              "SnowballAmiId": {}
+              "AmiId": {
+                "type": "string",
+                "max": 21,
+                "min": 12,
+                "pattern": "(ami-[0-9a-f]{8})|(ami-[0-9a-f]{17})"
+              },
+              "SnowballAmiId": {
+                "shape": "Sa"
+              }
             }
           }
         }
       }
     },
+    "Si": {
+      "type": "string",
+      "max": 255
+    },
+    "Sr": {
+      "type": "string",
+      "max": 255,
+      "pattern": "arn:aws.*:kms:.*:[0-9]{12}:key/.*"
+    },
+    "Ss": {
+      "type": "string",
+      "max": 255,
+      "pattern": "arn:aws.*:iam::[0-9]{12}:role/.*"
+    },
+    "St": {
+      "type": "string",
+      "enum": [
+        "STANDARD",
+        "EDGE"
+      ]
+    },
+    "Su": {
+      "type": "string",
+      "enum": [
+        "SECOND_DAY",
+        "NEXT_DAY",
+        "EXPRESS",
+        "STANDARD"
+      ]
+    },
     "Sv": {
       "type": "structure",
       "members": {
-        "SnsTopicARN": {},
+        "SnsTopicARN": {
+          "type": "string",
+          "max": 255,
+          "pattern": "arn:aws.*:sns:.*:[0-9]{12}:.*"
+        },
         "JobStatesToNotify": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "Sy"
+          }
         },
         "NotifyAll": {
           "type": "boolean"
         }
       }
     },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "New",
+        "PreparingAppliance",
+        "PreparingShipment",
+        "InTransitToCustomer",
+        "WithCustomer",
+        "InTransitToAWS",
+        "WithAWSSortingFacility",
+        "WithAWS",
+        "InProgress",
+        "Complete",
+        "Cancelled",
+        "Listing",
+        "Pending"
+      ]
+    },
+    "S11": {
+      "type": "string",
+      "enum": [
+        "T50",
+        "T80",
+        "T100",
+        "NoPreference"
+      ]
+    },
+    "S16": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
+    },
+    "S1c": {
+      "type": "string",
+      "enum": [
+        "AwaitingQuorum",
+        "Pending",
+        "InUse",
+        "Complete",
+        "Cancelled"
+      ]
+    },
     "S1g": {
       "type": "structure",
       "members": {
-        "JobId": {},
-        "JobState": {},
-        "JobType": {},
-        "SnowballType": {},
+        "JobId": {
+          "shape": "Sa"
+        },
+        "JobState": {
+          "shape": "Sy"
+        },
+        "JobType": {
+          "shape": "Se"
+        },
+        "SnowballType": {
+          "shape": "St"
+        },
         "CreationDate": {
           "type": "timestamp"
         },
         "Resources": {
           "shape": "Sf"
         },
-        "Description": {},
-        "KmsKeyARN": {},
-        "RoleARN": {},
-        "AddressId": {},
+        "Description": {
+          "shape": "Sa"
+        },
+        "KmsKeyARN": {
+          "shape": "Sr"
+        },
+        "RoleARN": {
+          "shape": "Ss"
+        },
+        "AddressId": {
+          "shape": "S9"
+        },
         "ShippingDetails": {
           "type": "structure",
           "members": {
-            "ShippingOption": {},
+            "ShippingOption": {
+              "shape": "Su"
+            },
             "InboundShipment": {
               "shape": "S1i"
             },
@@ -555,7 +862,9 @@
             }
           }
         },
-        "SnowballCapacityPreference": {},
+        "SnowballCapacityPreference": {
+          "shape": "S11"
+        },
         "Notification": {
           "shape": "Sv"
         },
@@ -579,20 +888,34 @@
         "JobLogInfo": {
           "type": "structure",
           "members": {
-            "JobCompletionReportURI": {},
-            "JobSuccessLogURI": {},
-            "JobFailureLogURI": {}
+            "JobCompletionReportURI": {
+              "shape": "Sa"
+            },
+            "JobSuccessLogURI": {
+              "shape": "Sa"
+            },
+            "JobFailureLogURI": {
+              "shape": "Sa"
+            }
           }
         },
-        "ClusterId": {},
-        "ForwardingAddressId": {}
+        "ClusterId": {
+          "shape": "Sa"
+        },
+        "ForwardingAddressId": {
+          "shape": "S9"
+        }
       }
     },
     "S1i": {
       "type": "structure",
       "members": {
-        "Status": {},
-        "TrackingNumber": {}
+        "Status": {
+          "shape": "Sa"
+        },
+        "TrackingNumber": {
+          "shape": "Sa"
+        }
       }
     },
     "S1w": {
@@ -600,17 +923,27 @@
       "member": {
         "type": "structure",
         "members": {
-          "JobId": {},
-          "JobState": {},
+          "JobId": {
+            "shape": "Sa"
+          },
+          "JobState": {
+            "shape": "Sy"
+          },
           "IsMaster": {
             "type": "boolean"
           },
-          "JobType": {},
-          "SnowballType": {},
+          "JobType": {
+            "shape": "Se"
+          },
+          "SnowballType": {
+            "shape": "St"
+          },
           "CreationDate": {
             "type": "timestamp"
           },
-          "Description": {}
+          "Description": {
+            "shape": "Sa"
+          }
         }
       }
     }

--- a/apis/sqs-2012-11-05.min.json
+++ b/apis/sqs-2012-11-05.min.json
@@ -380,7 +380,17 @@
                   "locationName": "Attribute",
                   "type": "map",
                   "key": {
-                    "locationName": "Name"
+                    "locationName": "Name",
+                    "type": "string",
+                    "enum": [
+                      "SenderId",
+                      "SentTimestamp",
+                      "ApproximateReceiveCount",
+                      "ApproximateFirstReceiveTimestamp",
+                      "SequenceNumber",
+                      "MessageDeduplicationId",
+                      "MessageGroupId"
+                    ]
                   },
                   "value": {
                     "locationName": "Value"
@@ -590,6 +600,7 @@
     "Sh": {
       "type": "map",
       "key": {
+        "shape": "Si",
         "locationName": "Name"
       },
       "value": {
@@ -598,9 +609,33 @@
       "flattened": true,
       "locationName": "Attribute"
     },
+    "Si": {
+      "type": "string",
+      "enum": [
+        "All",
+        "Policy",
+        "VisibilityTimeout",
+        "MaximumMessageSize",
+        "MessageRetentionPeriod",
+        "ApproximateNumberOfMessages",
+        "ApproximateNumberOfMessagesNotVisible",
+        "CreatedTimestamp",
+        "LastModifiedTimestamp",
+        "QueueArn",
+        "ApproximateNumberOfMessagesDelayed",
+        "DelaySeconds",
+        "ReceiveMessageWaitTimeSeconds",
+        "RedrivePolicy",
+        "FifoQueue",
+        "ContentBasedDeduplication",
+        "KmsMasterKeyId",
+        "KmsDataKeyReusePeriodSeconds"
+      ]
+    },
     "St": {
       "type": "list",
       "member": {
+        "shape": "Si",
         "locationName": "AttributeName"
       },
       "flattened": true

--- a/apis/ssm-2014-11-06.min.json
+++ b/apis/ssm-2014-11-06.min.json
@@ -22,7 +22,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceType": {},
+          "ResourceType": {
+            "shape": "S2"
+          },
           "ResourceId": {},
           "Tags": {
             "shape": "S4"
@@ -41,7 +43,9 @@
           "CommandId"
         ],
         "members": {
-          "CommandId": {},
+          "CommandId": {
+            "shape": "Sa"
+          },
           "InstanceIds": {
             "shape": "Sb"
           }
@@ -59,11 +63,17 @@
           "IamRole"
         ],
         "members": {
-          "Description": {},
-          "DefaultInstanceName": {},
-          "IamRole": {},
+          "Description": {
+            "shape": "Sf"
+          },
+          "DefaultInstanceName": {
+            "shape": "Sg"
+          },
+          "IamRole": {
+            "shape": "Sh"
+          },
           "RegistrationLimit": {
-            "type": "integer"
+            "shape": "Si"
           },
           "ExpirationDate": {
             "type": "timestamp"
@@ -73,8 +83,14 @@
       "output": {
         "type": "structure",
         "members": {
-          "ActivationId": {},
-          "ActivationCode": {}
+          "ActivationId": {
+            "shape": "Sl"
+          },
+          "ActivationCode": {
+            "type": "string",
+            "max": 250,
+            "min": 20
+          }
         }
       }
     },
@@ -85,20 +101,30 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "DocumentVersion": {},
-          "InstanceId": {},
+          "Name": {
+            "shape": "So"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "Parameters": {
             "shape": "Sq"
           },
           "Targets": {
             "shape": "Su"
           },
-          "ScheduleExpression": {},
+          "ScheduleExpression": {
+            "shape": "Sz"
+          },
           "OutputLocation": {
             "shape": "S10"
           },
-          "AssociationName": {}
+          "AssociationName": {
+            "shape": "S15"
+          }
         }
       },
       "output": {
@@ -121,7 +147,8 @@
             "type": "list",
             "member": {
               "shape": "S1l"
-            }
+            },
+            "min": 1
           }
         }
       },
@@ -143,7 +170,14 @@
                   "shape": "S1l"
                 },
                 "Message": {},
-                "Fault": {}
+                "Fault": {
+                  "type": "string",
+                  "enum": [
+                    "Client",
+                    "Server",
+                    "Unknown"
+                  ]
+                }
               }
             }
           }
@@ -158,11 +192,21 @@
           "Name"
         ],
         "members": {
-          "Content": {},
-          "Name": {},
-          "DocumentType": {},
-          "DocumentFormat": {},
-          "TargetType": {}
+          "Content": {
+            "shape": "S1t"
+          },
+          "Name": {
+            "shape": "So"
+          },
+          "DocumentType": {
+            "shape": "S1u"
+          },
+          "DocumentFormat": {
+            "shape": "S1v"
+          },
+          "TargetType": {
+            "shape": "S1w"
+          }
         }
       },
       "output": {
@@ -185,21 +229,26 @@
           "AllowUnassociatedTargets"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {},
+          "Schedule": {
+            "shape": "S2i"
+          },
           "Duration": {
-            "type": "integer"
+            "shape": "S2j"
           },
           "Cutoff": {
-            "type": "integer"
+            "shape": "S2k"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
           },
           "ClientToken": {
+            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -207,7 +256,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {}
+          "WindowId": {
+            "shape": "S2o"
+          }
         }
       }
     },
@@ -218,8 +269,12 @@
           "Name"
         ],
         "members": {
-          "OperatingSystem": {},
-          "Name": {},
+          "OperatingSystem": {
+            "shape": "S2q"
+          },
+          "Name": {
+            "shape": "S2r"
+          },
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -229,18 +284,23 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {},
+          "ApprovedPatchesComplianceLevel": {
+            "shape": "S31"
+          },
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
           "RejectedPatches": {
             "shape": "S34"
           },
-          "Description": {},
+          "Description": {
+            "shape": "S36"
+          },
           "Sources": {
             "shape": "S37"
           },
           "ClientToken": {
+            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -248,7 +308,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       }
     },
@@ -260,7 +322,9 @@
           "S3Destination"
         ],
         "members": {
-          "SyncName": {},
+          "SyncName": {
+            "shape": "S3g"
+          },
           "S3Destination": {
             "shape": "S3h"
           }
@@ -278,7 +342,9 @@
           "ActivationId"
         ],
         "members": {
-          "ActivationId": {}
+          "ActivationId": {
+            "shape": "Sl"
+          }
         }
       },
       "output": {
@@ -290,9 +356,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "InstanceId": {},
-          "AssociationId": {}
+          "Name": {
+            "shape": "So"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "AssociationId": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
@@ -307,7 +379,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "So"
+          }
         }
       },
       "output": {
@@ -322,12 +396,21 @@
           "TypeName"
         ],
         "members": {
-          "TypeName": {},
-          "SchemaDeleteOption": {},
+          "TypeName": {
+            "shape": "S3v"
+          },
+          "SchemaDeleteOption": {
+            "type": "string",
+            "enum": [
+              "DisableSchema",
+              "DeleteSchema"
+            ]
+          },
           "DryRun": {
             "type": "boolean"
           },
           "ClientToken": {
+            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -336,7 +419,9 @@
         "type": "structure",
         "members": {
           "DeletionId": {},
-          "TypeName": {},
+          "TypeName": {
+            "shape": "S3v"
+          },
           "DeletionSummary": {
             "shape": "S40"
           }
@@ -350,13 +435,17 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {}
+          "WindowId": {
+            "shape": "S2o"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {}
+          "WindowId": {
+            "shape": "S2o"
+          }
         }
       }
     },
@@ -367,7 +456,9 @@
           "Name"
         ],
         "members": {
-          "Name": {}
+          "Name": {
+            "shape": "S4a"
+          }
         }
       },
       "output": {
@@ -406,13 +497,17 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       }
     },
@@ -423,7 +518,9 @@
           "SyncName"
         ],
         "members": {
-          "SyncName": {}
+          "SyncName": {
+            "shape": "S3g"
+          }
         }
       },
       "output": {
@@ -438,7 +535,9 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {}
+          "InstanceId": {
+            "shape": "S4k"
+          }
         }
       },
       "output": {
@@ -454,15 +553,23 @@
           "PatchGroup"
         ],
         "members": {
-          "BaselineId": {},
-          "PatchGroup": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "PatchGroup": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "PatchGroup": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "PatchGroup": {
+            "shape": "S4n"
+          }
         }
       }
     },
@@ -474,8 +581,12 @@
           "WindowTargetId"
         ],
         "members": {
-          "WindowId": {},
-          "WindowTargetId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTargetId": {
+            "shape": "S4q"
+          },
           "Safe": {
             "type": "boolean"
           }
@@ -484,8 +595,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "WindowTargetId": {}
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTargetId": {
+            "shape": "S4q"
+          }
         }
       }
     },
@@ -497,15 +612,23 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {}
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {}
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          }
         }
       }
     },
@@ -518,7 +641,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "FilterKey": {},
+                "FilterKey": {
+                  "type": "string",
+                  "enum": [
+                    "ActivationIds",
+                    "DefaultInstanceName",
+                    "IamRole"
+                  ]
+                },
                 "FilterValues": {
                   "type": "list",
                   "member": {}
@@ -527,7 +657,7 @@
             }
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -540,15 +670,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "ActivationId": {},
-                "Description": {},
-                "DefaultInstanceName": {},
-                "IamRole": {},
+                "ActivationId": {
+                  "shape": "Sl"
+                },
+                "Description": {
+                  "shape": "Sf"
+                },
+                "DefaultInstanceName": {
+                  "shape": "Sg"
+                },
+                "IamRole": {
+                  "shape": "Sh"
+                },
                 "RegistrationLimit": {
-                  "type": "integer"
+                  "shape": "Si"
                 },
                 "RegistrationsCount": {
-                  "type": "integer"
+                  "type": "integer",
+                  "max": 1000,
+                  "min": 1
                 },
                 "ExpirationDate": {
                   "type": "timestamp"
@@ -570,10 +710,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "InstanceId": {},
-          "AssociationId": {},
-          "AssociationVersion": {}
+          "Name": {
+            "shape": "So"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "AssociationId": {
+            "shape": "S1i"
+          },
+          "AssociationVersion": {
+            "shape": "S18"
+          }
         }
       },
       "output": {
@@ -593,8 +741,12 @@
           "ExecutionId"
         ],
         "members": {
-          "AssociationId": {},
-          "ExecutionId": {},
+          "AssociationId": {
+            "shape": "S1i"
+          },
+          "ExecutionId": {
+            "shape": "S5b"
+          },
           "Filters": {
             "type": "list",
             "member": {
@@ -604,13 +756,24 @@
                 "Value"
               ],
               "members": {
-                "Key": {},
-                "Value": {}
+                "Key": {
+                  "type": "string",
+                  "enum": [
+                    "Status",
+                    "ResourceId",
+                    "ResourceType"
+                  ]
+                },
+                "Value": {
+                  "type": "string",
+                  "min": 1
+                }
               }
-            }
+            },
+            "min": 1
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -623,11 +786,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {},
-                "AssociationVersion": {},
-                "ExecutionId": {},
-                "ResourceId": {},
-                "ResourceType": {},
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                },
+                "ExecutionId": {
+                  "shape": "S5b"
+                },
+                "ResourceId": {
+                  "type": "string",
+                  "max": 100,
+                  "min": 1
+                },
+                "ResourceType": {
+                  "type": "string",
+                  "max": 50,
+                  "min": 1
+                },
                 "Status": {},
                 "DetailedStatus": {},
                 "LastExecutionDate": {
@@ -636,7 +813,11 @@
                 "OutputSource": {
                   "type": "structure",
                   "members": {
-                    "OutputSourceId": {},
+                    "OutputSourceId": {
+                      "type": "string",
+                      "max": 36,
+                      "min": 36
+                    },
                     "OutputSourceType": {}
                   }
                 }
@@ -654,7 +835,9 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {},
+          "AssociationId": {
+            "shape": "S1i"
+          },
           "Filters": {
             "type": "list",
             "member": {
@@ -665,14 +848,32 @@
                 "Type"
               ],
               "members": {
-                "Key": {},
-                "Value": {},
-                "Type": {}
+                "Key": {
+                  "type": "string",
+                  "enum": [
+                    "ExecutionId",
+                    "Status",
+                    "CreatedTime"
+                  ]
+                },
+                "Value": {
+                  "type": "string",
+                  "min": 1
+                },
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "EQUAL",
+                    "LESS_THAN",
+                    "GREATER_THAN"
+                  ]
+                }
               }
-            }
+            },
+            "min": 1
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -685,9 +886,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {},
-                "AssociationVersion": {},
-                "ExecutionId": {},
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                },
+                "ExecutionId": {
+                  "shape": "S5b"
+                },
                 "Status": {},
                 "DetailedStatus": {},
                 "CreatedTime": {
@@ -717,16 +924,35 @@
                 "Values"
               ],
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "enum": [
+                    "DocumentNamePrefix",
+                    "ExecutionStatus",
+                    "ExecutionId",
+                    "ParentExecutionId",
+                    "CurrentAction",
+                    "StartTimeBefore",
+                    "StartTimeAfter"
+                  ]
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 150,
+                    "min": 1
+                  },
+                  "max": 10,
+                  "min": 1
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 1
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -739,10 +965,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutomationExecutionId": {},
-                "DocumentName": {},
-                "DocumentVersion": {},
-                "AutomationExecutionStatus": {},
+                "AutomationExecutionId": {
+                  "shape": "S67"
+                },
+                "DocumentName": {
+                  "shape": "So"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
+                "AutomationExecutionStatus": {
+                  "shape": "S68"
+                },
                 "ExecutionStartTime": {
                   "type": "timestamp"
                 },
@@ -754,12 +988,18 @@
                 "Outputs": {
                   "shape": "S69"
                 },
-                "Mode": {},
-                "ParentAutomationExecutionId": {},
+                "Mode": {
+                  "shape": "S6d"
+                },
+                "ParentAutomationExecutionId": {
+                  "shape": "S67"
+                },
                 "CurrentStepName": {},
                 "CurrentAction": {},
                 "FailureMessage": {},
-                "TargetParameterName": {},
+                "TargetParameterName": {
+                  "shape": "S6a"
+                },
                 "Targets": {
                   "shape": "Su"
                 },
@@ -769,8 +1009,12 @@
                 "ResolvedTargets": {
                   "shape": "S6j"
                 },
-                "MaxConcurrency": {},
-                "MaxErrors": {},
+                "MaxConcurrency": {
+                  "shape": "S6l"
+                },
+                "MaxErrors": {
+                  "shape": "S6m"
+                },
                 "Target": {}
               }
             }
@@ -786,7 +1030,9 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {},
+          "AutomationExecutionId": {
+            "shape": "S67"
+          },
           "Filters": {
             "type": "list",
             "member": {
@@ -796,17 +1042,35 @@
                 "Values"
               ],
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "enum": [
+                    "StartTimeBefore",
+                    "StartTimeAfter",
+                    "StepExecutionStatus",
+                    "StepExecutionId",
+                    "StepName",
+                    "Action"
+                  ]
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 150,
+                    "min": 1
+                  },
+                  "max": 10,
+                  "min": 1
                 }
               }
-            }
+            },
+            "max": 6,
+            "min": 1
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "ReverseOrder": {
             "type": "boolean"
@@ -831,7 +1095,7 @@
             "shape": "S74"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S79"
           },
           "NextToken": {}
         }
@@ -856,8 +1120,12 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "DocumentVersion": {}
+          "Name": {
+            "shape": "S22"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          }
         }
       },
       "output": {
@@ -877,8 +1145,12 @@
           "PermissionType"
         ],
         "members": {
-          "Name": {},
-          "PermissionType": {}
+          "Name": {
+            "shape": "So"
+          },
+          "PermissionType": {
+            "shape": "S7r"
+          }
         }
       },
       "output": {
@@ -897,9 +1169,13 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 5,
+            "min": 1
           },
           "NextToken": {}
         }
@@ -912,10 +1188,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {},
-                "InstanceId": {},
-                "Content": {},
-                "AssociationVersion": {}
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "InstanceId": {
+                  "shape": "Sc"
+                },
+                "Content": {
+                  "shape": "S1t"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                }
               }
             }
           },
@@ -930,9 +1214,11 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {},
+          "BaselineId": {
+            "shape": "S3e"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S79"
           },
           "NextToken": {}
         }
@@ -951,8 +1237,18 @@
                 "PatchStatus": {
                   "type": "structure",
                   "members": {
-                    "DeploymentStatus": {},
-                    "ComplianceLevel": {},
+                    "DeploymentStatus": {
+                      "type": "string",
+                      "enum": [
+                        "APPROVED",
+                        "PENDING_APPROVAL",
+                        "EXPLICIT_APPROVED",
+                        "EXPLICIT_REJECTED"
+                      ]
+                    },
+                    "ComplianceLevel": {
+                      "shape": "S31"
+                    },
                     "ApprovalDate": {
                       "type": "timestamp"
                     }
@@ -972,9 +1268,11 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -987,18 +1285,35 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {},
-                "Name": {},
-                "DocumentVersion": {},
-                "AssociationVersion": {},
-                "InstanceId": {},
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "Name": {
+                  "shape": "So"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                },
+                "InstanceId": {
+                  "shape": "Sc"
+                },
                 "ExecutionDate": {
                   "type": "timestamp"
                 },
                 "Status": {},
                 "DetailedStatus": {},
-                "ExecutionSummary": {},
-                "ErrorCode": {},
+                "ExecutionSummary": {
+                  "type": "string",
+                  "max": 512,
+                  "min": 1
+                },
+                "ErrorCode": {
+                  "type": "string",
+                  "max": 10
+                },
                 "OutputUrl": {
                   "type": "structure",
                   "members": {
@@ -1010,7 +1325,9 @@
                     }
                   }
                 },
-                "AssociationName": {}
+                "AssociationName": {
+                  "shape": "S15"
+                }
               }
             }
           },
@@ -1031,12 +1348,25 @@
                 "valueSet"
               ],
               "members": {
-                "key": {},
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "InstanceIds",
+                    "AgentVersion",
+                    "PingStatus",
+                    "PlatformTypes",
+                    "ActivationIds",
+                    "IamRole",
+                    "ResourceType",
+                    "AssociationStatus"
+                  ]
+                },
                 "valueSet": {
                   "shape": "S8j"
                 }
               }
-            }
+            },
+            "min": 0
           },
           "Filters": {
             "type": "list",
@@ -1047,15 +1377,21 @@
                 "Values"
               ],
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "min": 1
+                },
                 "Values": {
                   "shape": "S8j"
                 }
               }
-            }
+            },
+            "min": 0
           },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 50,
+            "min": 5
           },
           "NextToken": {}
         }
@@ -1068,27 +1404,60 @@
             "member": {
               "type": "structure",
               "members": {
-                "InstanceId": {},
-                "PingStatus": {},
+                "InstanceId": {
+                  "shape": "Sc"
+                },
+                "PingStatus": {
+                  "type": "string",
+                  "enum": [
+                    "Online",
+                    "ConnectionLost",
+                    "Inactive"
+                  ]
+                },
                 "LastPingDateTime": {
                   "type": "timestamp"
                 },
-                "AgentVersion": {},
+                "AgentVersion": {
+                  "type": "string",
+                  "pattern": "^[0-9]{1,6}(\\.[0-9]{1,6}){2,3}$"
+                },
                 "IsLatestVersion": {
                   "type": "boolean"
                 },
-                "PlatformType": {},
+                "PlatformType": {
+                  "shape": "S2d"
+                },
                 "PlatformName": {},
                 "PlatformVersion": {},
-                "ActivationId": {},
-                "IamRole": {},
+                "ActivationId": {
+                  "shape": "Sl"
+                },
+                "IamRole": {
+                  "shape": "Sh"
+                },
                 "RegistrationDate": {
                   "type": "timestamp"
                 },
-                "ResourceType": {},
+                "ResourceType": {
+                  "type": "string",
+                  "enum": [
+                    "ManagedInstance",
+                    "Document",
+                    "EC2Instance"
+                  ]
+                },
                 "Name": {},
-                "IPAddress": {},
-                "ComputerName": {},
+                "IPAddress": {
+                  "type": "string",
+                  "max": 46,
+                  "min": 1
+                },
+                "ComputerName": {
+                  "type": "string",
+                  "max": 255,
+                  "min": 1
+                },
                 "AssociationStatus": {},
                 "LastAssociationExecutionDate": {
                   "type": "timestamp"
@@ -1128,7 +1497,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S90"
           }
         }
       },
@@ -1152,7 +1521,9 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {},
+          "PatchGroup": {
+            "shape": "S4n"
+          },
           "Filters": {
             "type": "list",
             "member": {
@@ -1163,18 +1534,34 @@
                 "Type"
               ],
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "max": 200,
+                  "min": 1
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {},
+                  "max": 1,
+                  "min": 1
                 },
-                "Type": {}
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "Equal",
+                    "NotEqual",
+                    "LessThan",
+                    "GreaterThan"
+                  ]
+                }
               }
-            }
+            },
+            "max": 4,
+            "min": 0
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S90"
           }
         }
       },
@@ -1185,7 +1572,9 @@
             "type": "list",
             "member": {
               "shape": "S93"
-            }
+            },
+            "max": 5,
+            "min": 1
           },
           "NextToken": {}
         }
@@ -1198,13 +1587,15 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "Filters": {
             "shape": "S74"
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S90"
           }
         }
       },
@@ -1228,7 +1619,16 @@
                 "KBId": {},
                 "Classification": {},
                 "Severity": {},
-                "State": {},
+                "State": {
+                  "type": "string",
+                  "enum": [
+                    "INSTALLED",
+                    "INSTALLED_OTHER",
+                    "MISSING",
+                    "NOT_APPLICABLE",
+                    "FAILED"
+                  ]
+                },
                 "InstalledTime": {
                   "type": "timestamp"
                 }
@@ -1246,7 +1646,7 @@
           "DeletionId": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -1259,11 +1659,19 @@
               "type": "structure",
               "members": {
                 "DeletionId": {},
-                "TypeName": {},
+                "TypeName": {
+                  "shape": "S3v"
+                },
                 "DeletionStartTime": {
                   "type": "timestamp"
                 },
-                "LastStatus": {},
+                "LastStatus": {
+                  "type": "string",
+                  "enum": [
+                    "InProgress",
+                    "Complete"
+                  ]
+                },
                 "LastStatusMessage": {},
                 "DeletionSummary": {
                   "shape": "S40"
@@ -1286,13 +1694,17 @@
           "TaskId"
         ],
         "members": {
-          "WindowExecutionId": {},
-          "TaskId": {},
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
+          "TaskId": {
+            "shape": "Sa1"
+          },
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1305,16 +1717,28 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowExecutionId": {},
-                "TaskExecutionId": {},
-                "InvocationId": {},
+                "WindowExecutionId": {
+                  "shape": "Sa0"
+                },
+                "TaskExecutionId": {
+                  "shape": "Sa1"
+                },
+                "InvocationId": {
+                  "shape": "Sab"
+                },
                 "ExecutionId": {},
-                "TaskType": {},
+                "TaskType": {
+                  "shape": "Sad"
+                },
                 "Parameters": {
                   "shape": "Sae"
                 },
-                "Status": {},
-                "StatusDetails": {},
+                "Status": {
+                  "shape": "Saf"
+                },
+                "StatusDetails": {
+                  "shape": "Sag"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -1324,7 +1748,9 @@
                 "OwnerInformation": {
                   "shape": "S95"
                 },
-                "WindowTargetId": {}
+                "WindowTargetId": {
+                  "shape": "Sah"
+                }
               }
             }
           },
@@ -1339,12 +1765,14 @@
           "WindowExecutionId"
         ],
         "members": {
-          "WindowExecutionId": {},
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1357,18 +1785,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowExecutionId": {},
-                "TaskExecutionId": {},
-                "Status": {},
-                "StatusDetails": {},
+                "WindowExecutionId": {
+                  "shape": "Sa0"
+                },
+                "TaskExecutionId": {
+                  "shape": "Sa1"
+                },
+                "Status": {
+                  "shape": "Saf"
+                },
+                "StatusDetails": {
+                  "shape": "Sag"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "TaskArn": {},
-                "TaskType": {}
+                "TaskArn": {
+                  "shape": "Sam"
+                },
+                "TaskType": {
+                  "shape": "Sad"
+                }
               }
             }
           },
@@ -1383,12 +1823,14 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1401,10 +1843,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {},
-                "WindowExecutionId": {},
-                "Status": {},
-                "StatusDetails": {},
+                "WindowId": {
+                  "shape": "S2o"
+                },
+                "WindowExecutionId": {
+                  "shape": "Sa0"
+                },
+                "Status": {
+                  "shape": "Saf"
+                },
+                "StatusDetails": {
+                  "shape": "Sag"
+                },
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -1425,12 +1875,14 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1443,16 +1895,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {},
-                "WindowTargetId": {},
-                "ResourceType": {},
+                "WindowId": {
+                  "shape": "S2o"
+                },
+                "WindowTargetId": {
+                  "shape": "S4q"
+                },
+                "ResourceType": {
+                  "shape": "Sav"
+                },
                 "Targets": {
                   "shape": "Su"
                 },
                 "OwnerInformation": {
                   "shape": "S95"
                 },
-                "Name": {},
+                "Name": {
+                  "shape": "S2g"
+                },
                 "Description": {
                   "shape": "S2h"
                 }
@@ -1470,12 +1930,14 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1488,10 +1950,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {},
-                "WindowTaskId": {},
-                "TaskArn": {},
-                "Type": {},
+                "WindowId": {
+                  "shape": "S2o"
+                },
+                "WindowTaskId": {
+                  "shape": "S4t"
+                },
+                "TaskArn": {
+                  "shape": "Sam"
+                },
+                "Type": {
+                  "shape": "Sad"
+                },
                 "Targets": {
                   "shape": "Su"
                 },
@@ -1499,15 +1969,21 @@
                   "shape": "Sb0"
                 },
                 "Priority": {
-                  "type": "integer"
+                  "shape": "Sb5"
                 },
                 "LoggingInfo": {
                   "shape": "Sb6"
                 },
                 "ServiceRoleArn": {},
-                "MaxConcurrency": {},
-                "MaxErrors": {},
-                "Name": {},
+                "MaxConcurrency": {
+                  "shape": "S6l"
+                },
+                "MaxErrors": {
+                  "shape": "S6m"
+                },
+                "Name": {
+                  "shape": "S2g"
+                },
                 "Description": {
                   "shape": "S2h"
                 }
@@ -1526,7 +2002,7 @@
             "shape": "Sa2"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sa7"
           },
           "NextToken": {}
         }
@@ -1539,8 +2015,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {},
-                "Name": {},
+                "WindowId": {
+                  "shape": "S2o"
+                },
+                "Name": {
+                  "shape": "S2g"
+                },
                 "Description": {
                   "shape": "S2h"
                 },
@@ -1548,10 +2028,10 @@
                   "type": "boolean"
                 },
                 "Duration": {
-                  "type": "integer"
+                  "shape": "S2j"
                 },
                 "Cutoff": {
-                  "type": "integer"
+                  "shape": "S2k"
                 }
               }
             }
@@ -1573,10 +2053,23 @@
                 "Values"
               ],
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "enum": [
+                    "Name",
+                    "Type",
+                    "KeyId"
+                  ]
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 1024,
+                    "min": 1
+                  },
+                  "max": 50,
+                  "min": 1
                 }
               }
             }
@@ -1585,7 +2078,7 @@
             "shape": "Sbj"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -1598,15 +2091,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Type": {},
-                "KeyId": {},
+                "Name": {
+                  "shape": "S4a"
+                },
+                "Type": {
+                  "shape": "Sbs"
+                },
+                "KeyId": {
+                  "shape": "Sbt"
+                },
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
                 "LastModifiedUser": {},
-                "Description": {},
-                "AllowedPattern": {},
+                "Description": {
+                  "shape": "Sbu"
+                },
+                "AllowedPattern": {
+                  "shape": "Sbv"
+                },
                 "Version": {
                   "type": "long"
                 }
@@ -1625,7 +2128,7 @@
             "shape": "S74"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S79"
           },
           "NextToken": {}
         }
@@ -1650,7 +2153,9 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {}
+          "PatchGroup": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
@@ -1682,7 +2187,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer"
+            "shape": "S79"
           },
           "Filters": {
             "shape": "S74"
@@ -1698,7 +2203,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "PatchGroup": {},
+                "PatchGroup": {
+                  "shape": "S4n"
+                },
                 "BaselineIdentity": {
                   "shape": "Sc0"
                 }
@@ -1716,9 +2223,17 @@
           "State"
         ],
         "members": {
-          "State": {},
+          "State": {
+            "type": "string",
+            "enum": [
+              "Active",
+              "History"
+            ]
+          },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 200,
+            "min": 1
           },
           "NextToken": {},
           "Filters": {
@@ -1730,10 +2245,25 @@
                 "value"
               ],
               "members": {
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "InvokedAfter",
+                    "InvokedBefore",
+                    "Target",
+                    "Owner",
+                    "Status"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "max": 200,
+                  "min": 1
+                }
               }
-            }
+            },
+            "max": 5,
+            "min": 1
           }
         }
       },
@@ -1745,23 +2275,55 @@
             "member": {
               "type": "structure",
               "members": {
-                "SessionId": {},
-                "Target": {},
-                "Status": {},
+                "SessionId": {
+                  "shape": "Sci"
+                },
+                "Target": {
+                  "shape": "Scj"
+                },
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "Connected",
+                    "Connecting",
+                    "Disconnected",
+                    "Terminated",
+                    "Terminating",
+                    "Failed"
+                  ]
+                },
                 "StartDate": {
                   "type": "timestamp"
                 },
                 "EndDate": {
                   "type": "timestamp"
                 },
-                "DocumentName": {},
-                "Owner": {},
-                "Details": {},
+                "DocumentName": {
+                  "shape": "So"
+                },
+                "Owner": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1
+                },
+                "Details": {
+                  "type": "string",
+                  "max": 1024,
+                  "min": 1
+                },
                 "OutputUrl": {
                   "type": "structure",
                   "members": {
-                    "S3OutputUrl": {},
-                    "CloudWatchOutputUrl": {}
+                    "S3OutputUrl": {
+                      "type": "string",
+                      "max": 2083,
+                      "min": 1
+                    },
+                    "CloudWatchOutputUrl": {
+                      "type": "string",
+                      "max": 2083,
+                      "min": 1
+                    }
                   }
                 }
               }
@@ -1778,7 +2340,9 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {}
+          "AutomationExecutionId": {
+            "shape": "S67"
+          }
         }
       },
       "output": {
@@ -1787,16 +2351,24 @@
           "AutomationExecution": {
             "type": "structure",
             "members": {
-              "AutomationExecutionId": {},
-              "DocumentName": {},
-              "DocumentVersion": {},
+              "AutomationExecutionId": {
+                "shape": "S67"
+              },
+              "DocumentName": {
+                "shape": "So"
+              },
+              "DocumentVersion": {
+                "shape": "Sp"
+              },
               "ExecutionStartTime": {
                 "type": "timestamp"
               },
               "ExecutionEndTime": {
                 "type": "timestamp"
               },
-              "AutomationExecutionStatus": {},
+              "AutomationExecutionStatus": {
+                "shape": "S68"
+              },
               "StepExecutions": {
                 "shape": "S6u"
               },
@@ -1810,12 +2382,18 @@
                 "shape": "S69"
               },
               "FailureMessage": {},
-              "Mode": {},
-              "ParentAutomationExecutionId": {},
+              "Mode": {
+                "shape": "S6d"
+              },
+              "ParentAutomationExecutionId": {
+                "shape": "S67"
+              },
               "ExecutedBy": {},
               "CurrentStepName": {},
               "CurrentAction": {},
-              "TargetParameterName": {},
+              "TargetParameterName": {
+                "shape": "S6a"
+              },
               "Targets": {
                 "shape": "Su"
               },
@@ -1825,8 +2403,12 @@
               "ResolvedTargets": {
                 "shape": "S6j"
               },
-              "MaxConcurrency": {},
-              "MaxErrors": {},
+              "MaxConcurrency": {
+                "shape": "S6l"
+              },
+              "MaxErrors": {
+                "shape": "S6m"
+              },
               "Target": {}
             }
           }
@@ -1841,31 +2423,65 @@
           "InstanceId"
         ],
         "members": {
-          "CommandId": {},
-          "InstanceId": {},
-          "PluginName": {}
+          "CommandId": {
+            "shape": "Sa"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "PluginName": {
+            "shape": "Scu"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CommandId": {},
-          "InstanceId": {},
-          "Comment": {},
-          "DocumentName": {},
-          "DocumentVersion": {},
-          "PluginName": {},
+          "CommandId": {
+            "shape": "Sa"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "Comment": {
+            "shape": "Scw"
+          },
+          "DocumentName": {
+            "shape": "So"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "PluginName": {
+            "shape": "Scu"
+          },
           "ResponseCode": {
             "type": "integer"
           },
-          "ExecutionStartDateTime": {},
-          "ExecutionElapsedTime": {},
-          "ExecutionEndDateTime": {},
-          "Status": {},
-          "StatusDetails": {},
-          "StandardOutputContent": {},
+          "ExecutionStartDateTime": {
+            "shape": "Scy"
+          },
+          "ExecutionElapsedTime": {
+            "shape": "Scy"
+          },
+          "ExecutionEndDateTime": {
+            "shape": "Scy"
+          },
+          "Status": {
+            "shape": "Scz"
+          },
+          "StatusDetails": {
+            "shape": "Sd0"
+          },
+          "StandardOutputContent": {
+            "type": "string",
+            "max": 24000
+          },
           "StandardOutputUrl": {},
-          "StandardErrorContent": {},
+          "StandardErrorContent": {
+            "type": "string",
+            "max": 8000
+          },
           "StandardErrorUrl": {},
           "CloudWatchOutputConfig": {
             "shape": "Sd3"
@@ -1880,14 +2496,24 @@
           "Target"
         ],
         "members": {
-          "Target": {}
+          "Target": {
+            "shape": "Scj"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Target": {},
-          "Status": {}
+          "Target": {
+            "shape": "Scj"
+          },
+          "Status": {
+            "type": "string",
+            "enum": [
+              "Connected",
+              "NotConnected"
+            ]
+          }
         }
       }
     },
@@ -1895,14 +2521,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "OperatingSystem": {}
+          "OperatingSystem": {
+            "shape": "S2q"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "OperatingSystem": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "OperatingSystem": {
+            "shape": "S2q"
+          }
         }
       }
     },
@@ -1914,15 +2546,23 @@
           "SnapshotId"
         ],
         "members": {
-          "InstanceId": {},
-          "SnapshotId": {}
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "SnapshotId": {
+            "shape": "S94"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "InstanceId": {},
-          "SnapshotId": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "SnapshotId": {
+            "shape": "S94"
+          },
           "SnapshotDownloadUrl": {},
           "Product": {}
         }
@@ -1935,19 +2575,35 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "DocumentVersion": {},
-          "DocumentFormat": {}
+          "Name": {
+            "shape": "S22"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "DocumentFormat": {
+            "shape": "S1v"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {},
-          "DocumentVersion": {},
-          "Content": {},
-          "DocumentType": {},
-          "DocumentFormat": {}
+          "Name": {
+            "shape": "S22"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "Content": {
+            "shape": "S1t"
+          },
+          "DocumentType": {
+            "shape": "S1u"
+          },
+          "DocumentFormat": {
+            "shape": "S1v"
+          }
         }
       }
     },
@@ -1969,13 +2625,17 @@
                 "TypeName"
               ],
               "members": {
-                "TypeName": {}
+                "TypeName": {
+                  "shape": "S3v"
+                }
               }
-            }
+            },
+            "max": 1,
+            "min": 1
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -1999,10 +2659,18 @@
                       "Content"
                     ],
                     "members": {
-                      "TypeName": {},
-                      "SchemaVersion": {},
-                      "CaptureTime": {},
-                      "ContentHash": {},
+                      "TypeName": {
+                        "shape": "S3v"
+                      },
+                      "SchemaVersion": {
+                        "shape": "S45"
+                      },
+                      "CaptureTime": {
+                        "shape": "Se3"
+                      },
+                      "ContentHash": {
+                        "shape": "Se4"
+                      },
                       "Content": {
                         "shape": "Se5"
                       }
@@ -2020,10 +2688,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "TypeName": {},
+          "TypeName": {
+            "type": "string",
+            "max": 100,
+            "min": 0
+          },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 200,
+            "min": 50
           },
           "Aggregator": {
             "type": "boolean"
@@ -2045,8 +2719,12 @@
                 "Attributes"
               ],
               "members": {
-                "TypeName": {},
-                "Version": {},
+                "TypeName": {
+                  "shape": "S3v"
+                },
+                "Version": {
+                  "shape": "S45"
+                },
                 "Attributes": {
                   "type": "list",
                   "member": {
@@ -2057,9 +2735,17 @@
                     ],
                     "members": {
                       "Name": {},
-                      "DataType": {}
+                      "DataType": {
+                        "type": "string",
+                        "enum": [
+                          "string",
+                          "number"
+                        ]
+                      }
                     }
-                  }
+                  },
+                  "max": 50,
+                  "min": 1
                 },
                 "DisplayName": {}
               }
@@ -2076,23 +2762,31 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {}
+          "WindowId": {
+            "shape": "S2o"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "Name": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {},
+          "Schedule": {
+            "shape": "S2i"
+          },
           "Duration": {
-            "type": "integer"
+            "shape": "S2j"
           },
           "Cutoff": {
-            "type": "integer"
+            "shape": "S2k"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -2116,19 +2810,29 @@
           "WindowExecutionId"
         ],
         "members": {
-          "WindowExecutionId": {}
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {},
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
           "TaskIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sa1"
+            }
           },
-          "Status": {},
-          "StatusDetails": {},
+          "Status": {
+            "shape": "Saf"
+          },
+          "StatusDetails": {
+            "shape": "Sag"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -2146,18 +2850,30 @@
           "TaskId"
         ],
         "members": {
-          "WindowExecutionId": {},
-          "TaskId": {}
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
+          "TaskId": {
+            "shape": "Sa1"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {},
-          "TaskExecutionId": {},
-          "TaskArn": {},
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
+          "TaskExecutionId": {
+            "shape": "Sa1"
+          },
+          "TaskArn": {
+            "shape": "Sam"
+          },
           "ServiceRole": {},
-          "Type": {},
+          "Type": {
+            "shape": "Sad"
+          },
           "TaskParameters": {
             "type": "list",
             "member": {
@@ -2166,12 +2882,20 @@
             "sensitive": true
           },
           "Priority": {
-            "type": "integer"
+            "shape": "Sb5"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {},
-          "Status": {},
-          "StatusDetails": {},
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
+          "Status": {
+            "shape": "Saf"
+          },
+          "StatusDetails": {
+            "shape": "Sag"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -2190,24 +2914,42 @@
           "InvocationId"
         ],
         "members": {
-          "WindowExecutionId": {},
-          "TaskId": {},
-          "InvocationId": {}
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
+          "TaskId": {
+            "shape": "Sa1"
+          },
+          "InvocationId": {
+            "shape": "Sab"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {},
-          "TaskExecutionId": {},
-          "InvocationId": {},
+          "WindowExecutionId": {
+            "shape": "Sa0"
+          },
+          "TaskExecutionId": {
+            "shape": "Sa1"
+          },
+          "InvocationId": {
+            "shape": "Sab"
+          },
           "ExecutionId": {},
-          "TaskType": {},
+          "TaskType": {
+            "shape": "Sad"
+          },
           "Parameters": {
             "shape": "Sae"
           },
-          "Status": {},
-          "StatusDetails": {},
+          "Status": {
+            "shape": "Saf"
+          },
+          "StatusDetails": {
+            "shape": "Sag"
+          },
           "StartTime": {
             "type": "timestamp"
           },
@@ -2217,7 +2959,9 @@
           "OwnerInformation": {
             "shape": "S95"
           },
-          "WindowTargetId": {}
+          "WindowTargetId": {
+            "shape": "Sah"
+          }
         }
       }
     },
@@ -2229,21 +2973,33 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {}
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          },
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {},
+          "TaskArn": {
+            "shape": "Sam"
+          },
           "ServiceRoleArn": {},
-          "TaskType": {},
+          "TaskType": {
+            "shape": "Sad"
+          },
           "TaskParameters": {
             "shape": "Sb0"
           },
@@ -2251,14 +3007,20 @@
             "shape": "Sey"
           },
           "Priority": {
-            "type": "integer"
+            "shape": "Sb5"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {},
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           }
@@ -2272,7 +3034,9 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S4a"
+          },
           "WithDecryption": {
             "type": "boolean"
           }
@@ -2294,12 +3058,14 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S4a"
+          },
           "WithDecryption": {
             "type": "boolean"
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -2312,16 +3078,28 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "Type": {},
-                "KeyId": {},
+                "Name": {
+                  "shape": "S4a"
+                },
+                "Type": {
+                  "shape": "Sbs"
+                },
+                "KeyId": {
+                  "shape": "Sbt"
+                },
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
                 "LastModifiedUser": {},
-                "Description": {},
-                "Value": {},
-                "AllowedPattern": {},
+                "Description": {
+                  "shape": "Sbu"
+                },
+                "Value": {
+                  "shape": "Sfh"
+                },
+                "AllowedPattern": {
+                  "shape": "Sbv"
+                },
                 "Version": {
                   "type": "long"
                 },
@@ -2369,7 +3147,9 @@
           "Path"
         ],
         "members": {
-          "Path": {},
+          "Path": {
+            "shape": "S4a"
+          },
           "Recursive": {
             "type": "boolean"
           },
@@ -2380,7 +3160,9 @@
             "type": "boolean"
           },
           "MaxResults": {
-            "type": "integer"
+            "type": "integer",
+            "max": 10,
+            "min": 1
           },
           "NextToken": {}
         }
@@ -2402,15 +3184,23 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "Name": {},
-          "OperatingSystem": {},
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "Name": {
+            "shape": "S2r"
+          },
+          "OperatingSystem": {
+            "shape": "S2q"
+          },
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -2420,7 +3210,9 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {},
+          "ApprovedPatchesComplianceLevel": {
+            "shape": "S31"
+          },
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
@@ -2429,7 +3221,9 @@
           },
           "PatchGroups": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4n"
+            }
           },
           "CreatedDate": {
             "type": "timestamp"
@@ -2437,7 +3231,9 @@
           "ModifiedDate": {
             "type": "timestamp"
           },
-          "Description": {},
+          "Description": {
+            "shape": "S36"
+          },
           "Sources": {
             "shape": "S37"
           }
@@ -2451,16 +3247,26 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {},
-          "OperatingSystem": {}
+          "PatchGroup": {
+            "shape": "S4n"
+          },
+          "OperatingSystem": {
+            "shape": "S2q"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "PatchGroup": {},
-          "OperatingSystem": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "PatchGroup": {
+            "shape": "S4n"
+          },
+          "OperatingSystem": {
+            "shape": "S2q"
+          }
         }
       }
     },
@@ -2472,7 +3278,9 @@
           "Labels"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S4a"
+          },
           "ParameterVersion": {
             "type": "long"
           },
@@ -2497,9 +3305,11 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {},
+          "AssociationId": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -2512,26 +3322,39 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {},
-                "AssociationVersion": {},
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                },
                 "CreatedDate": {
                   "type": "timestamp"
                 },
-                "Name": {},
-                "DocumentVersion": {},
+                "Name": {
+                  "shape": "So"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
                 "Parameters": {
                   "shape": "Sq"
                 },
                 "Targets": {
                   "shape": "Su"
                 },
-                "ScheduleExpression": {},
+                "ScheduleExpression": {
+                  "shape": "Sz"
+                },
                 "OutputLocation": {
                   "shape": "S10"
                 },
-                "AssociationName": {}
+                "AssociationName": {
+                  "shape": "S15"
+                }
               }
-            }
+            },
+            "min": 1
           },
           "NextToken": {}
         }
@@ -2550,13 +3373,28 @@
                 "value"
               ],
               "members": {
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "InstanceId",
+                    "Name",
+                    "AssociationId",
+                    "AssociationStatusName",
+                    "LastExecutedBefore",
+                    "LastExecutedAfter",
+                    "AssociationName"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "min": 1
+                }
               }
-            }
+            },
+            "min": 1
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -2569,11 +3407,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "InstanceId": {},
-                "AssociationId": {},
-                "AssociationVersion": {},
-                "DocumentVersion": {},
+                "Name": {
+                  "shape": "So"
+                },
+                "InstanceId": {
+                  "shape": "Sc"
+                },
+                "AssociationId": {
+                  "shape": "S1i"
+                },
+                "AssociationVersion": {
+                  "shape": "S18"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
                 "Targets": {
                   "shape": "Su"
                 },
@@ -2583,8 +3431,12 @@
                 "Overview": {
                   "shape": "S1e"
                 },
-                "ScheduleExpression": {},
-                "AssociationName": {}
+                "ScheduleExpression": {
+                  "shape": "Sz"
+                },
+                "AssociationName": {
+                  "shape": "S15"
+                }
               }
             }
           },
@@ -2596,10 +3448,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "CommandId": {},
-          "InstanceId": {},
+          "CommandId": {
+            "shape": "Sa"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sgf"
           },
           "NextToken": {},
           "Filters": {
@@ -2618,18 +3474,38 @@
             "member": {
               "type": "structure",
               "members": {
-                "CommandId": {},
-                "InstanceId": {},
-                "InstanceName": {},
-                "Comment": {},
-                "DocumentName": {},
-                "DocumentVersion": {},
+                "CommandId": {
+                  "shape": "Sa"
+                },
+                "InstanceId": {
+                  "shape": "Sc"
+                },
+                "InstanceName": {
+                  "type": "string",
+                  "max": 255
+                },
+                "Comment": {
+                  "shape": "Scw"
+                },
+                "DocumentName": {
+                  "shape": "So"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
                 "RequestedDateTime": {
                   "type": "timestamp"
                 },
-                "Status": {},
-                "StatusDetails": {},
-                "TraceOutput": {},
+                "Status": {
+                  "shape": "Scz"
+                },
+                "StatusDetails": {
+                  "shape": "Sd0"
+                },
+                "TraceOutput": {
+                  "type": "string",
+                  "max": 2500
+                },
                 "StandardOutputUrl": {},
                 "StandardErrorUrl": {},
                 "CommandPlugins": {
@@ -2637,9 +3513,23 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Name": {},
-                      "Status": {},
-                      "StatusDetails": {},
+                      "Name": {
+                        "shape": "Scu"
+                      },
+                      "Status": {
+                        "type": "string",
+                        "enum": [
+                          "Pending",
+                          "InProgress",
+                          "Success",
+                          "TimedOut",
+                          "Cancelled",
+                          "Failed"
+                        ]
+                      },
+                      "StatusDetails": {
+                        "shape": "Sd0"
+                      },
                       "ResponseCode": {
                         "type": "integer"
                       },
@@ -2649,12 +3539,21 @@
                       "ResponseFinishDateTime": {
                         "type": "timestamp"
                       },
-                      "Output": {},
+                      "Output": {
+                        "type": "string",
+                        "max": 2500
+                      },
                       "StandardOutputUrl": {},
                       "StandardErrorUrl": {},
-                      "OutputS3Region": {},
-                      "OutputS3BucketName": {},
-                      "OutputS3KeyPrefix": {}
+                      "OutputS3Region": {
+                        "shape": "S12"
+                      },
+                      "OutputS3BucketName": {
+                        "shape": "S13"
+                      },
+                      "OutputS3KeyPrefix": {
+                        "shape": "S14"
+                      }
                     }
                   }
                 },
@@ -2676,10 +3575,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "CommandId": {},
-          "InstanceId": {},
+          "CommandId": {
+            "shape": "Sa"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Sgf"
           },
           "NextToken": {},
           "Filters": {
@@ -2709,15 +3612,21 @@
           },
           "ResourceIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sha"
+            },
+            "min": 1
           },
           "ResourceTypes": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Shc"
+            },
+            "min": 1
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -2729,13 +3638,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {},
-                "ResourceType": {},
-                "ResourceId": {},
-                "Id": {},
-                "Title": {},
-                "Status": {},
-                "Severity": {},
+                "ComplianceType": {
+                  "shape": "Shg"
+                },
+                "ResourceType": {
+                  "shape": "Shc"
+                },
+                "ResourceId": {
+                  "shape": "Sha"
+                },
+                "Id": {
+                  "shape": "Shh"
+                },
+                "Title": {
+                  "shape": "Shi"
+                },
+                "Status": {
+                  "shape": "Shj"
+                },
+                "Severity": {
+                  "shape": "Shk"
+                },
                 "ExecutionSummary": {
                   "shape": "Shl"
                 },
@@ -2758,7 +3681,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -2770,7 +3693,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {},
+                "ComplianceType": {
+                  "shape": "Shg"
+                },
                 "CompliantSummary": {
                   "shape": "Sht"
                 },
@@ -2791,9 +3716,11 @@
           "Name"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "So"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -2806,17 +3733,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
-                "DocumentVersion": {},
+                "Name": {
+                  "shape": "So"
+                },
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
                 "CreatedDate": {
                   "type": "timestamp"
                 },
                 "IsDefaultVersion": {
                   "type": "boolean"
                 },
-                "DocumentFormat": {}
+                "DocumentFormat": {
+                  "shape": "S1v"
+                }
               }
-            }
+            },
+            "min": 1
           },
           "NextToken": {}
         }
@@ -2835,26 +3769,48 @@
                 "value"
               ],
               "members": {
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "enum": [
+                    "Name",
+                    "Owner",
+                    "PlatformTypes",
+                    "DocumentType"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "min": 1
+                }
               }
-            }
+            },
+            "min": 1
           },
           "Filters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {},
+                "Key": {
+                  "type": "string",
+                  "max": 128,
+                  "min": 1
+                },
                 "Values": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "type": "string",
+                    "max": 256,
+                    "min": 1
+                  }
                 }
               }
-            }
+            },
+            "max": 6,
+            "min": 0
           },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           },
           "NextToken": {}
         }
@@ -2867,16 +3823,28 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {},
+                "Name": {
+                  "shape": "S22"
+                },
                 "Owner": {},
                 "PlatformTypes": {
                   "shape": "S2c"
                 },
-                "DocumentVersion": {},
-                "DocumentType": {},
-                "SchemaVersion": {},
-                "DocumentFormat": {},
-                "TargetType": {},
+                "DocumentVersion": {
+                  "shape": "Sp"
+                },
+                "DocumentType": {
+                  "shape": "S1u"
+                },
+                "SchemaVersion": {
+                  "shape": "S2e"
+                },
+                "DocumentFormat": {
+                  "shape": "S1v"
+                },
+                "TargetType": {
+                  "shape": "S1w"
+                },
                 "Tags": {
                   "shape": "S4"
                 }
@@ -2895,24 +3863,36 @@
           "TypeName"
         ],
         "members": {
-          "InstanceId": {},
-          "TypeName": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "TypeName": {
+            "shape": "S3v"
+          },
           "Filters": {
             "shape": "Sdi"
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TypeName": {},
-          "InstanceId": {},
-          "SchemaVersion": {},
-          "CaptureTime": {},
+          "TypeName": {
+            "shape": "S3v"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
+          "SchemaVersion": {
+            "shape": "S45"
+          },
+          "CaptureTime": {
+            "shape": "Se3"
+          },
           "Entries": {
             "shape": "Se5"
           },
@@ -2929,7 +3909,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -2941,11 +3921,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {},
-                "ResourceType": {},
-                "ResourceId": {},
-                "Status": {},
-                "OverallSeverity": {},
+                "ComplianceType": {
+                  "shape": "Shg"
+                },
+                "ResourceType": {
+                  "shape": "Shc"
+                },
+                "ResourceId": {
+                  "shape": "Sha"
+                },
+                "Status": {
+                  "shape": "Shj"
+                },
+                "OverallSeverity": {
+                  "shape": "Shk"
+                },
                 "ExecutionSummary": {
                   "shape": "Shl"
                 },
@@ -2968,7 +3958,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer"
+            "shape": "S51"
           }
         }
       },
@@ -2980,7 +3970,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "SyncName": {},
+                "SyncName": {
+                  "shape": "S3g"
+                },
                 "S3Destination": {
                   "shape": "S3h"
                 },
@@ -2990,7 +3982,14 @@
                 "LastSuccessfulSyncTime": {
                   "type": "timestamp"
                 },
-                "LastStatus": {},
+                "LastStatus": {
+                  "type": "string",
+                  "enum": [
+                    "Successful",
+                    "Failed",
+                    "InProgress"
+                  ]
+                },
                 "SyncCreatedTime": {
                   "type": "timestamp"
                 },
@@ -3010,7 +4009,9 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceType": {},
+          "ResourceType": {
+            "shape": "S2"
+          },
           "ResourceId": {}
         }
       },
@@ -3031,8 +4032,12 @@
           "PermissionType"
         ],
         "members": {
-          "Name": {},
-          "PermissionType": {},
+          "Name": {
+            "shape": "So"
+          },
+          "PermissionType": {
+            "shape": "S7r"
+          },
           "AccountIdsToAdd": {
             "shape": "S7t"
           },
@@ -3057,9 +4062,15 @@
           "Items"
         ],
         "members": {
-          "ResourceId": {},
-          "ResourceType": {},
-          "ComplianceType": {},
+          "ResourceId": {
+            "shape": "Sha"
+          },
+          "ResourceType": {
+            "shape": "Shc"
+          },
+          "ComplianceType": {
+            "shape": "Shg"
+          },
           "ExecutionSummary": {
             "shape": "Shl"
           },
@@ -3072,17 +4083,30 @@
                 "Status"
               ],
               "members": {
-                "Id": {},
-                "Title": {},
-                "Severity": {},
-                "Status": {},
+                "Id": {
+                  "shape": "Shh"
+                },
+                "Title": {
+                  "shape": "Shi"
+                },
+                "Severity": {
+                  "shape": "Shk"
+                },
+                "Status": {
+                  "shape": "Shj"
+                },
                 "Details": {
                   "shape": "Sho"
                 }
               }
-            }
+            },
+            "max": 10000,
+            "min": 0
           },
-          "ItemContentHash": {}
+          "ItemContentHash": {
+            "type": "string",
+            "max": 256
+          }
         }
       },
       "output": {
@@ -3098,7 +4122,9 @@
           "Items"
         ],
         "members": {
-          "InstanceId": {},
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "Items": {
             "type": "list",
             "member": {
@@ -3109,20 +4135,36 @@
                 "CaptureTime"
               ],
               "members": {
-                "TypeName": {},
-                "SchemaVersion": {},
-                "CaptureTime": {},
-                "ContentHash": {},
+                "TypeName": {
+                  "shape": "S3v"
+                },
+                "SchemaVersion": {
+                  "shape": "S45"
+                },
+                "CaptureTime": {
+                  "shape": "Se3"
+                },
+                "ContentHash": {
+                  "shape": "Se4"
+                },
                 "Content": {
                   "shape": "Se5"
                 },
                 "Context": {
                   "type": "map",
-                  "key": {},
-                  "value": {}
+                  "key": {
+                    "shape": "Se7"
+                  },
+                  "value": {
+                    "shape": "Se8"
+                  },
+                  "max": 50,
+                  "min": 0
                 }
               }
-            }
+            },
+            "max": 30,
+            "min": 1
           }
         }
       },
@@ -3142,15 +4184,27 @@
           "Type"
         ],
         "members": {
-          "Name": {},
-          "Description": {},
-          "Value": {},
-          "Type": {},
-          "KeyId": {},
+          "Name": {
+            "shape": "S4a"
+          },
+          "Description": {
+            "shape": "Sbu"
+          },
+          "Value": {
+            "shape": "Sfh"
+          },
+          "Type": {
+            "shape": "Sbs"
+          },
+          "KeyId": {
+            "shape": "Sbt"
+          },
           "Overwrite": {
             "type": "boolean"
           },
-          "AllowedPattern": {}
+          "AllowedPattern": {
+            "shape": "Sbv"
+          }
         }
       },
       "output": {
@@ -3169,13 +4223,17 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {}
+          "BaselineId": {
+            "shape": "S3e"
+          }
         }
       }
     },
@@ -3187,15 +4245,23 @@
           "PatchGroup"
         ],
         "members": {
-          "BaselineId": {},
-          "PatchGroup": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "PatchGroup": {
+            "shape": "S4n"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "PatchGroup": {}
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "PatchGroup": {
+            "shape": "S4n"
+          }
         }
       }
     },
@@ -3208,19 +4274,26 @@
           "Targets"
         ],
         "members": {
-          "WindowId": {},
-          "ResourceType": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "ResourceType": {
+            "shape": "Sav"
+          },
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
           "ClientToken": {
+            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -3228,7 +4301,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowTargetId": {}
+          "WindowTargetId": {
+            "shape": "S4q"
+          }
         }
       }
     },
@@ -3244,13 +4319,19 @@
           "MaxErrors"
         ],
         "members": {
-          "WindowId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {},
+          "TaskArn": {
+            "shape": "Sam"
+          },
           "ServiceRoleArn": {},
-          "TaskType": {},
+          "TaskType": {
+            "shape": "Sad"
+          },
           "TaskParameters": {
             "shape": "Sb0"
           },
@@ -3258,18 +4339,25 @@
             "shape": "Sey"
           },
           "Priority": {
-            "type": "integer"
+            "shape": "Sb5"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {},
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
           "ClientToken": {
+            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -3277,7 +4365,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowTaskId": {}
+          "WindowTaskId": {
+            "shape": "S4t"
+          }
         }
       }
     },
@@ -3290,11 +4380,15 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceType": {},
+          "ResourceType": {
+            "shape": "S2"
+          },
           "ResourceId": {},
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S6"
+            }
           }
         }
       },
@@ -3310,14 +4404,20 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {}
+          "SessionId": {
+            "shape": "Sci"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {},
-          "TokenValue": {},
+          "SessionId": {
+            "shape": "Sci"
+          },
+          "TokenValue": {
+            "shape": "Sjn"
+          },
           "StreamUrl": {}
         }
       }
@@ -3330,8 +4430,19 @@
           "SignalType"
         ],
         "members": {
-          "AutomationExecutionId": {},
-          "SignalType": {},
+          "AutomationExecutionId": {
+            "shape": "S67"
+          },
+          "SignalType": {
+            "type": "string",
+            "enum": [
+              "Approve",
+              "Reject",
+              "StartStep",
+              "StopStep",
+              "Resume"
+            ]
+          },
           "Payload": {
             "shape": "S69"
           }
@@ -3355,22 +4466,42 @@
           "Targets": {
             "shape": "Su"
           },
-          "DocumentName": {},
-          "DocumentVersion": {},
-          "DocumentHash": {},
-          "DocumentHashType": {},
-          "TimeoutSeconds": {
-            "type": "integer"
+          "DocumentName": {
+            "shape": "S22"
           },
-          "Comment": {},
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "DocumentHash": {
+            "shape": "S20"
+          },
+          "DocumentHashType": {
+            "shape": "S21"
+          },
+          "TimeoutSeconds": {
+            "shape": "Sf5"
+          },
+          "Comment": {
+            "shape": "Scw"
+          },
           "Parameters": {
             "shape": "Sq"
           },
-          "OutputS3Region": {},
-          "OutputS3BucketName": {},
-          "OutputS3KeyPrefix": {},
-          "MaxConcurrency": {},
-          "MaxErrors": {},
+          "OutputS3Region": {
+            "shape": "S12"
+          },
+          "OutputS3BucketName": {
+            "shape": "S13"
+          },
+          "OutputS3KeyPrefix": {
+            "shape": "S14"
+          },
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
           "ServiceRoleArn": {},
           "NotificationConfig": {
             "shape": "Sf0"
@@ -3398,7 +4529,11 @@
         "members": {
           "AssociationIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S1i"
+            },
+            "max": 10,
+            "min": 1
           }
         }
       },
@@ -3414,28 +4549,47 @@
           "DocumentName"
         ],
         "members": {
-          "DocumentName": {},
-          "DocumentVersion": {},
+          "DocumentName": {
+            "shape": "S22"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
           "Parameters": {
             "shape": "S69"
           },
-          "ClientToken": {},
-          "Mode": {},
-          "TargetParameterName": {},
+          "ClientToken": {
+            "type": "string",
+            "max": 36,
+            "min": 36,
+            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+          },
+          "Mode": {
+            "shape": "S6d"
+          },
+          "TargetParameterName": {
+            "shape": "S6a"
+          },
           "Targets": {
             "shape": "Su"
           },
           "TargetMaps": {
             "shape": "S6e"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {}
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AutomationExecutionId": {}
+          "AutomationExecutionId": {
+            "shape": "S67"
+          }
         }
       }
     },
@@ -3446,14 +4600,26 @@
           "Target"
         ],
         "members": {
-          "Target": {},
-          "DocumentName": {},
+          "Target": {
+            "shape": "Scj"
+          },
+          "DocumentName": {
+            "shape": "S22"
+          },
           "Parameters": {
             "type": "map",
-            "key": {},
+            "key": {
+              "type": "string",
+              "max": 255,
+              "min": 1
+            },
             "value": {
               "type": "list",
-              "member": {}
+              "member": {
+                "type": "string",
+                "max": 65535,
+                "min": 1
+              }
             }
           }
         }
@@ -3461,8 +4627,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {},
-          "TokenValue": {},
+          "SessionId": {
+            "shape": "Sci"
+          },
+          "TokenValue": {
+            "shape": "Sjn"
+          },
           "StreamUrl": {}
         }
       }
@@ -3474,8 +4644,16 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {},
-          "Type": {}
+          "AutomationExecutionId": {
+            "shape": "S67"
+          },
+          "Type": {
+            "type": "string",
+            "enum": [
+              "Complete",
+              "Cancel"
+            ]
+          }
         }
       },
       "output": {
@@ -3490,13 +4668,17 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {}
+          "SessionId": {
+            "shape": "Sci"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {}
+          "SessionId": {
+            "shape": "Sci"
+          }
         }
       }
     },
@@ -3507,21 +4689,33 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {},
+          "AssociationId": {
+            "shape": "S1i"
+          },
           "Parameters": {
             "shape": "Sq"
           },
-          "DocumentVersion": {},
-          "ScheduleExpression": {},
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "ScheduleExpression": {
+            "shape": "Sz"
+          },
           "OutputLocation": {
             "shape": "S10"
           },
-          "Name": {},
+          "Name": {
+            "shape": "So"
+          },
           "Targets": {
             "shape": "Su"
           },
-          "AssociationName": {},
-          "AssociationVersion": {}
+          "AssociationName": {
+            "shape": "S15"
+          },
+          "AssociationVersion": {
+            "shape": "S18"
+          }
         }
       },
       "output": {
@@ -3542,8 +4736,12 @@
           "AssociationStatus"
         ],
         "members": {
-          "Name": {},
-          "InstanceId": {},
+          "Name": {
+            "shape": "So"
+          },
+          "InstanceId": {
+            "shape": "Sc"
+          },
           "AssociationStatus": {
             "shape": "S1a"
           }
@@ -3566,11 +4764,21 @@
           "Name"
         ],
         "members": {
-          "Content": {},
-          "Name": {},
-          "DocumentVersion": {},
-          "DocumentFormat": {},
-          "TargetType": {}
+          "Content": {
+            "shape": "S1t"
+          },
+          "Name": {
+            "shape": "So"
+          },
+          "DocumentVersion": {
+            "shape": "Sp"
+          },
+          "DocumentFormat": {
+            "shape": "S1v"
+          },
+          "TargetType": {
+            "shape": "S1w"
+          }
         }
       },
       "output": {
@@ -3590,8 +4798,13 @@
           "DocumentVersion"
         ],
         "members": {
-          "Name": {},
-          "DocumentVersion": {}
+          "Name": {
+            "shape": "So"
+          },
+          "DocumentVersion": {
+            "type": "string",
+            "pattern": "(^[1-9][0-9]*$)"
+          }
         }
       },
       "output": {
@@ -3600,8 +4813,12 @@
           "Description": {
             "type": "structure",
             "members": {
-              "Name": {},
-              "DefaultVersion": {}
+              "Name": {
+                "shape": "So"
+              },
+              "DefaultVersion": {
+                "shape": "Sp"
+              }
             }
           }
         }
@@ -3614,17 +4831,23 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {},
-          "Name": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {},
+          "Schedule": {
+            "shape": "S2i"
+          },
           "Duration": {
-            "type": "integer"
+            "shape": "S2j"
           },
           "Cutoff": {
-            "type": "integer"
+            "shape": "S2k"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -3640,17 +4863,23 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "Name": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {},
+          "Schedule": {
+            "shape": "S2i"
+          },
           "Duration": {
-            "type": "integer"
+            "shape": "S2j"
           },
           "Cutoff": {
-            "type": "integer"
+            "shape": "S2k"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -3669,15 +4898,21 @@
           "WindowTargetId"
         ],
         "members": {
-          "WindowId": {},
-          "WindowTargetId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTargetId": {
+            "shape": "S4q"
+          },
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
@@ -3689,15 +4924,21 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "WindowTargetId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTargetId": {
+            "shape": "S4q"
+          },
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           }
@@ -3712,12 +4953,18 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          },
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {},
+          "TaskArn": {
+            "shape": "Sam"
+          },
           "ServiceRoleArn": {},
           "TaskParameters": {
             "shape": "Sb0"
@@ -3726,14 +4973,20 @@
             "shape": "Sey"
           },
           "Priority": {
-            "type": "integer"
+            "shape": "Sb5"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {},
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           },
@@ -3745,12 +4998,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {},
-          "WindowTaskId": {},
+          "WindowId": {
+            "shape": "S2o"
+          },
+          "WindowTaskId": {
+            "shape": "S4t"
+          },
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {},
+          "TaskArn": {
+            "shape": "Sam"
+          },
           "ServiceRoleArn": {},
           "TaskParameters": {
             "shape": "Sb0"
@@ -3759,14 +5018,20 @@
             "shape": "Sey"
           },
           "Priority": {
-            "type": "integer"
+            "shape": "Sb5"
           },
-          "MaxConcurrency": {},
-          "MaxErrors": {},
+          "MaxConcurrency": {
+            "shape": "S6l"
+          },
+          "MaxErrors": {
+            "shape": "S6m"
+          },
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {},
+          "Name": {
+            "shape": "S2g"
+          },
           "Description": {
             "shape": "S2h"
           }
@@ -3781,8 +5046,12 @@
           "IamRole"
         ],
         "members": {
-          "InstanceId": {},
-          "IamRole": {}
+          "InstanceId": {
+            "shape": "S4k"
+          },
+          "IamRole": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -3797,8 +5066,12 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {},
-          "Name": {},
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "Name": {
+            "shape": "S2r"
+          },
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -3808,14 +5081,18 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {},
+          "ApprovedPatchesComplianceLevel": {
+            "shape": "S31"
+          },
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
           "RejectedPatches": {
             "shape": "S34"
           },
-          "Description": {},
+          "Description": {
+            "shape": "S36"
+          },
           "Sources": {
             "shape": "S37"
           },
@@ -3827,9 +5104,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {},
-          "Name": {},
-          "OperatingSystem": {},
+          "BaselineId": {
+            "shape": "S3e"
+          },
+          "Name": {
+            "shape": "S2r"
+          },
+          "OperatingSystem": {
+            "shape": "S2q"
+          },
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -3839,7 +5122,9 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {},
+          "ApprovedPatchesComplianceLevel": {
+            "shape": "S31"
+          },
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
@@ -3852,7 +5137,9 @@
           "ModifiedDate": {
             "type": "timestamp"
           },
-          "Description": {},
+          "Description": {
+            "shape": "S36"
+          },
           "Sources": {
             "shape": "S37"
           }
@@ -3861,6 +5148,16 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "enum": [
+        "Document",
+        "ManagedInstance",
+        "MaintenanceWindow",
+        "Parameter",
+        "PatchBaseline"
+      ]
+    },
     "S4": {
       "type": "list",
       "member": {
@@ -3870,14 +5167,72 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "S6"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256,
+            "min": 1,
+            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+          }
         }
       }
     },
+    "S6": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^(?!^(?i)aws:)(?=^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$).*$"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 36,
+      "min": 36
+    },
     "Sb": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sc"
+      },
+      "max": 50,
+      "min": 0
+    },
+    "Sc": {
+      "type": "string",
+      "pattern": "(^i-(\\w{8}|\\w{17})$)|(^mi-\\w{17}$)"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "Sg": {
+      "type": "string",
+      "max": 256,
+      "min": 0,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "Sh": {
+      "type": "string",
+      "max": 64
+    },
+    "Si": {
+      "type": "integer",
+      "max": 1000,
+      "min": 1
+    },
+    "Sl": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "So": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
+    },
+    "Sp": {
+      "type": "string",
+      "pattern": "([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)"
     },
     "Sq": {
       "type": "map",
@@ -3892,13 +5247,27 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1,
+            "pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=\\-@]*$"
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 50,
+            "min": 0
           }
         }
-      }
+      },
+      "max": 5,
+      "min": 0
+    },
+    "Sz": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     },
     "S10": {
       "type": "structure",
@@ -3906,19 +5275,49 @@
         "S3Location": {
           "type": "structure",
           "members": {
-            "OutputS3Region": {},
-            "OutputS3BucketName": {},
-            "OutputS3KeyPrefix": {}
+            "OutputS3Region": {
+              "shape": "S12"
+            },
+            "OutputS3BucketName": {
+              "shape": "S13"
+            },
+            "OutputS3KeyPrefix": {
+              "shape": "S14"
+            }
           }
         }
       }
     },
+    "S12": {
+      "type": "string",
+      "max": 20,
+      "min": 3
+    },
+    "S13": {
+      "type": "string",
+      "max": 63,
+      "min": 3
+    },
+    "S14": {
+      "type": "string",
+      "max": 500
+    },
+    "S15": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
+    },
     "S17": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "InstanceId": {},
-        "AssociationVersion": {},
+        "Name": {
+          "shape": "So"
+        },
+        "InstanceId": {
+          "shape": "Sc"
+        },
+        "AssociationVersion": {
+          "shape": "S18"
+        },
         "Date": {
           "type": "timestamp"
         },
@@ -3931,15 +5330,21 @@
         "Overview": {
           "shape": "S1e"
         },
-        "DocumentVersion": {},
+        "DocumentVersion": {
+          "shape": "Sp"
+        },
         "Parameters": {
           "shape": "Sq"
         },
-        "AssociationId": {},
+        "AssociationId": {
+          "shape": "S1i"
+        },
         "Targets": {
           "shape": "Su"
         },
-        "ScheduleExpression": {},
+        "ScheduleExpression": {
+          "shape": "Sz"
+        },
         "OutputLocation": {
           "shape": "S10"
         },
@@ -3949,8 +5354,14 @@
         "LastSuccessfulExecutionDate": {
           "type": "timestamp"
         },
-        "AssociationName": {}
+        "AssociationName": {
+          "shape": "S15"
+        }
       }
+    },
+    "S18": {
+      "type": "string",
+      "pattern": "([$]LATEST)|([1-9][0-9]*)"
     },
     "S1a": {
       "type": "structure",
@@ -3963,9 +5374,23 @@
         "Date": {
           "type": "timestamp"
         },
-        "Name": {},
-        "Message": {},
-        "AdditionalInfo": {}
+        "Name": {
+          "type": "string",
+          "enum": [
+            "Pending",
+            "Success",
+            "Failed"
+          ]
+        },
+        "Message": {
+          "type": "string",
+          "max": 1024,
+          "min": 1
+        },
+        "AdditionalInfo": {
+          "type": "string",
+          "max": 1024
+        }
       }
     },
     "S1e": {
@@ -3982,41 +5407,96 @@
         }
       }
     },
+    "S1i": {
+      "type": "string",
+      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    },
     "S1l": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {},
-        "InstanceId": {},
+        "Name": {
+          "shape": "So"
+        },
+        "InstanceId": {
+          "shape": "Sc"
+        },
         "Parameters": {
           "shape": "Sq"
         },
-        "DocumentVersion": {},
+        "DocumentVersion": {
+          "shape": "Sp"
+        },
         "Targets": {
           "shape": "Su"
         },
-        "ScheduleExpression": {},
+        "ScheduleExpression": {
+          "shape": "Sz"
+        },
         "OutputLocation": {
           "shape": "S10"
         },
-        "AssociationName": {}
+        "AssociationName": {
+          "shape": "S15"
+        }
       }
+    },
+    "S1t": {
+      "type": "string",
+      "min": 1
+    },
+    "S1u": {
+      "type": "string",
+      "enum": [
+        "Command",
+        "Policy",
+        "Automation",
+        "Session"
+      ]
+    },
+    "S1v": {
+      "type": "string",
+      "enum": [
+        "YAML",
+        "JSON"
+      ]
+    },
+    "S1w": {
+      "type": "string",
+      "max": 200,
+      "pattern": "^\\/[\\w\\.\\-\\:\\/]*$"
     },
     "S1y": {
       "type": "structure",
       "members": {
         "Sha1": {},
-        "Hash": {},
-        "HashType": {},
-        "Name": {},
+        "Hash": {
+          "shape": "S20"
+        },
+        "HashType": {
+          "shape": "S21"
+        },
+        "Name": {
+          "shape": "S22"
+        },
         "Owner": {},
         "CreatedDate": {
           "type": "timestamp"
         },
-        "Status": {},
-        "DocumentVersion": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Creating",
+            "Active",
+            "Updating",
+            "Deleting"
+          ]
+        },
+        "DocumentVersion": {
+          "shape": "Sp"
+        },
         "Description": {},
         "Parameters": {
           "type": "list",
@@ -4024,7 +5504,13 @@
             "type": "structure",
             "members": {
               "Name": {},
-              "Type": {},
+              "Type": {
+                "type": "string",
+                "enum": [
+                  "String",
+                  "StringList"
+                ]
+              },
               "Description": {},
               "DefaultValue": {}
             }
@@ -4033,24 +5519,116 @@
         "PlatformTypes": {
           "shape": "S2c"
         },
-        "DocumentType": {},
-        "SchemaVersion": {},
-        "LatestVersion": {},
-        "DefaultVersion": {},
-        "DocumentFormat": {},
-        "TargetType": {},
+        "DocumentType": {
+          "shape": "S1u"
+        },
+        "SchemaVersion": {
+          "shape": "S2e"
+        },
+        "LatestVersion": {
+          "shape": "Sp"
+        },
+        "DefaultVersion": {
+          "shape": "Sp"
+        },
+        "DocumentFormat": {
+          "shape": "S1v"
+        },
+        "TargetType": {
+          "shape": "S1w"
+        },
         "Tags": {
           "shape": "S4"
         }
       }
     },
+    "S20": {
+      "type": "string",
+      "max": 256
+    },
+    "S21": {
+      "type": "string",
+      "enum": [
+        "Sha256",
+        "Sha1"
+      ]
+    },
+    "S22": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9_\\-.:/]{3,128}$"
+    },
     "S2c": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S2d"
+      }
+    },
+    "S2d": {
+      "type": "string",
+      "enum": [
+        "Windows",
+        "Linux"
+      ]
+    },
+    "S2e": {
+      "type": "string",
+      "pattern": "([0-9]+)\\.([0-9]+)"
+    },
+    "S2g": {
+      "type": "string",
+      "max": 128,
+      "min": 3,
+      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
     },
     "S2h": {
       "type": "string",
+      "max": 128,
+      "min": 1,
       "sensitive": true
+    },
+    "S2i": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S2j": {
+      "type": "integer",
+      "max": 24,
+      "min": 1
+    },
+    "S2k": {
+      "type": "integer",
+      "max": 23,
+      "min": 0
+    },
+    "S2m": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "S2o": {
+      "type": "string",
+      "max": 20,
+      "min": 20,
+      "pattern": "^mw-[0-9a-f]{17}$"
+    },
+    "S2q": {
+      "type": "string",
+      "enum": [
+        "WINDOWS",
+        "AMAZON_LINUX",
+        "AMAZON_LINUX_2",
+        "UBUNTU",
+        "REDHAT_ENTERPRISE_LINUX",
+        "SUSE",
+        "CENTOS"
+      ]
+    },
+    "S2r": {
+      "type": "string",
+      "max": 128,
+      "min": 3,
+      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
     },
     "S2s": {
       "type": "structure",
@@ -4067,13 +5645,32 @@
               "Values"
             ],
             "members": {
-              "Key": {},
+              "Key": {
+                "type": "string",
+                "enum": [
+                  "PRODUCT",
+                  "CLASSIFICATION",
+                  "MSRC_SEVERITY",
+                  "PATCH_ID",
+                  "SECTION",
+                  "PRIORITY",
+                  "SEVERITY"
+                ]
+              },
               "Values": {
                 "type": "list",
-                "member": {}
+                "member": {
+                  "type": "string",
+                  "max": 64,
+                  "min": 1
+                },
+                "max": 20,
+                "min": 1
               }
             }
-          }
+          },
+          "max": 4,
+          "min": 0
         }
       }
     },
@@ -4095,21 +5692,52 @@
               "PatchFilterGroup": {
                 "shape": "S2s"
               },
-              "ComplianceLevel": {},
+              "ComplianceLevel": {
+                "shape": "S31"
+              },
               "ApproveAfterDays": {
-                "type": "integer"
+                "type": "integer",
+                "max": 100,
+                "min": 0
               },
               "EnableNonSecurity": {
                 "type": "boolean"
               }
             }
-          }
+          },
+          "max": 10,
+          "min": 0
         }
       }
     },
+    "S31": {
+      "type": "string",
+      "enum": [
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+        "LOW",
+        "INFORMATIONAL",
+        "UNSPECIFIED"
+      ]
+    },
     "S34": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S35"
+      },
+      "max": 50,
+      "min": 0
+    },
+    "S35": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S36": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
     },
     "S37": {
       "type": "list",
@@ -4121,17 +5749,41 @@
           "Configuration"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-.]{3,50}$"
+          },
           "Products": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 128,
+              "min": 1
+            },
+            "max": 20,
+            "min": 1
           },
           "Configuration": {
             "type": "string",
+            "max": 512,
+            "min": 1,
             "sensitive": true
           }
         }
-      }
+      },
+      "max": 20,
+      "min": 0
+    },
+    "S3e": {
+      "type": "string",
+      "max": 128,
+      "min": 20,
+      "pattern": "^[a-zA-Z0-9_\\-:/]{20,128}$"
+    },
+    "S3g": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "S3h": {
       "type": "structure",
@@ -4141,12 +5793,40 @@
         "Region"
       ],
       "members": {
-        "BucketName": {},
-        "Prefix": {},
-        "SyncFormat": {},
-        "Region": {},
-        "AWSKMSKeyARN": {}
+        "BucketName": {
+          "type": "string",
+          "max": 2048,
+          "min": 1
+        },
+        "Prefix": {
+          "type": "string",
+          "max": 256,
+          "min": 1
+        },
+        "SyncFormat": {
+          "type": "string",
+          "enum": [
+            "JsonSerDe"
+          ]
+        },
+        "Region": {
+          "type": "string",
+          "max": 64,
+          "min": 1
+        },
+        "AWSKMSKeyARN": {
+          "type": "string",
+          "max": 512,
+          "min": 1,
+          "pattern": "arn:.*"
+        }
       }
+    },
+    "S3v": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "^(AWS|Custom):.*$"
     },
     "S40": {
       "type": "structure",
@@ -4162,7 +5842,9 @@
           "member": {
             "type": "structure",
             "members": {
-              "Version": {},
+              "Version": {
+                "shape": "S45"
+              },
               "Count": {
                 "type": "integer"
               },
@@ -4174,28 +5856,126 @@
         }
       }
     },
+    "S45": {
+      "type": "string",
+      "pattern": "^([0-9]{1,6})(\\.[0-9]{1,6})$"
+    },
+    "S4a": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
     "S4d": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4a"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S4k": {
+      "type": "string",
+      "pattern": "^mi-[0-9a-f]{17}$"
+    },
+    "S4n": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "S4q": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
+    },
+    "S4t": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
+    },
+    "S51": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
+    },
+    "S5b": {
+      "type": "string",
+      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    },
+    "S67": {
+      "type": "string",
+      "max": 36,
+      "min": 36
+    },
+    "S68": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Waiting",
+        "Success",
+        "TimedOut",
+        "Cancelling",
+        "Cancelled",
+        "Failed"
+      ]
     },
     "S69": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "S6a"
+      },
       "value": {
         "type": "list",
-        "member": {}
-      }
+        "member": {
+          "type": "string",
+          "max": 512,
+          "min": 1
+        },
+        "max": 10,
+        "min": 0
+      },
+      "max": 200,
+      "min": 1
+    },
+    "S6a": {
+      "type": "string",
+      "max": 30,
+      "min": 1
+    },
+    "S6d": {
+      "type": "string",
+      "enum": [
+        "Auto",
+        "Interactive"
+      ]
     },
     "S6e": {
       "type": "list",
       "member": {
         "type": "map",
-        "key": {},
+        "key": {
+          "type": "string",
+          "max": 50,
+          "min": 1
+        },
         "value": {
           "type": "list",
-          "member": {}
-        }
-      }
+          "member": {
+            "type": "string",
+            "max": 50,
+            "min": 1
+          },
+          "max": 25,
+          "min": 0
+        },
+        "max": 20,
+        "min": 1
+      },
+      "max": 300,
+      "min": 0
     },
     "S6j": {
       "type": "structure",
@@ -4209,13 +5989,28 @@
         }
       }
     },
+    "S6l": {
+      "type": "string",
+      "max": 7,
+      "min": 1,
+      "pattern": "^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$"
+    },
+    "S6m": {
+      "type": "string",
+      "max": 7,
+      "min": 1,
+      "pattern": "^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$"
+    },
     "S6u": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "StepName": {},
-          "Action": {},
+          "Action": {
+            "type": "string",
+            "pattern": "^aws:[a-zA-Z]{3,25}$"
+          },
           "TimeoutSeconds": {
             "type": "long"
           },
@@ -4229,7 +6024,9 @@
           "ExecutionEndTime": {
             "type": "timestamp"
           },
-          "StepStatus": {},
+          "StepStatus": {
+            "shape": "S68"
+          },
           "ResponseCode": {},
           "Inputs": {
             "type": "map",
@@ -4264,7 +6061,11 @@
           },
           "ValidNextSteps": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 65535,
+              "min": 1
+            }
           }
         }
       }
@@ -4274,18 +6075,35 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 256,
+              "min": 1
+            }
           }
         }
-      }
+      },
+      "max": 5,
+      "min": 0
+    },
+    "S79": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     },
     "S7c": {
       "type": "structure",
       "members": {
-        "Id": {},
+        "Id": {
+          "shape": "S35"
+        },
         "ReleaseDate": {
           "type": "timestamp"
         },
@@ -4302,13 +6120,33 @@
         "Language": {}
       }
     },
+    "S7r": {
+      "type": "string",
+      "enum": [
+        "Share"
+      ]
+    },
     "S7t": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "pattern": "(?i)all|[0-9]{12}"
+      },
+      "max": 20
     },
     "S8j": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "min": 1
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S90": {
+      "type": "integer",
+      "max": 100,
+      "min": 10
     },
     "S93": {
       "type": "structure",
@@ -4321,10 +6159,18 @@
         "Operation"
       ],
       "members": {
-        "InstanceId": {},
-        "PatchGroup": {},
-        "BaselineId": {},
-        "SnapshotId": {},
+        "InstanceId": {
+          "shape": "Sc"
+        },
+        "PatchGroup": {
+          "shape": "S4n"
+        },
+        "BaselineId": {
+          "shape": "S3e"
+        },
+        "SnapshotId": {
+          "shape": "S94"
+        },
         "OwnerInformation": {
           "shape": "S95"
         },
@@ -4349,33 +6195,126 @@
         "OperationEndTime": {
           "type": "timestamp"
         },
-        "Operation": {}
+        "Operation": {
+          "type": "string",
+          "enum": [
+            "Scan",
+            "Install"
+          ]
+        }
       }
+    },
+    "S94": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     },
     "S95": {
       "type": "string",
+      "max": 128,
+      "min": 1,
       "sensitive": true
+    },
+    "Sa0": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
+    },
+    "Sa1": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
     },
     "Sa2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 256,
+              "min": 1
+            }
           }
         }
-      }
+      },
+      "max": 5,
+      "min": 0
+    },
+    "Sa7": {
+      "type": "integer",
+      "max": 100,
+      "min": 10
+    },
+    "Sab": {
+      "type": "string",
+      "max": 36,
+      "min": 36,
+      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
+    },
+    "Sad": {
+      "type": "string",
+      "enum": [
+        "RUN_COMMAND",
+        "AUTOMATION",
+        "STEP_FUNCTIONS",
+        "LAMBDA"
+      ]
     },
     "Sae": {
       "type": "string",
       "sensitive": true
     },
+    "Saf": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "IN_PROGRESS",
+        "SUCCESS",
+        "FAILED",
+        "TIMED_OUT",
+        "CANCELLING",
+        "CANCELLED",
+        "SKIPPED_OVERLAPPING"
+      ]
+    },
+    "Sag": {
+      "type": "string",
+      "max": 250,
+      "min": 0
+    },
+    "Sah": {
+      "type": "string",
+      "max": 36
+    },
+    "Sam": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "Sav": {
+      "type": "string",
+      "enum": [
+        "INSTANCE"
+      ]
+    },
     "Sb0": {
       "type": "map",
-      "key": {},
+      "key": {
+        "type": "string",
+        "max": 255,
+        "min": 1
+      },
       "value": {
         "type": "structure",
         "members": {
@@ -4383,6 +6322,8 @@
             "type": "list",
             "member": {
               "type": "string",
+              "max": 255,
+              "min": 1,
               "sensitive": true
             },
             "sensitive": true
@@ -4392,6 +6333,10 @@
       },
       "sensitive": true
     },
+    "Sb5": {
+      "type": "integer",
+      "min": 0
+    },
     "Sb6": {
       "type": "structure",
       "required": [
@@ -4399,9 +6344,15 @@
         "S3Region"
       ],
       "members": {
-        "S3BucketName": {},
-        "S3KeyPrefix": {},
-        "S3Region": {}
+        "S3BucketName": {
+          "shape": "S13"
+        },
+        "S3KeyPrefix": {
+          "shape": "S14"
+        },
+        "S3Region": {
+          "shape": "S12"
+        }
       }
     },
     "Sbj": {
@@ -4412,31 +6363,123 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Option": {},
+          "Key": {
+            "type": "string",
+            "max": 132,
+            "min": 1,
+            "pattern": "tag:.+|Name|Type|KeyId|Path|Label"
+          },
+          "Option": {
+            "type": "string",
+            "max": 10,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 1024,
+              "min": 1
+            },
+            "max": 50,
+            "min": 1
           }
         }
       }
     },
+    "Sbs": {
+      "type": "string",
+      "enum": [
+        "String",
+        "StringList",
+        "SecureString"
+      ]
+    },
+    "Sbt": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "^([a-zA-Z0-9:/_-]+)$"
+    },
+    "Sbu": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
+    "Sbv": {
+      "type": "string",
+      "max": 1024,
+      "min": 0
+    },
     "Sc0": {
       "type": "structure",
       "members": {
-        "BaselineId": {},
-        "BaselineName": {},
-        "OperatingSystem": {},
-        "BaselineDescription": {},
+        "BaselineId": {
+          "shape": "S3e"
+        },
+        "BaselineName": {
+          "shape": "S2r"
+        },
+        "OperatingSystem": {
+          "shape": "S2q"
+        },
+        "BaselineDescription": {
+          "shape": "S36"
+        },
         "DefaultBaseline": {
           "type": "boolean"
         }
       }
     },
+    "Sci": {
+      "type": "string",
+      "max": 96,
+      "min": 1
+    },
+    "Scj": {
+      "type": "string",
+      "max": 50,
+      "min": 1
+    },
+    "Scu": {
+      "type": "string",
+      "min": 4
+    },
+    "Scw": {
+      "type": "string",
+      "max": 100
+    },
+    "Scy": {
+      "type": "string",
+      "pattern": "^([\\-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d(?!:))?)?(\\17[0-5]\\d([\\.,]\\d)?)?([zZ]|([\\-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+    },
+    "Scz": {
+      "type": "string",
+      "enum": [
+        "Pending",
+        "InProgress",
+        "Delayed",
+        "Success",
+        "Cancelled",
+        "TimedOut",
+        "Failed",
+        "Cancelling"
+      ]
+    },
+    "Sd0": {
+      "type": "string",
+      "max": 100,
+      "min": 0
+    },
     "Sd3": {
       "type": "structure",
       "members": {
-        "CloudWatchLogGroupName": {},
+        "CloudWatchLogGroupName": {
+          "type": "string",
+          "max": 512,
+          "min": 1,
+          "pattern": "[\\.\\-_/#A-Za-z0-9]+"
+        },
         "CloudWatchOutputEnabled": {
           "type": "boolean"
         }
@@ -4451,21 +6494,43 @@
           "Values"
         ],
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 200,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 40,
+            "min": 1
           },
-          "Type": {}
+          "Type": {
+            "type": "string",
+            "enum": [
+              "Equal",
+              "NotEqual",
+              "BeginWith",
+              "LessThan",
+              "GreaterThan",
+              "Exists"
+            ]
+          }
         }
-      }
+      },
+      "max": 5,
+      "min": 1
     },
     "Sdo": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Expression": {},
+          "Expression": {
+            "type": "string",
+            "max": 1000,
+            "min": 1
+          },
           "Aggregators": {
             "shape": "Sdo"
           },
@@ -4478,23 +6543,57 @@
                 "Filters"
               ],
               "members": {
-                "Name": {},
+                "Name": {
+                  "type": "string",
+                  "max": 200,
+                  "min": 1
+                },
                 "Filters": {
                   "shape": "Sdi"
                 }
               }
-            }
+            },
+            "max": 10,
+            "min": 1
           }
         }
-      }
+      },
+      "max": 10,
+      "min": 1
+    },
+    "Se3": {
+      "type": "string",
+      "pattern": "^(20)[0-9][0-9]-(0[1-9]|1[012])-([12][0-9]|3[01]|0[1-9])(T)(2[0-3]|[0-1][0-9])(:[0-5][0-9])(:[0-5][0-9])(Z)$"
+    },
+    "Se4": {
+      "type": "string",
+      "max": 256
     },
     "Se5": {
       "type": "list",
       "member": {
         "type": "map",
-        "key": {},
-        "value": {}
-      }
+        "key": {
+          "shape": "Se7"
+        },
+        "value": {
+          "shape": "Se8"
+        },
+        "max": 50,
+        "min": 0
+      },
+      "max": 10000,
+      "min": 0
+    },
+    "Se7": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "Se8": {
+      "type": "string",
+      "max": 4096,
+      "min": 0
     },
     "Sey": {
       "type": "structure",
@@ -4502,27 +6601,39 @@
         "RunCommand": {
           "type": "structure",
           "members": {
-            "Comment": {},
-            "DocumentHash": {},
-            "DocumentHashType": {},
+            "Comment": {
+              "shape": "Scw"
+            },
+            "DocumentHash": {
+              "shape": "S20"
+            },
+            "DocumentHashType": {
+              "shape": "S21"
+            },
             "NotificationConfig": {
               "shape": "Sf0"
             },
-            "OutputS3BucketName": {},
-            "OutputS3KeyPrefix": {},
+            "OutputS3BucketName": {
+              "shape": "S13"
+            },
+            "OutputS3KeyPrefix": {
+              "shape": "S14"
+            },
             "Parameters": {
               "shape": "Sq"
             },
             "ServiceRoleArn": {},
             "TimeoutSeconds": {
-              "type": "integer"
+              "shape": "Sf5"
             }
           }
         },
         "Automation": {
           "type": "structure",
           "members": {
-            "DocumentVersion": {},
+            "DocumentVersion": {
+              "shape": "Sp"
+            },
             "Parameters": {
               "shape": "S69"
             }
@@ -4533,18 +6644,32 @@
           "members": {
             "Input": {
               "type": "string",
+              "max": 4096,
               "sensitive": true
             },
-            "Name": {}
+            "Name": {
+              "type": "string",
+              "max": 80,
+              "min": 1
+            }
           }
         },
         "Lambda": {
           "type": "structure",
           "members": {
-            "ClientContext": {},
-            "Qualifier": {},
+            "ClientContext": {
+              "type": "string",
+              "max": 8000,
+              "min": 1
+            },
+            "Qualifier": {
+              "type": "string",
+              "max": 128,
+              "min": 1
+            },
             "Payload": {
               "type": "blob",
+              "max": 4096,
               "sensitive": true
             }
           }
@@ -4557,21 +6682,52 @@
         "NotificationArn": {},
         "NotificationEvents": {
           "type": "list",
-          "member": {}
+          "member": {
+            "type": "string",
+            "enum": [
+              "All",
+              "InProgress",
+              "Success",
+              "TimedOut",
+              "Cancelled",
+              "Failed"
+            ]
+          }
         },
-        "NotificationType": {}
+        "NotificationType": {
+          "type": "string",
+          "enum": [
+            "Command",
+            "Invocation"
+          ]
+        }
       }
+    },
+    "Sf5": {
+      "type": "integer",
+      "max": 2592000,
+      "min": 30
     },
     "Sfg": {
       "type": "structure",
       "members": {
-        "Name": {},
-        "Type": {},
-        "Value": {},
+        "Name": {
+          "shape": "S4a"
+        },
+        "Type": {
+          "shape": "Sbs"
+        },
+        "Value": {
+          "shape": "Sfh"
+        },
         "Version": {
           "type": "long"
         },
-        "Selector": {},
+        "Selector": {
+          "type": "string",
+          "max": 128,
+          "min": 0
+        },
         "SourceResult": {},
         "LastModifiedDate": {
           "type": "timestamp"
@@ -4579,15 +6735,31 @@
         "ARN": {}
       }
     },
+    "Sfh": {
+      "type": "string",
+      "max": 4096,
+      "min": 1
+    },
     "Sfn": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 100,
+        "min": 1
+      },
+      "max": 10,
+      "min": 1
     },
     "Sfr": {
       "type": "list",
       "member": {
         "shape": "Sfg"
       }
+    },
+    "Sgf": {
+      "type": "integer",
+      "max": 50,
+      "min": 1
     },
     "Sgg": {
       "type": "list",
@@ -4598,18 +6770,41 @@
           "value"
         ],
         "members": {
-          "key": {},
-          "value": {}
+          "key": {
+            "type": "string",
+            "enum": [
+              "InvokedAfter",
+              "InvokedBefore",
+              "Status",
+              "ExecutionStage",
+              "DocumentName"
+            ]
+          },
+          "value": {
+            "type": "string",
+            "max": 128,
+            "min": 1
+          }
         }
-      }
+      },
+      "max": 5,
+      "min": 1
     },
     "Sgw": {
       "type": "structure",
       "members": {
-        "CommandId": {},
-        "DocumentName": {},
-        "DocumentVersion": {},
-        "Comment": {},
+        "CommandId": {
+          "shape": "Sa"
+        },
+        "DocumentName": {
+          "shape": "So"
+        },
+        "DocumentVersion": {
+          "shape": "Sp"
+        },
+        "Comment": {
+          "shape": "Scw"
+        },
         "ExpiresAfter": {
           "type": "timestamp"
         },
@@ -4625,13 +6820,36 @@
         "RequestedDateTime": {
           "type": "timestamp"
         },
-        "Status": {},
-        "StatusDetails": {},
-        "OutputS3Region": {},
-        "OutputS3BucketName": {},
-        "OutputS3KeyPrefix": {},
-        "MaxConcurrency": {},
-        "MaxErrors": {},
+        "Status": {
+          "type": "string",
+          "enum": [
+            "Pending",
+            "InProgress",
+            "Success",
+            "Cancelled",
+            "Failed",
+            "TimedOut",
+            "Cancelling"
+          ]
+        },
+        "StatusDetails": {
+          "shape": "Sd0"
+        },
+        "OutputS3Region": {
+          "shape": "S12"
+        },
+        "OutputS3BucketName": {
+          "shape": "S13"
+        },
+        "OutputS3KeyPrefix": {
+          "shape": "S14"
+        },
+        "MaxConcurrency": {
+          "shape": "S6l"
+        },
+        "MaxErrors": {
+          "shape": "S6m"
+        },
         "TargetCount": {
           "type": "integer"
         },
@@ -4658,14 +6876,72 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {},
+          "Key": {
+            "type": "string",
+            "max": 200,
+            "min": 1
+          },
           "Values": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 20,
+            "min": 1
           },
-          "Type": {}
+          "Type": {
+            "type": "string",
+            "enum": [
+              "EQUAL",
+              "NOT_EQUAL",
+              "BEGIN_WITH",
+              "LESS_THAN",
+              "GREATER_THAN"
+            ]
+          }
         }
       }
+    },
+    "Sha": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "Shc": {
+      "type": "string",
+      "max": 50,
+      "min": 1
+    },
+    "Shg": {
+      "type": "string",
+      "max": 100,
+      "min": 1,
+      "pattern": "[A-Za-z0-9_\\-]\\w+|Custom:[a-zA-Z0-9_\\-]\\w+"
+    },
+    "Shh": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "Shi": {
+      "type": "string",
+      "max": 500
+    },
+    "Shj": {
+      "type": "string",
+      "enum": [
+        "COMPLIANT",
+        "NON_COMPLIANT"
+      ]
+    },
+    "Shk": {
+      "type": "string",
+      "enum": [
+        "CRITICAL",
+        "HIGH",
+        "MEDIUM",
+        "LOW",
+        "INFORMATIONAL",
+        "UNSPECIFIED"
+      ]
     },
     "Shl": {
       "type": "structure",
@@ -4676,14 +6952,24 @@
         "ExecutionTime": {
           "type": "timestamp"
         },
-        "ExecutionId": {},
-        "ExecutionType": {}
+        "ExecutionId": {
+          "type": "string",
+          "max": 100
+        },
+        "ExecutionType": {
+          "type": "string",
+          "max": 50
+        }
       }
     },
     "Sho": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "Se7"
+      },
+      "value": {
+        "shape": "Se8"
+      }
     },
     "Sht": {
       "type": "structure",
@@ -4729,6 +7015,11 @@
           "shape": "Shv"
         }
       }
+    },
+    "Sjn": {
+      "type": "string",
+      "max": 300,
+      "min": 0
     }
   }
 }

--- a/apis/states-2016-11-23.min.json
+++ b/apis/states-2016-11-23.min.json
@@ -20,7 +20,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -30,7 +32,9 @@
           "creationDate"
         ],
         "members": {
-          "activityArn": {},
+          "activityArn": {
+            "shape": "S4"
+          },
           "creationDate": {
             "type": "timestamp"
           }
@@ -47,9 +51,15 @@
           "roleArn"
         ],
         "members": {
-          "name": {},
-          "definition": {},
-          "roleArn": {}
+          "name": {
+            "shape": "S2"
+          },
+          "definition": {
+            "shape": "S7"
+          },
+          "roleArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -59,7 +69,9 @@
           "creationDate"
         ],
         "members": {
-          "stateMachineArn": {},
+          "stateMachineArn": {
+            "shape": "S4"
+          },
           "creationDate": {
             "type": "timestamp"
           }
@@ -74,7 +86,9 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {}
+          "activityArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -89,7 +103,9 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {}
+          "stateMachineArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -104,7 +120,9 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {}
+          "activityArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -115,8 +133,12 @@
           "creationDate"
         ],
         "members": {
-          "activityArn": {},
-          "name": {},
+          "activityArn": {
+            "shape": "S4"
+          },
+          "name": {
+            "shape": "S2"
+          },
           "creationDate": {
             "type": "timestamp"
           }
@@ -130,7 +152,9 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {}
+          "executionArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -143,18 +167,30 @@
           "input"
         ],
         "members": {
-          "executionArn": {},
-          "stateMachineArn": {},
-          "name": {},
-          "status": {},
+          "executionArn": {
+            "shape": "S4"
+          },
+          "stateMachineArn": {
+            "shape": "S4"
+          },
+          "name": {
+            "shape": "S2"
+          },
+          "status": {
+            "shape": "Sh"
+          },
           "startDate": {
             "type": "timestamp"
           },
           "stopDate": {
             "type": "timestamp"
           },
-          "input": {},
-          "output": {}
+          "input": {
+            "shape": "Si"
+          },
+          "output": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -165,7 +201,9 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {}
+          "stateMachineArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -178,11 +216,25 @@
           "creationDate"
         ],
         "members": {
-          "stateMachineArn": {},
-          "name": {},
-          "status": {},
-          "definition": {},
-          "roleArn": {},
+          "stateMachineArn": {
+            "shape": "S4"
+          },
+          "name": {
+            "shape": "S2"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACTIVE",
+              "DELETING"
+            ]
+          },
+          "definition": {
+            "shape": "S7"
+          },
+          "roleArn": {
+            "shape": "S4"
+          },
           "creationDate": {
             "type": "timestamp"
           }
@@ -196,7 +248,9 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {}
+          "executionArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -209,10 +263,18 @@
           "updateDate"
         ],
         "members": {
-          "stateMachineArn": {},
-          "name": {},
-          "definition": {},
-          "roleArn": {},
+          "stateMachineArn": {
+            "shape": "S4"
+          },
+          "name": {
+            "shape": "S2"
+          },
+          "definition": {
+            "shape": "S7"
+          },
+          "roleArn": {
+            "shape": "S4"
+          },
           "updateDate": {
             "type": "timestamp"
           }
@@ -226,15 +288,23 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {},
-          "workerName": {}
+          "activityArn": {
+            "shape": "S4"
+          },
+          "workerName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskToken": {},
-          "input": {}
+          "taskToken": {
+            "shape": "Sq"
+          },
+          "input": {
+            "shape": "Si"
+          }
         }
       }
     },
@@ -245,14 +315,18 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {},
+          "executionArn": {
+            "shape": "S4"
+          },
           "maxResults": {
-            "type": "integer"
+            "shape": "Ss"
           },
           "reverseOrder": {
             "type": "boolean"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -274,7 +348,48 @@
                 "timestamp": {
                   "type": "timestamp"
                 },
-                "type": {},
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ActivityFailed",
+                    "ActivityScheduleFailed",
+                    "ActivityScheduled",
+                    "ActivityStarted",
+                    "ActivitySucceeded",
+                    "ActivityTimedOut",
+                    "ChoiceStateEntered",
+                    "ChoiceStateExited",
+                    "ExecutionFailed",
+                    "ExecutionStarted",
+                    "ExecutionSucceeded",
+                    "ExecutionAborted",
+                    "ExecutionTimedOut",
+                    "FailStateEntered",
+                    "LambdaFunctionFailed",
+                    "LambdaFunctionScheduleFailed",
+                    "LambdaFunctionScheduled",
+                    "LambdaFunctionStartFailed",
+                    "LambdaFunctionStarted",
+                    "LambdaFunctionSucceeded",
+                    "LambdaFunctionTimedOut",
+                    "SucceedStateEntered",
+                    "SucceedStateExited",
+                    "TaskStateAborted",
+                    "TaskStateEntered",
+                    "TaskStateExited",
+                    "PassStateEntered",
+                    "PassStateExited",
+                    "ParallelStateAborted",
+                    "ParallelStateEntered",
+                    "ParallelStateExited",
+                    "ParallelStateFailed",
+                    "ParallelStateStarted",
+                    "ParallelStateSucceeded",
+                    "WaitStateAborted",
+                    "WaitStateEntered",
+                    "WaitStateExited"
+                  ]
+                },
                 "id": {
                   "type": "long"
                 },
@@ -284,15 +399,23 @@
                 "activityFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "activityScheduleFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "activityScheduledEventDetails": {
@@ -301,8 +424,12 @@
                     "resource"
                   ],
                   "members": {
-                    "resource": {},
-                    "input": {},
+                    "resource": {
+                      "shape": "S4"
+                    },
+                    "input": {
+                      "shape": "Si"
+                    },
                     "timeoutInSeconds": {
                       "type": "long"
                     },
@@ -314,68 +441,103 @@
                 "activityStartedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "workerName": {}
+                    "workerName": {
+                      "type": "string",
+                      "max": 256
+                    }
                   }
                 },
                 "activitySucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {}
+                    "output": {
+                      "shape": "Si"
+                    }
                   }
                 },
                 "activityTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "executionFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "executionStartedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "input": {},
-                    "roleArn": {}
+                    "input": {
+                      "shape": "Si"
+                    },
+                    "roleArn": {
+                      "shape": "S4"
+                    }
                   }
                 },
                 "executionSucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {}
+                    "output": {
+                      "shape": "Si"
+                    }
                   }
                 },
                 "executionAbortedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "executionTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "lambdaFunctionFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "lambdaFunctionScheduleFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "lambdaFunctionScheduledEventDetails": {
@@ -384,8 +546,12 @@
                     "resource"
                   ],
                   "members": {
-                    "resource": {},
-                    "input": {},
+                    "resource": {
+                      "shape": "S4"
+                    },
+                    "input": {
+                      "shape": "Si"
+                    },
                     "timeoutInSeconds": {
                       "type": "long"
                     }
@@ -394,21 +560,31 @@
                 "lambdaFunctionStartFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "lambdaFunctionSucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {}
+                    "output": {
+                      "shape": "Si"
+                    }
                   }
                 },
                 "lambdaFunctionTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {},
-                    "cause": {}
+                    "error": {
+                      "shape": "S11"
+                    },
+                    "cause": {
+                      "shape": "S12"
+                    }
                   }
                 },
                 "stateEnteredEventDetails": {
@@ -417,8 +593,12 @@
                     "name"
                   ],
                   "members": {
-                    "name": {},
-                    "input": {}
+                    "name": {
+                      "shape": "S2"
+                    },
+                    "input": {
+                      "shape": "Si"
+                    }
                   }
                 },
                 "stateExitedEventDetails": {
@@ -427,14 +607,20 @@
                     "name"
                   ],
                   "members": {
-                    "name": {},
-                    "output": {}
+                    "name": {
+                      "shape": "S2"
+                    },
+                    "output": {
+                      "shape": "Si"
+                    }
                   }
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -443,9 +629,11 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "type": "integer"
+            "shape": "Ss"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -464,15 +652,21 @@
                 "creationDate"
               ],
               "members": {
-                "activityArn": {},
-                "name": {},
+                "activityArn": {
+                  "shape": "S4"
+                },
+                "name": {
+                  "shape": "S2"
+                },
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -483,12 +677,18 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {},
-          "statusFilter": {},
-          "maxResults": {
-            "type": "integer"
+          "stateMachineArn": {
+            "shape": "S4"
           },
-          "nextToken": {}
+          "statusFilter": {
+            "shape": "Sh"
+          },
+          "maxResults": {
+            "shape": "Ss"
+          },
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -509,10 +709,18 @@
                 "startDate"
               ],
               "members": {
-                "executionArn": {},
-                "stateMachineArn": {},
-                "name": {},
-                "status": {},
+                "executionArn": {
+                  "shape": "S4"
+                },
+                "stateMachineArn": {
+                  "shape": "S4"
+                },
+                "name": {
+                  "shape": "S2"
+                },
+                "status": {
+                  "shape": "Sh"
+                },
                 "startDate": {
                   "type": "timestamp"
                 },
@@ -522,7 +730,9 @@
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -531,9 +741,11 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "type": "integer"
+            "shape": "Ss"
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       },
       "output": {
@@ -552,15 +764,21 @@
                 "creationDate"
               ],
               "members": {
-                "stateMachineArn": {},
-                "name": {},
+                "stateMachineArn": {
+                  "shape": "S4"
+                },
+                "name": {
+                  "shape": "S2"
+                },
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextToken": {}
+          "nextToken": {
+            "shape": "Su"
+          }
         }
       }
     },
@@ -571,9 +789,15 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
-          "error": {},
-          "cause": {}
+          "taskToken": {
+            "shape": "Sq"
+          },
+          "error": {
+            "shape": "S11"
+          },
+          "cause": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -588,7 +812,9 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {}
+          "taskToken": {
+            "shape": "Sq"
+          }
         }
       },
       "output": {
@@ -604,8 +830,12 @@
           "output"
         ],
         "members": {
-          "taskToken": {},
-          "output": {}
+          "taskToken": {
+            "shape": "Sq"
+          },
+          "output": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -620,9 +850,15 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {},
-          "name": {},
-          "input": {}
+          "stateMachineArn": {
+            "shape": "S4"
+          },
+          "name": {
+            "shape": "S2"
+          },
+          "input": {
+            "shape": "Si"
+          }
         }
       },
       "output": {
@@ -632,7 +868,9 @@
           "startDate"
         ],
         "members": {
-          "executionArn": {},
+          "executionArn": {
+            "shape": "S4"
+          },
           "startDate": {
             "type": "timestamp"
           }
@@ -647,9 +885,15 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {},
-          "error": {},
-          "cause": {}
+          "executionArn": {
+            "shape": "S4"
+          },
+          "error": {
+            "shape": "S11"
+          },
+          "cause": {
+            "shape": "S12"
+          }
         }
       },
       "output": {
@@ -671,9 +915,15 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {},
-          "definition": {},
-          "roleArn": {}
+          "stateMachineArn": {
+            "shape": "S4"
+          },
+          "definition": {
+            "shape": "S7"
+          },
+          "roleArn": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -690,5 +940,60 @@
       "idempotent": true
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 80,
+      "min": 1
+    },
+    "S4": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "max": 1048576,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+        "TIMED_OUT",
+        "ABORTED"
+      ]
+    },
+    "Si": {
+      "type": "string",
+      "max": 32768
+    },
+    "Sq": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "Ss": {
+      "type": "integer",
+      "max": 1000,
+      "min": 0
+    },
+    "Su": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S11": {
+      "type": "string",
+      "max": 256,
+      "min": 0
+    },
+    "S12": {
+      "type": "string",
+      "max": 32768,
+      "min": 0
+    }
+  }
 }

--- a/apis/storagegateway-2013-06-30.min.json
+++ b/apis/storagegateway-2013-06-30.min.json
@@ -22,19 +22,43 @@
           "GatewayRegion"
         ],
         "members": {
-          "ActivationKey": {},
-          "GatewayName": {},
-          "GatewayTimezone": {},
-          "GatewayRegion": {},
-          "GatewayType": {},
-          "TapeDriveType": {},
-          "MediumChangerType": {}
+          "ActivationKey": {
+            "type": "string",
+            "max": 50,
+            "min": 1
+          },
+          "GatewayName": {
+            "shape": "S3"
+          },
+          "GatewayTimezone": {
+            "shape": "S4"
+          },
+          "GatewayRegion": {
+            "type": "string",
+            "max": 25,
+            "min": 1
+          },
+          "GatewayType": {
+            "shape": "S6"
+          },
+          "TapeDriveType": {
+            "type": "string",
+            "max": 50,
+            "min": 2
+          },
+          "MediumChangerType": {
+            "type": "string",
+            "max": 50,
+            "min": 2
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -46,7 +70,9 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           }
@@ -55,7 +81,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -67,7 +95,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceARN": {},
+          "ResourceARN": {
+            "shape": "Sg"
+          },
           "Tags": {
             "shape": "Sh"
           }
@@ -76,7 +106,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {}
+          "ResourceARN": {
+            "shape": "Sg"
+          }
         }
       }
     },
@@ -88,7 +120,9 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           }
@@ -97,7 +131,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -109,7 +145,9 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           }
@@ -118,7 +156,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -130,14 +170,20 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {},
-          "TapeARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -149,14 +195,20 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {},
-          "TapeARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -171,26 +223,44 @@
           "ClientToken"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "VolumeSizeInBytes": {
             "type": "long"
           },
-          "SnapshotId": {},
-          "TargetName": {},
-          "SourceVolumeARN": {},
-          "NetworkInterfaceId": {},
-          "ClientToken": {},
+          "SnapshotId": {
+            "shape": "Sx"
+          },
+          "TargetName": {
+            "shape": "Sy"
+          },
+          "SourceVolumeARN": {
+            "shape": "Sz"
+          },
+          "NetworkInterfaceId": {
+            "shape": "S10"
+          },
+          "ClientToken": {
+            "shape": "S11"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {}
+          "KMSKey": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {},
-          "TargetARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          },
+          "TargetARN": {
+            "shape": "S15"
+          }
         }
       }
     },
@@ -204,23 +274,39 @@
           "LocationARN"
         ],
         "members": {
-          "ClientToken": {},
+          "ClientToken": {
+            "shape": "S11"
+          },
           "NFSFileShareDefaults": {
             "shape": "S17"
           },
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {},
-          "Role": {},
-          "LocationARN": {},
-          "DefaultStorageClass": {},
-          "ObjectACL": {},
+          "KMSKey": {
+            "shape": "S13"
+          },
+          "Role": {
+            "shape": "S1a"
+          },
+          "LocationARN": {
+            "shape": "S1b"
+          },
+          "DefaultStorageClass": {
+            "shape": "S1c"
+          },
+          "ObjectACL": {
+            "shape": "S1d"
+          },
           "ClientList": {
             "shape": "S1e"
           },
-          "Squash": {},
+          "Squash": {
+            "shape": "S1g"
+          },
           "ReadOnly": {
             "type": "boolean"
           },
@@ -235,7 +321,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -249,16 +337,30 @@
           "LocationARN"
         ],
         "members": {
-          "ClientToken": {},
-          "GatewayARN": {},
+          "ClientToken": {
+            "shape": "S11"
+          },
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {},
-          "Role": {},
-          "LocationARN": {},
-          "DefaultStorageClass": {},
-          "ObjectACL": {},
+          "KMSKey": {
+            "shape": "S13"
+          },
+          "Role": {
+            "shape": "S1a"
+          },
+          "LocationARN": {
+            "shape": "S1b"
+          },
+          "DefaultStorageClass": {
+            "shape": "S1c"
+          },
+          "ObjectACL": {
+            "shape": "S1d"
+          },
           "ReadOnly": {
             "type": "boolean"
           },
@@ -274,13 +376,17 @@
           "InvalidUserList": {
             "shape": "S1k"
           },
-          "Authentication": {}
+          "Authentication": {
+            "shape": "S1m"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -292,15 +398,23 @@
           "SnapshotDescription"
         ],
         "members": {
-          "VolumeARN": {},
-          "SnapshotDescription": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          },
+          "SnapshotDescription": {
+            "shape": "S1p"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {},
-          "SnapshotId": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          },
+          "SnapshotId": {
+            "shape": "Sx"
+          }
         }
       }
     },
@@ -312,15 +426,23 @@
           "SnapshotDescription"
         ],
         "members": {
-          "VolumeARN": {},
-          "SnapshotDescription": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          },
+          "SnapshotDescription": {
+            "shape": "S1p"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {},
-          "VolumeARN": {},
+          "SnapshotId": {
+            "shape": "Sx"
+          },
+          "VolumeARN": {
+            "shape": "Sz"
+          },
           "VolumeRecoveryPointTime": {}
         }
       }
@@ -336,28 +458,44 @@
           "NetworkInterfaceId"
         ],
         "members": {
-          "GatewayARN": {},
-          "DiskId": {},
-          "SnapshotId": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "DiskId": {
+            "shape": "Sd"
+          },
+          "SnapshotId": {
+            "shape": "Sx"
+          },
           "PreserveExistingData": {
             "type": "boolean"
           },
-          "TargetName": {},
-          "NetworkInterfaceId": {},
+          "TargetName": {
+            "shape": "Sy"
+          },
+          "NetworkInterfaceId": {
+            "shape": "S10"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {}
+          "KMSKey": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {},
+          "VolumeARN": {
+            "shape": "Sz"
+          },
           "VolumeSizeInBytes": {
             "type": "long"
           },
-          "TargetARN": {}
+          "TargetARN": {
+            "shape": "S15"
+          }
         }
       }
     },
@@ -370,21 +508,29 @@
           "TapeBarcode"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "TapeSizeInBytes": {
             "type": "long"
           },
-          "TapeBarcode": {},
+          "TapeBarcode": {
+            "shape": "S1z"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {}
+          "KMSKey": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -399,19 +545,32 @@
           "TapeBarcodePrefix"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "TapeSizeInBytes": {
             "type": "long"
           },
-          "ClientToken": {},
-          "NumTapesToCreate": {
-            "type": "integer"
+          "ClientToken": {
+            "shape": "S11"
           },
-          "TapeBarcodePrefix": {},
+          "NumTapesToCreate": {
+            "type": "integer",
+            "max": 10,
+            "min": 1
+          },
+          "TapeBarcodePrefix": {
+            "type": "string",
+            "max": 4,
+            "min": 1,
+            "pattern": "^[A-Z]*$"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {}
+          "KMSKey": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
@@ -431,14 +590,22 @@
           "BandwidthType"
         ],
         "members": {
-          "GatewayARN": {},
-          "BandwidthType": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "BandwidthType": {
+            "type": "string",
+            "max": 25,
+            "min": 3
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -450,15 +617,23 @@
           "InitiatorName"
         ],
         "members": {
-          "TargetARN": {},
-          "InitiatorName": {}
+          "TargetARN": {
+            "shape": "S15"
+          },
+          "InitiatorName": {
+            "shape": "S2a"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TargetARN": {},
-          "InitiatorName": {}
+          "TargetARN": {
+            "shape": "S15"
+          },
+          "InitiatorName": {
+            "shape": "S2a"
+          }
         }
       }
     },
@@ -469,7 +644,9 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {},
+          "FileShareARN": {
+            "shape": "S1i"
+          },
           "ForceDelete": {
             "type": "boolean"
           }
@@ -478,7 +655,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -489,13 +668,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -506,13 +689,17 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -524,14 +711,20 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {},
-          "TapeARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -542,13 +735,17 @@
           "TapeARN"
         ],
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -559,13 +756,17 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -576,18 +777,22 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "AverageUploadRateLimitInBitsPerSec": {
-            "type": "long"
+            "shape": "S2q"
           },
           "AverageDownloadRateLimitInBitsPerSec": {
-            "type": "long"
+            "shape": "S2r"
           }
         }
       }
@@ -599,13 +804,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           },
@@ -647,17 +856,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {},
-                "VolumeId": {},
-                "VolumeType": {},
-                "VolumeStatus": {},
+                "VolumeARN": {
+                  "shape": "Sz"
+                },
+                "VolumeId": {
+                  "shape": "S30"
+                },
+                "VolumeType": {
+                  "shape": "S31"
+                },
+                "VolumeStatus": {
+                  "shape": "S32"
+                },
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
                 "VolumeProgress": {
                   "type": "double"
                 },
-                "SourceSnapshotId": {},
+                "SourceSnapshotId": {
+                  "shape": "Sx"
+                },
                 "VolumeiSCSIAttributes": {
                   "shape": "S34"
                 },
@@ -667,7 +886,9 @@
                 "VolumeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {}
+                "KMSKey": {
+                  "shape": "S13"
+                }
               }
             }
           }
@@ -681,7 +902,9 @@
           "TargetARN"
         ],
         "members": {
-          "TargetARN": {}
+          "TargetARN": {
+            "shape": "S15"
+          }
         }
       },
       "output": {
@@ -692,10 +915,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetARN": {},
-                "SecretToAuthenticateInitiator": {},
-                "InitiatorName": {},
-                "SecretToAuthenticateTarget": {}
+                "TargetARN": {
+                  "shape": "S15"
+                },
+                "SecretToAuthenticateInitiator": {
+                  "shape": "S3d"
+                },
+                "InitiatorName": {
+                  "shape": "S2a"
+                },
+                "SecretToAuthenticateTarget": {
+                  "shape": "S3d"
+                }
               }
             }
           }
@@ -709,17 +940,29 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
-          "GatewayId": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "GatewayId": {
+            "shape": "S3g"
+          },
           "GatewayName": {},
-          "GatewayTimezone": {},
-          "GatewayState": {},
+          "GatewayTimezone": {
+            "shape": "S4"
+          },
+          "GatewayState": {
+            "type": "string",
+            "max": 25,
+            "min": 2
+          },
           "GatewayNetworkInterfaces": {
             "type": "list",
             "member": {
@@ -731,9 +974,19 @@
               }
             }
           },
-          "GatewayType": {},
-          "NextUpdateAvailabilityDate": {},
-          "LastSoftwareUpdate": {}
+          "GatewayType": {
+            "shape": "S6"
+          },
+          "NextUpdateAvailabilityDate": {
+            "type": "string",
+            "max": 25,
+            "min": 1
+          },
+          "LastSoftwareUpdate": {
+            "type": "string",
+            "max": 25,
+            "min": 1
+          }
         }
       }
     },
@@ -744,23 +997,29 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "HourOfDay": {
-            "type": "integer"
+            "shape": "S3o"
           },
           "MinuteOfHour": {
-            "type": "integer"
+            "shape": "S3p"
           },
           "DayOfWeek": {
-            "type": "integer"
+            "shape": "S3q"
           },
-          "Timezone": {}
+          "Timezone": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -787,23 +1046,43 @@
                 "NFSFileShareDefaults": {
                   "shape": "S17"
                 },
-                "FileShareARN": {},
-                "FileShareId": {},
-                "FileShareStatus": {},
-                "GatewayARN": {},
+                "FileShareARN": {
+                  "shape": "S1i"
+                },
+                "FileShareId": {
+                  "shape": "S3w"
+                },
+                "FileShareStatus": {
+                  "shape": "S3x"
+                },
+                "GatewayARN": {
+                  "shape": "Sa"
+                },
                 "KMSEncrypted": {
                   "type": "boolean"
                 },
-                "KMSKey": {},
+                "KMSKey": {
+                  "shape": "S13"
+                },
                 "Path": {},
-                "Role": {},
-                "LocationARN": {},
-                "DefaultStorageClass": {},
-                "ObjectACL": {},
+                "Role": {
+                  "shape": "S1a"
+                },
+                "LocationARN": {
+                  "shape": "S1b"
+                },
+                "DefaultStorageClass": {
+                  "shape": "S1c"
+                },
+                "ObjectACL": {
+                  "shape": "S1d"
+                },
                 "ClientList": {
                   "shape": "S1e"
                 },
-                "Squash": {},
+                "Squash": {
+                  "shape": "S1g"
+                },
                 "ReadOnly": {
                   "type": "boolean"
                 },
@@ -839,19 +1118,37 @@
             "member": {
               "type": "structure",
               "members": {
-                "FileShareARN": {},
-                "FileShareId": {},
-                "FileShareStatus": {},
-                "GatewayARN": {},
+                "FileShareARN": {
+                  "shape": "S1i"
+                },
+                "FileShareId": {
+                  "shape": "S3w"
+                },
+                "FileShareStatus": {
+                  "shape": "S3x"
+                },
+                "GatewayARN": {
+                  "shape": "Sa"
+                },
                 "KMSEncrypted": {
                   "type": "boolean"
                 },
-                "KMSKey": {},
+                "KMSKey": {
+                  "shape": "S13"
+                },
                 "Path": {},
-                "Role": {},
-                "LocationARN": {},
-                "DefaultStorageClass": {},
-                "ObjectACL": {},
+                "Role": {
+                  "shape": "S1a"
+                },
+                "LocationARN": {
+                  "shape": "S1b"
+                },
+                "DefaultStorageClass": {
+                  "shape": "S1c"
+                },
+                "ObjectACL": {
+                  "shape": "S1d"
+                },
                 "ReadOnly": {
                   "type": "boolean"
                 },
@@ -867,7 +1164,9 @@
                 "InvalidUserList": {
                   "shape": "S1k"
                 },
-                "Authentication": {}
+                "Authentication": {
+                  "shape": "S1m"
+                }
               }
             }
           }
@@ -881,14 +1180,20 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
-          "DomainName": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "DomainName": {
+            "shape": "S45"
+          },
           "SMBGuestPasswordSet": {
             "type": "boolean"
           }
@@ -902,21 +1207,29 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {},
+          "VolumeARN": {
+            "shape": "Sz"
+          },
           "StartAt": {
-            "type": "integer"
+            "shape": "S3o"
           },
           "RecurrenceInHours": {
-            "type": "integer"
+            "shape": "S48"
           },
-          "Description": {},
-          "Timezone": {}
+          "Description": {
+            "shape": "S49"
+          },
+          "Timezone": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -940,18 +1253,30 @@
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {},
-                "VolumeId": {},
-                "VolumeType": {},
-                "VolumeStatus": {},
+                "VolumeARN": {
+                  "shape": "Sz"
+                },
+                "VolumeId": {
+                  "shape": "S30"
+                },
+                "VolumeType": {
+                  "shape": "S31"
+                },
+                "VolumeStatus": {
+                  "shape": "S32"
+                },
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
                 "VolumeProgress": {
                   "type": "double"
                 },
-                "VolumeDiskId": {},
-                "SourceSnapshotId": {},
+                "VolumeDiskId": {
+                  "shape": "Sd"
+                },
+                "SourceSnapshotId": {
+                  "shape": "Sx"
+                },
                 "PreservedExistingData": {
                   "type": "boolean"
                 },
@@ -964,7 +1289,9 @@
                 "VolumeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {}
+                "KMSKey": {
+                  "shape": "S13"
+                }
               }
             }
           }
@@ -978,9 +1305,11 @@
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
@@ -992,8 +1321,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {},
-                "TapeBarcode": {},
+                "TapeARN": {
+                  "shape": "Sr"
+                },
+                "TapeBarcode": {
+                  "shape": "S1z"
+                },
                 "TapeCreatedDate": {
                   "type": "timestamp"
                 },
@@ -1003,16 +1336,22 @@
                 "CompletionTime": {
                   "type": "timestamp"
                 },
-                "RetrievedTo": {},
+                "RetrievedTo": {
+                  "shape": "Sa"
+                },
                 "TapeStatus": {},
                 "TapeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {}
+                "KMSKey": {
+                  "shape": "S13"
+                }
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1023,23 +1362,31 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {},
-          "Marker": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "TapeRecoveryPointInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {},
+                "TapeARN": {
+                  "shape": "Sr"
+                },
                 "TapeRecoveryPointTime": {
                   "type": "timestamp"
                 },
@@ -1050,7 +1397,9 @@
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1061,13 +1410,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
@@ -1079,8 +1432,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {},
-                "TapeBarcode": {},
+                "TapeARN": {
+                  "shape": "Sr"
+                },
+                "TapeBarcode": {
+                  "shape": "S1z"
+                },
                 "TapeCreatedDate": {
                   "type": "timestamp"
                 },
@@ -1088,18 +1445,24 @@
                   "type": "long"
                 },
                 "TapeStatus": {},
-                "VTLDevice": {},
+                "VTLDevice": {
+                  "shape": "S4w"
+                },
                 "Progress": {
                   "type": "double"
                 },
                 "TapeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {}
+                "KMSKey": {
+                  "shape": "S13"
+                }
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1110,13 +1473,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           },
@@ -1136,35 +1503,49 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "VTLDeviceARNs": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S4w"
+            }
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "VTLDevices": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VTLDeviceARN": {},
+                "VTLDeviceARN": {
+                  "shape": "S4w"
+                },
                 "VTLDeviceType": {},
                 "VTLDeviceVendor": {},
                 "VTLDeviceProductIdentifier": {},
                 "DeviceiSCSIAttributes": {
                   "type": "structure",
                   "members": {
-                    "TargetARN": {},
-                    "NetworkInterfaceId": {},
+                    "TargetARN": {
+                      "shape": "S15"
+                    },
+                    "NetworkInterfaceId": {
+                      "shape": "S10"
+                    },
                     "NetworkInterfacePort": {
                       "type": "integer"
                     },
@@ -1176,7 +1557,9 @@
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1187,13 +1570,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "DiskIds": {
             "shape": "Sc"
           },
@@ -1213,13 +1600,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1233,11 +1624,19 @@
           "Password"
         ],
         "members": {
-          "GatewayARN": {},
-          "DomainName": {},
-          "UserName": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "DomainName": {
+            "shape": "S45"
+          },
+          "UserName": {
+            "type": "string",
+            "pattern": "^\\w[\\w\\.\\- ]*$"
+          },
           "Password": {
             "type": "string",
+            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -1245,7 +1644,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1253,28 +1654,50 @@
       "input": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
-          "Limit": {
-            "type": "integer"
+          "GatewayARN": {
+            "shape": "Sa"
           },
-          "Marker": {}
+          "Limit": {
+            "shape": "S36"
+          },
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Marker": {},
-          "NextMarker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
+          "NextMarker": {
+            "shape": "S4f"
+          },
           "FileShareInfoList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "FileShareType": {},
-                "FileShareARN": {},
-                "FileShareId": {},
-                "FileShareStatus": {},
-                "GatewayARN": {}
+                "FileShareType": {
+                  "type": "string",
+                  "enum": [
+                    "NFS",
+                    "SMB"
+                  ]
+                },
+                "FileShareARN": {
+                  "shape": "S1i"
+                },
+                "FileShareId": {
+                  "shape": "S3w"
+                },
+                "FileShareStatus": {
+                  "shape": "S3x"
+                },
+                "GatewayARN": {
+                  "shape": "Sa"
+                }
               }
             }
           }
@@ -1285,9 +1708,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
@@ -1299,15 +1724,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "GatewayId": {},
-                "GatewayARN": {},
-                "GatewayType": {},
-                "GatewayOperationalState": {},
+                "GatewayId": {
+                  "shape": "S3g"
+                },
+                "GatewayARN": {
+                  "shape": "Sa"
+                },
+                "GatewayType": {
+                  "shape": "S6"
+                },
+                "GatewayOperationalState": {
+                  "type": "string",
+                  "max": 25,
+                  "min": 2
+                },
                 "GatewayName": {}
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1318,26 +1755,36 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "Disks": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "DiskId": {},
+                "DiskId": {
+                  "shape": "Sd"
+                },
                 "DiskPath": {},
                 "DiskNode": {},
                 "DiskStatus": {},
                 "DiskSizeInBytes": {
                   "type": "long"
                 },
-                "DiskAllocationType": {},
+                "DiskAllocationType": {
+                  "type": "string",
+                  "max": 100,
+                  "min": 3
+                },
                 "DiskAllocationResource": {}
               }
             }
@@ -1352,18 +1799,26 @@
           "ResourceARN"
         ],
         "members": {
-          "ResourceARN": {},
-          "Marker": {},
+          "ResourceARN": {
+            "shape": "Sg"
+          },
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {},
-          "Marker": {},
+          "ResourceARN": {
+            "shape": "Sg"
+          },
+          "Marker": {
+            "shape": "S4f"
+          },
           "Tags": {
             "shape": "Sh"
           }
@@ -1377,9 +1832,11 @@
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {},
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
@@ -1391,17 +1848,25 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {},
-                "TapeBarcode": {},
+                "TapeARN": {
+                  "shape": "Sr"
+                },
+                "TapeBarcode": {
+                  "shape": "S1z"
+                },
                 "TapeSizeInBytes": {
                   "type": "long"
                 },
                 "TapeStatus": {},
-                "GatewayARN": {}
+                "GatewayARN": {
+                  "shape": "Sa"
+                }
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S4f"
+          }
         }
       }
     },
@@ -1412,7 +1877,9 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       },
       "output": {
@@ -1420,7 +1887,11 @@
         "members": {
           "Initiators": {
             "type": "list",
-            "member": {}
+            "member": {
+              "type": "string",
+              "max": 50,
+              "min": 1
+            }
           }
         }
       }
@@ -1432,19 +1903,25 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "VolumeRecoveryPointInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {},
+                "VolumeARN": {
+                  "shape": "Sz"
+                },
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
@@ -1462,28 +1939,46 @@
       "input": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
-          "Marker": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "Marker": {
+            "shape": "S4f"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S36"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
-          "Marker": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "Marker": {
+            "shape": "S4f"
+          },
           "VolumeInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {},
-                "VolumeId": {},
-                "GatewayARN": {},
-                "GatewayId": {},
-                "VolumeType": {},
+                "VolumeARN": {
+                  "shape": "Sz"
+                },
+                "VolumeId": {
+                  "shape": "S30"
+                },
+                "GatewayARN": {
+                  "shape": "Sa"
+                },
+                "GatewayId": {
+                  "shape": "S3g"
+                },
+                "VolumeType": {
+                  "shape": "S31"
+                },
                 "VolumeSizeInBytes": {
                   "type": "long"
                 }
@@ -1500,14 +1995,22 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {},
-          "NotificationId": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          },
+          "NotificationId": {
+            "type": "string",
+            "max": 2048,
+            "min": 1
+          }
         }
       }
     },
@@ -1518,13 +2021,17 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -1536,17 +2043,23 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceARN": {},
+          "ResourceARN": {
+            "shape": "Sg"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sj"
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {}
+          "ResourceARN": {
+            "shape": "Sg"
+          }
         }
       }
     },
@@ -1557,13 +2070,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1575,14 +2092,20 @@
           "GatewayARN"
         ],
         "members": {
-          "TapeARN": {},
-          "GatewayARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          },
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -1594,14 +2117,20 @@
           "GatewayARN"
         ],
         "members": {
-          "TapeARN": {},
-          "GatewayARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          },
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {}
+          "TapeARN": {
+            "shape": "Sr"
+          }
         }
       }
     },
@@ -1613,9 +2142,14 @@
           "LocalConsolePassword"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "LocalConsolePassword": {
             "type": "string",
+            "max": 512,
+            "min": 6,
+            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -1623,7 +2157,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1635,9 +2171,14 @@
           "Password"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "Password": {
             "type": "string",
+            "max": 512,
+            "min": 6,
+            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -1645,7 +2186,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1656,13 +2199,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1673,13 +2220,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1690,19 +2241,23 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "AverageUploadRateLimitInBitsPerSec": {
-            "type": "long"
+            "shape": "S2q"
           },
           "AverageDownloadRateLimitInBitsPerSec": {
-            "type": "long"
+            "shape": "S2r"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1715,17 +2270,29 @@
           "InitiatorName"
         ],
         "members": {
-          "TargetARN": {},
-          "SecretToAuthenticateInitiator": {},
-          "InitiatorName": {},
-          "SecretToAuthenticateTarget": {}
+          "TargetARN": {
+            "shape": "S15"
+          },
+          "SecretToAuthenticateInitiator": {
+            "shape": "S3d"
+          },
+          "InitiatorName": {
+            "shape": "S2a"
+          },
+          "SecretToAuthenticateTarget": {
+            "shape": "S3d"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TargetARN": {},
-          "InitiatorName": {}
+          "TargetARN": {
+            "shape": "S15"
+          },
+          "InitiatorName": {
+            "shape": "S2a"
+          }
         }
       }
     },
@@ -1736,15 +2303,23 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {},
-          "GatewayName": {},
-          "GatewayTimezone": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          },
+          "GatewayName": {
+            "shape": "S3"
+          },
+          "GatewayTimezone": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "GatewayName": {}
         }
       }
@@ -1756,13 +2331,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1776,22 +2355,26 @@
           "DayOfWeek"
         ],
         "members": {
-          "GatewayARN": {},
+          "GatewayARN": {
+            "shape": "Sa"
+          },
           "HourOfDay": {
-            "type": "integer"
+            "shape": "S3o"
           },
           "MinuteOfHour": {
-            "type": "integer"
+            "shape": "S3p"
           },
           "DayOfWeek": {
-            "type": "integer"
+            "shape": "S3q"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {}
+          "GatewayARN": {
+            "shape": "Sa"
+          }
         }
       }
     },
@@ -1802,20 +2385,30 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {},
+          "FileShareARN": {
+            "shape": "S1i"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {},
+          "KMSKey": {
+            "shape": "S13"
+          },
           "NFSFileShareDefaults": {
             "shape": "S17"
           },
-          "DefaultStorageClass": {},
-          "ObjectACL": {},
+          "DefaultStorageClass": {
+            "shape": "S1c"
+          },
+          "ObjectACL": {
+            "shape": "S1d"
+          },
           "ClientList": {
             "shape": "S1e"
           },
-          "Squash": {},
+          "Squash": {
+            "shape": "S1g"
+          },
           "ReadOnly": {
             "type": "boolean"
           },
@@ -1830,7 +2423,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -1841,13 +2436,21 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {},
+          "FileShareARN": {
+            "shape": "S1i"
+          },
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {},
-          "DefaultStorageClass": {},
-          "ObjectACL": {},
+          "KMSKey": {
+            "shape": "S13"
+          },
+          "DefaultStorageClass": {
+            "shape": "S1c"
+          },
+          "ObjectACL": {
+            "shape": "S1d"
+          },
           "ReadOnly": {
             "type": "boolean"
           },
@@ -1868,7 +2471,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {}
+          "FileShareARN": {
+            "shape": "S1i"
+          }
         }
       }
     },
@@ -1881,20 +2486,26 @@
           "RecurrenceInHours"
         ],
         "members": {
-          "VolumeARN": {},
+          "VolumeARN": {
+            "shape": "Sz"
+          },
           "StartAt": {
-            "type": "integer"
+            "shape": "S3o"
           },
           "RecurrenceInHours": {
-            "type": "integer"
+            "shape": "S48"
           },
-          "Description": {}
+          "Description": {
+            "shape": "S49"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {}
+          "VolumeARN": {
+            "shape": "Sz"
+          }
         }
       }
     },
@@ -1906,22 +2517,63 @@
           "DeviceType"
         ],
         "members": {
-          "VTLDeviceARN": {},
-          "DeviceType": {}
+          "VTLDeviceARN": {
+            "shape": "S4w"
+          },
+          "DeviceType": {
+            "type": "string",
+            "max": 50,
+            "min": 2
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VTLDeviceARN": {}
+          "VTLDeviceARN": {
+            "shape": "S4w"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 255,
+      "min": 2,
+      "pattern": "^[ -\\.0-\\[\\]-~]*[!-\\.0-\\[\\]-~][ -\\.0-\\[\\]-~]*$"
+    },
+    "S4": {
+      "type": "string",
+      "max": 10,
+      "min": 3
+    },
+    "S6": {
+      "type": "string",
+      "max": 20,
+      "min": 2
+    },
+    "Sa": {
+      "type": "string",
+      "max": 500,
+      "min": 50
+    },
     "Sc": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sd"
+      }
+    },
+    "Sd": {
+      "type": "string",
+      "max": 300,
+      "min": 1
+    },
+    "Sg": {
+      "type": "string",
+      "max": 500,
+      "min": 50
     },
     "Sh": {
       "type": "list",
@@ -1932,59 +2584,293 @@
           "Value"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "shape": "Sj"
+          },
+          "Value": {
+            "type": "string",
+            "max": 256
+          }
         }
       }
+    },
+    "Sj": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+    },
+    "Sr": {
+      "type": "string",
+      "max": 500,
+      "min": 50,
+      "pattern": "^arn:(aws|aws-cn|aws-us-gov):storagegateway:[a-z\\-0-9]+:[0-9]+:tape\\/[0-9A-Z]{7,16}$"
+    },
+    "Sx": {
+      "type": "string",
+      "pattern": "\\Asnap-([0-9A-Fa-f]{8}|[0-9A-Fa-f]{17})\\z"
+    },
+    "Sy": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "^[-\\.;a-z0-9]+$"
+    },
+    "Sz": {
+      "type": "string",
+      "max": 500,
+      "min": 50
+    },
+    "S10": {
+      "type": "string",
+      "pattern": "\\A(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}\\z"
+    },
+    "S11": {
+      "type": "string",
+      "max": 100,
+      "min": 5
+    },
+    "S13": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S15": {
+      "type": "string",
+      "max": 800,
+      "min": 50
     },
     "S17": {
       "type": "structure",
       "members": {
-        "FileMode": {},
-        "DirectoryMode": {},
+        "FileMode": {
+          "shape": "S18"
+        },
+        "DirectoryMode": {
+          "shape": "S18"
+        },
         "GroupId": {
-          "type": "long"
+          "shape": "S19"
         },
         "OwnerId": {
-          "type": "long"
+          "shape": "S19"
         }
       }
     },
+    "S18": {
+      "type": "string",
+      "max": 4,
+      "min": 1,
+      "pattern": "^[0-7]{4}$"
+    },
+    "S19": {
+      "type": "long",
+      "max": 4294967294,
+      "min": 0
+    },
+    "S1a": {
+      "type": "string",
+      "max": 2048,
+      "min": 20
+    },
+    "S1b": {
+      "type": "string",
+      "max": 310,
+      "min": 16
+    },
+    "S1c": {
+      "type": "string",
+      "max": 20,
+      "min": 5
+    },
+    "S1d": {
+      "type": "string",
+      "enum": [
+        "private",
+        "public-read",
+        "public-read-write",
+        "authenticated-read",
+        "bucket-owner-read",
+        "bucket-owner-full-control",
+        "aws-exec-read"
+      ]
+    },
     "S1e": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?$"
+      },
+      "max": 100,
+      "min": 1
+    },
+    "S1g": {
+      "type": "string",
+      "max": 15,
+      "min": 5
+    },
+    "S1i": {
+      "type": "string",
+      "max": 500,
+      "min": 50
     },
     "S1k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 64,
+        "min": 1
+      },
+      "max": 100,
+      "min": 0
+    },
+    "S1m": {
+      "type": "string",
+      "max": 15,
+      "min": 5
+    },
+    "S1p": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S1z": {
+      "type": "string",
+      "max": 16,
+      "min": 7,
+      "pattern": "^[A-Z0-9]*$"
     },
     "S25": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sr"
+      }
+    },
+    "S2a": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[0-9a-z:.-]+"
+    },
+    "S2q": {
+      "type": "long",
+      "min": 51200
+    },
+    "S2r": {
+      "type": "long",
+      "min": 102400
     },
     "S2w": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sz"
+      }
+    },
+    "S30": {
+      "type": "string",
+      "max": 30,
+      "min": 12
+    },
+    "S31": {
+      "type": "string",
+      "max": 100,
+      "min": 3
+    },
+    "S32": {
+      "type": "string",
+      "max": 50,
+      "min": 3
     },
     "S34": {
       "type": "structure",
       "members": {
-        "TargetARN": {},
-        "NetworkInterfaceId": {},
+        "TargetARN": {
+          "shape": "S15"
+        },
+        "NetworkInterfaceId": {
+          "shape": "S10"
+        },
         "NetworkInterfacePort": {
           "type": "integer"
         },
         "LunNumber": {
-          "type": "integer"
+          "shape": "S36"
         },
         "ChapEnabled": {
           "type": "boolean"
         }
       }
     },
+    "S36": {
+      "type": "integer",
+      "min": 1
+    },
+    "S3d": {
+      "type": "string",
+      "max": 100,
+      "min": 1
+    },
+    "S3g": {
+      "type": "string",
+      "max": 30,
+      "min": 12
+    },
+    "S3o": {
+      "type": "integer",
+      "max": 23,
+      "min": 0
+    },
+    "S3p": {
+      "type": "integer",
+      "max": 59,
+      "min": 0
+    },
+    "S3q": {
+      "type": "integer",
+      "max": 6,
+      "min": 0
+    },
     "S3s": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S1i"
+      },
+      "max": 10,
+      "min": 1
+    },
+    "S3w": {
+      "type": "string",
+      "max": 30,
+      "min": 12
+    },
+    "S3x": {
+      "type": "string",
+      "max": 50,
+      "min": 3
+    },
+    "S45": {
+      "type": "string",
+      "pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
+    },
+    "S48": {
+      "type": "integer",
+      "max": 24,
+      "min": 1
+    },
+    "S49": {
+      "type": "string",
+      "max": 255,
+      "min": 1
+    },
+    "S4f": {
+      "type": "string",
+      "max": 1000,
+      "min": 1
+    },
+    "S4w": {
+      "type": "string",
+      "max": 500,
+      "min": 50
     }
   }
 }

--- a/apis/streams.dynamodb-2012-08-10.min.json
+++ b/apis/streams.dynamodb-2012-08-10.min.json
@@ -20,11 +20,15 @@
           "StreamArn"
         ],
         "members": {
-          "StreamArn": {},
-          "Limit": {
-            "type": "integer"
+          "StreamArn": {
+            "shape": "S2"
           },
-          "ExclusiveStartShardId": {}
+          "Limit": {
+            "shape": "S3"
+          },
+          "ExclusiveStartShardId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -33,14 +37,28 @@
           "StreamDescription": {
             "type": "structure",
             "members": {
-              "StreamArn": {},
+              "StreamArn": {
+                "shape": "S2"
+              },
               "StreamLabel": {},
-              "StreamStatus": {},
-              "StreamViewType": {},
+              "StreamStatus": {
+                "type": "string",
+                "enum": [
+                  "ENABLING",
+                  "ENABLED",
+                  "DISABLING",
+                  "DISABLED"
+                ]
+              },
+              "StreamViewType": {
+                "shape": "S9"
+              },
               "CreationRequestDateTime": {
                 "type": "timestamp"
               },
-              "TableName": {},
+              "TableName": {
+                "shape": "Sb"
+              },
               "KeySchema": {
                 "type": "list",
                 "member": {
@@ -50,29 +68,51 @@
                     "KeyType"
                   ],
                   "members": {
-                    "AttributeName": {},
-                    "KeyType": {}
+                    "AttributeName": {
+                      "type": "string",
+                      "max": 255,
+                      "min": 1
+                    },
+                    "KeyType": {
+                      "type": "string",
+                      "enum": [
+                        "HASH",
+                        "RANGE"
+                      ]
+                    }
                   }
-                }
+                },
+                "max": 2,
+                "min": 1
               },
               "Shards": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "ShardId": {},
+                    "ShardId": {
+                      "shape": "S4"
+                    },
                     "SequenceNumberRange": {
                       "type": "structure",
                       "members": {
-                        "StartingSequenceNumber": {},
-                        "EndingSequenceNumber": {}
+                        "StartingSequenceNumber": {
+                          "shape": "Sj"
+                        },
+                        "EndingSequenceNumber": {
+                          "shape": "Sj"
+                        }
                       }
                     },
-                    "ParentShardId": {}
+                    "ParentShardId": {
+                      "shape": "S4"
+                    }
                   }
                 }
               },
-              "LastEvaluatedShardId": {}
+              "LastEvaluatedShardId": {
+                "shape": "S4"
+              }
             }
           }
         }
@@ -85,9 +125,11 @@
           "ShardIterator"
         ],
         "members": {
-          "ShardIterator": {},
+          "ShardIterator": {
+            "shape": "Sl"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S3"
           }
         }
       },
@@ -100,7 +142,14 @@
               "type": "structure",
               "members": {
                 "eventID": {},
-                "eventName": {},
+                "eventName": {
+                  "type": "string",
+                  "enum": [
+                    "INSERT",
+                    "MODIFY",
+                    "REMOVE"
+                  ]
+                },
                 "eventVersion": {},
                 "eventSource": {},
                 "awsRegion": {},
@@ -119,11 +168,16 @@
                     "OldImage": {
                       "shape": "Sr"
                     },
-                    "SequenceNumber": {},
-                    "SizeBytes": {
-                      "type": "long"
+                    "SequenceNumber": {
+                      "shape": "Sj"
                     },
-                    "StreamViewType": {}
+                    "SizeBytes": {
+                      "type": "long",
+                      "min": 1
+                    },
+                    "StreamViewType": {
+                      "shape": "S9"
+                    }
                   }
                 },
                 "userIdentity": {
@@ -136,7 +190,9 @@
               }
             }
           },
-          "NextShardIterator": {}
+          "NextShardIterator": {
+            "shape": "Sl"
+          }
         }
       }
     },
@@ -149,16 +205,32 @@
           "ShardIteratorType"
         ],
         "members": {
-          "StreamArn": {},
-          "ShardId": {},
-          "ShardIteratorType": {},
-          "SequenceNumber": {}
+          "StreamArn": {
+            "shape": "S2"
+          },
+          "ShardId": {
+            "shape": "S4"
+          },
+          "ShardIteratorType": {
+            "type": "string",
+            "enum": [
+              "TRIM_HORIZON",
+              "LATEST",
+              "AT_SEQUENCE_NUMBER",
+              "AFTER_SEQUENCE_NUMBER"
+            ]
+          },
+          "SequenceNumber": {
+            "shape": "Sj"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ShardIterator": {}
+          "ShardIterator": {
+            "shape": "Sl"
+          }
         }
       }
     },
@@ -166,11 +238,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "TableName": {},
-          "Limit": {
-            "type": "integer"
+          "TableName": {
+            "shape": "Sb"
           },
-          "ExclusiveStartStreamArn": {}
+          "Limit": {
+            "shape": "S3"
+          },
+          "ExclusiveStartStreamArn": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -181,24 +257,75 @@
             "member": {
               "type": "structure",
               "members": {
-                "StreamArn": {},
-                "TableName": {},
+                "StreamArn": {
+                  "shape": "S2"
+                },
+                "TableName": {
+                  "shape": "Sb"
+                },
                 "StreamLabel": {}
               }
             }
           },
-          "LastEvaluatedStreamArn": {}
+          "LastEvaluatedStreamArn": {
+            "shape": "S2"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 1024,
+      "min": 37
+    },
+    "S3": {
+      "type": "integer",
+      "min": 1
+    },
+    "S4": {
+      "type": "string",
+      "max": 65,
+      "min": 28
+    },
+    "S9": {
+      "type": "string",
+      "enum": [
+        "NEW_IMAGE",
+        "OLD_IMAGE",
+        "NEW_AND_OLD_IMAGES",
+        "KEYS_ONLY"
+      ]
+    },
+    "Sb": {
+      "type": "string",
+      "max": 255,
+      "min": 3,
+      "pattern": "[a-zA-Z0-9_.-]+"
+    },
+    "Sj": {
+      "type": "string",
+      "max": 40,
+      "min": 21
+    },
+    "Sl": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
     "Sr": {
       "type": "map",
-      "key": {},
+      "key": {
+        "shape": "Ss"
+      },
       "value": {
         "shape": "St"
       }
+    },
+    "Ss": {
+      "type": "string",
+      "max": 65535
     },
     "St": {
       "type": "structure",
@@ -224,7 +351,9 @@
         },
         "M": {
           "type": "map",
-          "key": {},
+          "key": {
+            "shape": "Ss"
+          },
           "value": {
             "shape": "St"
           }

--- a/apis/sts-2011-06-15.min.json
+++ b/apis/sts-2011-06-15.min.json
@@ -21,15 +21,30 @@
           "RoleSessionName"
         ],
         "members": {
-          "RoleArn": {},
-          "RoleSessionName": {},
-          "Policy": {},
-          "DurationSeconds": {
-            "type": "integer"
+          "RoleArn": {
+            "shape": "S2"
           },
-          "ExternalId": {},
-          "SerialNumber": {},
-          "TokenCode": {}
+          "RoleSessionName": {
+            "shape": "S3"
+          },
+          "Policy": {
+            "shape": "S4"
+          },
+          "DurationSeconds": {
+            "shape": "S5"
+          },
+          "ExternalId": {
+            "type": "string",
+            "max": 1224,
+            "min": 2,
+            "pattern": "[\\w+=,.@:\\/-]*"
+          },
+          "SerialNumber": {
+            "shape": "S7"
+          },
+          "TokenCode": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -43,7 +58,7 @@
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "type": "integer"
+            "shape": "Sh"
           }
         }
       }
@@ -57,12 +72,22 @@
           "SAMLAssertion"
         ],
         "members": {
-          "RoleArn": {},
-          "PrincipalArn": {},
-          "SAMLAssertion": {},
-          "Policy": {},
+          "RoleArn": {
+            "shape": "S2"
+          },
+          "PrincipalArn": {
+            "shape": "S2"
+          },
+          "SAMLAssertion": {
+            "type": "string",
+            "max": 100000,
+            "min": 4
+          },
+          "Policy": {
+            "shape": "S4"
+          },
           "DurationSeconds": {
-            "type": "integer"
+            "shape": "S5"
           }
         }
       },
@@ -77,7 +102,7 @@
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "type": "integer"
+            "shape": "Sh"
           },
           "Subject": {},
           "SubjectType": {},
@@ -96,13 +121,27 @@
           "WebIdentityToken"
         ],
         "members": {
-          "RoleArn": {},
-          "RoleSessionName": {},
-          "WebIdentityToken": {},
-          "ProviderId": {},
-          "Policy": {},
+          "RoleArn": {
+            "shape": "S2"
+          },
+          "RoleSessionName": {
+            "shape": "S3"
+          },
+          "WebIdentityToken": {
+            "type": "string",
+            "max": 2048,
+            "min": 4
+          },
+          "ProviderId": {
+            "type": "string",
+            "max": 2048,
+            "min": 4
+          },
+          "Policy": {
+            "shape": "S4"
+          },
           "DurationSeconds": {
-            "type": "integer"
+            "shape": "S5"
           }
         }
       },
@@ -113,12 +152,16 @@
           "Credentials": {
             "shape": "Sa"
           },
-          "SubjectFromWebIdentityToken": {},
+          "SubjectFromWebIdentityToken": {
+            "type": "string",
+            "max": 255,
+            "min": 6
+          },
           "AssumedRoleUser": {
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "type": "integer"
+            "shape": "Sh"
           },
           "Provider": {},
           "Audience": {}
@@ -132,7 +175,11 @@
           "EncodedMessage"
         ],
         "members": {
-          "EncodedMessage": {}
+          "EncodedMessage": {
+            "type": "string",
+            "max": 10240,
+            "min": 1
+          }
         }
       },
       "output": {
@@ -154,7 +201,9 @@
         "members": {
           "UserId": {},
           "Account": {},
-          "Arn": {}
+          "Arn": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -165,10 +214,17 @@
           "Name"
         ],
         "members": {
-          "Name": {},
-          "Policy": {},
+          "Name": {
+            "type": "string",
+            "max": 32,
+            "min": 2,
+            "pattern": "[\\w+=,.@-]*"
+          },
+          "Policy": {
+            "shape": "S4"
+          },
           "DurationSeconds": {
-            "type": "integer"
+            "shape": "S15"
           }
         }
       },
@@ -186,12 +242,19 @@
               "Arn"
             ],
             "members": {
-              "FederatedUserId": {},
-              "Arn": {}
+              "FederatedUserId": {
+                "type": "string",
+                "max": 193,
+                "min": 2,
+                "pattern": "[\\w+=,.@\\:-]*"
+              },
+              "Arn": {
+                "shape": "S2"
+              }
             }
           },
           "PackedPolicySize": {
-            "type": "integer"
+            "shape": "Sh"
           }
         }
       }
@@ -201,10 +264,14 @@
         "type": "structure",
         "members": {
           "DurationSeconds": {
-            "type": "integer"
+            "shape": "S15"
           },
-          "SerialNumber": {},
-          "TokenCode": {}
+          "SerialNumber": {
+            "shape": "S7"
+          },
+          "TokenCode": {
+            "shape": "S8"
+          }
         }
       },
       "output": {
@@ -219,6 +286,41 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 2048,
+      "min": 20,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]+"
+    },
+    "S3": {
+      "type": "string",
+      "max": 64,
+      "min": 2,
+      "pattern": "[\\w+=,.@-]*"
+    },
+    "S4": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
+    },
+    "S5": {
+      "type": "integer",
+      "max": 43200,
+      "min": 900
+    },
+    "S7": {
+      "type": "string",
+      "max": 256,
+      "min": 9,
+      "pattern": "[\\w+=/:,.@-]*"
+    },
+    "S8": {
+      "type": "string",
+      "max": 6,
+      "min": 6,
+      "pattern": "[\\d]*"
+    },
     "Sa": {
       "type": "structure",
       "required": [
@@ -228,7 +330,12 @@
         "Expiration"
       ],
       "members": {
-        "AccessKeyId": {},
+        "AccessKeyId": {
+          "type": "string",
+          "max": 128,
+          "min": 16,
+          "pattern": "[\\w]*"
+        },
         "SecretAccessKey": {},
         "SessionToken": {},
         "Expiration": {
@@ -243,9 +350,25 @@
         "Arn"
       ],
       "members": {
-        "AssumedRoleId": {},
-        "Arn": {}
+        "AssumedRoleId": {
+          "type": "string",
+          "max": 193,
+          "min": 2,
+          "pattern": "[\\w+=,.@:-]*"
+        },
+        "Arn": {
+          "shape": "S2"
+        }
       }
+    },
+    "Sh": {
+      "type": "integer",
+      "min": 0
+    },
+    "S15": {
+      "type": "integer",
+      "max": 129600,
+      "min": 900
     }
   }
 }

--- a/apis/support-2013-04-15.min.json
+++ b/apis/support-2013-04-15.min.json
@@ -44,7 +44,9 @@
         ],
         "members": {
           "caseId": {},
-          "communicationBody": {},
+          "communicationBody": {
+            "shape": "Sb"
+          },
           "ccEmailAddresses": {
             "shape": "Sc"
           },
@@ -72,7 +74,9 @@
           "serviceCode": {},
           "severityCode": {},
           "categoryCode": {},
-          "communicationBody": {},
+          "communicationBody": {
+            "shape": "Sb"
+          },
           "ccEmailAddresses": {
             "shape": "Sc"
           },
@@ -113,7 +117,9 @@
         "members": {
           "caseIdList": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 100,
+            "min": 0
           },
           "displayId": {},
           "afterTime": {},
@@ -123,7 +129,7 @@
           },
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "Sy"
           },
           "language": {},
           "includeCommunications": {
@@ -180,7 +186,7 @@
           "afterTime": {},
           "nextToken": {},
           "maxResults": {
-            "type": "integer"
+            "shape": "Sy"
           }
         }
       },
@@ -200,7 +206,9 @@
         "members": {
           "serviceCodeList": {
             "type": "list",
-            "member": {}
+            "member": {},
+            "max": 100,
+            "min": 0
           },
           "language": {}
         }
@@ -479,9 +487,21 @@
         }
       }
     },
+    "Sb": {
+      "type": "string",
+      "max": 8000,
+      "min": 1
+    },
     "Sc": {
       "type": "list",
-      "member": {}
+      "member": {},
+      "max": 10,
+      "min": 0
+    },
+    "Sy": {
+      "type": "integer",
+      "max": 100,
+      "min": 10
     },
     "S17": {
       "type": "list",
@@ -489,7 +509,9 @@
         "type": "structure",
         "members": {
           "caseId": {},
-          "body": {},
+          "body": {
+            "shape": "Sb"
+          },
           "submittedBy": {},
           "timeCreated": {},
           "attachmentSet": {

--- a/apis/swf-2012-01-25.min.json
+++ b/apis/swf-2012-01-25.min.json
@@ -21,7 +21,9 @@
           "domain"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -54,7 +56,9 @@
           "startTimeFilter"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -81,7 +85,9 @@
           "taskList"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "taskList": {
             "shape": "Sj"
           }
@@ -99,7 +105,9 @@
           "taskList"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "taskList": {
             "shape": "Sj"
           }
@@ -117,7 +125,9 @@
           "activityType"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "activityType": {
             "shape": "Sn"
           }
@@ -131,7 +141,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -143,7 +155,9 @@
           "workflowType"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "workflowType": {
             "shape": "Sr"
           }
@@ -158,7 +172,9 @@
           "activityType"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "activityType": {
             "shape": "Sn"
           }
@@ -177,14 +193,22 @@
           "configuration": {
             "type": "structure",
             "members": {
-              "defaultTaskStartToCloseTimeout": {},
-              "defaultTaskHeartbeatTimeout": {},
+              "defaultTaskStartToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "defaultTaskHeartbeatTimeout": {
+                "shape": "Sy"
+              },
               "defaultTaskList": {
                 "shape": "Sj"
               },
               "defaultTaskPriority": {},
-              "defaultTaskScheduleToStartTimeout": {},
-              "defaultTaskScheduleToCloseTimeout": {}
+              "defaultTaskScheduleToStartTimeout": {
+                "shape": "Sy"
+              },
+              "defaultTaskScheduleToCloseTimeout": {
+                "shape": "Sy"
+              }
             }
           }
         }
@@ -197,7 +221,9 @@
           "name"
         ],
         "members": {
-          "name": {}
+          "name": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -216,7 +242,9 @@
               "workflowExecutionRetentionPeriodInDays"
             ],
             "members": {
-              "workflowExecutionRetentionPeriodInDays": {}
+              "workflowExecutionRetentionPeriodInDays": {
+                "shape": "S14"
+              }
             }
           }
         }
@@ -230,7 +258,9 @@
           "execution"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "execution": {
             "shape": "S16"
           }
@@ -256,14 +286,22 @@
               "childPolicy"
             ],
             "members": {
-              "taskStartToCloseTimeout": {},
-              "executionStartToCloseTimeout": {},
+              "taskStartToCloseTimeout": {
+                "shape": "S1e"
+              },
+              "executionStartToCloseTimeout": {
+                "shape": "S1e"
+              },
               "taskList": {
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "childPolicy": {},
-              "lambdaRole": {}
+              "childPolicy": {
+                "shape": "S1f"
+              },
+              "lambdaRole": {
+                "shape": "S1g"
+              }
             }
           },
           "openCounts": {
@@ -276,26 +314,30 @@
             ],
             "members": {
               "openActivityTasks": {
-                "type": "integer"
+                "shape": "Sf"
               },
               "openDecisionTasks": {
-                "type": "integer"
+                "type": "integer",
+                "max": 1,
+                "min": 0
               },
               "openTimers": {
-                "type": "integer"
+                "shape": "Sf"
               },
               "openChildWorkflowExecutions": {
-                "type": "integer"
+                "shape": "Sf"
               },
               "openLambdaFunctions": {
-                "type": "integer"
+                "shape": "Sf"
               }
             }
           },
           "latestActivityTaskTimestamp": {
             "type": "timestamp"
           },
-          "latestExecutionContext": {}
+          "latestExecutionContext": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -307,7 +349,9 @@
           "workflowType"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "workflowType": {
             "shape": "Sr"
           }
@@ -326,14 +370,22 @@
           "configuration": {
             "type": "structure",
             "members": {
-              "defaultTaskStartToCloseTimeout": {},
-              "defaultExecutionStartToCloseTimeout": {},
+              "defaultTaskStartToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "defaultExecutionStartToCloseTimeout": {
+                "shape": "Sy"
+              },
               "defaultTaskList": {
                 "shape": "Sj"
               },
               "defaultTaskPriority": {},
-              "defaultChildPolicy": {},
-              "defaultLambdaRole": {}
+              "defaultChildPolicy": {
+                "shape": "S1f"
+              },
+              "defaultLambdaRole": {
+                "shape": "S1g"
+              }
             }
           }
         }
@@ -347,13 +399,17 @@
           "execution"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "execution": {
             "shape": "S16"
           },
-          "nextPageToken": {},
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -369,7 +425,9 @@
           "events": {
             "shape": "S1t"
           },
-          "nextPageToken": {}
+          "nextPageToken": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -381,12 +439,20 @@
           "registrationStatus"
         ],
         "members": {
-          "domain": {},
-          "name": {},
-          "registrationStatus": {},
-          "nextPageToken": {},
+          "domain": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S8"
+          },
+          "registrationStatus": {
+            "shape": "Sv"
+          },
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -405,7 +471,9 @@
               "shape": "Su"
             }
           },
-          "nextPageToken": {}
+          "nextPageToken": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -416,7 +484,9 @@
           "domain"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -435,9 +505,11 @@
           "tagFilter": {
             "shape": "Sa"
           },
-          "nextPageToken": {},
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -455,10 +527,14 @@
           "registrationStatus"
         ],
         "members": {
-          "nextPageToken": {},
-          "registrationStatus": {},
+          "nextPageToken": {
+            "shape": "S1p"
+          },
+          "registrationStatus": {
+            "shape": "Sv"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -477,7 +553,9 @@
               "shape": "S12"
             }
           },
-          "nextPageToken": {}
+          "nextPageToken": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -489,7 +567,9 @@
           "startTimeFilter"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -499,9 +579,11 @@
           "tagFilter": {
             "shape": "Sa"
           },
-          "nextPageToken": {},
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -523,12 +605,20 @@
           "registrationStatus"
         ],
         "members": {
-          "domain": {},
-          "name": {},
-          "registrationStatus": {},
-          "nextPageToken": {},
+          "domain": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S8"
+          },
+          "registrationStatus": {
+            "shape": "Sv"
+          },
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -547,7 +637,9 @@
               "shape": "S1m"
             }
           },
-          "nextPageToken": {}
+          "nextPageToken": {
+            "shape": "S1p"
+          }
         }
       }
     },
@@ -559,11 +651,15 @@
           "taskList"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "taskList": {
             "shape": "Sj"
           },
-          "identity": {}
+          "identity": {
+            "shape": "S2l"
+          }
         }
       },
       "output": {
@@ -576,8 +672,12 @@
           "activityType"
         ],
         "members": {
-          "taskToken": {},
-          "activityId": {},
+          "taskToken": {
+            "shape": "S4r"
+          },
+          "activityId": {
+            "shape": "S2q"
+          },
           "startedEventId": {
             "type": "long"
           },
@@ -587,7 +687,9 @@
           "activityType": {
             "shape": "Sn"
           },
-          "input": {}
+          "input": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -599,14 +701,20 @@
           "taskList"
         ],
         "members": {
-          "domain": {},
+          "domain": {
+            "shape": "S2"
+          },
           "taskList": {
             "shape": "Sj"
           },
-          "identity": {},
-          "nextPageToken": {},
+          "identity": {
+            "shape": "S2l"
+          },
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "maximumPageSize": {
-            "type": "integer"
+            "shape": "S1q"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -623,7 +731,9 @@
           "events"
         ],
         "members": {
-          "taskToken": {},
+          "taskToken": {
+            "shape": "S4r"
+          },
           "startedEventId": {
             "type": "long"
           },
@@ -636,7 +746,9 @@
           "events": {
             "shape": "S1t"
           },
-          "nextPageToken": {},
+          "nextPageToken": {
+            "shape": "S1p"
+          },
           "previousStartedEventId": {
             "type": "long"
           }
@@ -650,8 +762,12 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
-          "details": {}
+          "taskToken": {
+            "shape": "S4r"
+          },
+          "details": {
+            "shape": "S2w"
+          }
         }
       },
       "output": {
@@ -675,18 +791,34 @@
           "version"
         ],
         "members": {
-          "domain": {},
-          "name": {},
-          "version": {},
-          "description": {},
-          "defaultTaskStartToCloseTimeout": {},
-          "defaultTaskHeartbeatTimeout": {},
+          "domain": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S8"
+          },
+          "version": {
+            "shape": "So"
+          },
+          "description": {
+            "shape": "Sw"
+          },
+          "defaultTaskStartToCloseTimeout": {
+            "shape": "Sy"
+          },
+          "defaultTaskHeartbeatTimeout": {
+            "shape": "Sy"
+          },
           "defaultTaskList": {
             "shape": "Sj"
           },
           "defaultTaskPriority": {},
-          "defaultTaskScheduleToStartTimeout": {},
-          "defaultTaskScheduleToCloseTimeout": {}
+          "defaultTaskScheduleToStartTimeout": {
+            "shape": "Sy"
+          },
+          "defaultTaskScheduleToCloseTimeout": {
+            "shape": "Sy"
+          }
         }
       }
     },
@@ -698,9 +830,15 @@
           "workflowExecutionRetentionPeriodInDays"
         ],
         "members": {
-          "name": {},
-          "description": {},
-          "workflowExecutionRetentionPeriodInDays": {}
+          "name": {
+            "shape": "S2"
+          },
+          "description": {
+            "shape": "Sw"
+          },
+          "workflowExecutionRetentionPeriodInDays": {
+            "shape": "S14"
+          }
         }
       }
     },
@@ -713,18 +851,34 @@
           "version"
         ],
         "members": {
-          "domain": {},
-          "name": {},
-          "version": {},
-          "description": {},
-          "defaultTaskStartToCloseTimeout": {},
-          "defaultExecutionStartToCloseTimeout": {},
+          "domain": {
+            "shape": "S2"
+          },
+          "name": {
+            "shape": "S8"
+          },
+          "version": {
+            "shape": "So"
+          },
+          "description": {
+            "shape": "Sw"
+          },
+          "defaultTaskStartToCloseTimeout": {
+            "shape": "Sy"
+          },
+          "defaultExecutionStartToCloseTimeout": {
+            "shape": "Sy"
+          },
           "defaultTaskList": {
             "shape": "Sj"
           },
           "defaultTaskPriority": {},
-          "defaultChildPolicy": {},
-          "defaultLambdaRole": {}
+          "defaultChildPolicy": {
+            "shape": "S1f"
+          },
+          "defaultLambdaRole": {
+            "shape": "S1g"
+          }
         }
       }
     },
@@ -736,9 +890,15 @@
           "workflowId"
         ],
         "members": {
-          "domain": {},
-          "workflowId": {},
-          "runId": {}
+          "domain": {
+            "shape": "S2"
+          },
+          "workflowId": {
+            "shape": "S6"
+          },
+          "runId": {
+            "shape": "S1y"
+          }
         }
       }
     },
@@ -749,8 +909,12 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
-          "details": {}
+          "taskToken": {
+            "shape": "S4r"
+          },
+          "details": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -761,8 +925,12 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
-          "result": {}
+          "taskToken": {
+            "shape": "S4r"
+          },
+          "result": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -773,9 +941,15 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
-          "reason": {},
-          "details": {}
+          "taskToken": {
+            "shape": "S4r"
+          },
+          "reason": {
+            "shape": "S23"
+          },
+          "details": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -786,7 +960,9 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {},
+          "taskToken": {
+            "shape": "S4r"
+          },
           "decisions": {
             "type": "list",
             "member": {
@@ -795,7 +971,24 @@
                 "decisionType"
               ],
               "members": {
-                "decisionType": {},
+                "decisionType": {
+                  "type": "string",
+                  "enum": [
+                    "ScheduleActivityTask",
+                    "RequestCancelActivityTask",
+                    "CompleteWorkflowExecution",
+                    "FailWorkflowExecution",
+                    "CancelWorkflowExecution",
+                    "ContinueAsNewWorkflowExecution",
+                    "RecordMarker",
+                    "StartTimer",
+                    "CancelTimer",
+                    "SignalExternalWorkflowExecution",
+                    "RequestCancelExternalWorkflowExecution",
+                    "StartChildWorkflowExecution",
+                    "ScheduleLambdaFunction"
+                  ]
+                },
                 "scheduleActivityTaskDecisionAttributes": {
                   "type": "structure",
                   "required": [
@@ -806,17 +999,31 @@
                     "activityType": {
                       "shape": "Sn"
                     },
-                    "activityId": {},
-                    "control": {},
-                    "input": {},
-                    "scheduleToCloseTimeout": {},
+                    "activityId": {
+                      "shape": "S2q"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    },
+                    "input": {
+                      "shape": "S1j"
+                    },
+                    "scheduleToCloseTimeout": {
+                      "shape": "Sy"
+                    },
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "scheduleToStartTimeout": {},
-                    "startToCloseTimeout": {},
-                    "heartbeatTimeout": {}
+                    "scheduleToStartTimeout": {
+                      "shape": "Sy"
+                    },
+                    "startToCloseTimeout": {
+                      "shape": "Sy"
+                    },
+                    "heartbeatTimeout": {
+                      "shape": "Sy"
+                    }
                   }
                 },
                 "requestCancelActivityTaskDecisionAttributes": {
@@ -825,44 +1032,66 @@
                     "activityId"
                   ],
                   "members": {
-                    "activityId": {}
+                    "activityId": {
+                      "shape": "S2q"
+                    }
                   }
                 },
                 "completeWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "result": {}
+                    "result": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "failWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "reason": {},
-                    "details": {}
+                    "reason": {
+                      "shape": "S23"
+                    },
+                    "details": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "cancelWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "details": {}
+                    "details": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "continueAsNewWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "input": {},
-                    "executionStartToCloseTimeout": {},
+                    "input": {
+                      "shape": "S1j"
+                    },
+                    "executionStartToCloseTimeout": {
+                      "shape": "Sy"
+                    },
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "taskStartToCloseTimeout": {},
-                    "childPolicy": {},
+                    "taskStartToCloseTimeout": {
+                      "shape": "Sy"
+                    },
+                    "childPolicy": {
+                      "shape": "S1f"
+                    },
                     "tagList": {
                       "shape": "S1b"
                     },
-                    "workflowTypeVersion": {},
-                    "lambdaRole": {}
+                    "workflowTypeVersion": {
+                      "shape": "So"
+                    },
+                    "lambdaRole": {
+                      "shape": "S1g"
+                    }
                   }
                 },
                 "recordMarkerDecisionAttributes": {
@@ -871,8 +1100,12 @@
                     "markerName"
                   ],
                   "members": {
-                    "markerName": {},
-                    "details": {}
+                    "markerName": {
+                      "shape": "S32"
+                    },
+                    "details": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "startTimerDecisionAttributes": {
@@ -882,9 +1115,15 @@
                     "startToFireTimeout"
                   ],
                   "members": {
-                    "timerId": {},
-                    "control": {},
-                    "startToFireTimeout": {}
+                    "timerId": {
+                      "shape": "S36"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    },
+                    "startToFireTimeout": {
+                      "shape": "S1e"
+                    }
                   }
                 },
                 "cancelTimerDecisionAttributes": {
@@ -893,7 +1132,9 @@
                     "timerId"
                   ],
                   "members": {
-                    "timerId": {}
+                    "timerId": {
+                      "shape": "S36"
+                    }
                   }
                 },
                 "signalExternalWorkflowExecutionDecisionAttributes": {
@@ -903,11 +1144,21 @@
                     "signalName"
                   ],
                   "members": {
-                    "workflowId": {},
-                    "runId": {},
-                    "signalName": {},
-                    "input": {},
-                    "control": {}
+                    "workflowId": {
+                      "shape": "S6"
+                    },
+                    "runId": {
+                      "shape": "S1y"
+                    },
+                    "signalName": {
+                      "shape": "S30"
+                    },
+                    "input": {
+                      "shape": "S1j"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "requestCancelExternalWorkflowExecutionDecisionAttributes": {
@@ -916,9 +1167,15 @@
                     "workflowId"
                   ],
                   "members": {
-                    "workflowId": {},
-                    "runId": {},
-                    "control": {}
+                    "workflowId": {
+                      "shape": "S6"
+                    },
+                    "runId": {
+                      "shape": "S1y"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    }
                   }
                 },
                 "startChildWorkflowExecutionDecisionAttributes": {
@@ -931,20 +1188,34 @@
                     "workflowType": {
                       "shape": "Sr"
                     },
-                    "workflowId": {},
-                    "control": {},
-                    "input": {},
-                    "executionStartToCloseTimeout": {},
+                    "workflowId": {
+                      "shape": "S6"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    },
+                    "input": {
+                      "shape": "S1j"
+                    },
+                    "executionStartToCloseTimeout": {
+                      "shape": "Sy"
+                    },
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "taskStartToCloseTimeout": {},
-                    "childPolicy": {},
+                    "taskStartToCloseTimeout": {
+                      "shape": "Sy"
+                    },
+                    "childPolicy": {
+                      "shape": "S1f"
+                    },
                     "tagList": {
                       "shape": "S1b"
                     },
-                    "lambdaRole": {}
+                    "lambdaRole": {
+                      "shape": "S1g"
+                    }
                   }
                 },
                 "scheduleLambdaFunctionDecisionAttributes": {
@@ -954,17 +1225,29 @@
                     "name"
                   ],
                   "members": {
-                    "id": {},
-                    "name": {},
-                    "control": {},
-                    "input": {},
-                    "startToCloseTimeout": {}
+                    "id": {
+                      "shape": "S3z"
+                    },
+                    "name": {
+                      "shape": "S40"
+                    },
+                    "control": {
+                      "shape": "S1j"
+                    },
+                    "input": {
+                      "shape": "S41"
+                    },
+                    "startToCloseTimeout": {
+                      "shape": "Sy"
+                    }
                   }
                 }
               }
             }
           },
-          "executionContext": {}
+          "executionContext": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -977,11 +1260,21 @@
           "signalName"
         ],
         "members": {
-          "domain": {},
-          "workflowId": {},
-          "runId": {},
-          "signalName": {},
-          "input": {}
+          "domain": {
+            "shape": "S2"
+          },
+          "workflowId": {
+            "shape": "S6"
+          },
+          "runId": {
+            "shape": "S1y"
+          },
+          "signalName": {
+            "shape": "S30"
+          },
+          "input": {
+            "shape": "S1j"
+          }
         }
       }
     },
@@ -994,8 +1287,12 @@
           "workflowType"
         ],
         "members": {
-          "domain": {},
-          "workflowId": {},
+          "domain": {
+            "shape": "S2"
+          },
+          "workflowId": {
+            "shape": "S6"
+          },
           "workflowType": {
             "shape": "Sr"
           },
@@ -1003,20 +1300,32 @@
             "shape": "Sj"
           },
           "taskPriority": {},
-          "input": {},
-          "executionStartToCloseTimeout": {},
+          "input": {
+            "shape": "S1j"
+          },
+          "executionStartToCloseTimeout": {
+            "shape": "Sy"
+          },
           "tagList": {
             "shape": "S1b"
           },
-          "taskStartToCloseTimeout": {},
-          "childPolicy": {},
-          "lambdaRole": {}
+          "taskStartToCloseTimeout": {
+            "shape": "Sy"
+          },
+          "childPolicy": {
+            "shape": "S1f"
+          },
+          "lambdaRole": {
+            "shape": "S1g"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "runId": {}
+          "runId": {
+            "shape": "S17"
+          }
         }
       }
     },
@@ -1028,17 +1337,34 @@
           "workflowId"
         ],
         "members": {
-          "domain": {},
-          "workflowId": {},
-          "runId": {},
-          "reason": {},
-          "details": {},
-          "childPolicy": {}
+          "domain": {
+            "shape": "S2"
+          },
+          "workflowId": {
+            "shape": "S6"
+          },
+          "runId": {
+            "shape": "S1y"
+          },
+          "reason": {
+            "shape": "S2f"
+          },
+          "details": {
+            "shape": "S1j"
+          },
+          "childPolicy": {
+            "shape": "S1f"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
     "S3": {
       "type": "structure",
       "required": [
@@ -1059,8 +1385,15 @@
         "workflowId"
       ],
       "members": {
-        "workflowId": {}
+        "workflowId": {
+          "shape": "S6"
+        }
       }
+    },
+    "S6": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     },
     "S7": {
       "type": "structure",
@@ -1068,9 +1401,19 @@
         "name"
       ],
       "members": {
-        "name": {},
-        "version": {}
+        "name": {
+          "shape": "S8"
+        },
+        "version": {
+          "type": "string",
+          "max": 64
+        }
       }
+    },
+    "S8": {
+      "type": "string",
+      "max": 256,
+      "min": 1
     },
     "Sa": {
       "type": "structure",
@@ -1078,8 +1421,15 @@
         "tag"
       ],
       "members": {
-        "tag": {}
+        "tag": {
+          "shape": "Sb"
+        }
       }
+    },
+    "Sb": {
+      "type": "string",
+      "max": 256,
+      "min": 0
     },
     "Sc": {
       "type": "structure",
@@ -1087,8 +1437,21 @@
         "status"
       ],
       "members": {
-        "status": {}
+        "status": {
+          "shape": "Sd"
+        }
       }
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "COMPLETED",
+        "FAILED",
+        "CANCELED",
+        "TERMINATED",
+        "CONTINUED_AS_NEW",
+        "TIMED_OUT"
+      ]
     },
     "Se": {
       "type": "structure",
@@ -1097,12 +1460,16 @@
       ],
       "members": {
         "count": {
-          "type": "integer"
+          "shape": "Sf"
         },
         "truncated": {
           "type": "boolean"
         }
       }
+    },
+    "Sf": {
+      "type": "integer",
+      "min": 0
     },
     "Sj": {
       "type": "structure",
@@ -1110,7 +1477,9 @@
         "name"
       ],
       "members": {
-        "name": {}
+        "name": {
+          "shape": "S8"
+        }
       }
     },
     "Sk": {
@@ -1120,7 +1489,7 @@
       ],
       "members": {
         "count": {
-          "type": "integer"
+          "shape": "Sf"
         },
         "truncated": {
           "type": "boolean"
@@ -1134,9 +1503,18 @@
         "version"
       ],
       "members": {
-        "name": {},
-        "version": {}
+        "name": {
+          "shape": "S8"
+        },
+        "version": {
+          "shape": "So"
+        }
       }
+    },
+    "So": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "Sr": {
       "type": "structure",
@@ -1145,8 +1523,12 @@
         "version"
       ],
       "members": {
-        "name": {},
-        "version": {}
+        "name": {
+          "shape": "S8"
+        },
+        "version": {
+          "shape": "So"
+        }
       }
     },
     "Su": {
@@ -1160,8 +1542,12 @@
         "activityType": {
           "shape": "Sn"
         },
-        "status": {},
-        "description": {},
+        "status": {
+          "shape": "Sv"
+        },
+        "description": {
+          "shape": "Sw"
+        },
         "creationDate": {
           "type": "timestamp"
         },
@@ -1170,6 +1556,21 @@
         }
       }
     },
+    "Sv": {
+      "type": "string",
+      "enum": [
+        "REGISTERED",
+        "DEPRECATED"
+      ]
+    },
+    "Sw": {
+      "type": "string",
+      "max": 1024
+    },
+    "Sy": {
+      "type": "string",
+      "max": 8
+    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1177,10 +1578,21 @@
         "status"
       ],
       "members": {
-        "name": {},
-        "status": {},
-        "description": {}
+        "name": {
+          "shape": "S2"
+        },
+        "status": {
+          "shape": "Sv"
+        },
+        "description": {
+          "shape": "Sw"
+        }
       }
+    },
+    "S14": {
+      "type": "string",
+      "max": 8,
+      "min": 1
     },
     "S16": {
       "type": "structure",
@@ -1189,9 +1601,18 @@
         "runId"
       ],
       "members": {
-        "workflowId": {},
-        "runId": {}
+        "workflowId": {
+          "shape": "S6"
+        },
+        "runId": {
+          "shape": "S17"
+        }
       }
+    },
+    "S17": {
+      "type": "string",
+      "max": 64,
+      "min": 1
     },
     "S19": {
       "type": "structure",
@@ -1214,8 +1635,16 @@
         "closeTimestamp": {
           "type": "timestamp"
         },
-        "executionStatus": {},
-        "closeStatus": {},
+        "executionStatus": {
+          "type": "string",
+          "enum": [
+            "OPEN",
+            "CLOSED"
+          ]
+        },
+        "closeStatus": {
+          "shape": "Sd"
+        },
         "parent": {
           "shape": "S16"
         },
@@ -1229,7 +1658,32 @@
     },
     "S1b": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "Sb"
+      },
+      "max": 5
+    },
+    "S1e": {
+      "type": "string",
+      "max": 8,
+      "min": 1
+    },
+    "S1f": {
+      "type": "string",
+      "enum": [
+        "TERMINATE",
+        "REQUEST_CANCEL",
+        "ABANDON"
+      ]
+    },
+    "S1g": {
+      "type": "string",
+      "max": 1600,
+      "min": 1
+    },
+    "S1j": {
+      "type": "string",
+      "max": 32768
     },
     "S1m": {
       "type": "structure",
@@ -1242,8 +1696,12 @@
         "workflowType": {
           "shape": "Sr"
         },
-        "status": {},
-        "description": {},
+        "status": {
+          "shape": "Sv"
+        },
+        "description": {
+          "shape": "Sw"
+        },
         "creationDate": {
           "type": "timestamp"
         },
@@ -1251,6 +1709,15 @@
           "type": "timestamp"
         }
       }
+    },
+    "S1p": {
+      "type": "string",
+      "max": 2048
+    },
+    "S1q": {
+      "type": "integer",
+      "max": 1000,
+      "min": 0
     },
     "S1t": {
       "type": "list",
@@ -1265,7 +1732,65 @@
           "eventTimestamp": {
             "type": "timestamp"
           },
-          "eventType": {},
+          "eventType": {
+            "type": "string",
+            "enum": [
+              "WorkflowExecutionStarted",
+              "WorkflowExecutionCancelRequested",
+              "WorkflowExecutionCompleted",
+              "CompleteWorkflowExecutionFailed",
+              "WorkflowExecutionFailed",
+              "FailWorkflowExecutionFailed",
+              "WorkflowExecutionTimedOut",
+              "WorkflowExecutionCanceled",
+              "CancelWorkflowExecutionFailed",
+              "WorkflowExecutionContinuedAsNew",
+              "ContinueAsNewWorkflowExecutionFailed",
+              "WorkflowExecutionTerminated",
+              "DecisionTaskScheduled",
+              "DecisionTaskStarted",
+              "DecisionTaskCompleted",
+              "DecisionTaskTimedOut",
+              "ActivityTaskScheduled",
+              "ScheduleActivityTaskFailed",
+              "ActivityTaskStarted",
+              "ActivityTaskCompleted",
+              "ActivityTaskFailed",
+              "ActivityTaskTimedOut",
+              "ActivityTaskCanceled",
+              "ActivityTaskCancelRequested",
+              "RequestCancelActivityTaskFailed",
+              "WorkflowExecutionSignaled",
+              "MarkerRecorded",
+              "RecordMarkerFailed",
+              "TimerStarted",
+              "StartTimerFailed",
+              "TimerFired",
+              "TimerCanceled",
+              "CancelTimerFailed",
+              "StartChildWorkflowExecutionInitiated",
+              "StartChildWorkflowExecutionFailed",
+              "ChildWorkflowExecutionStarted",
+              "ChildWorkflowExecutionCompleted",
+              "ChildWorkflowExecutionFailed",
+              "ChildWorkflowExecutionTimedOut",
+              "ChildWorkflowExecutionCanceled",
+              "ChildWorkflowExecutionTerminated",
+              "SignalExternalWorkflowExecutionInitiated",
+              "SignalExternalWorkflowExecutionFailed",
+              "ExternalWorkflowExecutionSignaled",
+              "RequestCancelExternalWorkflowExecutionInitiated",
+              "RequestCancelExternalWorkflowExecutionFailed",
+              "ExternalWorkflowExecutionCancelRequested",
+              "LambdaFunctionScheduled",
+              "LambdaFunctionStarted",
+              "LambdaFunctionCompleted",
+              "LambdaFunctionFailed",
+              "LambdaFunctionTimedOut",
+              "ScheduleLambdaFunctionFailed",
+              "StartLambdaFunctionFailed"
+            ]
+          },
           "eventId": {
             "type": "long"
           },
@@ -1277,10 +1802,18 @@
               "workflowType"
             ],
             "members": {
-              "input": {},
-              "executionStartToCloseTimeout": {},
-              "taskStartToCloseTimeout": {},
-              "childPolicy": {},
+              "input": {
+                "shape": "S1j"
+              },
+              "executionStartToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "taskStartToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "childPolicy": {
+                "shape": "S1f"
+              },
               "taskList": {
                 "shape": "Sj"
               },
@@ -1291,14 +1824,18 @@
               "tagList": {
                 "shape": "S1b"
               },
-              "continuedExecutionRunId": {},
+              "continuedExecutionRunId": {
+                "shape": "S1y"
+              },
               "parentWorkflowExecution": {
                 "shape": "S16"
               },
               "parentInitiatedEventId": {
                 "type": "long"
               },
-              "lambdaRole": {}
+              "lambdaRole": {
+                "shape": "S1g"
+              }
             }
           },
           "workflowExecutionCompletedEventAttributes": {
@@ -1307,7 +1844,9 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "result": {},
+              "result": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1320,7 +1859,13 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {},
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNHANDLED_DECISION",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1332,8 +1877,12 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "reason": {},
-              "details": {},
+              "reason": {
+                "shape": "S23"
+              },
+              "details": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1346,7 +1895,13 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {},
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNHANDLED_DECISION",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1359,8 +1914,12 @@
               "childPolicy"
             ],
             "members": {
-              "timeoutType": {},
-              "childPolicy": {}
+              "timeoutType": {
+                "shape": "S27"
+              },
+              "childPolicy": {
+                "shape": "S1f"
+              }
             }
           },
           "workflowExecutionCanceledEventAttributes": {
@@ -1369,7 +1928,9 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "details": {},
+              "details": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1382,7 +1943,13 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {},
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNHANDLED_DECISION",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1398,25 +1965,37 @@
               "workflowType"
             ],
             "members": {
-              "input": {},
+              "input": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "newExecutionRunId": {},
-              "executionStartToCloseTimeout": {},
+              "newExecutionRunId": {
+                "shape": "S17"
+              },
+              "executionStartToCloseTimeout": {
+                "shape": "Sy"
+              },
               "taskList": {
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "taskStartToCloseTimeout": {},
-              "childPolicy": {},
+              "taskStartToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "childPolicy": {
+                "shape": "S1f"
+              },
               "tagList": {
                 "shape": "S1b"
               },
               "workflowType": {
                 "shape": "Sr"
               },
-              "lambdaRole": {}
+              "lambdaRole": {
+                "shape": "S1g"
+              }
             }
           },
           "continueAsNewWorkflowExecutionFailedEventAttributes": {
@@ -1426,7 +2005,20 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {},
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNHANDLED_DECISION",
+                  "WORKFLOW_TYPE_DEPRECATED",
+                  "WORKFLOW_TYPE_DOES_NOT_EXIST",
+                  "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_TASK_LIST_UNDEFINED",
+                  "DEFAULT_CHILD_POLICY_UNDEFINED",
+                  "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1438,10 +2030,23 @@
               "childPolicy"
             ],
             "members": {
-              "reason": {},
-              "details": {},
-              "childPolicy": {},
-              "cause": {}
+              "reason": {
+                "shape": "S2f"
+              },
+              "details": {
+                "shape": "S1j"
+              },
+              "childPolicy": {
+                "shape": "S1f"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "CHILD_POLICY_APPLIED",
+                  "EVENT_LIMIT_EXCEEDED",
+                  "OPERATOR_INITIATED"
+                ]
+              }
             }
           },
           "workflowExecutionCancelRequestedEventAttributes": {
@@ -1453,7 +2058,12 @@
               "externalInitiatedEventId": {
                 "type": "long"
               },
-              "cause": {}
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "CHILD_POLICY_APPLIED"
+                ]
+              }
             }
           },
           "decisionTaskScheduledEventAttributes": {
@@ -1466,7 +2076,9 @@
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "startToCloseTimeout": {}
+              "startToCloseTimeout": {
+                "shape": "Sy"
+              }
             }
           },
           "decisionTaskStartedEventAttributes": {
@@ -1475,7 +2087,9 @@
               "scheduledEventId"
             ],
             "members": {
-              "identity": {},
+              "identity": {
+                "shape": "S2l"
+              },
               "scheduledEventId": {
                 "type": "long"
               }
@@ -1488,7 +2102,9 @@
               "startedEventId"
             ],
             "members": {
-              "executionContext": {},
+              "executionContext": {
+                "shape": "S1j"
+              },
               "scheduledEventId": {
                 "type": "long"
               },
@@ -1505,7 +2121,12 @@
               "startedEventId"
             ],
             "members": {
-              "timeoutType": {},
+              "timeoutType": {
+                "type": "string",
+                "enum": [
+                  "START_TO_CLOSE"
+                ]
+              },
               "scheduledEventId": {
                 "type": "long"
               },
@@ -1526,12 +2147,24 @@
               "activityType": {
                 "shape": "Sn"
               },
-              "activityId": {},
-              "input": {},
-              "control": {},
-              "scheduleToStartTimeout": {},
-              "scheduleToCloseTimeout": {},
-              "startToCloseTimeout": {},
+              "activityId": {
+                "shape": "S2q"
+              },
+              "input": {
+                "shape": "S1j"
+              },
+              "control": {
+                "shape": "S1j"
+              },
+              "scheduleToStartTimeout": {
+                "shape": "Sy"
+              },
+              "scheduleToCloseTimeout": {
+                "shape": "Sy"
+              },
+              "startToCloseTimeout": {
+                "shape": "Sy"
+              },
               "taskList": {
                 "shape": "Sj"
               },
@@ -1539,7 +2172,9 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "heartbeatTimeout": {}
+              "heartbeatTimeout": {
+                "shape": "Sy"
+              }
             }
           },
           "activityTaskStartedEventAttributes": {
@@ -1548,7 +2183,9 @@
               "scheduledEventId"
             ],
             "members": {
-              "identity": {},
+              "identity": {
+                "shape": "S2l"
+              },
               "scheduledEventId": {
                 "type": "long"
               }
@@ -1561,7 +2198,9 @@
               "startedEventId"
             ],
             "members": {
-              "result": {},
+              "result": {
+                "shape": "S1j"
+              },
               "scheduledEventId": {
                 "type": "long"
               },
@@ -1577,8 +2216,12 @@
               "startedEventId"
             ],
             "members": {
-              "reason": {},
-              "details": {},
+              "reason": {
+                "shape": "S23"
+              },
+              "details": {
+                "shape": "S1j"
+              },
               "scheduledEventId": {
                 "type": "long"
               },
@@ -1595,14 +2238,24 @@
               "startedEventId"
             ],
             "members": {
-              "timeoutType": {},
+              "timeoutType": {
+                "type": "string",
+                "enum": [
+                  "START_TO_CLOSE",
+                  "SCHEDULE_TO_START",
+                  "SCHEDULE_TO_CLOSE",
+                  "HEARTBEAT"
+                ]
+              },
               "scheduledEventId": {
                 "type": "long"
               },
               "startedEventId": {
                 "type": "long"
               },
-              "details": {}
+              "details": {
+                "shape": "S2w"
+              }
             }
           },
           "activityTaskCanceledEventAttributes": {
@@ -1612,7 +2265,9 @@
               "startedEventId"
             ],
             "members": {
-              "details": {},
+              "details": {
+                "shape": "S1j"
+              },
               "scheduledEventId": {
                 "type": "long"
               },
@@ -1634,7 +2289,9 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "activityId": {}
+              "activityId": {
+                "shape": "S2q"
+              }
             }
           },
           "workflowExecutionSignaledEventAttributes": {
@@ -1643,8 +2300,12 @@
               "signalName"
             ],
             "members": {
-              "signalName": {},
-              "input": {},
+              "signalName": {
+                "shape": "S30"
+              },
+              "input": {
+                "shape": "S1j"
+              },
               "externalWorkflowExecution": {
                 "shape": "S16"
               },
@@ -1660,8 +2321,12 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "markerName": {},
-              "details": {},
+              "markerName": {
+                "shape": "S32"
+              },
+              "details": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1675,8 +2340,15 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "markerName": {},
-              "cause": {},
+              "markerName": {
+                "shape": "S32"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1690,9 +2362,15 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {},
-              "control": {},
-              "startToFireTimeout": {},
+              "timerId": {
+                "shape": "S36"
+              },
+              "control": {
+                "shape": "S1j"
+              },
+              "startToFireTimeout": {
+                "shape": "S1e"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1705,7 +2383,9 @@
               "startedEventId"
             ],
             "members": {
-              "timerId": {},
+              "timerId": {
+                "shape": "S36"
+              },
               "startedEventId": {
                 "type": "long"
               }
@@ -1719,7 +2399,9 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {},
+              "timerId": {
+                "shape": "S36"
+              },
               "startedEventId": {
                 "type": "long"
               },
@@ -1738,13 +2420,21 @@
               "childPolicy"
             ],
             "members": {
-              "workflowId": {},
+              "workflowId": {
+                "shape": "S6"
+              },
               "workflowType": {
                 "shape": "Sr"
               },
-              "control": {},
-              "input": {},
-              "executionStartToCloseTimeout": {},
+              "control": {
+                "shape": "S1j"
+              },
+              "input": {
+                "shape": "S1j"
+              },
+              "executionStartToCloseTimeout": {
+                "shape": "Sy"
+              },
               "taskList": {
                 "shape": "Sj"
               },
@@ -1752,12 +2442,18 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "childPolicy": {},
-              "taskStartToCloseTimeout": {},
+              "childPolicy": {
+                "shape": "S1f"
+              },
+              "taskStartToCloseTimeout": {
+                "shape": "Sy"
+              },
               "tagList": {
                 "shape": "S1b"
               },
-              "lambdaRole": {}
+              "lambdaRole": {
+                "shape": "S1g"
+              }
             }
           },
           "childWorkflowExecutionStartedEventAttributes": {
@@ -1794,7 +2490,9 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "result": {},
+              "result": {
+                "shape": "S1j"
+              },
               "initiatedEventId": {
                 "type": "long"
               },
@@ -1818,8 +2516,12 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "reason": {},
-              "details": {},
+              "reason": {
+                "shape": "S23"
+              },
+              "details": {
+                "shape": "S1j"
+              },
               "initiatedEventId": {
                 "type": "long"
               },
@@ -1844,7 +2546,9 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "timeoutType": {},
+              "timeoutType": {
+                "shape": "S27"
+              },
               "initiatedEventId": {
                 "type": "long"
               },
@@ -1868,7 +2572,9 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "details": {},
+              "details": {
+                "shape": "S1j"
+              },
               "initiatedEventId": {
                 "type": "long"
               },
@@ -1908,14 +2614,24 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {},
-              "runId": {},
-              "signalName": {},
-              "input": {},
+              "workflowId": {
+                "shape": "S6"
+              },
+              "runId": {
+                "shape": "S1y"
+              },
+              "signalName": {
+                "shape": "S30"
+              },
+              "input": {
+                "shape": "S1j"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {}
+              "control": {
+                "shape": "S1j"
+              }
             }
           },
           "externalWorkflowExecutionSignaledEventAttributes": {
@@ -1942,16 +2658,29 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {},
-              "runId": {},
-              "cause": {},
+              "workflowId": {
+                "shape": "S6"
+              },
+              "runId": {
+                "shape": "S1y"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
+                  "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {}
+              "control": {
+                "shape": "S1j"
+              }
             }
           },
           "externalWorkflowExecutionCancelRequestedEventAttributes": {
@@ -1976,12 +2705,18 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {},
-              "runId": {},
+              "workflowId": {
+                "shape": "S6"
+              },
+              "runId": {
+                "shape": "S1y"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {}
+              "control": {
+                "shape": "S1j"
+              }
             }
           },
           "requestCancelExternalWorkflowExecutionFailedEventAttributes": {
@@ -1993,16 +2728,29 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {},
-              "runId": {},
-              "cause": {},
+              "workflowId": {
+                "shape": "S6"
+              },
+              "runId": {
+                "shape": "S1y"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
+                  "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {}
+              "control": {
+                "shape": "S1j"
+              }
             }
           },
           "scheduleActivityTaskFailedEventAttributes": {
@@ -2017,8 +2765,25 @@
               "activityType": {
                 "shape": "Sn"
               },
-              "activityId": {},
-              "cause": {},
+              "activityId": {
+                "shape": "S2q"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "ACTIVITY_TYPE_DEPRECATED",
+                  "ACTIVITY_TYPE_DOES_NOT_EXIST",
+                  "ACTIVITY_ID_ALREADY_IN_USE",
+                  "OPEN_ACTIVITIES_LIMIT_EXCEEDED",
+                  "ACTIVITY_CREATION_RATE_EXCEEDED",
+                  "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_TASK_LIST_UNDEFINED",
+                  "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED",
+                  "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2032,8 +2797,16 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "activityId": {},
-              "cause": {},
+              "activityId": {
+                "shape": "S2q"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "ACTIVITY_ID_UNKNOWN",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2047,8 +2820,18 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {},
-              "cause": {},
+              "timerId": {
+                "shape": "S36"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "TIMER_ID_ALREADY_IN_USE",
+                  "OPEN_TIMERS_LIMIT_EXCEEDED",
+                  "TIMER_CREATION_RATE_EXCEEDED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2062,8 +2845,16 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {},
-              "cause": {},
+              "timerId": {
+                "shape": "S36"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "TIMER_ID_UNKNOWN",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2082,15 +2873,34 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "cause": {},
-              "workflowId": {},
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "WORKFLOW_TYPE_DOES_NOT_EXIST",
+                  "WORKFLOW_TYPE_DEPRECATED",
+                  "OPEN_CHILDREN_LIMIT_EXCEEDED",
+                  "OPEN_WORKFLOWS_LIMIT_EXCEEDED",
+                  "CHILD_CREATION_RATE_EXCEEDED",
+                  "WORKFLOW_ALREADY_RUNNING",
+                  "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_TASK_LIST_UNDEFINED",
+                  "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED",
+                  "DEFAULT_CHILD_POLICY_UNDEFINED",
+                  "OPERATION_NOT_PERMITTED"
+                ]
+              },
+              "workflowId": {
+                "shape": "S6"
+              },
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {}
+              "control": {
+                "shape": "S1j"
+              }
             }
           },
           "lambdaFunctionScheduledEventAttributes": {
@@ -2101,11 +2911,21 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "id": {},
-              "name": {},
-              "control": {},
-              "input": {},
-              "startToCloseTimeout": {},
+              "id": {
+                "shape": "S3z"
+              },
+              "name": {
+                "shape": "S40"
+              },
+              "control": {
+                "shape": "S1j"
+              },
+              "input": {
+                "shape": "S41"
+              },
+              "startToCloseTimeout": {
+                "shape": "Sy"
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2135,7 +2955,9 @@
               "startedEventId": {
                 "type": "long"
               },
-              "result": {}
+              "result": {
+                "shape": "S1j"
+              }
             }
           },
           "lambdaFunctionFailedEventAttributes": {
@@ -2151,8 +2973,12 @@
               "startedEventId": {
                 "type": "long"
               },
-              "reason": {},
-              "details": {}
+              "reason": {
+                "shape": "S23"
+              },
+              "details": {
+                "shape": "S1j"
+              }
             }
           },
           "lambdaFunctionTimedOutEventAttributes": {
@@ -2168,7 +2994,12 @@
               "startedEventId": {
                 "type": "long"
               },
-              "timeoutType": {}
+              "timeoutType": {
+                "type": "string",
+                "enum": [
+                  "START_TO_CLOSE"
+                ]
+              }
             }
           },
           "scheduleLambdaFunctionFailedEventAttributes": {
@@ -2180,9 +3011,21 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "id": {},
-              "name": {},
-              "cause": {},
+              "id": {
+                "shape": "S3z"
+              },
+              "name": {
+                "shape": "S40"
+              },
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "ID_ALREADY_IN_USE",
+                  "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED",
+                  "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED",
+                  "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
+                ]
+              },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2194,12 +3037,81 @@
               "scheduledEventId": {
                 "type": "long"
               },
-              "cause": {},
-              "message": {}
+              "cause": {
+                "type": "string",
+                "enum": [
+                  "ASSUME_ROLE_FAILED"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "max": 1728
+              }
             }
           }
         }
       }
+    },
+    "S1y": {
+      "type": "string",
+      "max": 64
+    },
+    "S23": {
+      "type": "string",
+      "max": 256
+    },
+    "S27": {
+      "type": "string",
+      "enum": [
+        "START_TO_CLOSE"
+      ]
+    },
+    "S2f": {
+      "type": "string",
+      "max": 256
+    },
+    "S2l": {
+      "type": "string",
+      "max": 256
+    },
+    "S2q": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S2w": {
+      "type": "string",
+      "max": 2048
+    },
+    "S30": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S32": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S36": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S3z": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S40": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "S41": {
+      "type": "string",
+      "max": 32768,
+      "min": 0
     },
     "S4g": {
       "type": "structure",
@@ -2213,8 +3125,15 @@
             "shape": "S19"
           }
         },
-        "nextPageToken": {}
+        "nextPageToken": {
+          "shape": "S1p"
+        }
       }
+    },
+    "S4r": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
     }
   }
 }

--- a/apis/transcribe-2017-10-26.min.json
+++ b/apis/transcribe-2017-10-26.min.json
@@ -22,8 +22,12 @@
           "Phrases"
         ],
         "members": {
-          "VocabularyName": {},
-          "LanguageCode": {},
+          "VocabularyName": {
+            "shape": "S2"
+          },
+          "LanguageCode": {
+            "shape": "S3"
+          },
           "Phrases": {
             "shape": "S4"
           }
@@ -32,9 +36,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {},
-          "LanguageCode": {},
-          "VocabularyState": {},
+          "VocabularyName": {
+            "shape": "S2"
+          },
+          "LanguageCode": {
+            "shape": "S3"
+          },
+          "VocabularyState": {
+            "shape": "S7"
+          },
           "LastModifiedTime": {
             "type": "timestamp"
           },
@@ -49,7 +59,9 @@
           "VocabularyName"
         ],
         "members": {
-          "VocabularyName": {}
+          "VocabularyName": {
+            "shape": "S2"
+          }
         }
       }
     },
@@ -60,7 +72,9 @@
           "TranscriptionJobName"
         ],
         "members": {
-          "TranscriptionJobName": {}
+          "TranscriptionJobName": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
@@ -79,20 +93,30 @@
           "VocabularyName"
         ],
         "members": {
-          "VocabularyName": {}
+          "VocabularyName": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {},
-          "LanguageCode": {},
-          "VocabularyState": {},
+          "VocabularyName": {
+            "shape": "S2"
+          },
+          "LanguageCode": {
+            "shape": "S3"
+          },
+          "VocabularyState": {
+            "shape": "S7"
+          },
           "LastModifiedTime": {
             "type": "timestamp"
           },
           "FailureReason": {},
-          "DownloadUri": {}
+          "DownloadUri": {
+            "shape": "Sj"
+          }
         }
       }
     },
@@ -100,35 +124,57 @@
       "input": {
         "type": "structure",
         "members": {
-          "Status": {},
-          "JobNameContains": {},
-          "NextToken": {},
+          "Status": {
+            "shape": "Sf"
+          },
+          "JobNameContains": {
+            "shape": "Sc"
+          },
+          "NextToken": {
+            "shape": "Sr"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "Ss"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {},
-          "NextToken": {},
+          "Status": {
+            "shape": "Sf"
+          },
+          "NextToken": {
+            "shape": "Sr"
+          },
           "TranscriptionJobSummaries": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "TranscriptionJobName": {},
+                "TranscriptionJobName": {
+                  "shape": "Sc"
+                },
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "CompletionTime": {
                   "type": "timestamp"
                 },
-                "LanguageCode": {},
-                "TranscriptionJobStatus": {},
+                "LanguageCode": {
+                  "shape": "S3"
+                },
+                "TranscriptionJobStatus": {
+                  "shape": "Sf"
+                },
                 "FailureReason": {},
-                "OutputLocationType": {}
+                "OutputLocationType": {
+                  "type": "string",
+                  "enum": [
+                    "CUSTOMER_BUCKET",
+                    "SERVICE_BUCKET"
+                  ]
+                }
               }
             }
           }
@@ -139,30 +185,46 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
-          "MaxResults": {
-            "type": "integer"
+          "NextToken": {
+            "shape": "Sr"
           },
-          "StateEquals": {},
-          "NameContains": {}
+          "MaxResults": {
+            "shape": "Ss"
+          },
+          "StateEquals": {
+            "shape": "S7"
+          },
+          "NameContains": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {},
-          "NextToken": {},
+          "Status": {
+            "shape": "Sf"
+          },
+          "NextToken": {
+            "shape": "Sr"
+          },
           "Vocabularies": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VocabularyName": {},
-                "LanguageCode": {},
+                "VocabularyName": {
+                  "shape": "S2"
+                },
+                "LanguageCode": {
+                  "shape": "S3"
+                },
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "VocabularyState": {}
+                "VocabularyState": {
+                  "shape": "S7"
+                }
               }
             }
           }
@@ -179,16 +241,25 @@
           "Media"
         ],
         "members": {
-          "TranscriptionJobName": {},
-          "LanguageCode": {},
-          "MediaSampleRateHertz": {
-            "type": "integer"
+          "TranscriptionJobName": {
+            "shape": "Sc"
           },
-          "MediaFormat": {},
+          "LanguageCode": {
+            "shape": "S3"
+          },
+          "MediaSampleRateHertz": {
+            "shape": "Sg"
+          },
+          "MediaFormat": {
+            "shape": "Sh"
+          },
           "Media": {
             "shape": "Si"
           },
-          "OutputBucketName": {},
+          "OutputBucketName": {
+            "type": "string",
+            "pattern": "[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]"
+          },
           "Settings": {
             "shape": "Sl"
           }
@@ -212,8 +283,12 @@
           "Phrases"
         ],
         "members": {
-          "VocabularyName": {},
-          "LanguageCode": {},
+          "VocabularyName": {
+            "shape": "S2"
+          },
+          "LanguageCode": {
+            "shape": "S3"
+          },
           "Phrases": {
             "shape": "S4"
           }
@@ -222,38 +297,85 @@
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {},
-          "LanguageCode": {},
+          "VocabularyName": {
+            "shape": "S2"
+          },
+          "LanguageCode": {
+            "shape": "S3"
+          },
           "LastModifiedTime": {
             "type": "timestamp"
           },
-          "VocabularyState": {}
+          "VocabularyState": {
+            "shape": "S7"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "^[0-9a-zA-Z._-]+"
+    },
+    "S3": {
+      "type": "string",
+      "enum": [
+        "en-US",
+        "es-US"
+      ]
+    },
     "S4": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 256,
+        "min": 0
+      }
+    },
+    "S7": {
+      "type": "string",
+      "enum": [
+        "PENDING",
+        "READY",
+        "FAILED"
+      ]
+    },
+    "Sc": {
+      "type": "string",
+      "max": 200,
+      "min": 1,
+      "pattern": "^[0-9a-zA-Z._-]+"
     },
     "Se": {
       "type": "structure",
       "members": {
-        "TranscriptionJobName": {},
-        "TranscriptionJobStatus": {},
-        "LanguageCode": {},
-        "MediaSampleRateHertz": {
-          "type": "integer"
+        "TranscriptionJobName": {
+          "shape": "Sc"
         },
-        "MediaFormat": {},
+        "TranscriptionJobStatus": {
+          "shape": "Sf"
+        },
+        "LanguageCode": {
+          "shape": "S3"
+        },
+        "MediaSampleRateHertz": {
+          "shape": "Sg"
+        },
+        "MediaFormat": {
+          "shape": "Sh"
+        },
         "Media": {
           "shape": "Si"
         },
         "Transcript": {
           "type": "structure",
           "members": {
-            "TranscriptFileUri": {}
+            "TranscriptFileUri": {
+              "shape": "Sj"
+            }
           }
         },
         "CreationTime": {
@@ -268,26 +390,68 @@
         }
       }
     },
+    "Sf": {
+      "type": "string",
+      "enum": [
+        "IN_PROGRESS",
+        "FAILED",
+        "COMPLETED"
+      ]
+    },
+    "Sg": {
+      "type": "integer",
+      "max": 48000,
+      "min": 8000
+    },
+    "Sh": {
+      "type": "string",
+      "enum": [
+        "mp3",
+        "mp4",
+        "wav",
+        "flac"
+      ]
+    },
     "Si": {
       "type": "structure",
       "members": {
-        "MediaFileUri": {}
+        "MediaFileUri": {
+          "shape": "Sj"
+        }
       }
+    },
+    "Sj": {
+      "type": "string",
+      "max": 2000,
+      "min": 1
     },
     "Sl": {
       "type": "structure",
       "members": {
-        "VocabularyName": {},
+        "VocabularyName": {
+          "shape": "S2"
+        },
         "ShowSpeakerLabels": {
           "type": "boolean"
         },
         "MaxSpeakerLabels": {
-          "type": "integer"
+          "type": "integer",
+          "max": 10,
+          "min": 2
         },
         "ChannelIdentification": {
           "type": "boolean"
         }
       }
+    },
+    "Sr": {
+      "type": "string",
+      "max": 8192
+    },
+    "Ss": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
     }
   }
 }

--- a/apis/translate-2017-07-01.min.json
+++ b/apis/translate-2017-07-01.min.json
@@ -22,9 +22,17 @@
           "TargetLanguageCode"
         ],
         "members": {
-          "Text": {},
-          "SourceLanguageCode": {},
-          "TargetLanguageCode": {}
+          "Text": {
+            "type": "string",
+            "max": 5000,
+            "min": 1
+          },
+          "SourceLanguageCode": {
+            "shape": "S3"
+          },
+          "TargetLanguageCode": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -35,12 +43,25 @@
           "TargetLanguageCode"
         ],
         "members": {
-          "TranslatedText": {},
-          "SourceLanguageCode": {},
-          "TargetLanguageCode": {}
+          "TranslatedText": {
+            "type": "string",
+            "min": 1
+          },
+          "SourceLanguageCode": {
+            "shape": "S3"
+          },
+          "TargetLanguageCode": {
+            "shape": "S3"
+          }
         }
       }
     }
   },
-  "shapes": {}
+  "shapes": {
+    "S3": {
+      "type": "string",
+      "max": 5,
+      "min": 2
+    }
+  }
 }

--- a/apis/waf-2015-08-24.min.json
+++ b/apis/waf-2015-08-24.min.json
@@ -21,8 +21,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -31,7 +35,9 @@
           "ByteMatchSet": {
             "shape": "S5"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -43,8 +49,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -53,7 +63,9 @@
           "GeoMatchSet": {
             "shape": "Sh"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -65,8 +77,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -75,7 +91,9 @@
           "IPSet": {
             "shape": "So"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -90,13 +108,19 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "MetricName": {},
-          "RateKey": {},
-          "RateLimit": {
-            "type": "long"
+          "Name": {
+            "shape": "S2"
           },
-          "ChangeToken": {}
+          "MetricName": {},
+          "RateKey": {
+            "shape": "Sv"
+          },
+          "RateLimit": {
+            "shape": "Sw"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -105,7 +129,9 @@
           "Rule": {
             "shape": "Sy"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -117,8 +143,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -127,7 +157,9 @@
           "RegexMatchSet": {
             "shape": "S15"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -139,8 +171,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -149,7 +185,9 @@
           "RegexPatternSet": {
             "shape": "S1a"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -162,9 +200,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "MetricName": {},
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -173,7 +215,9 @@
           "Rule": {
             "shape": "S1f"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -186,9 +230,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "MetricName": {},
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -197,7 +245,9 @@
           "RuleGroup": {
             "shape": "S1i"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -209,8 +259,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -219,7 +273,9 @@
           "SizeConstraintSet": {
             "shape": "S1l"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -231,8 +287,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -241,7 +301,9 @@
           "SqlInjectionMatchSet": {
             "shape": "S1s"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -255,12 +317,16 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S2"
+          },
           "MetricName": {},
           "DefaultAction": {
             "shape": "S1w"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -269,7 +335,9 @@
           "WebACL": {
             "shape": "S1z"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -281,8 +349,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -291,7 +363,9 @@
           "XssMatchSet": {
             "shape": "S28"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -303,14 +377,20 @@
           "ChangeToken"
         ],
         "members": {
-          "ByteMatchSetId": {},
-          "ChangeToken": {}
+          "ByteMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -322,14 +402,20 @@
           "ChangeToken"
         ],
         "members": {
-          "GeoMatchSetId": {},
-          "ChangeToken": {}
+          "GeoMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -341,14 +427,20 @@
           "ChangeToken"
         ],
         "members": {
-          "IPSetId": {},
-          "ChangeToken": {}
+          "IPSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -359,7 +451,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
@@ -374,7 +468,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
@@ -390,14 +486,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {}
+          "RuleId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -409,14 +511,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {},
-          "ChangeToken": {}
+          "RegexMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -428,14 +536,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {},
-          "ChangeToken": {}
+          "RegexPatternSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -447,14 +561,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {}
+          "RuleId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -466,14 +586,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {},
-          "ChangeToken": {}
+          "RuleGroupId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -485,14 +611,20 @@
           "ChangeToken"
         ],
         "members": {
-          "SizeConstraintSetId": {},
-          "ChangeToken": {}
+          "SizeConstraintSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -504,14 +636,20 @@
           "ChangeToken"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {},
-          "ChangeToken": {}
+          "SqlInjectionMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -523,14 +661,20 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {},
-          "ChangeToken": {}
+          "WebACLId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -542,14 +686,20 @@
           "ChangeToken"
         ],
         "members": {
-          "XssMatchSetId": {},
-          "ChangeToken": {}
+          "XssMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -560,7 +710,9 @@
           "ByteMatchSetId"
         ],
         "members": {
-          "ByteMatchSetId": {}
+          "ByteMatchSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -580,7 +732,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -591,13 +745,22 @@
           "ChangeToken"
         ],
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeTokenStatus": {}
+          "ChangeTokenStatus": {
+            "type": "string",
+            "enum": [
+              "PROVISIONED",
+              "PENDING",
+              "INSYNC"
+            ]
+          }
         }
       }
     },
@@ -608,7 +771,9 @@
           "GeoMatchSetId"
         ],
         "members": {
-          "GeoMatchSetId": {}
+          "GeoMatchSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -627,7 +792,9 @@
           "IPSetId"
         ],
         "members": {
-          "IPSetId": {}
+          "IPSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -646,7 +813,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
@@ -665,13 +834,17 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S2i"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {}
+          "Policy": {
+            "shape": "S3m"
+          }
         }
       }
     },
@@ -682,7 +855,9 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {}
+          "RuleId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -701,8 +876,12 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {},
-          "NextMarker": {}
+          "RuleId": {
+            "shape": "S6"
+          },
+          "NextMarker": {
+            "shape": "S3q"
+          }
         }
       },
       "output": {
@@ -712,7 +891,9 @@
             "type": "list",
             "member": {}
           },
-          "NextMarker": {}
+          "NextMarker": {
+            "shape": "S3q"
+          }
         }
       }
     },
@@ -723,7 +904,9 @@
           "RegexMatchSetId"
         ],
         "members": {
-          "RegexMatchSetId": {}
+          "RegexMatchSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -742,7 +925,9 @@
           "RegexPatternSetId"
         ],
         "members": {
-          "RegexPatternSetId": {}
+          "RegexPatternSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -761,7 +946,9 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {}
+          "RuleId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -780,7 +967,9 @@
           "RuleGroupId"
         ],
         "members": {
-          "RuleGroupId": {}
+          "RuleGroupId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -802,13 +991,19 @@
           "MaxItems"
         ],
         "members": {
-          "WebAclId": {},
-          "RuleId": {},
+          "WebAclId": {
+            "shape": "S6"
+          },
+          "RuleId": {
+            "shape": "S6"
+          },
           "TimeWindow": {
             "shape": "S43"
           },
           "MaxItems": {
-            "type": "long"
+            "type": "long",
+            "max": 500,
+            "min": 1
           }
         }
       },
@@ -845,13 +1040,16 @@
                   }
                 },
                 "Weight": {
-                  "type": "long"
+                  "type": "long",
+                  "min": 0
                 },
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "Action": {},
-                "RuleWithinRuleGroup": {}
+                "RuleWithinRuleGroup": {
+                  "shape": "S6"
+                }
               }
             }
           },
@@ -871,7 +1069,9 @@
           "SizeConstraintSetId"
         ],
         "members": {
-          "SizeConstraintSetId": {}
+          "SizeConstraintSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -890,7 +1090,9 @@
           "SqlInjectionMatchSetId"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {}
+          "SqlInjectionMatchSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -909,7 +1111,9 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {}
+          "WebACLId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -928,7 +1132,9 @@
           "XssMatchSetId"
         ],
         "members": {
-          "XssMatchSetId": {}
+          "XssMatchSetId": {
+            "shape": "S6"
+          }
         }
       },
       "output": {
@@ -944,17 +1150,23 @@
       "input": {
         "type": "structure",
         "members": {
-          "RuleGroupId": {},
-          "NextMarker": {},
+          "RuleGroupId": {
+            "shape": "S6"
+          },
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "ActivatedRules": {
             "shape": "S20"
           }
@@ -965,16 +1177,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "ByteMatchSets": {
             "type": "list",
             "member": {
@@ -984,8 +1200,12 @@
                 "Name"
               ],
               "members": {
-                "ByteMatchSetId": {},
-                "Name": {}
+                "ByteMatchSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -996,16 +1216,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "GeoMatchSets": {
             "type": "list",
             "member": {
@@ -1015,8 +1239,12 @@
                 "Name"
               ],
               "members": {
-                "GeoMatchSetId": {},
-                "Name": {}
+                "GeoMatchSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1027,16 +1255,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "IPSets": {
             "type": "list",
             "member": {
@@ -1046,8 +1278,12 @@
                 "Name"
               ],
               "members": {
-                "IPSetId": {},
-                "Name": {}
+                "IPSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1058,9 +1294,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
@@ -1073,7 +1311,9 @@
               "shape": "S3h"
             }
           },
-          "NextMarker": {}
+          "NextMarker": {
+            "shape": "S3q"
+          }
         }
       }
     },
@@ -1081,16 +1321,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Rules": {
             "shape": "S5e"
           }
@@ -1101,16 +1345,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "RegexMatchSets": {
             "type": "list",
             "member": {
@@ -1120,8 +1368,12 @@
                 "Name"
               ],
               "members": {
-                "RegexMatchSetId": {},
-                "Name": {}
+                "RegexMatchSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1132,16 +1384,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "RegexPatternSets": {
             "type": "list",
             "member": {
@@ -1151,8 +1407,12 @@
                 "Name"
               ],
               "members": {
-                "RegexPatternSetId": {},
-                "Name": {}
+                "RegexPatternSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1163,16 +1423,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1182,8 +1446,12 @@
                 "Name"
               ],
               "members": {
-                "RuleGroupId": {},
-                "Name": {}
+                "RuleGroupId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1194,16 +1462,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Rules": {
             "shape": "S5e"
           }
@@ -1214,16 +1486,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "SizeConstraintSets": {
             "type": "list",
             "member": {
@@ -1233,8 +1509,12 @@
                 "Name"
               ],
               "members": {
-                "SizeConstraintSetId": {},
-                "Name": {}
+                "SizeConstraintSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1245,16 +1525,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "SqlInjectionMatchSets": {
             "type": "list",
             "member": {
@@ -1264,8 +1548,12 @@
                 "Name"
               ],
               "members": {
-                "SqlInjectionMatchSetId": {},
-                "Name": {}
+                "SqlInjectionMatchSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1276,16 +1564,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1296,8 +1588,12 @@
                 "MetricName"
               ],
               "members": {
-                "RuleGroupId": {},
-                "Name": {},
+                "RuleGroupId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                },
                 "MetricName": {}
               }
             }
@@ -1309,16 +1605,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "WebACLs": {
             "type": "list",
             "member": {
@@ -1328,8 +1628,12 @@
                 "Name"
               ],
               "members": {
-                "WebACLId": {},
-                "Name": {}
+                "WebACLId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1340,16 +1644,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S4v"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3q"
+          },
           "XssMatchSets": {
             "type": "list",
             "member": {
@@ -1359,8 +1667,12 @@
                 "Name"
               ],
               "members": {
-                "XssMatchSetId": {},
-                "Name": {}
+                "XssMatchSetId": {
+                  "shape": "S6"
+                },
+                "Name": {
+                  "shape": "S2"
+                }
               }
             }
           }
@@ -1396,8 +1708,12 @@
           "Policy"
         ],
         "members": {
-          "ResourceArn": {},
-          "Policy": {}
+          "ResourceArn": {
+            "shape": "S2i"
+          },
+          "Policy": {
+            "shape": "S3m"
+          }
         }
       },
       "output": {
@@ -1414,8 +1730,12 @@
           "Updates"
         ],
         "members": {
-          "ByteMatchSetId": {},
-          "ChangeToken": {},
+          "ByteMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1425,19 +1745,24 @@
                 "ByteMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "ByteMatchTuple": {
                   "shape": "S8"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1450,8 +1775,12 @@
           "Updates"
         ],
         "members": {
-          "GeoMatchSetId": {},
-          "ChangeToken": {},
+          "GeoMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1461,19 +1790,24 @@
                 "GeoMatchConstraint"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "GeoMatchConstraint": {
                   "shape": "Sj"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1486,8 +1820,12 @@
           "Updates"
         ],
         "members": {
-          "IPSetId": {},
-          "ChangeToken": {},
+          "IPSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1497,19 +1835,24 @@
                 "IPSetDescriptor"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "IPSetDescriptor": {
                   "shape": "Sq"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1523,20 +1866,26 @@
           "RateLimit"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {},
+          "RuleId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "shape": "S6w"
           },
           "RateLimit": {
-            "type": "long"
+            "shape": "Sw"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1549,7 +1898,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {},
+          "RegexMatchSetId": {
+            "shape": "S6"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1559,20 +1910,27 @@
                 "RegexMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "RegexMatchTuple": {
                   "shape": "S17"
                 }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1585,7 +1943,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {},
+          "RegexPatternSetId": {
+            "shape": "S6"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1595,18 +1955,27 @@
                 "RegexPatternString"
               ],
               "members": {
-                "Action": {},
-                "RegexPatternString": {}
+                "Action": {
+                  "shape": "S6l"
+                },
+                "RegexPatternString": {
+                  "shape": "S1c"
+                }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1619,8 +1988,12 @@
           "Updates"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {},
+          "RuleId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "shape": "S6w"
           }
@@ -1629,7 +2002,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1642,7 +2017,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {},
+          "RuleGroupId": {
+            "shape": "S6"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1652,20 +2029,27 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "ActivatedRule": {
                   "shape": "S21"
                 }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1678,8 +2062,12 @@
           "Updates"
         ],
         "members": {
-          "SizeConstraintSetId": {},
-          "ChangeToken": {},
+          "SizeConstraintSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1689,19 +2077,24 @@
                 "SizeConstraint"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "SizeConstraint": {
                   "shape": "S1n"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1714,8 +2107,12 @@
           "Updates"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {},
-          "ChangeToken": {},
+          "SqlInjectionMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1725,19 +2122,24 @@
                 "SqlInjectionMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "SqlInjectionMatchTuple": {
                   "shape": "S1u"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1749,8 +2151,12 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {},
-          "ChangeToken": {},
+          "WebACLId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1760,7 +2166,9 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "ActivatedRule": {
                   "shape": "S21"
                 }
@@ -1775,7 +2183,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     },
@@ -1788,8 +2198,12 @@
           "Updates"
         ],
         "members": {
-          "XssMatchSetId": {},
-          "ChangeToken": {},
+          "XssMatchSetId": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S3"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1799,24 +2213,38 @@
                 "XssMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6l"
+                },
                 "XssMatchTuple": {
                   "shape": "S2a"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S3"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "min": 1
+    },
     "S5": {
       "type": "structure",
       "required": [
@@ -1824,8 +2252,12 @@
         "ByteMatchTuples"
       ],
       "members": {
-        "ByteMatchSetId": {},
-        "Name": {},
+        "ByteMatchSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "ByteMatchTuples": {
           "type": "list",
           "member": {
@@ -1833,6 +2265,11 @@
           }
         }
       }
+    },
+    "S6": {
+      "type": "string",
+      "max": 128,
+      "min": 1
     },
     "S8": {
       "type": "structure",
@@ -1849,8 +2286,19 @@
         "TargetString": {
           "type": "blob"
         },
-        "TextTransformation": {},
-        "PositionalConstraint": {}
+        "TextTransformation": {
+          "shape": "Sd"
+        },
+        "PositionalConstraint": {
+          "type": "string",
+          "enum": [
+            "EXACTLY",
+            "STARTS_WITH",
+            "ENDS_WITH",
+            "CONTAINS",
+            "CONTAINS_WORD"
+          ]
+        }
       }
     },
     "S9": {
@@ -1859,9 +2307,31 @@
         "Type"
       ],
       "members": {
-        "Type": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "URI",
+            "QUERY_STRING",
+            "HEADER",
+            "METHOD",
+            "BODY",
+            "SINGLE_QUERY_ARG",
+            "ALL_QUERY_ARGS"
+          ]
+        },
         "Data": {}
       }
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "COMPRESS_WHITE_SPACE",
+        "HTML_ENTITY_DECODE",
+        "LOWERCASE",
+        "CMD_LINE",
+        "URL_DECODE"
+      ]
     },
     "Sh": {
       "type": "structure",
@@ -1870,8 +2340,12 @@
         "GeoMatchConstraints"
       ],
       "members": {
-        "GeoMatchSetId": {},
-        "Name": {},
+        "GeoMatchSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "GeoMatchConstraints": {
           "type": "list",
           "member": {
@@ -1887,8 +2361,266 @@
         "Value"
       ],
       "members": {
-        "Type": {},
-        "Value": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Country"
+          ]
+        },
+        "Value": {
+          "type": "string",
+          "enum": [
+            "AF",
+            "AX",
+            "AL",
+            "DZ",
+            "AS",
+            "AD",
+            "AO",
+            "AI",
+            "AQ",
+            "AG",
+            "AR",
+            "AM",
+            "AW",
+            "AU",
+            "AT",
+            "AZ",
+            "BS",
+            "BH",
+            "BD",
+            "BB",
+            "BY",
+            "BE",
+            "BZ",
+            "BJ",
+            "BM",
+            "BT",
+            "BO",
+            "BQ",
+            "BA",
+            "BW",
+            "BV",
+            "BR",
+            "IO",
+            "BN",
+            "BG",
+            "BF",
+            "BI",
+            "KH",
+            "CM",
+            "CA",
+            "CV",
+            "KY",
+            "CF",
+            "TD",
+            "CL",
+            "CN",
+            "CX",
+            "CC",
+            "CO",
+            "KM",
+            "CG",
+            "CD",
+            "CK",
+            "CR",
+            "CI",
+            "HR",
+            "CU",
+            "CW",
+            "CY",
+            "CZ",
+            "DK",
+            "DJ",
+            "DM",
+            "DO",
+            "EC",
+            "EG",
+            "SV",
+            "GQ",
+            "ER",
+            "EE",
+            "ET",
+            "FK",
+            "FO",
+            "FJ",
+            "FI",
+            "FR",
+            "GF",
+            "PF",
+            "TF",
+            "GA",
+            "GM",
+            "GE",
+            "DE",
+            "GH",
+            "GI",
+            "GR",
+            "GL",
+            "GD",
+            "GP",
+            "GU",
+            "GT",
+            "GG",
+            "GN",
+            "GW",
+            "GY",
+            "HT",
+            "HM",
+            "VA",
+            "HN",
+            "HK",
+            "HU",
+            "IS",
+            "IN",
+            "ID",
+            "IR",
+            "IQ",
+            "IE",
+            "IM",
+            "IL",
+            "IT",
+            "JM",
+            "JP",
+            "JE",
+            "JO",
+            "KZ",
+            "KE",
+            "KI",
+            "KP",
+            "KR",
+            "KW",
+            "KG",
+            "LA",
+            "LV",
+            "LB",
+            "LS",
+            "LR",
+            "LY",
+            "LI",
+            "LT",
+            "LU",
+            "MO",
+            "MK",
+            "MG",
+            "MW",
+            "MY",
+            "MV",
+            "ML",
+            "MT",
+            "MH",
+            "MQ",
+            "MR",
+            "MU",
+            "YT",
+            "MX",
+            "FM",
+            "MD",
+            "MC",
+            "MN",
+            "ME",
+            "MS",
+            "MA",
+            "MZ",
+            "MM",
+            "NA",
+            "NR",
+            "NP",
+            "NL",
+            "NC",
+            "NZ",
+            "NI",
+            "NE",
+            "NG",
+            "NU",
+            "NF",
+            "MP",
+            "NO",
+            "OM",
+            "PK",
+            "PW",
+            "PS",
+            "PA",
+            "PG",
+            "PY",
+            "PE",
+            "PH",
+            "PN",
+            "PL",
+            "PT",
+            "PR",
+            "QA",
+            "RE",
+            "RO",
+            "RU",
+            "RW",
+            "BL",
+            "SH",
+            "KN",
+            "LC",
+            "MF",
+            "PM",
+            "VC",
+            "WS",
+            "SM",
+            "ST",
+            "SA",
+            "SN",
+            "RS",
+            "SC",
+            "SL",
+            "SG",
+            "SX",
+            "SK",
+            "SI",
+            "SB",
+            "SO",
+            "ZA",
+            "GS",
+            "SS",
+            "ES",
+            "LK",
+            "SD",
+            "SR",
+            "SJ",
+            "SZ",
+            "SE",
+            "CH",
+            "SY",
+            "TW",
+            "TJ",
+            "TZ",
+            "TH",
+            "TL",
+            "TG",
+            "TK",
+            "TO",
+            "TT",
+            "TN",
+            "TR",
+            "TM",
+            "TC",
+            "TV",
+            "UG",
+            "UA",
+            "AE",
+            "GB",
+            "US",
+            "UM",
+            "UY",
+            "UZ",
+            "VU",
+            "VE",
+            "VN",
+            "VG",
+            "VI",
+            "WF",
+            "EH",
+            "YE",
+            "ZM",
+            "ZW"
+          ]
+        }
       }
     },
     "So": {
@@ -1898,8 +2630,12 @@
         "IPSetDescriptors"
       ],
       "members": {
-        "IPSetId": {},
-        "Name": {},
+        "IPSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "IPSetDescriptors": {
           "type": "list",
           "member": {
@@ -1915,9 +2651,26 @@
         "Value"
       ],
       "members": {
-        "Type": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "IPV4",
+            "IPV6"
+          ]
+        },
         "Value": {}
       }
+    },
+    "Sv": {
+      "type": "string",
+      "enum": [
+        "IP"
+      ]
+    },
+    "Sw": {
+      "type": "long",
+      "max": 2000000000,
+      "min": 2000
     },
     "Sy": {
       "type": "structure",
@@ -1928,15 +2681,21 @@
         "RateLimit"
       ],
       "members": {
-        "RuleId": {},
-        "Name": {},
+        "RuleId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "MetricName": {},
         "MatchPredicates": {
           "shape": "Sz"
         },
-        "RateKey": {},
+        "RateKey": {
+          "shape": "Sv"
+        },
         "RateLimit": {
-          "type": "long"
+          "shape": "Sw"
         }
       }
     },
@@ -1957,15 +2716,32 @@
         "Negated": {
           "type": "boolean"
         },
-        "Type": {},
-        "DataId": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "IPMatch",
+            "ByteMatch",
+            "SqlInjectionMatch",
+            "GeoMatch",
+            "SizeConstraint",
+            "XssMatch",
+            "RegexMatch"
+          ]
+        },
+        "DataId": {
+          "shape": "S6"
+        }
       }
     },
     "S15": {
       "type": "structure",
       "members": {
-        "RegexMatchSetId": {},
-        "Name": {},
+        "RegexMatchSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "RegexMatchTuples": {
           "type": "list",
           "member": {
@@ -1985,8 +2761,12 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {},
-        "RegexPatternSetId": {}
+        "TextTransformation": {
+          "shape": "Sd"
+        },
+        "RegexPatternSetId": {
+          "shape": "S6"
+        }
       }
     },
     "S1a": {
@@ -1996,13 +2776,24 @@
         "RegexPatternStrings"
       ],
       "members": {
-        "RegexPatternSetId": {},
-        "Name": {},
+        "RegexPatternSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "RegexPatternStrings": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S1c"
+          },
+          "max": 10
         }
       }
+    },
+    "S1c": {
+      "type": "string",
+      "min": 1
     },
     "S1f": {
       "type": "structure",
@@ -2011,8 +2802,12 @@
         "Predicates"
       ],
       "members": {
-        "RuleId": {},
-        "Name": {},
+        "RuleId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "MetricName": {},
         "Predicates": {
           "shape": "Sz"
@@ -2025,8 +2820,12 @@
         "RuleGroupId"
       ],
       "members": {
-        "RuleGroupId": {},
-        "Name": {},
+        "RuleGroupId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "MetricName": {}
       }
     },
@@ -2037,8 +2836,12 @@
         "SizeConstraints"
       ],
       "members": {
-        "SizeConstraintSetId": {},
-        "Name": {},
+        "SizeConstraintSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "SizeConstraints": {
           "type": "list",
           "member": {
@@ -2059,10 +2862,24 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {},
-        "ComparisonOperator": {},
+        "TextTransformation": {
+          "shape": "Sd"
+        },
+        "ComparisonOperator": {
+          "type": "string",
+          "enum": [
+            "EQ",
+            "NE",
+            "LE",
+            "LT",
+            "GE",
+            "GT"
+          ]
+        },
         "Size": {
-          "type": "long"
+          "type": "long",
+          "max": 21474836480,
+          "min": 0
         }
       }
     },
@@ -2073,8 +2890,12 @@
         "SqlInjectionMatchTuples"
       ],
       "members": {
-        "SqlInjectionMatchSetId": {},
-        "Name": {},
+        "SqlInjectionMatchSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "SqlInjectionMatchTuples": {
           "type": "list",
           "member": {
@@ -2093,7 +2914,9 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {}
+        "TextTransformation": {
+          "shape": "Sd"
+        }
       }
     },
     "S1w": {
@@ -2102,7 +2925,14 @@
         "Type"
       ],
       "members": {
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "BLOCK",
+            "ALLOW",
+            "COUNT"
+          ]
+        }
       }
     },
     "S1z": {
@@ -2113,8 +2943,12 @@
         "Rules"
       ],
       "members": {
-        "WebACLId": {},
-        "Name": {},
+        "WebACLId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "MetricName": {},
         "DefaultAction": {
           "shape": "S1w"
@@ -2140,7 +2974,9 @@
         "Priority": {
           "type": "integer"
         },
-        "RuleId": {},
+        "RuleId": {
+          "shape": "S6"
+        },
         "Action": {
           "shape": "S1w"
         },
@@ -2150,10 +2986,23 @@
             "Type"
           ],
           "members": {
-            "Type": {}
+            "Type": {
+              "type": "string",
+              "enum": [
+                "NONE",
+                "COUNT"
+              ]
+            }
           }
         },
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "REGULAR",
+            "RATE_BASED",
+            "GROUP"
+          ]
+        }
       }
     },
     "S28": {
@@ -2163,8 +3012,12 @@
         "XssMatchTuples"
       ],
       "members": {
-        "XssMatchSetId": {},
-        "Name": {},
+        "XssMatchSetId": {
+          "shape": "S6"
+        },
+        "Name": {
+          "shape": "S2"
+        },
         "XssMatchTuples": {
           "type": "list",
           "member": {
@@ -2183,8 +3036,15 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {}
+        "TextTransformation": {
+          "shape": "Sd"
+        }
       }
+    },
+    "S2i": {
+      "type": "string",
+      "max": 1224,
+      "min": 1
     },
     "S3h": {
       "type": "structure",
@@ -2193,10 +3053,16 @@
         "LogDestinationConfigs"
       ],
       "members": {
-        "ResourceArn": {},
+        "ResourceArn": {
+          "shape": "S2i"
+        },
         "LogDestinationConfigs": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S2i"
+          },
+          "max": 1,
+          "min": 1
         },
         "RedactedFields": {
           "type": "list",
@@ -2205,6 +3071,14 @@
           }
         }
       }
+    },
+    "S3m": {
+      "type": "string",
+      "min": 1
+    },
+    "S3q": {
+      "type": "string",
+      "min": 1
     },
     "S43": {
       "type": "structure",
@@ -2221,6 +3095,11 @@
         }
       }
     },
+    "S4v": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
+    },
     "S5e": {
       "type": "list",
       "member": {
@@ -2230,10 +3109,21 @@
           "Name"
         ],
         "members": {
-          "RuleId": {},
-          "Name": {}
+          "RuleId": {
+            "shape": "S6"
+          },
+          "Name": {
+            "shape": "S2"
+          }
         }
       }
+    },
+    "S6l": {
+      "type": "string",
+      "enum": [
+        "INSERT",
+        "DELETE"
+      ]
     },
     "S6w": {
       "type": "list",
@@ -2244,7 +3134,9 @@
           "Predicate"
         ],
         "members": {
-          "Action": {},
+          "Action": {
+            "shape": "S6l"
+          },
           "Predicate": {
             "shape": "S10"
           }

--- a/apis/waf-regional-2016-11-28.min.json
+++ b/apis/waf-regional-2016-11-28.min.json
@@ -21,8 +21,12 @@
           "ResourceArn"
         ],
         "members": {
-          "WebACLId": {},
-          "ResourceArn": {}
+          "WebACLId": {
+            "shape": "S2"
+          },
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -38,8 +42,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -48,7 +56,9 @@
           "ByteMatchSet": {
             "shape": "S9"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -60,8 +70,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -70,7 +84,9 @@
           "GeoMatchSet": {
             "shape": "Sk"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -82,8 +98,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -92,7 +112,9 @@
           "IPSet": {
             "shape": "Sr"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -107,13 +129,19 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "MetricName": {},
-          "RateKey": {},
-          "RateLimit": {
-            "type": "long"
+          "Name": {
+            "shape": "S6"
           },
-          "ChangeToken": {}
+          "MetricName": {},
+          "RateKey": {
+            "shape": "Sy"
+          },
+          "RateLimit": {
+            "shape": "Sz"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -122,7 +150,9 @@
           "Rule": {
             "shape": "S11"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -134,8 +164,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -144,7 +178,9 @@
           "RegexMatchSet": {
             "shape": "S18"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -156,8 +192,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -166,7 +206,9 @@
           "RegexPatternSet": {
             "shape": "S1d"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -179,9 +221,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S6"
+          },
           "MetricName": {},
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -190,7 +236,9 @@
           "Rule": {
             "shape": "S1i"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -203,9 +251,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S6"
+          },
           "MetricName": {},
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -214,7 +266,9 @@
           "RuleGroup": {
             "shape": "S1l"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -226,8 +280,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -236,7 +294,9 @@
           "SizeConstraintSet": {
             "shape": "S1o"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -248,8 +308,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -258,7 +322,9 @@
           "SqlInjectionMatchSet": {
             "shape": "S1v"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -272,12 +338,16 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
+          "Name": {
+            "shape": "S6"
+          },
           "MetricName": {},
           "DefaultAction": {
             "shape": "S1z"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -286,7 +356,9 @@
           "WebACL": {
             "shape": "S22"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -298,8 +370,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {},
-          "ChangeToken": {}
+          "Name": {
+            "shape": "S6"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
@@ -308,7 +384,9 @@
           "XssMatchSet": {
             "shape": "S2b"
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -320,14 +398,20 @@
           "ChangeToken"
         ],
         "members": {
-          "ByteMatchSetId": {},
-          "ChangeToken": {}
+          "ByteMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -339,14 +423,20 @@
           "ChangeToken"
         ],
         "members": {
-          "GeoMatchSetId": {},
-          "ChangeToken": {}
+          "GeoMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -358,14 +448,20 @@
           "ChangeToken"
         ],
         "members": {
-          "IPSetId": {},
-          "ChangeToken": {}
+          "IPSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -376,7 +472,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -391,7 +489,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -407,14 +507,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {}
+          "RuleId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -426,14 +532,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {},
-          "ChangeToken": {}
+          "RegexMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -445,14 +557,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {},
-          "ChangeToken": {}
+          "RegexPatternSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -464,14 +582,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {}
+          "RuleId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -483,14 +607,20 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {},
-          "ChangeToken": {}
+          "RuleGroupId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -502,14 +632,20 @@
           "ChangeToken"
         ],
         "members": {
-          "SizeConstraintSetId": {},
-          "ChangeToken": {}
+          "SizeConstraintSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -521,14 +657,20 @@
           "ChangeToken"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {},
-          "ChangeToken": {}
+          "SqlInjectionMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -540,14 +682,20 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {},
-          "ChangeToken": {}
+          "WebACLId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -559,14 +707,20 @@
           "ChangeToken"
         ],
         "members": {
-          "XssMatchSetId": {},
-          "ChangeToken": {}
+          "XssMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -577,7 +731,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -592,7 +748,9 @@
           "ByteMatchSetId"
         ],
         "members": {
-          "ByteMatchSetId": {}
+          "ByteMatchSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -612,7 +770,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -623,13 +783,22 @@
           "ChangeToken"
         ],
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeTokenStatus": {}
+          "ChangeTokenStatus": {
+            "type": "string",
+            "enum": [
+              "PROVISIONED",
+              "PENDING",
+              "INSYNC"
+            ]
+          }
         }
       }
     },
@@ -640,7 +809,9 @@
           "GeoMatchSetId"
         ],
         "members": {
-          "GeoMatchSetId": {}
+          "GeoMatchSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -659,7 +830,9 @@
           "IPSetId"
         ],
         "members": {
-          "IPSetId": {}
+          "IPSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -678,7 +851,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -697,13 +872,17 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {}
+          "Policy": {
+            "shape": "S3q"
+          }
         }
       }
     },
@@ -714,7 +893,9 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {}
+          "RuleId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -733,8 +914,12 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {},
-          "NextMarker": {}
+          "RuleId": {
+            "shape": "S2"
+          },
+          "NextMarker": {
+            "shape": "S3u"
+          }
         }
       },
       "output": {
@@ -744,7 +929,9 @@
             "type": "list",
             "member": {}
           },
-          "NextMarker": {}
+          "NextMarker": {
+            "shape": "S3u"
+          }
         }
       }
     },
@@ -755,7 +942,9 @@
           "RegexMatchSetId"
         ],
         "members": {
-          "RegexMatchSetId": {}
+          "RegexMatchSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -774,7 +963,9 @@
           "RegexPatternSetId"
         ],
         "members": {
-          "RegexPatternSetId": {}
+          "RegexPatternSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -793,7 +984,9 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {}
+          "RuleId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -812,7 +1005,9 @@
           "RuleGroupId"
         ],
         "members": {
-          "RuleGroupId": {}
+          "RuleGroupId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -834,13 +1029,19 @@
           "MaxItems"
         ],
         "members": {
-          "WebAclId": {},
-          "RuleId": {},
+          "WebAclId": {
+            "shape": "S2"
+          },
+          "RuleId": {
+            "shape": "S2"
+          },
           "TimeWindow": {
             "shape": "S47"
           },
           "MaxItems": {
-            "type": "long"
+            "type": "long",
+            "max": 500,
+            "min": 1
           }
         }
       },
@@ -877,13 +1078,16 @@
                   }
                 },
                 "Weight": {
-                  "type": "long"
+                  "type": "long",
+                  "min": 0
                 },
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "Action": {},
-                "RuleWithinRuleGroup": {}
+                "RuleWithinRuleGroup": {
+                  "shape": "S2"
+                }
               }
             }
           },
@@ -903,7 +1107,9 @@
           "SizeConstraintSetId"
         ],
         "members": {
-          "SizeConstraintSetId": {}
+          "SizeConstraintSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -922,7 +1128,9 @@
           "SqlInjectionMatchSetId"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {}
+          "SqlInjectionMatchSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -941,7 +1149,9 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {}
+          "WebACLId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -960,7 +1170,9 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {}
+          "ResourceArn": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -979,7 +1191,9 @@
           "XssMatchSetId"
         ],
         "members": {
-          "XssMatchSetId": {}
+          "XssMatchSetId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -995,17 +1209,23 @@
       "input": {
         "type": "structure",
         "members": {
-          "RuleGroupId": {},
-          "NextMarker": {},
+          "RuleGroupId": {
+            "shape": "S2"
+          },
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "ActivatedRules": {
             "shape": "S23"
           }
@@ -1016,16 +1236,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "ByteMatchSets": {
             "type": "list",
             "member": {
@@ -1035,8 +1259,12 @@
                 "Name"
               ],
               "members": {
-                "ByteMatchSetId": {},
-                "Name": {}
+                "ByteMatchSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1047,16 +1275,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "GeoMatchSets": {
             "type": "list",
             "member": {
@@ -1066,8 +1298,12 @@
                 "Name"
               ],
               "members": {
-                "GeoMatchSetId": {},
-                "Name": {}
+                "GeoMatchSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1078,16 +1314,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "IPSets": {
             "type": "list",
             "member": {
@@ -1097,8 +1337,12 @@
                 "Name"
               ],
               "members": {
-                "IPSetId": {},
-                "Name": {}
+                "IPSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1109,9 +1353,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
@@ -1124,7 +1370,9 @@
               "shape": "S3l"
             }
           },
-          "NextMarker": {}
+          "NextMarker": {
+            "shape": "S3u"
+          }
         }
       }
     },
@@ -1132,16 +1380,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Rules": {
             "shape": "S5l"
           }
@@ -1152,16 +1404,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "RegexMatchSets": {
             "type": "list",
             "member": {
@@ -1171,8 +1427,12 @@
                 "Name"
               ],
               "members": {
-                "RegexMatchSetId": {},
-                "Name": {}
+                "RegexMatchSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1183,16 +1443,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "RegexPatternSets": {
             "type": "list",
             "member": {
@@ -1202,8 +1466,12 @@
                 "Name"
               ],
               "members": {
-                "RegexPatternSetId": {},
-                "Name": {}
+                "RegexPatternSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1217,7 +1485,9 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {}
+          "WebACLId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
@@ -1225,7 +1495,9 @@
         "members": {
           "ResourceArns": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           }
         }
       }
@@ -1234,16 +1506,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1253,8 +1529,12 @@
                 "Name"
               ],
               "members": {
-                "RuleGroupId": {},
-                "Name": {}
+                "RuleGroupId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1265,16 +1545,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Rules": {
             "shape": "S5l"
           }
@@ -1285,16 +1569,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "SizeConstraintSets": {
             "type": "list",
             "member": {
@@ -1304,8 +1592,12 @@
                 "Name"
               ],
               "members": {
-                "SizeConstraintSetId": {},
-                "Name": {}
+                "SizeConstraintSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1316,16 +1608,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "SqlInjectionMatchSets": {
             "type": "list",
             "member": {
@@ -1335,8 +1631,12 @@
                 "Name"
               ],
               "members": {
-                "SqlInjectionMatchSetId": {},
-                "Name": {}
+                "SqlInjectionMatchSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1347,16 +1647,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1367,8 +1671,12 @@
                 "MetricName"
               ],
               "members": {
-                "RuleGroupId": {},
-                "Name": {},
+                "RuleGroupId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                },
                 "MetricName": {}
               }
             }
@@ -1380,16 +1688,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "WebACLs": {
             "type": "list",
             "member": {
@@ -1403,16 +1715,20 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "Limit": {
-            "type": "integer"
+            "shape": "S52"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {},
+          "NextMarker": {
+            "shape": "S3u"
+          },
           "XssMatchSets": {
             "type": "list",
             "member": {
@@ -1422,8 +1738,12 @@
                 "Name"
               ],
               "members": {
-                "XssMatchSetId": {},
-                "Name": {}
+                "XssMatchSetId": {
+                  "shape": "S2"
+                },
+                "Name": {
+                  "shape": "S6"
+                }
               }
             }
           }
@@ -1459,8 +1779,12 @@
           "Policy"
         ],
         "members": {
-          "ResourceArn": {},
-          "Policy": {}
+          "ResourceArn": {
+            "shape": "S3"
+          },
+          "Policy": {
+            "shape": "S3q"
+          }
         }
       },
       "output": {
@@ -1477,8 +1801,12 @@
           "Updates"
         ],
         "members": {
-          "ByteMatchSetId": {},
-          "ChangeToken": {},
+          "ByteMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1488,19 +1816,24 @@
                 "ByteMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "ByteMatchTuple": {
                   "shape": "Sb"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1513,8 +1846,12 @@
           "Updates"
         ],
         "members": {
-          "GeoMatchSetId": {},
-          "ChangeToken": {},
+          "GeoMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1524,19 +1861,24 @@
                 "GeoMatchConstraint"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "GeoMatchConstraint": {
                   "shape": "Sm"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1549,8 +1891,12 @@
           "Updates"
         ],
         "members": {
-          "IPSetId": {},
-          "ChangeToken": {},
+          "IPSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1560,19 +1906,24 @@
                 "IPSetDescriptor"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "IPSetDescriptor": {
                   "shape": "St"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1586,20 +1937,26 @@
           "RateLimit"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {},
+          "RuleId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "shape": "S75"
           },
           "RateLimit": {
-            "type": "long"
+            "shape": "Sz"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1612,7 +1969,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {},
+          "RegexMatchSetId": {
+            "shape": "S2"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1622,20 +1981,27 @@
                 "RegexMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "RegexMatchTuple": {
                   "shape": "S1a"
                 }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1648,7 +2014,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {},
+          "RegexPatternSetId": {
+            "shape": "S2"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1658,18 +2026,27 @@
                 "RegexPatternString"
               ],
               "members": {
-                "Action": {},
-                "RegexPatternString": {}
+                "Action": {
+                  "shape": "S6u"
+                },
+                "RegexPatternString": {
+                  "shape": "S1f"
+                }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1682,8 +2059,12 @@
           "Updates"
         ],
         "members": {
-          "RuleId": {},
-          "ChangeToken": {},
+          "RuleId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "shape": "S75"
           }
@@ -1692,7 +2073,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1705,7 +2088,9 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {},
+          "RuleGroupId": {
+            "shape": "S2"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1715,20 +2100,27 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "ActivatedRule": {
                   "shape": "S24"
                 }
               }
-            }
+            },
+            "min": 1
           },
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1741,8 +2133,12 @@
           "Updates"
         ],
         "members": {
-          "SizeConstraintSetId": {},
-          "ChangeToken": {},
+          "SizeConstraintSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1752,19 +2148,24 @@
                 "SizeConstraint"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "SizeConstraint": {
                   "shape": "S1q"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1777,8 +2178,12 @@
           "Updates"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {},
-          "ChangeToken": {},
+          "SqlInjectionMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1788,19 +2193,24 @@
                 "SqlInjectionMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "SqlInjectionMatchTuple": {
                   "shape": "S1x"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1812,8 +2222,12 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {},
-          "ChangeToken": {},
+          "WebACLId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1823,7 +2237,9 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "ActivatedRule": {
                   "shape": "S24"
                 }
@@ -1838,7 +2254,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     },
@@ -1851,8 +2269,12 @@
           "Updates"
         ],
         "members": {
-          "XssMatchSetId": {},
-          "ChangeToken": {},
+          "XssMatchSetId": {
+            "shape": "S2"
+          },
+          "ChangeToken": {
+            "shape": "S7"
+          },
           "Updates": {
             "type": "list",
             "member": {
@@ -1862,24 +2284,48 @@
                 "XssMatchTuple"
               ],
               "members": {
-                "Action": {},
+                "Action": {
+                  "shape": "S6u"
+                },
                 "XssMatchTuple": {
                   "shape": "S2d"
                 }
               }
-            }
+            },
+            "min": 1
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {}
+          "ChangeToken": {
+            "shape": "S7"
+          }
         }
       }
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S3": {
+      "type": "string",
+      "max": 1224,
+      "min": 1
+    },
+    "S6": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
+    "S7": {
+      "type": "string",
+      "min": 1
+    },
     "S9": {
       "type": "structure",
       "required": [
@@ -1887,8 +2333,12 @@
         "ByteMatchTuples"
       ],
       "members": {
-        "ByteMatchSetId": {},
-        "Name": {},
+        "ByteMatchSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "ByteMatchTuples": {
           "type": "list",
           "member": {
@@ -1912,8 +2362,19 @@
         "TargetString": {
           "type": "blob"
         },
-        "TextTransformation": {},
-        "PositionalConstraint": {}
+        "TextTransformation": {
+          "shape": "Sg"
+        },
+        "PositionalConstraint": {
+          "type": "string",
+          "enum": [
+            "EXACTLY",
+            "STARTS_WITH",
+            "ENDS_WITH",
+            "CONTAINS",
+            "CONTAINS_WORD"
+          ]
+        }
       }
     },
     "Sc": {
@@ -1922,9 +2383,31 @@
         "Type"
       ],
       "members": {
-        "Type": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "URI",
+            "QUERY_STRING",
+            "HEADER",
+            "METHOD",
+            "BODY",
+            "SINGLE_QUERY_ARG",
+            "ALL_QUERY_ARGS"
+          ]
+        },
         "Data": {}
       }
+    },
+    "Sg": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "COMPRESS_WHITE_SPACE",
+        "HTML_ENTITY_DECODE",
+        "LOWERCASE",
+        "CMD_LINE",
+        "URL_DECODE"
+      ]
     },
     "Sk": {
       "type": "structure",
@@ -1933,8 +2416,12 @@
         "GeoMatchConstraints"
       ],
       "members": {
-        "GeoMatchSetId": {},
-        "Name": {},
+        "GeoMatchSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "GeoMatchConstraints": {
           "type": "list",
           "member": {
@@ -1950,8 +2437,266 @@
         "Value"
       ],
       "members": {
-        "Type": {},
-        "Value": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Country"
+          ]
+        },
+        "Value": {
+          "type": "string",
+          "enum": [
+            "AF",
+            "AX",
+            "AL",
+            "DZ",
+            "AS",
+            "AD",
+            "AO",
+            "AI",
+            "AQ",
+            "AG",
+            "AR",
+            "AM",
+            "AW",
+            "AU",
+            "AT",
+            "AZ",
+            "BS",
+            "BH",
+            "BD",
+            "BB",
+            "BY",
+            "BE",
+            "BZ",
+            "BJ",
+            "BM",
+            "BT",
+            "BO",
+            "BQ",
+            "BA",
+            "BW",
+            "BV",
+            "BR",
+            "IO",
+            "BN",
+            "BG",
+            "BF",
+            "BI",
+            "KH",
+            "CM",
+            "CA",
+            "CV",
+            "KY",
+            "CF",
+            "TD",
+            "CL",
+            "CN",
+            "CX",
+            "CC",
+            "CO",
+            "KM",
+            "CG",
+            "CD",
+            "CK",
+            "CR",
+            "CI",
+            "HR",
+            "CU",
+            "CW",
+            "CY",
+            "CZ",
+            "DK",
+            "DJ",
+            "DM",
+            "DO",
+            "EC",
+            "EG",
+            "SV",
+            "GQ",
+            "ER",
+            "EE",
+            "ET",
+            "FK",
+            "FO",
+            "FJ",
+            "FI",
+            "FR",
+            "GF",
+            "PF",
+            "TF",
+            "GA",
+            "GM",
+            "GE",
+            "DE",
+            "GH",
+            "GI",
+            "GR",
+            "GL",
+            "GD",
+            "GP",
+            "GU",
+            "GT",
+            "GG",
+            "GN",
+            "GW",
+            "GY",
+            "HT",
+            "HM",
+            "VA",
+            "HN",
+            "HK",
+            "HU",
+            "IS",
+            "IN",
+            "ID",
+            "IR",
+            "IQ",
+            "IE",
+            "IM",
+            "IL",
+            "IT",
+            "JM",
+            "JP",
+            "JE",
+            "JO",
+            "KZ",
+            "KE",
+            "KI",
+            "KP",
+            "KR",
+            "KW",
+            "KG",
+            "LA",
+            "LV",
+            "LB",
+            "LS",
+            "LR",
+            "LY",
+            "LI",
+            "LT",
+            "LU",
+            "MO",
+            "MK",
+            "MG",
+            "MW",
+            "MY",
+            "MV",
+            "ML",
+            "MT",
+            "MH",
+            "MQ",
+            "MR",
+            "MU",
+            "YT",
+            "MX",
+            "FM",
+            "MD",
+            "MC",
+            "MN",
+            "ME",
+            "MS",
+            "MA",
+            "MZ",
+            "MM",
+            "NA",
+            "NR",
+            "NP",
+            "NL",
+            "NC",
+            "NZ",
+            "NI",
+            "NE",
+            "NG",
+            "NU",
+            "NF",
+            "MP",
+            "NO",
+            "OM",
+            "PK",
+            "PW",
+            "PS",
+            "PA",
+            "PG",
+            "PY",
+            "PE",
+            "PH",
+            "PN",
+            "PL",
+            "PT",
+            "PR",
+            "QA",
+            "RE",
+            "RO",
+            "RU",
+            "RW",
+            "BL",
+            "SH",
+            "KN",
+            "LC",
+            "MF",
+            "PM",
+            "VC",
+            "WS",
+            "SM",
+            "ST",
+            "SA",
+            "SN",
+            "RS",
+            "SC",
+            "SL",
+            "SG",
+            "SX",
+            "SK",
+            "SI",
+            "SB",
+            "SO",
+            "ZA",
+            "GS",
+            "SS",
+            "ES",
+            "LK",
+            "SD",
+            "SR",
+            "SJ",
+            "SZ",
+            "SE",
+            "CH",
+            "SY",
+            "TW",
+            "TJ",
+            "TZ",
+            "TH",
+            "TL",
+            "TG",
+            "TK",
+            "TO",
+            "TT",
+            "TN",
+            "TR",
+            "TM",
+            "TC",
+            "TV",
+            "UG",
+            "UA",
+            "AE",
+            "GB",
+            "US",
+            "UM",
+            "UY",
+            "UZ",
+            "VU",
+            "VE",
+            "VN",
+            "VG",
+            "VI",
+            "WF",
+            "EH",
+            "YE",
+            "ZM",
+            "ZW"
+          ]
+        }
       }
     },
     "Sr": {
@@ -1961,8 +2706,12 @@
         "IPSetDescriptors"
       ],
       "members": {
-        "IPSetId": {},
-        "Name": {},
+        "IPSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "IPSetDescriptors": {
           "type": "list",
           "member": {
@@ -1978,9 +2727,26 @@
         "Value"
       ],
       "members": {
-        "Type": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "IPV4",
+            "IPV6"
+          ]
+        },
         "Value": {}
       }
+    },
+    "Sy": {
+      "type": "string",
+      "enum": [
+        "IP"
+      ]
+    },
+    "Sz": {
+      "type": "long",
+      "max": 2000000000,
+      "min": 2000
     },
     "S11": {
       "type": "structure",
@@ -1991,15 +2757,21 @@
         "RateLimit"
       ],
       "members": {
-        "RuleId": {},
-        "Name": {},
+        "RuleId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "MetricName": {},
         "MatchPredicates": {
           "shape": "S12"
         },
-        "RateKey": {},
+        "RateKey": {
+          "shape": "Sy"
+        },
         "RateLimit": {
-          "type": "long"
+          "shape": "Sz"
         }
       }
     },
@@ -2020,15 +2792,32 @@
         "Negated": {
           "type": "boolean"
         },
-        "Type": {},
-        "DataId": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "IPMatch",
+            "ByteMatch",
+            "SqlInjectionMatch",
+            "GeoMatch",
+            "SizeConstraint",
+            "XssMatch",
+            "RegexMatch"
+          ]
+        },
+        "DataId": {
+          "shape": "S2"
+        }
       }
     },
     "S18": {
       "type": "structure",
       "members": {
-        "RegexMatchSetId": {},
-        "Name": {},
+        "RegexMatchSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "RegexMatchTuples": {
           "type": "list",
           "member": {
@@ -2048,8 +2837,12 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {},
-        "RegexPatternSetId": {}
+        "TextTransformation": {
+          "shape": "Sg"
+        },
+        "RegexPatternSetId": {
+          "shape": "S2"
+        }
       }
     },
     "S1d": {
@@ -2059,13 +2852,24 @@
         "RegexPatternStrings"
       ],
       "members": {
-        "RegexPatternSetId": {},
-        "Name": {},
+        "RegexPatternSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "RegexPatternStrings": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S1f"
+          },
+          "max": 10
         }
       }
+    },
+    "S1f": {
+      "type": "string",
+      "min": 1
     },
     "S1i": {
       "type": "structure",
@@ -2074,8 +2878,12 @@
         "Predicates"
       ],
       "members": {
-        "RuleId": {},
-        "Name": {},
+        "RuleId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "MetricName": {},
         "Predicates": {
           "shape": "S12"
@@ -2088,8 +2896,12 @@
         "RuleGroupId"
       ],
       "members": {
-        "RuleGroupId": {},
-        "Name": {},
+        "RuleGroupId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "MetricName": {}
       }
     },
@@ -2100,8 +2912,12 @@
         "SizeConstraints"
       ],
       "members": {
-        "SizeConstraintSetId": {},
-        "Name": {},
+        "SizeConstraintSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "SizeConstraints": {
           "type": "list",
           "member": {
@@ -2122,10 +2938,24 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {},
-        "ComparisonOperator": {},
+        "TextTransformation": {
+          "shape": "Sg"
+        },
+        "ComparisonOperator": {
+          "type": "string",
+          "enum": [
+            "EQ",
+            "NE",
+            "LE",
+            "LT",
+            "GE",
+            "GT"
+          ]
+        },
         "Size": {
-          "type": "long"
+          "type": "long",
+          "max": 21474836480,
+          "min": 0
         }
       }
     },
@@ -2136,8 +2966,12 @@
         "SqlInjectionMatchTuples"
       ],
       "members": {
-        "SqlInjectionMatchSetId": {},
-        "Name": {},
+        "SqlInjectionMatchSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "SqlInjectionMatchTuples": {
           "type": "list",
           "member": {
@@ -2156,7 +2990,9 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {}
+        "TextTransformation": {
+          "shape": "Sg"
+        }
       }
     },
     "S1z": {
@@ -2165,7 +3001,14 @@
         "Type"
       ],
       "members": {
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "BLOCK",
+            "ALLOW",
+            "COUNT"
+          ]
+        }
       }
     },
     "S22": {
@@ -2176,8 +3019,12 @@
         "Rules"
       ],
       "members": {
-        "WebACLId": {},
-        "Name": {},
+        "WebACLId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "MetricName": {},
         "DefaultAction": {
           "shape": "S1z"
@@ -2203,7 +3050,9 @@
         "Priority": {
           "type": "integer"
         },
-        "RuleId": {},
+        "RuleId": {
+          "shape": "S2"
+        },
         "Action": {
           "shape": "S1z"
         },
@@ -2213,10 +3062,23 @@
             "Type"
           ],
           "members": {
-            "Type": {}
+            "Type": {
+              "type": "string",
+              "enum": [
+                "NONE",
+                "COUNT"
+              ]
+            }
           }
         },
-        "Type": {}
+        "Type": {
+          "type": "string",
+          "enum": [
+            "REGULAR",
+            "RATE_BASED",
+            "GROUP"
+          ]
+        }
       }
     },
     "S2b": {
@@ -2226,8 +3088,12 @@
         "XssMatchTuples"
       ],
       "members": {
-        "XssMatchSetId": {},
-        "Name": {},
+        "XssMatchSetId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        },
         "XssMatchTuples": {
           "type": "list",
           "member": {
@@ -2246,7 +3112,9 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {}
+        "TextTransformation": {
+          "shape": "Sg"
+        }
       }
     },
     "S3l": {
@@ -2256,10 +3124,16 @@
         "LogDestinationConfigs"
       ],
       "members": {
-        "ResourceArn": {},
+        "ResourceArn": {
+          "shape": "S3"
+        },
         "LogDestinationConfigs": {
           "type": "list",
-          "member": {}
+          "member": {
+            "shape": "S3"
+          },
+          "max": 1,
+          "min": 1
         },
         "RedactedFields": {
           "type": "list",
@@ -2268,6 +3142,14 @@
           }
         }
       }
+    },
+    "S3q": {
+      "type": "string",
+      "min": 1
+    },
+    "S3u": {
+      "type": "string",
+      "min": 1
     },
     "S47": {
       "type": "structure",
@@ -2291,9 +3173,18 @@
         "Name"
       ],
       "members": {
-        "WebACLId": {},
-        "Name": {}
+        "WebACLId": {
+          "shape": "S2"
+        },
+        "Name": {
+          "shape": "S6"
+        }
       }
+    },
+    "S52": {
+      "type": "integer",
+      "max": 100,
+      "min": 0
     },
     "S5l": {
       "type": "list",
@@ -2304,10 +3195,21 @@
           "Name"
         ],
         "members": {
-          "RuleId": {},
-          "Name": {}
+          "RuleId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "S6"
+          }
         }
       }
+    },
+    "S6u": {
+      "type": "string",
+      "enum": [
+        "INSERT",
+        "DELETE"
+      ]
     },
     "S75": {
       "type": "list",
@@ -2318,7 +3220,9 @@
           "Predicate"
         ],
         "members": {
-          "Action": {},
+          "Action": {
+            "shape": "S6u"
+          },
           "Predicate": {
             "shape": "S13"
           }

--- a/apis/workdocs-2016-05-01.min.json
+++ b/apis/workdocs-2016-05-01.min.json
@@ -30,10 +30,12 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           }
@@ -52,6 +54,7 @@
         ],
         "members": {
           "UserId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
@@ -89,6 +92,7 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -102,9 +106,15 @@
                 "Role"
               ],
               "members": {
-                "Id": {},
-                "Type": {},
-                "Role": {}
+                "Id": {
+                  "shape": "S6"
+                },
+                "Type": {
+                  "shape": "Sp"
+                },
+                "Role": {
+                  "shape": "Sq"
+                }
               }
             }
           },
@@ -129,10 +139,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "PrincipalId": {},
-                "Role": {},
-                "Status": {},
-                "ShareId": {},
+                "PrincipalId": {
+                  "shape": "S6"
+                },
+                "Role": {
+                  "shape": "Sq"
+                },
+                "Status": {
+                  "type": "string",
+                  "enum": [
+                    "SUCCESS",
+                    "FAILURE"
+                  ]
+                },
+                "ShareId": {
+                  "shape": "S3"
+                },
                 "StatusMessage": {
                   "shape": "St"
                 }
@@ -161,19 +183,27 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
-          "ParentId": {},
-          "ThreadId": {},
+          "ParentId": {
+            "shape": "Sz"
+          },
+          "ThreadId": {
+            "shape": "Sz"
+          },
           "Text": {
             "shape": "S10"
           },
-          "Visibility": {},
+          "Visibility": {
+            "shape": "S11"
+          },
           "NotifyCollaborators": {
             "type": "boolean"
           }
@@ -207,10 +237,12 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "querystring",
             "locationName": "versionid"
           },
@@ -240,8 +272,12 @@
             "location": "header",
             "locationName": "Authentication"
           },
-          "Name": {},
-          "ParentFolderId": {}
+          "Name": {
+            "shape": "S1b"
+          },
+          "ParentFolderId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -267,6 +303,7 @@
         ],
         "members": {
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -300,12 +337,22 @@
         ],
         "members": {
           "OrganizationId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           },
-          "Endpoint": {},
-          "Protocol": {},
-          "SubscriptionType": {}
+          "Endpoint": {
+            "shape": "S1l"
+          },
+          "Protocol": {
+            "shape": "S1m"
+          },
+          "SubscriptionType": {
+            "type": "string",
+            "enum": [
+              "ALL"
+            ]
+          }
         }
       },
       "output": {
@@ -331,16 +378,31 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {},
-          "Username": {},
-          "EmailAddress": {},
-          "GivenName": {},
-          "Surname": {},
+          "OrganizationId": {
+            "shape": "S6"
+          },
+          "Username": {
+            "shape": "S9"
+          },
+          "EmailAddress": {
+            "shape": "Sa"
+          },
+          "GivenName": {
+            "shape": "Sb"
+          },
+          "Surname": {
+            "shape": "Sb"
+          },
           "Password": {
             "type": "string",
+            "max": 32,
+            "min": 4,
+            "pattern": "[\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "TimeZoneId": {},
+          "TimeZoneId": {
+            "shape": "Sf"
+          },
           "StorageRule": {
             "shape": "Sj"
           },
@@ -373,6 +435,7 @@
         ],
         "members": {
           "UserId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
@@ -404,14 +467,17 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "CommentId": {
+            "shape": "Sz",
             "location": "uri",
             "locationName": "CommentId"
           }
@@ -436,10 +502,12 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "querystring",
             "locationName": "versionId"
           },
@@ -447,7 +515,10 @@
             "location": "querystring",
             "locationName": "keys",
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S17"
+            },
+            "max": 8
           },
           "DeleteAll": {
             "location": "querystring",
@@ -479,6 +550,7 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           }
@@ -503,6 +575,7 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           }
@@ -527,6 +600,7 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           }
@@ -546,6 +620,7 @@
         ],
         "members": {
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -585,10 +660,12 @@
         ],
         "members": {
           "SubscriptionId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "SubscriptionId"
           },
           "OrganizationId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           }
@@ -613,6 +690,7 @@
             "locationName": "Authentication"
           },
           "UserId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           }
@@ -644,19 +722,22 @@
             "type": "timestamp"
           },
           "OrganizationId": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "UserId": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "userId"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Marker": {
+            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -670,11 +751,48 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {},
+                "Type": {
+                  "type": "string",
+                  "enum": [
+                    "DOCUMENT_CHECKED_IN",
+                    "DOCUMENT_CHECKED_OUT",
+                    "DOCUMENT_RENAMED",
+                    "DOCUMENT_VERSION_UPLOADED",
+                    "DOCUMENT_VERSION_DELETED",
+                    "DOCUMENT_RECYCLED",
+                    "DOCUMENT_RESTORED",
+                    "DOCUMENT_REVERTED",
+                    "DOCUMENT_SHARED",
+                    "DOCUMENT_UNSHARED",
+                    "DOCUMENT_SHARE_PERMISSION_CHANGED",
+                    "DOCUMENT_SHAREABLE_LINK_CREATED",
+                    "DOCUMENT_SHAREABLE_LINK_REMOVED",
+                    "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED",
+                    "DOCUMENT_MOVED",
+                    "DOCUMENT_COMMENT_ADDED",
+                    "DOCUMENT_COMMENT_DELETED",
+                    "DOCUMENT_ANNOTATION_ADDED",
+                    "DOCUMENT_ANNOTATION_DELETED",
+                    "FOLDER_CREATED",
+                    "FOLDER_DELETED",
+                    "FOLDER_RENAMED",
+                    "FOLDER_RECYCLED",
+                    "FOLDER_RESTORED",
+                    "FOLDER_SHARED",
+                    "FOLDER_UNSHARED",
+                    "FOLDER_SHARE_PERMISSION_CHANGED",
+                    "FOLDER_SHAREABLE_LINK_CREATED",
+                    "FOLDER_SHAREABLE_LINK_REMOVED",
+                    "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED",
+                    "FOLDER_MOVED"
+                  ]
+                },
                 "TimeStamp": {
                   "type": "timestamp"
                 },
-                "OrganizationId": {},
+                "OrganizationId": {
+                  "shape": "S6"
+                },
                 "Initiator": {
                   "shape": "S2c"
                 },
@@ -701,21 +819,29 @@
                 "CommentMetadata": {
                   "type": "structure",
                   "members": {
-                    "CommentId": {},
+                    "CommentId": {
+                      "shape": "Sz"
+                    },
                     "Contributor": {
                       "shape": "S8"
                     },
                     "CreatedTimestamp": {
                       "type": "timestamp"
                     },
-                    "CommentStatus": {},
-                    "RecipientId": {}
+                    "CommentStatus": {
+                      "shape": "S14"
+                    },
+                    "RecipientId": {
+                      "shape": "S6"
+                    }
                   }
                 }
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S27"
+          }
         }
       }
     },
@@ -738,19 +864,22 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Marker": {
+            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -765,7 +894,9 @@
               "shape": "S13"
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S27"
+          }
         }
       }
     },
@@ -787,23 +918,27 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Include": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "include"
           },
           "Fields": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           }
@@ -818,7 +953,9 @@
               "shape": "S2t"
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -840,31 +977,46 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
           "Sort": {
             "location": "querystring",
-            "locationName": "sort"
+            "locationName": "sort",
+            "type": "string",
+            "enum": [
+              "DATE",
+              "NAME"
+            ]
           },
           "Order": {
+            "shape": "S33",
             "location": "querystring",
             "locationName": "order"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Type": {
             "location": "querystring",
-            "locationName": "type"
+            "locationName": "type",
+            "type": "string",
+            "enum": [
+              "ALL",
+              "DOCUMENT",
+              "FOLDER"
+            ]
           },
           "Include": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "include"
           }
@@ -882,7 +1034,9 @@
               "shape": "S38"
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -909,17 +1063,20 @@
             "locationName": "searchQuery"
           },
           "OrganizationId": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "Marker": {
+            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
             "location": "querystring",
             "locationName": "limit",
-            "type": "integer"
+            "type": "integer",
+            "min": 1
           }
         }
       },
@@ -929,7 +1086,9 @@
           "Groups": {
             "shape": "S2f"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S27"
+          }
         }
       }
     },
@@ -946,17 +1105,19 @@
         ],
         "members": {
           "OrganizationId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           }
         }
       },
@@ -967,9 +1128,12 @@
             "type": "list",
             "member": {
               "shape": "S1p"
-            }
+            },
+            "max": 256
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -991,19 +1155,22 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "PrincipalId": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "principalId"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1017,22 +1184,36 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Type": {},
+                "Id": {
+                  "shape": "S6"
+                },
+                "Type": {
+                  "shape": "Sp"
+                },
                 "Roles": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Role": {},
-                      "Type": {}
+                      "Role": {
+                        "shape": "Sq"
+                      },
+                      "Type": {
+                        "type": "string",
+                        "enum": [
+                          "DIRECT",
+                          "INHERITED"
+                        ]
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -1054,11 +1235,12 @@
             "locationName": "Authentication"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1070,7 +1252,9 @@
           "Folders": {
             "shape": "S36"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -1089,12 +1273,17 @@
             "locationName": "Authentication"
           },
           "OrganizationId": {
+            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "UserIds": {
             "location": "querystring",
-            "locationName": "userIds"
+            "locationName": "userIds",
+            "type": "string",
+            "max": 2000,
+            "min": 1,
+            "pattern": "[&\\w+-.@, ]+"
           },
           "Query": {
             "shape": "S3a",
@@ -1103,26 +1292,42 @@
           },
           "Include": {
             "location": "querystring",
-            "locationName": "include"
+            "locationName": "include",
+            "type": "string",
+            "enum": [
+              "ALL",
+              "ACTIVE_PENDING"
+            ]
           },
           "Order": {
+            "shape": "S33",
             "location": "querystring",
             "locationName": "order"
           },
           "Sort": {
             "location": "querystring",
-            "locationName": "sort"
+            "locationName": "sort",
+            "type": "string",
+            "enum": [
+              "USER_NAME",
+              "FULL_NAME",
+              "STORAGE_LIMIT",
+              "USER_STATUS",
+              "STORAGE_USED"
+            ]
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Fields": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           }
@@ -1141,7 +1346,9 @@
             "deprecated": true,
             "type": "long"
           },
-          "Marker": {}
+          "Marker": {
+            "shape": "S2p"
+          }
         }
       }
     },
@@ -1191,6 +1398,7 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
@@ -1231,19 +1439,22 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Fields": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1277,14 +1488,17 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "Fields": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
@@ -1325,6 +1539,7 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
@@ -1365,19 +1580,22 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "FolderId"
           },
           "Limit": {
+            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit",
-            "type": "integer"
+            "locationName": "limit"
           },
           "Fields": {
+            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
           "Marker": {
+            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1408,19 +1626,27 @@
             "location": "header",
             "locationName": "Authentication"
           },
-          "Id": {},
-          "Name": {},
+          "Id": {
+            "shape": "S3"
+          },
+          "Name": {
+            "shape": "S1b"
+          },
           "ContentCreatedTimestamp": {
             "type": "timestamp"
           },
           "ContentModifiedTimestamp": {
             "type": "timestamp"
           },
-          "ContentType": {},
+          "ContentType": {
+            "shape": "S2u"
+          },
           "DocumentSizeInBytes": {
             "type": "long"
           },
-          "ParentFolderId": {}
+          "ParentFolderId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -1437,8 +1663,17 @@
               },
               "SignedHeaders": {
                 "type": "map",
-                "key": {},
-                "value": {}
+                "key": {
+                  "type": "string",
+                  "max": 256,
+                  "min": 1,
+                  "pattern": "[\\w-]+"
+                },
+                "value": {
+                  "type": "string",
+                  "max": 1024,
+                  "min": 1
+                }
               }
             }
           }
@@ -1463,6 +1698,7 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           }
@@ -1488,14 +1724,17 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "PrincipalId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "PrincipalId"
           },
           "PrincipalType": {
+            "shape": "Sp",
             "location": "querystring",
             "locationName": "type"
           }
@@ -1520,12 +1759,19 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
-          "Name": {},
-          "ParentFolderId": {},
-          "ResourceState": {}
+          "Name": {
+            "shape": "S1b"
+          },
+          "ParentFolderId": {
+            "shape": "S3"
+          },
+          "ResourceState": {
+            "shape": "S1e"
+          }
         }
       }
     },
@@ -1548,14 +1794,21 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
+            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
-          "VersionStatus": {}
+          "VersionStatus": {
+            "type": "string",
+            "enum": [
+              "ACTIVE"
+            ]
+          }
         }
       }
     },
@@ -1577,12 +1830,19 @@
             "locationName": "Authentication"
           },
           "FolderId": {
+            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
-          "Name": {},
-          "ParentFolderId": {},
-          "ResourceState": {}
+          "Name": {
+            "shape": "S1b"
+          },
+          "ParentFolderId": {
+            "shape": "S3"
+          },
+          "ResourceState": {
+            "shape": "S1e"
+          }
         }
       }
     },
@@ -1604,18 +1864,35 @@
             "locationName": "Authentication"
           },
           "UserId": {
+            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
-          "GivenName": {},
-          "Surname": {},
-          "Type": {},
+          "GivenName": {
+            "shape": "Sb"
+          },
+          "Surname": {
+            "shape": "Sb"
+          },
+          "Type": {
+            "shape": "Sd"
+          },
           "StorageRule": {
             "shape": "Sj"
           },
-          "TimeZoneId": {},
-          "Locale": {},
-          "GrantPoweruserPrivileges": {}
+          "TimeZoneId": {
+            "shape": "Sf"
+          },
+          "Locale": {
+            "shape": "Sg"
+          },
+          "GrantPoweruserPrivileges": {
+            "type": "string",
+            "enum": [
+              "TRUE",
+              "FALSE"
+            ]
+          }
         }
       },
       "output": {
@@ -1631,29 +1908,78 @@
   "shapes": {
     "S2": {
       "type": "string",
+      "max": 8199,
+      "min": 1,
       "sensitive": true
+    },
+    "S3": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+-.@]+"
+    },
+    "S4": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+-.@]+"
+    },
+    "S6": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[&\\w+-.@]+"
     },
     "S8": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Username": {},
-        "EmailAddress": {},
-        "GivenName": {},
-        "Surname": {},
-        "OrganizationId": {},
-        "RootFolderId": {},
-        "RecycleBinFolderId": {},
-        "Status": {},
-        "Type": {},
+        "Id": {
+          "shape": "S6"
+        },
+        "Username": {
+          "shape": "S9"
+        },
+        "EmailAddress": {
+          "shape": "Sa"
+        },
+        "GivenName": {
+          "shape": "Sb"
+        },
+        "Surname": {
+          "shape": "Sb"
+        },
+        "OrganizationId": {
+          "shape": "S6"
+        },
+        "RootFolderId": {
+          "shape": "S3"
+        },
+        "RecycleBinFolderId": {
+          "shape": "S3"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "ACTIVE",
+            "INACTIVE",
+            "PENDING"
+          ]
+        },
+        "Type": {
+          "shape": "Sd"
+        },
         "CreatedTimestamp": {
           "type": "timestamp"
         },
         "ModifiedTimestamp": {
           "type": "timestamp"
         },
-        "TimeZoneId": {},
-        "Locale": {},
+        "TimeZoneId": {
+          "shape": "Sf"
+        },
+        "Locale": {
+          "shape": "Sg"
+        },
         "Storage": {
           "type": "structure",
           "members": {
@@ -1667,22 +1993,113 @@
         }
       }
     },
+    "S9": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\w\\-+.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]+)?"
+    },
+    "Sa": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+    },
+    "Sb": {
+      "type": "string",
+      "max": 64,
+      "min": 1
+    },
+    "Sd": {
+      "type": "string",
+      "enum": [
+        "USER",
+        "ADMIN",
+        "POWERUSER",
+        "MINIMALUSER",
+        "WORKSPACESUSER"
+      ]
+    },
+    "Sf": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "Sg": {
+      "type": "string",
+      "enum": [
+        "en",
+        "fr",
+        "ko",
+        "de",
+        "es",
+        "ja",
+        "ru",
+        "zh_CN",
+        "zh_TW",
+        "pt_BR",
+        "default"
+      ]
+    },
     "Sj": {
       "type": "structure",
       "members": {
         "StorageAllocatedInBytes": {
-          "type": "long"
+          "type": "long",
+          "min": 0
         },
-        "StorageType": {}
+        "StorageType": {
+          "type": "string",
+          "enum": [
+            "UNLIMITED",
+            "QUOTA"
+          ]
+        }
       }
+    },
+    "Sp": {
+      "type": "string",
+      "enum": [
+        "USER",
+        "GROUP",
+        "INVITE",
+        "ANONYMOUS",
+        "ORGANIZATION"
+      ]
+    },
+    "Sq": {
+      "type": "string",
+      "enum": [
+        "VIEWER",
+        "CONTRIBUTOR",
+        "OWNER",
+        "COOWNER"
+      ]
     },
     "St": {
       "type": "string",
+      "max": 2048,
+      "min": 0,
       "sensitive": true
+    },
+    "Sz": {
+      "type": "string",
+      "max": 128,
+      "min": 1,
+      "pattern": "[\\w+-.@]+"
     },
     "S10": {
       "type": "string",
+      "max": 2048,
+      "min": 1,
       "sensitive": true
+    },
+    "S11": {
+      "type": "string",
+      "enum": [
+        "PUBLIC",
+        "PRIVATE"
+      ]
     },
     "S13": {
       "type": "structure",
@@ -1690,9 +2107,15 @@
         "CommentId"
       ],
       "members": {
-        "CommentId": {},
-        "ParentId": {},
-        "ThreadId": {},
+        "CommentId": {
+          "shape": "Sz"
+        },
+        "ParentId": {
+          "shape": "Sz"
+        },
+        "ThreadId": {
+          "shape": "Sz"
+        },
         "Text": {
           "shape": "S10"
         },
@@ -1702,31 +2125,78 @@
         "CreatedTimestamp": {
           "type": "timestamp"
         },
-        "Status": {},
-        "Visibility": {},
-        "RecipientId": {}
+        "Status": {
+          "shape": "S14"
+        },
+        "Visibility": {
+          "shape": "S11"
+        },
+        "RecipientId": {
+          "shape": "S6"
+        }
       }
+    },
+    "S14": {
+      "type": "string",
+      "enum": [
+        "DRAFT",
+        "PUBLISHED",
+        "DELETED"
+      ]
     },
     "S16": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "shape": "S17"
+      },
+      "value": {
+        "type": "string",
+        "max": 256,
+        "min": 1,
+        "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
+      },
+      "max": 8,
+      "min": 1
+    },
+    "S17": {
+      "type": "string",
+      "max": 56,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
+    },
+    "S1b": {
+      "type": "string",
+      "max": 255,
+      "min": 1,
+      "pattern": "[\\u0020-\\u202D\\u202F-\\uFFFF]+"
     },
     "S1d": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Name": {},
-        "CreatorId": {},
-        "ParentFolderId": {},
+        "Id": {
+          "shape": "S3"
+        },
+        "Name": {
+          "shape": "S1b"
+        },
+        "CreatorId": {
+          "shape": "S6"
+        },
+        "ParentFolderId": {
+          "shape": "S3"
+        },
         "CreatedTimestamp": {
           "type": "timestamp"
         },
         "ModifiedTimestamp": {
           "type": "timestamp"
         },
-        "ResourceState": {},
-        "Signature": {},
+        "ResourceState": {
+          "shape": "S1e"
+        },
+        "Signature": {
+          "shape": "S1f"
+        },
         "Labels": {
           "shape": "S1g"
         },
@@ -1738,26 +2208,85 @@
         }
       }
     },
+    "S1e": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "RESTORING",
+        "RECYCLING",
+        "RECYCLED"
+      ]
+    },
+    "S1f": {
+      "type": "string",
+      "max": 128,
+      "min": 0,
+      "pattern": "[&\\w+-.@]+"
+    },
     "S1g": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "max": 32,
+        "min": 1,
+        "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
+      },
+      "max": 20
+    },
+    "S1l": {
+      "type": "string",
+      "max": 256,
+      "min": 1
+    },
+    "S1m": {
+      "type": "string",
+      "enum": [
+        "HTTPS"
+      ]
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "SubscriptionId": {},
-        "EndPoint": {},
-        "Protocol": {}
+        "SubscriptionId": {
+          "shape": "S6"
+        },
+        "EndPoint": {
+          "shape": "S1l"
+        },
+        "Protocol": {
+          "shape": "S1m"
+        }
       }
+    },
+    "S26": {
+      "type": "integer",
+      "max": 999,
+      "min": 1
+    },
+    "S27": {
+      "type": "string",
+      "max": 2048,
+      "min": 1,
+      "pattern": "[\\u0000-\\u00FF]+"
     },
     "S2c": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Username": {},
-        "GivenName": {},
-        "Surname": {},
-        "EmailAddress": {}
+        "Id": {
+          "shape": "S6"
+        },
+        "Username": {
+          "shape": "S9"
+        },
+        "GivenName": {
+          "shape": "Sb"
+        },
+        "Surname": {
+          "shape": "Sb"
+        },
+        "EmailAddress": {
+          "shape": "Sa"
+        }
       }
     },
     "S2f": {
@@ -1765,7 +2294,9 @@
       "member": {
         "type": "structure",
         "members": {
-          "Id": {},
+          "Id": {
+            "shape": "S6"
+          },
           "Name": {}
         }
       }
@@ -1773,28 +2304,69 @@
     "S2i": {
       "type": "structure",
       "members": {
-        "Type": {},
-        "Name": {},
-        "OriginalName": {},
-        "Id": {},
-        "VersionId": {},
+        "Type": {
+          "type": "string",
+          "enum": [
+            "FOLDER",
+            "DOCUMENT"
+          ]
+        },
+        "Name": {
+          "shape": "S1b"
+        },
+        "OriginalName": {
+          "shape": "S1b"
+        },
+        "Id": {
+          "shape": "S3"
+        },
+        "VersionId": {
+          "shape": "S4"
+        },
         "Owner": {
           "shape": "S2c"
         },
-        "ParentId": {}
+        "ParentId": {
+          "shape": "S3"
+        }
       }
+    },
+    "S2p": {
+      "type": "string",
+      "max": 2048,
+      "min": 1
+    },
+    "S2q": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\w,]+"
     },
     "S2t": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "Name": {},
-        "ContentType": {},
+        "Id": {
+          "shape": "S4"
+        },
+        "Name": {
+          "shape": "S1b"
+        },
+        "ContentType": {
+          "shape": "S2u"
+        },
         "Size": {
           "type": "long"
         },
-        "Signature": {},
-        "Status": {},
+        "Signature": {
+          "shape": "S1f"
+        },
+        "Status": {
+          "type": "string",
+          "enum": [
+            "INITIALIZED",
+            "ACTIVE"
+          ]
+        },
         "CreatedTimestamp": {
           "type": "timestamp"
         },
@@ -1807,26 +2379,55 @@
         "ContentModifiedTimestamp": {
           "type": "timestamp"
         },
-        "CreatorId": {},
+        "CreatorId": {
+          "shape": "S6"
+        },
         "Thumbnail": {
           "type": "map",
-          "key": {},
+          "key": {
+            "type": "string",
+            "enum": [
+              "SMALL",
+              "SMALL_HQ",
+              "LARGE"
+            ]
+          },
           "value": {
             "shape": "S2y"
           }
         },
         "Source": {
           "type": "map",
-          "key": {},
+          "key": {
+            "type": "string",
+            "enum": [
+              "ORIGINAL",
+              "WITH_COMMENTS"
+            ]
+          },
           "value": {
             "shape": "S2y"
           }
         }
       }
     },
+    "S2u": {
+      "type": "string",
+      "max": 128,
+      "min": 1
+    },
     "S2y": {
       "type": "string",
+      "max": 1024,
+      "min": 1,
       "sensitive": true
+    },
+    "S33": {
+      "type": "string",
+      "enum": [
+        "ASCENDING",
+        "DESCENDING"
+      ]
     },
     "S36": {
       "type": "list",
@@ -1837,9 +2438,15 @@
     "S38": {
       "type": "structure",
       "members": {
-        "Id": {},
-        "CreatorId": {},
-        "ParentFolderId": {},
+        "Id": {
+          "shape": "S3"
+        },
+        "CreatorId": {
+          "shape": "S6"
+        },
+        "ParentFolderId": {
+          "shape": "S3"
+        },
         "CreatedTimestamp": {
           "type": "timestamp"
         },
@@ -1849,7 +2456,9 @@
         "LatestVersionMetadata": {
           "shape": "S2t"
         },
-        "ResourceState": {},
+        "ResourceState": {
+          "shape": "S1e"
+        },
         "Labels": {
           "shape": "S1g"
         }
@@ -1857,6 +2466,9 @@
     },
     "S3a": {
       "type": "string",
+      "max": 512,
+      "min": 1,
+      "pattern": "[\\u0020-\\uFFFF]+",
       "sensitive": true
     },
     "S41": {
@@ -1867,8 +2479,12 @@
           "member": {
             "type": "structure",
             "members": {
-              "Id": {},
-              "Name": {}
+              "Id": {
+                "shape": "S6"
+              },
+              "Name": {
+                "shape": "S1b"
+              }
             }
           }
         }

--- a/apis/workmail-2017-10-01.min.json
+++ b/apis/workmail-2017-10-01.min.json
@@ -21,9 +21,15 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {},
-          "EntityId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S3"
+          },
+          "EntityId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -41,9 +47,15 @@
           "MemberId"
         ],
         "members": {
-          "OrganizationId": {},
-          "GroupId": {},
-          "MemberId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "GroupId": {
+            "shape": "S4"
+          },
+          "MemberId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -61,9 +73,15 @@
           "Alias"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "Alias": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "Alias": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -80,14 +98,20 @@
           "Name"
         ],
         "members": {
-          "OrganizationId": {},
-          "Name": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "Sc"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {}
+          "GroupId": {
+            "shape": "S4"
+          }
         }
       },
       "idempotent": true
@@ -101,15 +125,23 @@
           "Type"
         ],
         "members": {
-          "OrganizationId": {},
-          "Name": {},
-          "Type": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "Sf"
+          },
+          "Type": {
+            "shape": "Sg"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {}
+          "ResourceId": {
+            "shape": "S3"
+          }
         }
       },
       "idempotent": true
@@ -124,9 +156,15 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {},
-          "Name": {},
-          "DisplayName": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "Name": {
+            "shape": "Sj"
+          },
+          "DisplayName": {
+            "shape": "Sk"
+          },
           "Password": {
             "shape": "Sl"
           }
@@ -135,7 +173,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "UserId": {}
+          "UserId": {
+            "shape": "S4"
+          }
         }
       },
       "idempotent": true
@@ -149,9 +189,15 @@
           "Alias"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "Alias": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "Alias": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -168,8 +214,12 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {},
-          "GroupId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "GroupId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -187,9 +237,15 @@
           "GranteeId"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "GranteeId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "GranteeId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -206,8 +262,12 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
@@ -224,8 +284,12 @@
           "UserId"
         ],
         "members": {
-          "OrganizationId": {},
-          "UserId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "UserId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -242,8 +306,12 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -260,17 +328,29 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {},
-          "GroupId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "GroupId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {},
-          "Name": {},
-          "Email": {},
-          "State": {},
+          "GroupId": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "Sc"
+          },
+          "Email": {
+            "shape": "S9"
+          },
+          "State": {
+            "shape": "S11"
+          },
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -288,22 +368,38 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OrganizationId": {},
-          "Alias": {},
-          "State": {},
-          "DirectoryId": {},
-          "DirectoryType": {},
-          "DefaultMailDomain": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "Alias": {
+            "shape": "S15"
+          },
+          "State": {
+            "shape": "Sk"
+          },
+          "DirectoryId": {
+            "shape": "Sk"
+          },
+          "DirectoryType": {
+            "shape": "Sk"
+          },
+          "DefaultMailDomain": {
+            "shape": "Sk"
+          },
           "CompletedDate": {
             "type": "timestamp"
           },
-          "ErrorMessage": {}
+          "ErrorMessage": {
+            "shape": "Sk"
+          }
         }
       },
       "idempotent": true
@@ -316,21 +412,35 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S3"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {},
-          "Email": {},
-          "Name": {},
-          "Type": {},
+          "ResourceId": {
+            "shape": "S3"
+          },
+          "Email": {
+            "shape": "S9"
+          },
+          "Name": {
+            "shape": "Sf"
+          },
+          "Type": {
+            "shape": "Sg"
+          },
           "BookingOptions": {
             "shape": "S18"
           },
-          "State": {},
+          "State": {
+            "shape": "S11"
+          },
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -349,19 +459,35 @@
           "UserId"
         ],
         "members": {
-          "OrganizationId": {},
-          "UserId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "UserId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UserId": {},
-          "Name": {},
-          "Email": {},
-          "DisplayName": {},
-          "State": {},
-          "UserRole": {},
+          "UserId": {
+            "shape": "S4"
+          },
+          "Name": {
+            "shape": "Sj"
+          },
+          "Email": {
+            "shape": "S9"
+          },
+          "DisplayName": {
+            "shape": "Sk"
+          },
+          "State": {
+            "shape": "S11"
+          },
+          "UserRole": {
+            "shape": "S1c"
+          },
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -381,9 +507,15 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {},
-          "EntityId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S3"
+          },
+          "EntityId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -401,9 +533,15 @@
           "MemberId"
         ],
         "members": {
-          "OrganizationId": {},
-          "GroupId": {},
-          "MemberId": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "GroupId": {
+            "shape": "S4"
+          },
+          "MemberId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -420,11 +558,17 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -433,9 +577,13 @@
         "members": {
           "Aliases": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S9"
+            }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -448,11 +596,17 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {},
-          "GroupId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "GroupId": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -464,10 +618,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Name": {},
-                "Type": {},
-                "State": {},
+                "Id": {
+                  "shape": "Sk"
+                },
+                "Name": {
+                  "shape": "Sk"
+                },
+                "Type": {
+                  "shape": "S1q"
+                },
+                "State": {
+                  "shape": "S11"
+                },
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -477,7 +639,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -489,10 +653,14 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -504,10 +672,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Email": {},
-                "Name": {},
-                "State": {},
+                "Id": {
+                  "shape": "S4"
+                },
+                "Email": {
+                  "shape": "S9"
+                },
+                "Name": {
+                  "shape": "Sc"
+                },
+                "State": {
+                  "shape": "S11"
+                },
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -517,7 +693,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -530,11 +708,17 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -551,15 +735,21 @@
                 "PermissionValues"
               ],
               "members": {
-                "GranteeId": {},
-                "GranteeType": {},
+                "GranteeId": {
+                  "shape": "S4"
+                },
+                "GranteeType": {
+                  "shape": "S1q"
+                },
                 "PermissionValues": {
                   "shape": "S1z"
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -568,9 +758,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -582,14 +774,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "OrganizationId": {},
-                "Alias": {},
-                "ErrorMessage": {},
-                "State": {}
+                "OrganizationId": {
+                  "shape": "S2"
+                },
+                "Alias": {
+                  "shape": "S15"
+                },
+                "ErrorMessage": {
+                  "shape": "Sk"
+                },
+                "State": {
+                  "shape": "Sk"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -602,11 +804,17 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S4"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -622,12 +830,18 @@
                 "Type"
               ],
               "members": {
-                "Id": {},
-                "Type": {}
+                "Id": {
+                  "shape": "Sk"
+                },
+                "Type": {
+                  "shape": "S1q"
+                }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -639,10 +853,14 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -654,11 +872,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Email": {},
-                "Name": {},
-                "Type": {},
-                "State": {},
+                "Id": {
+                  "shape": "S4"
+                },
+                "Email": {
+                  "shape": "S9"
+                },
+                "Name": {
+                  "shape": "Sf"
+                },
+                "Type": {
+                  "shape": "Sg"
+                },
+                "State": {
+                  "shape": "S11"
+                },
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -668,7 +896,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -680,10 +910,14 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {},
-          "NextToken": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "NextToken": {
+            "shape": "S1i"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1j"
           }
         }
       },
@@ -695,12 +929,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
-                "Email": {},
-                "Name": {},
-                "DisplayName": {},
-                "State": {},
-                "UserRole": {},
+                "Id": {
+                  "shape": "S4"
+                },
+                "Email": {
+                  "shape": "S9"
+                },
+                "Name": {
+                  "shape": "Sj"
+                },
+                "DisplayName": {
+                  "shape": "Sk"
+                },
+                "State": {
+                  "shape": "S11"
+                },
+                "UserRole": {
+                  "shape": "S1c"
+                },
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -710,7 +956,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1i"
+          }
         }
       },
       "idempotent": true
@@ -725,9 +973,15 @@
           "PermissionValues"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "GranteeId": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "GranteeId": {
+            "shape": "S4"
+          },
           "PermissionValues": {
             "shape": "S1z"
           }
@@ -748,9 +1002,15 @@
           "Email"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "Email": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "Email": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -768,8 +1028,12 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {},
-          "UserId": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "UserId": {
+            "shape": "S4"
+          },
           "Password": {
             "shape": "Sl"
           }
@@ -790,9 +1054,15 @@
           "Email"
         ],
         "members": {
-          "OrganizationId": {},
-          "EntityId": {},
-          "Email": {}
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "EntityId": {
+            "shape": "S4"
+          },
+          "Email": {
+            "shape": "S9"
+          }
         }
       },
       "output": {
@@ -809,9 +1079,15 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {},
-          "ResourceId": {},
-          "Name": {},
+          "OrganizationId": {
+            "shape": "S2"
+          },
+          "ResourceId": {
+            "shape": "S3"
+          },
+          "Name": {
+            "shape": "Sf"
+          },
           "BookingOptions": {
             "shape": "S18"
           }
@@ -825,9 +1101,73 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "^m-[0-9a-f]{32}$"
+    },
+    "S3": {
+      "type": "string",
+      "pattern": "^r-[0-9a-f]{32}$"
+    },
+    "S4": {
+      "type": "string",
+      "max": 256,
+      "min": 12
+    },
+    "S9": {
+      "type": "string",
+      "max": 254,
+      "min": 1,
+      "pattern": "[a-zA-Z0-9._%+-]{1,64}@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+    },
+    "Sc": {
+      "type": "string",
+      "max": 256,
+      "min": 1,
+      "pattern": "[\\u0020-\\u00FF]+"
+    },
+    "Sf": {
+      "type": "string",
+      "max": 20,
+      "min": 1,
+      "pattern": "[\\w\\-.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z0-9]{2,})?"
+    },
+    "Sg": {
+      "type": "string",
+      "enum": [
+        "ROOM",
+        "EQUIPMENT"
+      ]
+    },
+    "Sj": {
+      "type": "string",
+      "max": 64,
+      "min": 1,
+      "pattern": "[\\w\\-.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z0-9]{2,})?"
+    },
+    "Sk": {
+      "type": "string",
+      "max": 256
+    },
     "Sl": {
       "type": "string",
+      "max": 256,
+      "pattern": "[\\u0020-\\u00FF]+",
       "sensitive": true
+    },
+    "S11": {
+      "type": "string",
+      "enum": [
+        "ENABLED",
+        "DISABLED",
+        "DELETED"
+      ]
+    },
+    "S15": {
+      "type": "string",
+      "max": 62,
+      "min": 1,
+      "pattern": "^(?!d-)([\\da-zA-Z]+)([-]*[\\da-zA-Z])*"
     },
     "S18": {
       "type": "structure",
@@ -843,9 +1183,41 @@
         }
       }
     },
+    "S1c": {
+      "type": "string",
+      "enum": [
+        "USER",
+        "RESOURCE",
+        "SYSTEM_USER"
+      ]
+    },
+    "S1i": {
+      "type": "string",
+      "max": 1024,
+      "min": 1
+    },
+    "S1j": {
+      "type": "integer",
+      "max": 100,
+      "min": 1
+    },
+    "S1q": {
+      "type": "string",
+      "enum": [
+        "GROUP",
+        "USER"
+      ]
+    },
     "S1z": {
       "type": "list",
-      "member": {}
+      "member": {
+        "type": "string",
+        "enum": [
+          "FULL_ACCESS",
+          "SEND_AS",
+          "SEND_ON_BEHALF"
+        ]
+      }
     }
   }
 }

--- a/apis/workspaces-2015-04-08.min.json
+++ b/apis/workspaces-2015-04-08.min.json
@@ -20,7 +20,9 @@
           "GroupIds"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "GroupIds": {
             "shape": "S3"
           }
@@ -39,7 +41,9 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {},
+          "GroupId": {
+            "shape": "S4"
+          },
           "UserRules": {
             "shape": "S7"
           }
@@ -67,7 +71,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {}
+          "GroupId": {
+            "shape": "S4"
+          }
         }
       }
     },
@@ -79,7 +85,9 @@
           "Tags"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "Sh"
+          },
           "Tags": {
             "shape": "Si"
           }
@@ -101,7 +109,9 @@
             "type": "list",
             "member": {
               "shape": "Sp"
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -134,7 +144,9 @@
           "GroupId"
         ],
         "members": {
-          "GroupId": {}
+          "GroupId": {
+            "shape": "S4"
+          }
         }
       },
       "output": {
@@ -150,10 +162,14 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceId": {},
+          "ResourceId": {
+            "shape": "Sh"
+          },
           "TagKeys": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sh"
+            }
           }
         }
       },
@@ -169,9 +185,11 @@
           "GroupIds": {
             "shape": "S3"
           },
-          "NextToken": {},
+          "NextToken": {
+            "shape": "S1n"
+          },
           "MaxResults": {
-            "type": "integer"
+            "shape": "S1o"
           }
         }
       },
@@ -183,7 +201,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "groupId": {},
+                "groupId": {
+                  "shape": "S4"
+                },
                 "groupName": {},
                 "groupDesc": {},
                 "userRules": {
@@ -192,7 +212,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -203,7 +225,9 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {}
+          "ResourceId": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -221,10 +245,16 @@
         "members": {
           "BundleIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "Sr"
+            },
+            "max": 25,
+            "min": 1
           },
           "Owner": {},
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
@@ -235,32 +265,44 @@
             "member": {
               "type": "structure",
               "members": {
-                "BundleId": {},
-                "Name": {},
+                "BundleId": {
+                  "shape": "Sr"
+                },
+                "Name": {
+                  "shape": "Sh"
+                },
                 "Owner": {},
                 "Description": {},
                 "RootStorage": {
                   "type": "structure",
                   "members": {
-                    "Capacity": {}
+                    "Capacity": {
+                      "shape": "Sh"
+                    }
                   }
                 },
                 "UserStorage": {
                   "type": "structure",
                   "members": {
-                    "Capacity": {}
+                    "Capacity": {
+                      "shape": "Sh"
+                    }
                   }
                 },
                 "ComputeType": {
                   "type": "structure",
                   "members": {
-                    "Name": {}
+                    "Name": {
+                      "shape": "Sz"
+                    }
                   }
                 }
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -270,9 +312,15 @@
         "members": {
           "DirectoryIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S2"
+            },
+            "max": 25,
+            "min": 1
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
@@ -283,23 +331,53 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {},
+                "DirectoryId": {
+                  "shape": "S2"
+                },
                 "Alias": {},
                 "DirectoryName": {},
-                "RegistrationCode": {},
+                "RegistrationCode": {
+                  "type": "string",
+                  "max": 20,
+                  "min": 1
+                },
                 "SubnetIds": {
                   "type": "list",
-                  "member": {}
+                  "member": {
+                    "shape": "S1a"
+                  }
                 },
                 "DnsIpAddresses": {
                   "type": "list",
                   "member": {}
                 },
-                "CustomerUserName": {},
-                "IamRoleId": {},
-                "DirectoryType": {},
-                "WorkspaceSecurityGroupId": {},
-                "State": {},
+                "CustomerUserName": {
+                  "shape": "Sq"
+                },
+                "IamRoleId": {
+                  "type": "string",
+                  "pattern": "^arn:aws:[A-Za-z0-9][A-za-z0-9_/.-]{0,62}:[A-za-z0-9_/.-]{0,63}:[A-za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-za-z0-9_/.-]{0,127}$"
+                },
+                "DirectoryType": {
+                  "type": "string",
+                  "enum": [
+                    "SIMPLE_AD",
+                    "AD_CONNECTOR"
+                  ]
+                },
+                "WorkspaceSecurityGroupId": {
+                  "shape": "S2f"
+                },
+                "State": {
+                  "type": "string",
+                  "enum": [
+                    "REGISTERING",
+                    "REGISTERED",
+                    "DEREGISTERING",
+                    "DEREGISTERED",
+                    "ERROR"
+                  ]
+                },
                 "WorkspaceCreationProperties": {
                   "type": "structure",
                   "members": {
@@ -310,7 +388,9 @@
                       "type": "boolean"
                     },
                     "DefaultOu": {},
-                    "CustomSecurityGroupId": {},
+                    "CustomSecurityGroupId": {
+                      "shape": "S2f"
+                    },
                     "UserEnabledAsLocalAdministrator": {
                       "type": "boolean"
                     }
@@ -322,7 +402,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -333,13 +415,21 @@
           "WorkspaceIds": {
             "shape": "S2k"
           },
-          "DirectoryId": {},
-          "UserName": {},
-          "BundleId": {},
-          "Limit": {
-            "type": "integer"
+          "DirectoryId": {
+            "shape": "S2"
           },
-          "NextToken": {}
+          "UserName": {
+            "shape": "Sq"
+          },
+          "BundleId": {
+            "shape": "Sr"
+          },
+          "Limit": {
+            "shape": "S1o"
+          },
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
@@ -348,7 +438,9 @@
           "Workspaces": {
             "shape": "S15"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -359,7 +451,9 @@
           "WorkspaceIds": {
             "shape": "S2k"
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       },
       "output": {
@@ -370,8 +464,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {},
-                "ConnectionState": {},
+                "WorkspaceId": {
+                  "shape": "S17"
+                },
+                "ConnectionState": {
+                  "type": "string",
+                  "enum": [
+                    "CONNECTED",
+                    "DISCONNECTED",
+                    "UNKNOWN"
+                  ]
+                },
                 "ConnectionStateCheckTimestamp": {
                   "type": "timestamp"
                 },
@@ -381,7 +484,9 @@
               }
             }
           },
-          "NextToken": {}
+          "NextToken": {
+            "shape": "S1n"
+          }
         }
       }
     },
@@ -393,7 +498,9 @@
           "GroupIds"
         ],
         "members": {
-          "DirectoryId": {},
+          "DirectoryId": {
+            "shape": "S2"
+          },
           "GroupIds": {
             "shape": "S3"
           }
@@ -412,7 +519,9 @@
           "WorkspaceProperties"
         ],
         "members": {
-          "WorkspaceId": {},
+          "WorkspaceId": {
+            "shape": "S17"
+          },
           "WorkspaceProperties": {
             "shape": "Su"
           }
@@ -431,8 +540,16 @@
           "WorkspaceState"
         ],
         "members": {
-          "WorkspaceId": {},
-          "WorkspaceState": {}
+          "WorkspaceId": {
+            "shape": "S17"
+          },
+          "WorkspaceState": {
+            "type": "string",
+            "enum": [
+              "AVAILABLE",
+              "ADMIN_MAINTENANCE"
+            ]
+          }
         }
       },
       "output": {
@@ -455,9 +572,13 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {}
+                "WorkspaceId": {
+                  "shape": "S17"
+                }
               }
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -488,9 +609,13 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {}
+                "WorkspaceId": {
+                  "shape": "S17"
+                }
               }
-            }
+            },
+            "max": 1,
+            "min": 1
           }
         }
       },
@@ -514,7 +639,9 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {},
+          "GroupId": {
+            "shape": "S4"
+          },
           "UserRules": {
             "type": "list",
             "member": {}
@@ -538,9 +665,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {}
+                "WorkspaceId": {
+                  "shape": "S17"
+                }
               }
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -568,9 +699,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {}
+                "WorkspaceId": {
+                  "shape": "S17"
+                }
               }
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -601,9 +736,13 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {}
+                "WorkspaceId": {
+                  "shape": "S17"
+                }
               }
-            }
+            },
+            "max": 25,
+            "min": 1
           }
         }
       },
@@ -627,7 +766,9 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {},
+          "GroupId": {
+            "shape": "S4"
+          },
           "UserRules": {
             "shape": "S7"
           }
@@ -640,9 +781,19 @@
     }
   },
   "shapes": {
+    "S2": {
+      "type": "string",
+      "pattern": "^d-[0-9a-f]{8,63}$"
+    },
     "S3": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S4"
+      }
+    },
+    "S4": {
+      "type": "string",
+      "pattern": "wsipg-[0-9a-z]{8,63}$"
     },
     "S7": {
       "type": "list",
@@ -654,6 +805,10 @@
         }
       }
     },
+    "Sh": {
+      "type": "string",
+      "min": 1
+    },
     "Si": {
       "type": "list",
       "member": {
@@ -662,8 +817,15 @@
           "Key"
         ],
         "members": {
-          "Key": {},
-          "Value": {}
+          "Key": {
+            "type": "string",
+            "max": 127,
+            "min": 1
+          },
+          "Value": {
+            "type": "string",
+            "max": 255
+          }
         }
       }
     },
@@ -675,9 +837,15 @@
         "BundleId"
       ],
       "members": {
-        "DirectoryId": {},
-        "UserName": {},
-        "BundleId": {},
+        "DirectoryId": {
+          "shape": "S2"
+        },
+        "UserName": {
+          "shape": "Sq"
+        },
+        "BundleId": {
+          "shape": "Sr"
+        },
         "VolumeEncryptionKey": {},
         "UserVolumeEncryptionEnabled": {
           "type": "boolean"
@@ -693,10 +861,25 @@
         }
       }
     },
+    "Sq": {
+      "type": "string",
+      "max": 63,
+      "min": 1
+    },
+    "Sr": {
+      "type": "string",
+      "pattern": "^wsb-[0-9a-z]{8,63}$"
+    },
     "Su": {
       "type": "structure",
       "members": {
-        "RunningMode": {},
+        "RunningMode": {
+          "type": "string",
+          "enum": [
+            "AUTO_STOP",
+            "ALWAYS_ON"
+          ]
+        },
         "RunningModeAutoStopTimeoutInMinutes": {
           "type": "integer"
         },
@@ -706,21 +889,63 @@
         "UserVolumeSizeGib": {
           "type": "integer"
         },
-        "ComputeTypeName": {}
+        "ComputeTypeName": {
+          "shape": "Sz"
+        }
       }
+    },
+    "Sz": {
+      "type": "string",
+      "enum": [
+        "VALUE",
+        "STANDARD",
+        "PERFORMANCE",
+        "POWER",
+        "GRAPHICS"
+      ]
     },
     "S15": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "WorkspaceId": {},
-          "DirectoryId": {},
-          "UserName": {},
+          "WorkspaceId": {
+            "shape": "S17"
+          },
+          "DirectoryId": {
+            "shape": "S2"
+          },
+          "UserName": {
+            "shape": "Sq"
+          },
           "IpAddress": {},
-          "State": {},
-          "BundleId": {},
-          "SubnetId": {},
+          "State": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "AVAILABLE",
+              "IMPAIRED",
+              "UNHEALTHY",
+              "REBOOTING",
+              "STARTING",
+              "REBUILDING",
+              "MAINTENANCE",
+              "ADMIN_MAINTENANCE",
+              "TERMINATING",
+              "TERMINATED",
+              "SUSPENDED",
+              "UPDATING",
+              "STOPPING",
+              "STOPPED",
+              "ERROR"
+            ]
+          },
+          "BundleId": {
+            "shape": "Sr"
+          },
+          "SubnetId": {
+            "shape": "S1a"
+          },
           "ErrorMessage": {},
           "ErrorCode": {},
           "ComputerName": {},
@@ -739,22 +964,63 @@
             "member": {
               "type": "structure",
               "members": {
-                "Resource": {},
-                "State": {}
+                "Resource": {
+                  "type": "string",
+                  "enum": [
+                    "ROOT_VOLUME",
+                    "USER_VOLUME",
+                    "COMPUTE_TYPE"
+                  ]
+                },
+                "State": {
+                  "type": "string",
+                  "enum": [
+                    "UPDATE_INITIATED",
+                    "UPDATE_IN_PROGRESS"
+                  ]
+                }
               }
             }
           }
         }
       }
     },
+    "S17": {
+      "type": "string",
+      "pattern": "^ws-[0-9a-z]{8,63}$"
+    },
+    "S1a": {
+      "type": "string",
+      "pattern": "^(subnet-[0-9a-f]{8})$"
+    },
+    "S1n": {
+      "type": "string",
+      "max": 63,
+      "min": 1
+    },
+    "S1o": {
+      "type": "integer",
+      "max": 25,
+      "min": 1
+    },
+    "S2f": {
+      "type": "string",
+      "pattern": "^(sg-[0-9a-f]{8})$"
+    },
     "S2k": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S17"
+      },
+      "max": 25,
+      "min": 1
     },
     "S34": {
       "type": "structure",
       "members": {
-        "WorkspaceId": {},
+        "WorkspaceId": {
+          "shape": "S17"
+        },
         "ErrorCode": {},
         "ErrorMessage": {}
       }

--- a/apis/xray-2016-04-12.min.json
+++ b/apis/xray-2016-04-12.min.json
@@ -34,7 +34,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S3"
+                },
                 "Duration": {
                   "type": "double"
                 },
@@ -44,7 +46,10 @@
                     "type": "structure",
                     "members": {
                       "Id": {},
-                      "Document": {}
+                      "Document": {
+                        "type": "string",
+                        "min": 1
+                      }
                     }
                   }
                 }
@@ -53,7 +58,9 @@
           },
           "UnprocessedTraceIds": {
             "type": "list",
-            "member": {}
+            "member": {
+              "shape": "S3"
+            }
           },
           "NextToken": {}
         }
@@ -203,22 +210,32 @@
                 "SampledCount"
               ],
               "members": {
-                "RuleName": {},
-                "ClientID": {},
+                "RuleName": {
+                  "shape": "Sg"
+                },
+                "ClientID": {
+                  "type": "string",
+                  "max": 24,
+                  "min": 24
+                },
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "RequestCount": {
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0
                 },
                 "SampledCount": {
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0
                 },
                 "BorrowCount": {
-                  "type": "integer"
+                  "type": "integer",
+                  "min": 0
                 }
               }
-            }
+            },
+            "max": 25
           }
         }
       },
@@ -345,7 +362,11 @@
           "Sampling": {
             "type": "boolean"
           },
-          "FilterExpression": {},
+          "FilterExpression": {
+            "type": "string",
+            "max": 2000,
+            "min": 1
+          },
           "NextToken": {}
         }
       },
@@ -357,7 +378,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {},
+                "Id": {
+                  "shape": "S3"
+                },
                 "Duration": {
                   "type": "double"
                 },
@@ -453,8 +476,14 @@
           "Type"
         ],
         "members": {
-          "KeyId": {},
-          "Type": {}
+          "KeyId": {
+            "type": "string",
+            "max": 3000,
+            "min": 1
+          },
+          "Type": {
+            "shape": "S13"
+          }
         }
       },
       "output": {
@@ -525,9 +554,17 @@
               }
             }
           },
-          "EC2InstanceId": {},
-          "Hostname": {},
-          "ResourceARN": {}
+          "EC2InstanceId": {
+            "type": "string",
+            "max": 20
+          },
+          "Hostname": {
+            "type": "string",
+            "max": 255
+          },
+          "ResourceARN": {
+            "shape": "Sh"
+          }
         }
       },
       "output": {
@@ -581,9 +618,13 @@
           "SamplingRuleUpdate": {
             "type": "structure",
             "members": {
-              "RuleName": {},
+              "RuleName": {
+                "shape": "Sg"
+              },
               "RuleARN": {},
-              "ResourceARN": {},
+              "ResourceARN": {
+                "shape": "Sh"
+              },
               "Priority": {
                 "type": "integer"
               },
@@ -593,11 +634,21 @@
               "ReservoirSize": {
                 "type": "integer"
               },
-              "Host": {},
-              "ServiceName": {},
-              "ServiceType": {},
-              "HTTPMethod": {},
-              "URLPath": {},
+              "Host": {
+                "shape": "Sn"
+              },
+              "ServiceName": {
+                "shape": "Sl"
+              },
+              "ServiceType": {
+                "shape": "Sm"
+              },
+              "HTTPMethod": {
+                "shape": "So"
+              },
+              "URLPath": {
+                "shape": "Sp"
+              },
               "Attributes": {
                 "shape": "Sr"
               }
@@ -618,7 +669,14 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {}
+      "member": {
+        "shape": "S3"
+      }
+    },
+    "S3": {
+      "type": "string",
+      "max": 35,
+      "min": 1
     },
     "Sf": {
       "type": "structure",
@@ -635,35 +693,93 @@
         "Version"
       ],
       "members": {
-        "RuleName": {},
+        "RuleName": {
+          "shape": "Sg"
+        },
         "RuleARN": {},
-        "ResourceARN": {},
+        "ResourceARN": {
+          "shape": "Sh"
+        },
         "Priority": {
-          "type": "integer"
+          "type": "integer",
+          "max": 9999,
+          "min": 1
         },
         "FixedRate": {
-          "type": "double"
+          "type": "double",
+          "max": 1,
+          "min": 0
         },
         "ReservoirSize": {
-          "type": "integer"
+          "type": "integer",
+          "min": 0
         },
-        "ServiceName": {},
-        "ServiceType": {},
-        "Host": {},
-        "HTTPMethod": {},
-        "URLPath": {},
+        "ServiceName": {
+          "shape": "Sl"
+        },
+        "ServiceType": {
+          "shape": "Sm"
+        },
+        "Host": {
+          "shape": "Sn"
+        },
+        "HTTPMethod": {
+          "shape": "So"
+        },
+        "URLPath": {
+          "shape": "Sp"
+        },
         "Version": {
-          "type": "integer"
+          "type": "integer",
+          "min": 1
         },
         "Attributes": {
           "shape": "Sr"
         }
       }
     },
+    "Sg": {
+      "type": "string",
+      "max": 32,
+      "min": 1
+    },
+    "Sh": {
+      "type": "string",
+      "max": 500
+    },
+    "Sl": {
+      "type": "string",
+      "max": 64
+    },
+    "Sm": {
+      "type": "string",
+      "max": 64
+    },
+    "Sn": {
+      "type": "string",
+      "max": 64
+    },
+    "So": {
+      "type": "string",
+      "max": 10
+    },
+    "Sp": {
+      "type": "string",
+      "max": 128
+    },
     "Sr": {
       "type": "map",
-      "key": {},
-      "value": {}
+      "key": {
+        "type": "string",
+        "max": 32,
+        "min": 1
+      },
+      "value": {
+        "type": "string",
+        "max": 32,
+        "min": 1
+      },
+      "max": 5
     },
     "Sv": {
       "type": "structure",
@@ -683,9 +799,24 @@
       "type": "structure",
       "members": {
         "KeyId": {},
-        "Status": {},
-        "Type": {}
+        "Status": {
+          "type": "string",
+          "enum": [
+            "UPDATING",
+            "ACTIVE"
+          ]
+        },
+        "Type": {
+          "shape": "S13"
+        }
       }
+    },
+    "S13": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "KMS"
+      ]
     },
     "S1s": {
       "type": "list",

--- a/scripts/lib/foo-2018-03-30.normal.json
+++ b/scripts/lib/foo-2018-03-30.normal.json
@@ -121,7 +121,13 @@
             "timestampFormat": "rfc822"
         },
         "StringShape": {
-            "type": "string"
+            "type": "string",
+            "min": 1,
+            "max": 100,
+            "enum": [
+                "test"
+            ],
+            "pattern": "\\w+"
         }
     }
 }

--- a/scripts/lib/translate-api.spec.js
+++ b/scripts/lib/translate-api.spec.js
@@ -4,6 +4,19 @@ var Translator = require('./translator');
 var Api = require('../../lib/model/api');
 var fooModel = require('./foo-2018-03-30.normal.json');
 
+describe('Translator', function() {
+    it('does not remove min, max, enum, or pattern traits form shapes', function() {
+        var mockModel = deepCopyObject(fooModel);
+        var modifiedModel = new Translator(mockModel, {documentation: false});
+
+        // shapes are renamed when they are reused
+        expect(modifiedModel.shapes['S2'].min).to.equal(1);
+        expect(modifiedModel.shapes['S2'].max).to.equal(100);
+        expect(modifiedModel.shapes['S2'].enum).to.eql(["test"]);
+        expect(modifiedModel.shapes['S2'].pattern).to.equal("\\w+");
+    });
+});
+
 describe('removeEventStreamOperations', function() {
     describe('removes operations when eventstream', function() {
         it('is on the input shape shape', function() {

--- a/scripts/lib/translator.js
+++ b/scripts/lib/translator.js
@@ -43,10 +43,6 @@ function Translator(api, options) {
       delete obj.documentation;
       delete obj.documentationUrl;
       delete obj.errors;
-      delete obj.min;
-      delete obj.max;
-      delete obj.pattern;
-      delete obj['enum'];
       delete obj.box;
     }
   }


### PR DESCRIPTION
By default, the SDK parameter validation should check if a field meets the minimum length constraint if it is defined for a shape. Optionally, enum, pattern, and maximum length can also be checked.

However, the minified models had the min, max, enum and pattern constraints removed from shapes. This is because prior to parameter validation supporting these constraints, they were not used and were purged to reduce the size of our models. When parameter validation was enhanced, the model minifier was not updated to stop removing these fields.

This update will effectively start causing the SDK to check the minimum length constraint by default.

Fixes #2278 