### PR TITLE
Reverts #2279 until integration tests are updated

### DIFF
--- a/.changes/next-release/bugfix-ParameterValidation-09255151.json
+++ b/.changes/next-release/bugfix-ParameterValidation-09255151.json
@@ -1,5 +1,0 @@
-{
-  "type": "bugfix",
-  "category": "ParameterValidation",
-  "description": "Updates service models to include min, max, enum, and pattern data for use with SDK parameter validation."
-}

--- a/apis/AWSMigrationHub-2017-05-31.min.json
+++ b/apis/AWSMigrationHub-2017-05-31.min.json
@@ -21,12 +21,8 @@
           "CreatedArtifact"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "CreatedArtifact": {
             "shape": "S4"
           },
@@ -49,12 +45,8 @@
           "DiscoveredResource"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "DiscoveredResource": {
             "shape": "Sa"
           },
@@ -75,9 +67,7 @@
           "ProgressUpdateStreamName"
         ],
         "members": {
-          "ProgressUpdateStreamName": {
-            "shape": "S2"
-          },
+          "ProgressUpdateStreamName": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -95,9 +85,7 @@
           "ProgressUpdateStreamName"
         ],
         "members": {
-          "ProgressUpdateStreamName": {
-            "shape": "S2"
-          },
+          "ProgressUpdateStreamName": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -115,17 +103,13 @@
           "ApplicationId"
         ],
         "members": {
-          "ApplicationId": {
-            "shape": "Sj"
-          }
+          "ApplicationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ApplicationStatus": {
-            "shape": "Sl"
-          },
+          "ApplicationStatus": {},
           "LastUpdatedTime": {
             "type": "timestamp"
           }
@@ -140,12 +124,8 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          }
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {}
         }
       },
       "output": {
@@ -154,12 +134,8 @@
           "MigrationTask": {
             "type": "structure",
             "members": {
-              "ProgressUpdateStream": {
-                "shape": "S2"
-              },
-              "MigrationTaskName": {
-                "shape": "S3"
-              },
+              "ProgressUpdateStream": {},
+              "MigrationTaskName": {},
               "Task": {
                 "shape": "Sq"
               },
@@ -170,9 +146,7 @@
                 "type": "list",
                 "member": {
                   "shape": "Sv"
-                },
-                "max": 100,
-                "min": 0
+                }
               }
             }
           }
@@ -188,15 +162,9 @@
           "CreatedArtifactName"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
-          "CreatedArtifactName": {
-            "shape": "S5"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
+          "CreatedArtifactName": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -216,15 +184,9 @@
           "ConfigurationId"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
-          "ConfigurationId": {
-            "shape": "Sb"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
+          "ConfigurationId": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -243,12 +205,8 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -267,17 +225,11 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -302,17 +254,11 @@
           "MigrationTaskName"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -335,13 +281,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S1e"
+            "type": "integer"
           },
-          "ResourceName": {
-            "type": "string",
-            "max": 1600,
-            "min": 1
-          }
+          "ResourceName": {}
         }
       },
       "output": {
@@ -353,21 +295,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProgressUpdateStream": {
-                  "shape": "S2"
-                },
-                "MigrationTaskName": {
-                  "shape": "S3"
-                },
-                "Status": {
-                  "shape": "Sr"
-                },
+                "ProgressUpdateStream": {},
+                "MigrationTaskName": {},
+                "Status": {},
                 "ProgressPercent": {
-                  "shape": "St"
+                  "type": "integer"
                 },
-                "StatusDetail": {
-                  "shape": "Ss"
-                },
+                "StatusDetail": {},
                 "UpdateDateTime": {
                   "type": "timestamp"
                 }
@@ -383,7 +317,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S1e"
+            "type": "integer"
           }
         }
       },
@@ -395,9 +329,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProgressUpdateStreamName": {
-                  "shape": "S2"
-                }
+                "ProgressUpdateStreamName": {}
               }
             }
           },
@@ -413,12 +345,8 @@
           "Status"
         ],
         "members": {
-          "ApplicationId": {
-            "shape": "Sj"
-          },
-          "Status": {
-            "shape": "Sl"
-          },
+          "ApplicationId": {},
+          "Status": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -440,12 +368,8 @@
           "NextUpdateSeconds"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "Task": {
             "shape": "Sq"
           },
@@ -453,8 +377,7 @@
             "type": "timestamp"
           },
           "NextUpdateSeconds": {
-            "type": "integer",
-            "min": 0
+            "type": "integer"
           },
           "DryRun": {
             "type": "boolean"
@@ -475,19 +398,13 @@
           "ResourceAttributeList"
         ],
         "members": {
-          "ProgressUpdateStream": {
-            "shape": "S2"
-          },
-          "MigrationTaskName": {
-            "shape": "S3"
-          },
+          "ProgressUpdateStream": {},
+          "MigrationTaskName": {},
           "ResourceAttributeList": {
             "type": "list",
             "member": {
               "shape": "Sv"
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "DryRun": {
             "type": "boolean"
@@ -501,39 +418,15 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 50,
-      "min": 1,
-      "pattern": "[^/:|\\000-\\037]+"
-    },
-    "S3": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[^:|]+"
-    },
     "S4": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S5"
-        },
-        "Description": {
-          "type": "string",
-          "max": 500,
-          "min": 0
-        }
+        "Name": {},
+        "Description": {}
       }
-    },
-    "S5": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "arn:[a-z-]+:[a-z0-9-]+:(?:[a-z0-9-]+|):(?:[0-9]{12}|):.*"
     },
     "Sa": {
       "type": "structure",
@@ -541,32 +434,9 @@
         "ConfigurationId"
       ],
       "members": {
-        "ConfigurationId": {
-          "shape": "Sb"
-        },
-        "Description": {
-          "type": "string",
-          "max": 500,
-          "min": 0
-        }
+        "ConfigurationId": {},
+        "Description": {}
       }
-    },
-    "Sb": {
-      "type": "string",
-      "min": 1
-    },
-    "Sj": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "NOT_STARTED",
-        "IN_PROGRESS",
-        "COMPLETED"
-      ]
     },
     "Sq": {
       "type": "structure",
@@ -574,35 +444,12 @@
         "Status"
       ],
       "members": {
-        "Status": {
-          "shape": "Sr"
-        },
-        "StatusDetail": {
-          "shape": "Ss"
-        },
+        "Status": {},
+        "StatusDetail": {},
         "ProgressPercent": {
-          "shape": "St"
+          "type": "integer"
         }
       }
-    },
-    "Sr": {
-      "type": "string",
-      "enum": [
-        "NOT_STARTED",
-        "IN_PROGRESS",
-        "FAILED",
-        "COMPLETED"
-      ]
-    },
-    "Ss": {
-      "type": "string",
-      "max": 500,
-      "min": 0
-    },
-    "St": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
     },
     "Sv": {
       "type": "structure",
@@ -611,32 +458,9 @@
         "Value"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "IPV4_ADDRESS",
-            "IPV6_ADDRESS",
-            "MAC_ADDRESS",
-            "FQDN",
-            "VM_MANAGER_ID",
-            "VM_MANAGED_OBJECT_REFERENCE",
-            "VM_NAME",
-            "VM_PATH",
-            "BIOS_ID",
-            "MOTHERBOARD_SERIAL_NUMBER"
-          ]
-        },
-        "Value": {
-          "type": "string",
-          "max": 256,
-          "min": 1
-        }
+        "Type": {},
+        "Value": {}
       }
-    },
-    "S1e": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     }
   }
 }

--- a/apis/acm-2015-12-08.min.json
+++ b/apis/acm-2015-12-08.min.json
@@ -21,9 +21,7 @@
           "Tags"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
+          "CertificateArn": {},
           "Tags": {
             "shape": "S3"
           }
@@ -37,9 +35,7 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       }
     },
@@ -50,9 +46,7 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       },
       "output": {
@@ -61,12 +55,8 @@
           "Certificate": {
             "type": "structure",
             "members": {
-              "CertificateArn": {
-                "shape": "S2"
-              },
-              "DomainName": {
-                "shape": "Sb"
-              },
+              "CertificateArn": {},
+              "DomainName": {},
               "SubjectAlternativeNames": {
                 "shape": "Sc"
               },
@@ -85,66 +75,25 @@
               "ImportedAt": {
                 "type": "timestamp"
               },
-              "Status": {
-                "shape": "Sm"
-              },
+              "Status": {},
               "RevokedAt": {
                 "type": "timestamp"
               },
-              "RevocationReason": {
-                "type": "string",
-                "enum": [
-                  "UNSPECIFIED",
-                  "KEY_COMPROMISE",
-                  "CA_COMPROMISE",
-                  "AFFILIATION_CHANGED",
-                  "SUPERCEDED",
-                  "CESSATION_OF_OPERATION",
-                  "CERTIFICATE_HOLD",
-                  "REMOVE_FROM_CRL",
-                  "PRIVILEGE_WITHDRAWN",
-                  "A_A_COMPROMISE"
-                ]
-              },
+              "RevocationReason": {},
               "NotBefore": {
                 "type": "timestamp"
               },
               "NotAfter": {
                 "type": "timestamp"
               },
-              "KeyAlgorithm": {
-                "shape": "So"
-              },
+              "KeyAlgorithm": {},
               "SignatureAlgorithm": {},
               "InUseBy": {
                 "type": "list",
                 "member": {}
               },
-              "FailureReason": {
-                "type": "string",
-                "enum": [
-                  "NO_AVAILABLE_CONTACTS",
-                  "ADDITIONAL_VERIFICATION_REQUIRED",
-                  "DOMAIN_NOT_ALLOWED",
-                  "INVALID_PUBLIC_DOMAIN",
-                  "CAA_ERROR",
-                  "PCA_LIMIT_EXCEEDED",
-                  "PCA_INVALID_ARN",
-                  "PCA_INVALID_STATE",
-                  "PCA_REQUEST_FAILED",
-                  "PCA_RESOURCE_NOT_FOUND",
-                  "PCA_INVALID_ARGS",
-                  "OTHER"
-                ]
-              },
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "IMPORTED",
-                  "AMAZON_ISSUED",
-                  "PRIVATE"
-                ]
-              },
+              "FailureReason": {},
+              "Type": {},
               "RenewalSummary": {
                 "type": "structure",
                 "required": [
@@ -152,15 +101,7 @@
                   "DomainValidationOptions"
                 ],
                 "members": {
-                  "RenewalStatus": {
-                    "type": "string",
-                    "enum": [
-                      "PENDING_AUTO_RENEWAL",
-                      "PENDING_VALIDATION",
-                      "SUCCESS",
-                      "FAILED"
-                    ]
-                  },
+                  "RenewalStatus": {},
                   "DomainValidationOptions": {
                     "shape": "Sd"
                   }
@@ -171,9 +112,7 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Name": {
-                      "shape": "Sw"
-                    }
+                    "Name": {}
                   }
                 }
               },
@@ -182,23 +121,13 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Name": {
-                      "shape": "Sz"
-                    },
+                    "Name": {},
                     "OID": {}
                   }
                 }
               },
-              "CertificateAuthorityArn": {
-                "shape": "S2"
-              },
-              "RenewalEligibility": {
-                "type": "string",
-                "enum": [
-                  "ELIGIBLE",
-                  "INELIGIBLE"
-                ]
-              },
+              "CertificateAuthorityArn": {},
+              "RenewalEligibility": {},
               "Options": {
                 "shape": "S11"
               }
@@ -215,13 +144,9 @@
           "Passphrase"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
+          "CertificateArn": {},
           "Passphrase": {
             "type": "blob",
-            "max": 128,
-            "min": 4,
             "sensitive": true
           }
         }
@@ -229,17 +154,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "Certificate": {
-            "shape": "S16"
-          },
-          "CertificateChain": {
-            "shape": "S17"
-          },
+          "Certificate": {},
+          "CertificateChain": {},
           "PrivateKey": {
             "type": "string",
-            "max": 524288,
-            "min": 1,
-            "pattern": "-{5}BEGIN PRIVATE KEY-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END PRIVATE KEY-{5}(\\u000D?\\u000A)?",
             "sensitive": true
           }
         }
@@ -252,20 +170,14 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Certificate": {
-            "shape": "S16"
-          },
-          "CertificateChain": {
-            "shape": "S17"
-          }
+          "Certificate": {},
+          "CertificateChain": {}
         }
       }
     },
@@ -277,33 +189,23 @@
           "PrivateKey"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
+          "CertificateArn": {},
           "Certificate": {
-            "type": "blob",
-            "max": 32768,
-            "min": 1
+            "type": "blob"
           },
           "PrivateKey": {
             "type": "blob",
-            "max": 524288,
-            "min": 1,
             "sensitive": true
           },
           "CertificateChain": {
-            "type": "blob",
-            "max": 2097152,
-            "min": 1
+            "type": "blob"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       }
     },
@@ -313,60 +215,42 @@
         "members": {
           "CertificateStatuses": {
             "type": "list",
-            "member": {
-              "shape": "Sm"
-            }
+            "member": {}
           },
           "Includes": {
             "type": "structure",
             "members": {
               "extendedKeyUsage": {
                 "type": "list",
-                "member": {
-                  "shape": "Sz"
-                }
+                "member": {}
               },
               "keyUsage": {
                 "type": "list",
-                "member": {
-                  "shape": "Sw"
-                }
+                "member": {}
               },
               "keyTypes": {
                 "type": "list",
-                "member": {
-                  "shape": "So"
-                }
+                "member": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S1m"
-          },
+          "NextToken": {},
           "MaxItems": {
-            "type": "integer",
-            "max": 1000,
-            "min": 1
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1m"
-          },
+          "NextToken": {},
           "CertificateSummaryList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "CertificateArn": {
-                  "shape": "S2"
-                },
-                "DomainName": {
-                  "shape": "Sb"
-                }
+                "CertificateArn": {},
+                "DomainName": {}
               }
             }
           }
@@ -380,9 +264,7 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       },
       "output": {
@@ -402,9 +284,7 @@
           "Tags"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
+          "CertificateArn": {},
           "Tags": {
             "shape": "S3"
           }
@@ -418,21 +298,12 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "Sb"
-          },
-          "ValidationMethod": {
-            "shape": "Sk"
-          },
+          "DomainName": {},
+          "ValidationMethod": {},
           "SubjectAlternativeNames": {
             "shape": "Sc"
           },
-          "IdempotencyToken": {
-            "type": "string",
-            "max": 32,
-            "min": 1,
-            "pattern": "\\w+"
-          },
+          "IdempotencyToken": {},
           "DomainValidationOptions": {
             "type": "list",
             "member": {
@@ -442,31 +313,21 @@
                 "ValidationDomain"
               ],
               "members": {
-                "DomainName": {
-                  "shape": "Sb"
-                },
-                "ValidationDomain": {
-                  "shape": "Sb"
-                }
+                "DomainName": {},
+                "ValidationDomain": {}
               }
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "Options": {
             "shape": "S11"
           },
-          "CertificateAuthorityArn": {
-            "shape": "S2"
-          }
+          "CertificateAuthorityArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          }
+          "CertificateArn": {}
         }
       }
     },
@@ -479,15 +340,9 @@
           "ValidationDomain"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
-          "Domain": {
-            "shape": "Sb"
-          },
-          "ValidationDomain": {
-            "shape": "Sb"
-          }
+          "CertificateArn": {},
+          "Domain": {},
+          "ValidationDomain": {}
         }
       }
     },
@@ -499,9 +354,7 @@
           "Options"
         ],
         "members": {
-          "CertificateArn": {
-            "shape": "S2"
-          },
+          "CertificateArn": {},
           "Options": {
             "shape": "S11"
           }
@@ -510,12 +363,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 20,
-      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:[\\w+=/,.@-]*:[0-9]+:[\\w+=,.@-]+(/[\\w+=,.@-]+)*"
-    },
     "S3": {
       "type": "list",
       "member": {
@@ -524,36 +371,14 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 50,
-      "min": 1
-    },
-    "Sb": {
-      "type": "string",
-      "max": 253,
-      "min": 1,
-      "pattern": "^(\\*\\.)?(((?!-)[A-Za-z0-9-]{0,62}[A-Za-z0-9])\\.)+((?!-)[A-Za-z0-9-]{1,62}[A-Za-z0-9])$"
+      }
     },
     "Sc": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      },
-      "max": 100,
-      "min": 1
+      "member": {}
     },
     "Sd": {
       "type": "list",
@@ -563,24 +388,13 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "Sb"
-          },
+          "DomainName": {},
           "ValidationEmails": {
             "type": "list",
             "member": {}
           },
-          "ValidationDomain": {
-            "shape": "Sb"
-          },
-          "ValidationStatus": {
-            "type": "string",
-            "enum": [
-              "PENDING_VALIDATION",
-              "SUCCESS",
-              "FAILED"
-            ]
-          },
+          "ValidationDomain": {},
+          "ValidationStatus": {},
           "ResourceRecord": {
             "type": "structure",
             "required": [
@@ -590,115 +404,19 @@
             ],
             "members": {
               "Name": {},
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "CNAME"
-                ]
-              },
+              "Type": {},
               "Value": {}
             }
           },
-          "ValidationMethod": {
-            "shape": "Sk"
-          }
+          "ValidationMethod": {}
         }
-      },
-      "max": 1000,
-      "min": 1
-    },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "EMAIL",
-        "DNS"
-      ]
-    },
-    "Sm": {
-      "type": "string",
-      "enum": [
-        "PENDING_VALIDATION",
-        "ISSUED",
-        "INACTIVE",
-        "EXPIRED",
-        "VALIDATION_TIMED_OUT",
-        "REVOKED",
-        "FAILED"
-      ]
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "RSA_2048",
-        "RSA_1024",
-        "RSA_4096",
-        "EC_prime256v1",
-        "EC_secp384r1",
-        "EC_secp521r1"
-      ]
-    },
-    "Sw": {
-      "type": "string",
-      "enum": [
-        "DIGITAL_SIGNATURE",
-        "NON_REPUDIATION",
-        "KEY_ENCIPHERMENT",
-        "DATA_ENCIPHERMENT",
-        "KEY_AGREEMENT",
-        "CERTIFICATE_SIGNING",
-        "CRL_SIGNING",
-        "ENCIPHER_ONLY",
-        "DECIPHER_ONLY",
-        "ANY",
-        "CUSTOM"
-      ]
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "TLS_WEB_SERVER_AUTHENTICATION",
-        "TLS_WEB_CLIENT_AUTHENTICATION",
-        "CODE_SIGNING",
-        "EMAIL_PROTECTION",
-        "TIME_STAMPING",
-        "OCSP_SIGNING",
-        "IPSEC_END_SYSTEM",
-        "IPSEC_TUNNEL",
-        "IPSEC_USER",
-        "ANY",
-        "NONE",
-        "CUSTOM"
-      ]
+      }
     },
     "S11": {
       "type": "structure",
       "members": {
-        "CertificateTransparencyLoggingPreference": {
-          "type": "string",
-          "enum": [
-            "ENABLED",
-            "DISABLED"
-          ]
-        }
+        "CertificateTransparencyLoggingPreference": {}
       }
-    },
-    "S16": {
-      "type": "string",
-      "max": 32768,
-      "min": 1,
-      "pattern": "-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}(\\u000D?\\u000A)?"
-    },
-    "S17": {
-      "type": "string",
-      "max": 2097152,
-      "min": 1,
-      "pattern": "(-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}\\u000D?\\u000A)*-{5}BEGIN CERTIFICATE-{5}\\u000D?\\u000A([A-Za-z0-9/+]{64}\\u000D?\\u000A)*[A-Za-z0-9/+]{1,64}={0,2}\\u000D?\\u000A-{5}END CERTIFICATE-{5}(\\u000D?\\u000A)?"
-    },
-    "S1m": {
-      "type": "string",
-      "max": 320,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]*"
     }
   }
 }

--- a/apis/acm-pca-2017-08-22.min.json
+++ b/apis/acm-pca-2017-08-22.min.json
@@ -27,20 +27,14 @@
           "RevocationConfiguration": {
             "shape": "Se"
           },
-          "CertificateAuthorityType": {
-            "shape": "Sk"
-          },
-          "IdempotencyToken": {
-            "shape": "Sl"
-          }
+          "CertificateAuthorityType": {},
+          "IdempotencyToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {}
         }
       },
       "idempotent": true
@@ -54,25 +48,15 @@
           "AuditReportResponseFormat"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "S3BucketName": {},
-          "AuditReportResponseFormat": {
-            "type": "string",
-            "enum": [
-              "JSON",
-              "CSV"
-            ]
-          }
+          "AuditReportResponseFormat": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AuditReportId": {
-            "shape": "Ss"
-          },
+          "AuditReportId": {},
           "S3Key": {}
         }
       },
@@ -85,13 +69,9 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "PermanentDeletionTimeInDays": {
-            "type": "integer",
-            "max": 30,
-            "min": 7
+            "type": "integer"
           }
         }
       }
@@ -103,9 +83,7 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {}
         }
       },
       "output": {
@@ -125,25 +103,14 @@
           "AuditReportId"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
-          "AuditReportId": {
-            "shape": "Ss"
-          }
+          "CertificateAuthorityArn": {},
+          "AuditReportId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AuditReportStatus": {
-            "type": "string",
-            "enum": [
-              "CREATING",
-              "SUCCESS",
-              "FAILED"
-            ]
-          },
+          "AuditReportStatus": {},
           "S3BucketName": {},
           "S3Key": {},
           "CreatedAt": {
@@ -160,12 +127,8 @@
           "CertificateArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
-          "CertificateArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {},
+          "CertificateArn": {}
         }
       },
       "output": {
@@ -183,9 +146,7 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {}
         }
       },
       "output": {
@@ -203,9 +164,7 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {}
         }
       },
       "output": {
@@ -224,18 +183,12 @@
           "CertificateChain"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "Certificate": {
-            "type": "blob",
-            "max": 32768,
-            "min": 1
+            "type": "blob"
           },
           "CertificateChain": {
-            "type": "blob",
-            "max": 2097152,
-            "min": 0
+            "type": "blob"
           }
         }
       }
@@ -250,17 +203,11 @@
           "Validity"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "Csr": {
-            "type": "blob",
-            "max": 32768,
-            "min": 1
+            "type": "blob"
           },
-          "SigningAlgorithm": {
-            "shape": "S4"
-          },
+          "SigningAlgorithm": {},
           "Validity": {
             "type": "structure",
             "required": [
@@ -269,32 +216,18 @@
             ],
             "members": {
               "Value": {
-                "type": "long",
-                "min": 1
+                "type": "long"
               },
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "END_DATE",
-                  "ABSOLUTE",
-                  "DAYS",
-                  "MONTHS",
-                  "YEARS"
-                ]
-              }
+              "Type": {}
             }
           },
-          "IdempotencyToken": {
-            "shape": "Sl"
-          }
+          "IdempotencyToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CertificateArn": {
-            "shape": "Sn"
-          }
+          "CertificateArn": {}
         }
       },
       "idempotent": true
@@ -303,11 +236,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1n"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1o"
+            "type": "integer"
           }
         }
       },
@@ -320,9 +251,7 @@
               "shape": "Sx"
             }
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -333,14 +262,10 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
-          "NextToken": {
-            "shape": "S1n"
-          },
+          "CertificateAuthorityArn": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1o"
+            "type": "integer"
           }
         }
       },
@@ -350,9 +275,7 @@
           "Tags": {
             "shape": "S1t"
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -363,9 +286,7 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          }
+          "CertificateAuthorityArn": {}
         }
       }
     },
@@ -378,25 +299,9 @@
           "RevocationReason"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
-          "CertificateSerial": {
-            "shape": "S9"
-          },
-          "RevocationReason": {
-            "type": "string",
-            "enum": [
-              "UNSPECIFIED",
-              "KEY_COMPROMISE",
-              "CERTIFICATE_AUTHORITY_COMPROMISE",
-              "AFFILIATION_CHANGED",
-              "SUPERSEDED",
-              "CESSATION_OF_OPERATION",
-              "PRIVILEGE_WITHDRAWN",
-              "A_A_COMPROMISE"
-            ]
-          }
+          "CertificateAuthorityArn": {},
+          "CertificateSerial": {},
+          "RevocationReason": {}
         }
       }
     },
@@ -408,9 +313,7 @@
           "Tags"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "Tags": {
             "shape": "S1t"
           }
@@ -425,9 +328,7 @@
           "Tags"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "Tags": {
             "shape": "S1t"
           }
@@ -441,15 +342,11 @@
           "CertificateAuthorityArn"
         ],
         "members": {
-          "CertificateAuthorityArn": {
-            "shape": "Sn"
-          },
+          "CertificateAuthorityArn": {},
           "RevocationConfiguration": {
             "shape": "Se"
           },
-          "Status": {
-            "shape": "Sz"
-          }
+          "Status": {}
         }
       }
     }
@@ -463,99 +360,28 @@
         "Subject"
       ],
       "members": {
-        "KeyAlgorithm": {
-          "type": "string",
-          "enum": [
-            "RSA_2048",
-            "RSA_4096",
-            "EC_prime256v1",
-            "EC_secp384r1"
-          ]
-        },
-        "SigningAlgorithm": {
-          "shape": "S4"
-        },
+        "KeyAlgorithm": {},
+        "SigningAlgorithm": {},
         "Subject": {
           "type": "structure",
           "members": {
-            "Country": {
-              "type": "string",
-              "pattern": "[A-Za-z]{2}"
-            },
-            "Organization": {
-              "shape": "S7"
-            },
-            "OrganizationalUnit": {
-              "shape": "S7"
-            },
-            "DistinguishedNameQualifier": {
-              "type": "string",
-              "max": 64,
-              "min": 0,
-              "pattern": "[a-zA-Z0-9'()+-.?:/= ]*"
-            },
-            "State": {
-              "shape": "S9"
-            },
-            "CommonName": {
-              "shape": "S7"
-            },
-            "SerialNumber": {
-              "shape": "S7"
-            },
-            "Locality": {
-              "shape": "S9"
-            },
-            "Title": {
-              "shape": "S7"
-            },
-            "Surname": {
-              "type": "string",
-              "max": 40,
-              "min": 0
-            },
-            "GivenName": {
-              "type": "string",
-              "max": 16,
-              "min": 0
-            },
-            "Initials": {
-              "type": "string",
-              "max": 5,
-              "min": 0
-            },
-            "Pseudonym": {
-              "shape": "S9"
-            },
-            "GenerationQualifier": {
-              "type": "string",
-              "max": 3,
-              "min": 0
-            }
+            "Country": {},
+            "Organization": {},
+            "OrganizationalUnit": {},
+            "DistinguishedNameQualifier": {},
+            "State": {},
+            "CommonName": {},
+            "SerialNumber": {},
+            "Locality": {},
+            "Title": {},
+            "Surname": {},
+            "GivenName": {},
+            "Initials": {},
+            "Pseudonym": {},
+            "GenerationQualifier": {}
           }
         }
       }
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "SHA256WITHECDSA",
-        "SHA384WITHECDSA",
-        "SHA512WITHECDSA",
-        "SHA256WITHRSA",
-        "SHA384WITHRSA",
-        "SHA512WITHRSA"
-      ]
-    },
-    "S7": {
-      "type": "string",
-      "max": 64,
-      "min": 0
-    },
-    "S9": {
-      "type": "string",
-      "max": 128,
-      "min": 0
     },
     "Se": {
       "type": "structure",
@@ -570,81 +396,34 @@
               "type": "boolean"
             },
             "ExpirationInDays": {
-              "type": "integer",
-              "max": 5000,
-              "min": 1
+              "type": "integer"
             },
-            "CustomCname": {
-              "type": "string",
-              "max": 253,
-              "min": 0
-            },
-            "S3BucketName": {
-              "type": "string",
-              "max": 255,
-              "min": 3
-            }
+            "CustomCname": {},
+            "S3BucketName": {}
           }
         }
       }
     },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "SUBORDINATE"
-      ]
-    },
-    "Sl": {
-      "type": "string",
-      "max": 36,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]*"
-    },
-    "Sn": {
-      "type": "string",
-      "max": 200,
-      "min": 5,
-      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:[\\w+=/,.@-]*:[0-9]+:[\\w+=,.@-]+(/[\\w+=/,.@-]+)*"
-    },
-    "Ss": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"
-    },
     "Sx": {
       "type": "structure",
       "members": {
-        "Arn": {
-          "shape": "Sn"
-        },
+        "Arn": {},
         "CreatedAt": {
           "type": "timestamp"
         },
         "LastStateChangeAt": {
           "type": "timestamp"
         },
-        "Type": {
-          "shape": "Sk"
-        },
+        "Type": {},
         "Serial": {},
-        "Status": {
-          "shape": "Sz"
-        },
+        "Status": {},
         "NotBefore": {
           "type": "timestamp"
         },
         "NotAfter": {
           "type": "timestamp"
         },
-        "FailureReason": {
-          "type": "string",
-          "enum": [
-            "REQUEST_TIMED_OUT",
-            "UNSUPPORTED_ALGORITHM",
-            "OTHER"
-          ]
-        },
+        "FailureReason": {},
         "CertificateAuthorityConfiguration": {
           "shape": "S2"
         },
@@ -656,28 +435,6 @@
         }
       }
     },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "PENDING_CERTIFICATE",
-        "ACTIVE",
-        "DELETED",
-        "DISABLED",
-        "EXPIRED",
-        "FAILED"
-      ]
-    },
-    "S1n": {
-      "type": "string",
-      "max": 500,
-      "min": 1
-    },
-    "S1o": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
     "S1t": {
       "type": "list",
       "member": {
@@ -686,22 +443,10 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "[\\p{L}\\p{Z}\\p{N}_.:\\/=+\\-@]*"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 50,
-      "min": 1
+      }
     }
   }
 }

--- a/apis/alexaforbusiness-2017-11-09.min.json
+++ b/apis/alexaforbusiness-2017-11-09.min.json
@@ -20,12 +20,8 @@
           "AddressBookArn"
         ],
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          },
-          "AddressBookArn": {
-            "shape": "S2"
-          }
+          "ContactArn": {},
+          "AddressBookArn": {}
         }
       },
       "output": {
@@ -37,12 +33,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {
-            "shape": "S2"
-          },
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "DeviceArn": {},
+          "RoomArn": {}
         }
       },
       "output": {
@@ -54,12 +46,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          },
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "SkillGroupArn": {},
+          "RoomArn": {}
         }
       },
       "output": {
@@ -74,14 +62,9 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S9"
-          },
-          "Description": {
-            "shape": "Sa"
-          },
+          "Name": {},
+          "Description": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -89,9 +72,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "AddressBookArn": {
-            "shape": "S2"
-          }
+          "AddressBookArn": {}
         }
       }
     },
@@ -103,20 +84,11 @@
           "PhoneNumber"
         ],
         "members": {
-          "DisplayName": {
-            "shape": "Se"
-          },
-          "FirstName": {
-            "shape": "Se"
-          },
-          "LastName": {
-            "shape": "Se"
-          },
-          "PhoneNumber": {
-            "shape": "Sf"
-          },
+          "DisplayName": {},
+          "FirstName": {},
+          "LastName": {},
+          "PhoneNumber": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -124,9 +96,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          }
+          "ContactArn": {}
         }
       }
     },
@@ -142,26 +112,13 @@
           "WakeWord"
         ],
         "members": {
-          "ProfileName": {
-            "shape": "Si"
-          },
-          "Timezone": {
-            "shape": "Sj"
-          },
-          "Address": {
-            "shape": "Sk"
-          },
-          "DistanceUnit": {
-            "shape": "Sl"
-          },
-          "TemperatureUnit": {
-            "shape": "Sm"
-          },
-          "WakeWord": {
-            "shape": "Sn"
-          },
+          "ProfileName": {},
+          "Timezone": {},
+          "Address": {},
+          "DistanceUnit": {},
+          "TemperatureUnit": {},
+          "WakeWord": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           },
           "SetupModeDisabled": {
@@ -178,9 +135,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ProfileArn": {
-            "shape": "S2"
-          }
+          "ProfileArn": {}
         }
       }
     },
@@ -191,20 +146,11 @@
           "RoomName"
         ],
         "members": {
-          "RoomName": {
-            "shape": "Ss"
-          },
-          "Description": {
-            "shape": "St"
-          },
-          "ProfileArn": {
-            "shape": "S2"
-          },
-          "ProviderCalendarId": {
-            "shape": "Su"
-          },
+          "RoomName": {},
+          "Description": {},
+          "ProfileArn": {},
+          "ProviderCalendarId": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           },
           "Tags": {
@@ -215,9 +161,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "RoomArn": {}
         }
       }
     },
@@ -228,14 +172,9 @@
           "SkillGroupName"
         ],
         "members": {
-          "SkillGroupName": {
-            "shape": "S11"
-          },
-          "Description": {
-            "shape": "S12"
-          },
+          "SkillGroupName": {},
+          "Description": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           }
         }
@@ -243,9 +182,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          }
+          "SkillGroupArn": {}
         }
       }
     },
@@ -256,23 +193,11 @@
           "UserId"
         ],
         "members": {
-          "UserId": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[a-zA-Z0-9@_+.-]*"
-          },
-          "FirstName": {
-            "shape": "S16"
-          },
-          "LastName": {
-            "shape": "S17"
-          },
-          "Email": {
-            "shape": "S18"
-          },
+          "UserId": {},
+          "FirstName": {},
+          "LastName": {},
+          "Email": {},
           "ClientRequestToken": {
-            "shape": "Sb",
             "idempotencyToken": true
           },
           "Tags": {
@@ -283,9 +208,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "UserArn": {
-            "shape": "S2"
-          }
+          "UserArn": {}
         }
       }
     },
@@ -296,9 +219,7 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {
-            "shape": "S2"
-          }
+          "AddressBookArn": {}
         }
       },
       "output": {
@@ -313,9 +234,7 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          }
+          "ContactArn": {}
         }
       },
       "output": {
@@ -327,9 +246,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {
-            "shape": "S2"
-          }
+          "ProfileArn": {}
         }
       },
       "output": {
@@ -341,9 +258,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "RoomArn": {}
         }
       },
       "output": {
@@ -359,15 +274,9 @@
           "ParameterKey"
         ],
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "SkillId": {
-            "shape": "S1j"
-          },
-          "ParameterKey": {
-            "shape": "S1k"
-          }
+          "RoomArn": {},
+          "SkillId": {},
+          "ParameterKey": {}
         }
       },
       "output": {
@@ -379,9 +288,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          }
+          "SkillGroupArn": {}
         }
       },
       "output": {
@@ -396,12 +303,8 @@
           "EnrollmentId"
         ],
         "members": {
-          "UserArn": {
-            "shape": "S2"
-          },
-          "EnrollmentId": {
-            "shape": "S1p"
-          }
+          "UserArn": {},
+          "EnrollmentId": {}
         }
       },
       "output": {
@@ -417,12 +320,8 @@
           "AddressBookArn"
         ],
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          },
-          "AddressBookArn": {
-            "shape": "S2"
-          }
+          "ContactArn": {},
+          "AddressBookArn": {}
         }
       },
       "output": {
@@ -434,9 +333,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {
-            "shape": "S2"
-          }
+          "DeviceArn": {}
         }
       },
       "output": {
@@ -448,12 +345,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          },
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "SkillGroupArn": {},
+          "RoomArn": {}
         }
       },
       "output": {
@@ -468,9 +361,7 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {
-            "shape": "S2"
-          }
+          "AddressBookArn": {}
         }
       },
       "output": {
@@ -479,15 +370,9 @@
           "AddressBook": {
             "type": "structure",
             "members": {
-              "AddressBookArn": {
-                "shape": "S2"
-              },
-              "Name": {
-                "shape": "S9"
-              },
-              "Description": {
-                "shape": "Sa"
-              }
+              "AddressBookArn": {},
+              "Name": {},
+              "Description": {}
             }
           }
         }
@@ -500,9 +385,7 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          }
+          "ContactArn": {}
         }
       },
       "output": {
@@ -511,21 +394,11 @@
           "Contact": {
             "type": "structure",
             "members": {
-              "ContactArn": {
-                "shape": "S2"
-              },
-              "DisplayName": {
-                "shape": "Se"
-              },
-              "FirstName": {
-                "shape": "Se"
-              },
-              "LastName": {
-                "shape": "Se"
-              },
-              "PhoneNumber": {
-                "shape": "Sf"
-              }
+              "ContactArn": {},
+              "DisplayName": {},
+              "FirstName": {},
+              "LastName": {},
+              "PhoneNumber": {}
             }
           }
         }
@@ -535,9 +408,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {
-            "shape": "S2"
-          }
+          "DeviceArn": {}
         }
       },
       "output": {
@@ -546,26 +417,14 @@
           "Device": {
             "type": "structure",
             "members": {
-              "DeviceArn": {
-                "shape": "S2"
-              },
-              "DeviceSerialNumber": {
-                "shape": "S26"
-              },
-              "DeviceType": {
-                "shape": "S27"
-              },
-              "DeviceName": {
-                "shape": "S28"
-              },
+              "DeviceArn": {},
+              "DeviceSerialNumber": {},
+              "DeviceType": {},
+              "DeviceName": {},
               "SoftwareVersion": {},
               "MacAddress": {},
-              "RoomArn": {
-                "shape": "S2"
-              },
-              "DeviceStatus": {
-                "shape": "S2b"
-              },
+              "RoomArn": {},
+              "DeviceStatus": {},
               "DeviceStatusInfo": {
                 "shape": "S2c"
               }
@@ -578,9 +437,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {
-            "shape": "S2"
-          }
+          "ProfileArn": {}
         }
       },
       "output": {
@@ -589,27 +446,13 @@
           "Profile": {
             "type": "structure",
             "members": {
-              "ProfileArn": {
-                "shape": "S2"
-              },
-              "ProfileName": {
-                "shape": "Si"
-              },
-              "Address": {
-                "shape": "Sk"
-              },
-              "Timezone": {
-                "shape": "Sj"
-              },
-              "DistanceUnit": {
-                "shape": "Sl"
-              },
-              "TemperatureUnit": {
-                "shape": "Sm"
-              },
-              "WakeWord": {
-                "shape": "Sn"
-              },
+              "ProfileArn": {},
+              "ProfileName": {},
+              "Address": {},
+              "Timezone": {},
+              "DistanceUnit": {},
+              "TemperatureUnit": {},
+              "WakeWord": {},
               "SetupModeDisabled": {
                 "type": "boolean"
               },
@@ -628,9 +471,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          }
+          "RoomArn": {}
         }
       },
       "output": {
@@ -639,21 +480,11 @@
           "Room": {
             "type": "structure",
             "members": {
-              "RoomArn": {
-                "shape": "S2"
-              },
-              "RoomName": {
-                "shape": "Ss"
-              },
-              "Description": {
-                "shape": "St"
-              },
-              "ProviderCalendarId": {
-                "shape": "Su"
-              },
-              "ProfileArn": {
-                "shape": "S2"
-              }
+              "RoomArn": {},
+              "RoomName": {},
+              "Description": {},
+              "ProviderCalendarId": {},
+              "ProfileArn": {}
             }
           }
         }
@@ -667,15 +498,9 @@
           "ParameterKey"
         ],
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "SkillId": {
-            "shape": "S1j"
-          },
-          "ParameterKey": {
-            "shape": "S1k"
-          }
+          "RoomArn": {},
+          "SkillId": {},
+          "ParameterKey": {}
         }
       },
       "output": {
@@ -691,9 +516,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          }
+          "SkillGroupArn": {}
         }
       },
       "output": {
@@ -702,15 +525,9 @@
           "SkillGroup": {
             "type": "structure",
             "members": {
-              "SkillGroupArn": {
-                "shape": "S2"
-              },
-              "SkillGroupName": {
-                "shape": "S11"
-              },
-              "Description": {
-                "shape": "S12"
-              }
+              "SkillGroupArn": {},
+              "SkillGroupName": {},
+              "Description": {}
             }
           }
         }
@@ -723,17 +540,11 @@
           "DeviceArn"
         ],
         "members": {
-          "DeviceArn": {
-            "shape": "S2"
-          },
-          "EventType": {
-            "shape": "S2v"
-          },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "DeviceArn": {},
+          "EventType": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           }
         }
       },
@@ -745,9 +556,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {
-                  "shape": "S2v"
-                },
+                "Type": {},
                 "Value": {},
                 "Timestamp": {
                   "type": "timestamp"
@@ -755,9 +564,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -765,16 +572,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "SkillGroupArn": {},
+          "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -786,24 +587,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "SkillId": {
-                  "shape": "S1j"
-                },
-                "SkillName": {
-                  "type": "string",
-                  "max": 100,
-                  "min": 1,
-                  "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-                },
+                "SkillId": {},
+                "SkillName": {},
                 "SupportsLinking": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -814,14 +606,10 @@
           "Arn"
         ],
         "members": {
-          "Arn": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "Arn": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           }
         }
       },
@@ -831,9 +619,7 @@
           "Tags": {
             "shape": "Sv"
           },
-          "NextToken": {
-            "shape": "S2w"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -845,12 +631,8 @@
           "RoomSkillParameter"
         ],
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "SkillId": {
-            "shape": "S1j"
-          },
+          "RoomArn": {},
+          "SkillId": {},
           "RoomSkillParameter": {
             "shape": "S2p"
           }
@@ -869,24 +651,15 @@
           "SkillId"
         ],
         "members": {
-          "UserId": {
-            "type": "string",
-            "pattern": "amzn1\\.[A-Za-z0-9+-\\/=.]{1,300}"
-          },
-          "SkillId": {
-            "shape": "S1j"
-          }
+          "UserId": {},
+          "SkillId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "RoomName": {
-            "shape": "Ss"
-          },
+          "RoomArn": {},
+          "RoomName": {},
           "RoomSkillParameters": {
             "type": "list",
             "member": {
@@ -900,12 +673,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserArn": {
-            "shape": "S2"
-          },
-          "EnrollmentId": {
-            "shape": "S1p"
-          }
+          "UserArn": {},
+          "EnrollmentId": {}
         }
       },
       "output": {
@@ -923,11 +692,9 @@
           "SortCriteria": {
             "shape": "S3q"
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           }
         }
       },
@@ -939,21 +706,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "AddressBookArn": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S9"
-                },
-                "Description": {
-                  "shape": "Sa"
-                }
+                "AddressBookArn": {},
+                "Name": {},
+                "Description": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -970,11 +729,9 @@
           "SortCriteria": {
             "shape": "S3q"
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           }
         }
       },
@@ -986,27 +743,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "ContactArn": {
-                  "shape": "S2"
-                },
-                "DisplayName": {
-                  "shape": "Se"
-                },
-                "FirstName": {
-                  "shape": "Se"
-                },
-                "LastName": {
-                  "shape": "Se"
-                },
-                "PhoneNumber": {
-                  "shape": "Sf"
-                }
+                "ContactArn": {},
+                "DisplayName": {},
+                "FirstName": {},
+                "LastName": {},
+                "PhoneNumber": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1017,11 +762,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S3l"
@@ -1039,38 +782,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "DeviceArn": {
-                  "shape": "S2"
-                },
-                "DeviceSerialNumber": {
-                  "shape": "S26"
-                },
-                "DeviceType": {
-                  "shape": "S27"
-                },
-                "DeviceName": {
-                  "shape": "S28"
-                },
+                "DeviceArn": {},
+                "DeviceSerialNumber": {},
+                "DeviceType": {},
+                "DeviceName": {},
                 "SoftwareVersion": {},
                 "MacAddress": {},
-                "DeviceStatus": {
-                  "shape": "S2b"
-                },
-                "RoomArn": {
-                  "shape": "S2"
-                },
-                "RoomName": {
-                  "shape": "Ss"
-                },
+                "DeviceStatus": {},
+                "RoomArn": {},
+                "RoomName": {},
                 "DeviceStatusInfo": {
                   "shape": "S2c"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1081,11 +808,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S3l"
@@ -1103,33 +828,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProfileArn": {
-                  "shape": "S2"
-                },
-                "ProfileName": {
-                  "shape": "Si"
-                },
-                "Address": {
-                  "shape": "Sk"
-                },
-                "Timezone": {
-                  "shape": "Sj"
-                },
-                "DistanceUnit": {
-                  "shape": "Sl"
-                },
-                "TemperatureUnit": {
-                  "shape": "Sm"
-                },
-                "WakeWord": {
-                  "shape": "Sn"
-                }
+                "ProfileArn": {},
+                "ProfileName": {},
+                "Address": {},
+                "Timezone": {},
+                "DistanceUnit": {},
+                "TemperatureUnit": {},
+                "WakeWord": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1140,11 +849,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S3l"
@@ -1162,30 +869,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "RoomArn": {
-                  "shape": "S2"
-                },
-                "RoomName": {
-                  "shape": "Ss"
-                },
-                "Description": {
-                  "shape": "St"
-                },
-                "ProviderCalendarId": {
-                  "shape": "Su"
-                },
-                "ProfileArn": {
-                  "shape": "S2"
-                },
-                "ProfileName": {
-                  "shape": "Si"
-                }
+                "RoomArn": {},
+                "RoomName": {},
+                "Description": {},
+                "ProviderCalendarId": {},
+                "ProfileArn": {},
+                "ProfileName": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1196,11 +889,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S3l"
@@ -1218,21 +909,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "SkillGroupArn": {
-                  "shape": "S2"
-                },
-                "SkillGroupName": {
-                  "shape": "S11"
-                },
-                "Description": {
-                  "shape": "S12"
-                }
+                "SkillGroupArn": {},
+                "SkillGroupName": {},
+                "Description": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1243,11 +926,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2x"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S3l"
@@ -1265,37 +946,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserArn": {
-                  "shape": "S2"
-                },
-                "FirstName": {
-                  "shape": "S16"
-                },
-                "LastName": {
-                  "shape": "S17"
-                },
-                "Email": {
-                  "shape": "S18"
-                },
-                "EnrollmentStatus": {
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZED",
-                    "PENDING",
-                    "REGISTERED",
-                    "DISASSOCIATING",
-                    "DEREGISTERING"
-                  ]
-                },
-                "EnrollmentId": {
-                  "shape": "S1p"
-                }
+                "UserArn": {},
+                "FirstName": {},
+                "LastName": {},
+                "Email": {},
+                "EnrollmentStatus": {},
+                "EnrollmentId": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S2w"
-          },
+          "NextToken": {},
           "TotalCount": {
             "type": "integer"
           }
@@ -1306,9 +966,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserArn": {
-            "shape": "S2"
-          }
+          "UserArn": {}
         }
       },
       "output": {
@@ -1323,25 +981,11 @@
           "Features"
         ],
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "DeviceArn": {
-            "shape": "S2"
-          },
+          "RoomArn": {},
+          "DeviceArn": {},
           "Features": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "BLUETOOTH",
-                "VOLUME",
-                "NOTIFICATIONS",
-                "LISTS",
-                "SKILLS",
-                "ALL"
-              ]
-            }
+            "member": {}
           }
         }
       },
@@ -1358,9 +1002,7 @@
           "Tags"
         ],
         "members": {
-          "Arn": {
-            "shape": "S2"
-          },
+          "Arn": {},
           "Tags": {
             "shape": "Sv"
           }
@@ -1379,14 +1021,10 @@
           "TagKeys"
         ],
         "members": {
-          "Arn": {
-            "shape": "S2"
-          },
+          "Arn": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sx"
-            }
+            "member": {}
           }
         }
       },
@@ -1402,15 +1040,9 @@
           "AddressBookArn"
         ],
         "members": {
-          "AddressBookArn": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S9"
-          },
-          "Description": {
-            "shape": "Sa"
-          }
+          "AddressBookArn": {},
+          "Name": {},
+          "Description": {}
         }
       },
       "output": {
@@ -1425,21 +1057,11 @@
           "ContactArn"
         ],
         "members": {
-          "ContactArn": {
-            "shape": "S2"
-          },
-          "DisplayName": {
-            "shape": "Se"
-          },
-          "FirstName": {
-            "shape": "Se"
-          },
-          "LastName": {
-            "shape": "Se"
-          },
-          "PhoneNumber": {
-            "shape": "Sf"
-          }
+          "ContactArn": {},
+          "DisplayName": {},
+          "FirstName": {},
+          "LastName": {},
+          "PhoneNumber": {}
         }
       },
       "output": {
@@ -1451,12 +1073,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "DeviceArn": {
-            "shape": "S2"
-          },
-          "DeviceName": {
-            "shape": "S28"
-          }
+          "DeviceArn": {},
+          "DeviceName": {}
         }
       },
       "output": {
@@ -1468,27 +1086,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "ProfileArn": {
-            "shape": "S2"
-          },
-          "ProfileName": {
-            "shape": "Si"
-          },
-          "Timezone": {
-            "shape": "Sj"
-          },
-          "Address": {
-            "shape": "Sk"
-          },
-          "DistanceUnit": {
-            "shape": "Sl"
-          },
-          "TemperatureUnit": {
-            "shape": "Sm"
-          },
-          "WakeWord": {
-            "shape": "Sn"
-          },
+          "ProfileArn": {},
+          "ProfileName": {},
+          "Timezone": {},
+          "Address": {},
+          "DistanceUnit": {},
+          "TemperatureUnit": {},
+          "WakeWord": {},
           "SetupModeDisabled": {
             "type": "boolean"
           },
@@ -1509,21 +1113,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoomArn": {
-            "shape": "S2"
-          },
-          "RoomName": {
-            "shape": "Ss"
-          },
-          "Description": {
-            "shape": "St"
-          },
-          "ProviderCalendarId": {
-            "shape": "Su"
-          },
-          "ProfileArn": {
-            "shape": "S2"
-          }
+          "RoomArn": {},
+          "RoomName": {},
+          "Description": {},
+          "ProviderCalendarId": {},
+          "ProfileArn": {}
         }
       },
       "output": {
@@ -1535,15 +1129,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "SkillGroupArn": {
-            "shape": "S2"
-          },
-          "SkillGroupName": {
-            "shape": "S11"
-          },
-          "Description": {
-            "shape": "S12"
-          }
+          "SkillGroupArn": {},
+          "SkillGroupName": {},
+          "Description": {}
         }
       },
       "output": {
@@ -1553,183 +1141,15 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
-    },
-    "S9": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "Sb": {
-      "type": "string",
-      "max": 150,
-      "min": 10,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
-    },
-    "Se": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "Sf": {
-      "type": "string",
-      "pattern": "^\\+\\d{8,}$"
-    },
-    "Si": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "Sj": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "Sk": {
-      "type": "string",
-      "max": 500,
-      "min": 1
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "METRIC",
-        "IMPERIAL"
-      ]
-    },
-    "Sm": {
-      "type": "string",
-      "enum": [
-        "FAHRENHEIT",
-        "CELSIUS"
-      ]
-    },
-    "Sn": {
-      "type": "string",
-      "enum": [
-        "ALEXA",
-        "AMAZON",
-        "ECHO",
-        "COMPUTER"
-      ]
-    },
-    "Ss": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "St": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "Su": {
-      "type": "string",
-      "max": 100,
-      "min": 0
-    },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "Sx"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "Sx": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "S11": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "S12": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "S16": {
-      "type": "string",
-      "max": 30,
-      "min": 0,
-      "pattern": "([A-Za-z\\-' 0-9._]|\\p{IsLetter})*"
-    },
-    "S17": {
-      "type": "string",
-      "max": 30,
-      "min": 0,
-      "pattern": "([A-Za-z\\-' 0-9._]|\\p{IsLetter})*"
-    },
-    "S18": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "([0-9a-zA-Z]([+-.\\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\\w]*[0-9a-zA-Z]\\.)+[a-zA-Z]{2,9})"
-    },
-    "S1j": {
-      "type": "string",
-      "pattern": "(^amzn1\\.ask\\.skill\\.[0-9a-f\\-]{1,200})|(^amzn1\\.echo-sdk-ams\\.app\\.[0-9a-f\\-]{1,200})"
-    },
-    "S1k": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S1p": {
-      "type": "string",
-      "max": 128,
-      "min": 0
-    },
-    "S26": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9]{1,200}"
-    },
-    "S27": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9]{1,200}"
-    },
-    "S28": {
-      "type": "string",
-      "max": 100,
-      "min": 2,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]*"
-    },
-    "S2b": {
-      "type": "string",
-      "enum": [
-        "READY",
-        "PENDING",
-        "WAS_OFFLINE",
-        "DEREGISTERED"
-      ]
     },
     "S2c": {
       "type": "structure",
@@ -1739,23 +1159,11 @@
           "member": {
             "type": "structure",
             "members": {
-              "Code": {
-                "type": "string",
-                "enum": [
-                  "DEVICE_SOFTWARE_UPDATE_NEEDED",
-                  "DEVICE_WAS_OFFLINE"
-                ]
-              }
+              "Code": {}
             }
           }
         },
-        "ConnectionStatus": {
-          "type": "string",
-          "enum": [
-            "ONLINE",
-            "OFFLINE"
-          ]
-        }
+        "ConnectionStatus": {}
       }
     },
     "S2p": {
@@ -1765,32 +1173,9 @@
         "ParameterValue"
       ],
       "members": {
-        "ParameterKey": {
-          "shape": "S1k"
-        },
-        "ParameterValue": {
-          "type": "string",
-          "max": 512,
-          "min": 1
-        }
+        "ParameterKey": {},
+        "ParameterValue": {}
       }
-    },
-    "S2v": {
-      "type": "string",
-      "enum": [
-        "CONNECTION_STATUS",
-        "DEVICE_STATUS"
-      ]
-    },
-    "S2w": {
-      "type": "string",
-      "max": 1000,
-      "min": 1
-    },
-    "S2x": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
     },
     "S3l": {
       "type": "list",
@@ -1801,23 +1186,13 @@
           "Values"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 500,
-            "min": 1
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 500,
-              "min": 1
-            },
-            "max": 5
+            "member": {}
           }
         }
-      },
-      "max": 25
+      }
     },
     "S3q": {
       "type": "list",
@@ -1828,21 +1203,10 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 500,
-            "min": 1
-          },
-          "Value": {
-            "type": "string",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 25
+      }
     }
   }
 }

--- a/apis/apigateway-2015-07-09.min.json
+++ b/apis/apigateway-2015-07-09.min.json
@@ -62,9 +62,7 @@
             "locationName": "restapi_id"
           },
           "name": {},
-          "type": {
-            "shape": "Sa"
-          },
+          "type": {},
           "providerARNs": {
             "shape": "Sb"
           },
@@ -128,9 +126,7 @@
           "cacheClusterEnabled": {
             "type": "boolean"
           },
-          "cacheClusterSize": {
-            "shape": "Sj"
-          },
+          "cacheClusterSize": {},
           "variables": {
             "shape": "Sk"
           },
@@ -341,9 +337,7 @@
           "minimumCompressionSize": {
             "type": "integer"
           },
-          "apiKeySource": {
-            "shape": "S1n"
-          },
+          "apiKeySource": {},
           "endpointConfiguration": {
             "shape": "Sz"
           },
@@ -377,9 +371,7 @@
           "cacheClusterEnabled": {
             "type": "boolean"
           },
-          "cacheClusterSize": {
-            "shape": "Sj"
-          },
+          "cacheClusterSize": {},
           "variables": {
             "shape": "Sk"
           },
@@ -670,7 +662,6 @@
             "locationName": "restapi_id"
           },
           "responseType": {
-            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           }
@@ -734,7 +725,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -798,7 +788,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -1432,7 +1421,6 @@
             "locationName": "restapi_id"
           },
           "type": {
-            "shape": "St",
             "location": "querystring",
             "locationName": "type"
           },
@@ -1455,12 +1443,7 @@
           },
           "locationStatus": {
             "location": "querystring",
-            "locationName": "locationStatus",
-            "type": "string",
-            "enum": [
-              "DOCUMENTED",
-              "UNDOCUMENTED"
-            ]
+            "locationName": "locationStatus"
           }
         }
       },
@@ -1669,7 +1652,6 @@
             "locationName": "restapi_id"
           },
           "responseType": {
-            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           }
@@ -1777,7 +1759,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -1845,7 +1826,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           }
@@ -2593,11 +2573,7 @@
           },
           "format": {
             "location": "querystring",
-            "locationName": "format",
-            "type": "string",
-            "enum": [
-              "csv"
-            ]
+            "locationName": "format"
           },
           "failOnWarnings": {
             "location": "querystring",
@@ -2636,7 +2612,6 @@
             "locationName": "restapi_id"
           },
           "mode": {
-            "shape": "S5u",
             "location": "querystring",
             "locationName": "mode"
           },
@@ -2711,13 +2686,10 @@
             "locationName": "restapi_id"
           },
           "responseType": {
-            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           },
-          "statusCode": {
-            "shape": "S1e"
-          },
+          "statusCode": {},
           "responseParameters": {
             "shape": "Sk"
           },
@@ -2757,16 +2729,12 @@
             "location": "uri",
             "locationName": "http_method"
           },
-          "type": {
-            "shape": "S1g"
-          },
+          "type": {},
           "integrationHttpMethod": {
             "locationName": "httpMethod"
           },
           "uri": {},
-          "connectionType": {
-            "shape": "S1h"
-          },
+          "connectionType": {},
           "connectionId": {},
           "credentials": {},
           "requestParameters": {
@@ -2780,9 +2748,7 @@
           "cacheKeyParameters": {
             "shape": "S8"
           },
-          "contentHandling": {
-            "shape": "S1i"
-          },
+          "contentHandling": {},
           "timeoutInMillis": {
             "type": "integer"
           }
@@ -2820,7 +2786,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -2831,9 +2796,7 @@
           "responseTemplates": {
             "shape": "Sk"
           },
-          "contentHandling": {
-            "shape": "S1i"
-          }
+          "contentHandling": {}
         }
       },
       "output": {
@@ -2917,7 +2880,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -2950,7 +2912,6 @@
             "locationName": "restapi_id"
           },
           "mode": {
-            "shape": "S5u",
             "location": "querystring",
             "locationName": "mode"
           },
@@ -3381,7 +3342,6 @@
             "locationName": "restapi_id"
           },
           "responseType": {
-            "shape": "S2j",
             "location": "uri",
             "locationName": "response_type"
           },
@@ -3455,7 +3415,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -3530,7 +3489,6 @@
             "locationName": "http_method"
           },
           "statusCode": {
-            "shape": "S1e",
             "location": "uri",
             "locationName": "status_code"
           },
@@ -3788,14 +3746,6 @@
       "type": "list",
       "member": {}
     },
-    "Sa": {
-      "type": "string",
-      "enum": [
-        "TOKEN",
-        "REQUEST",
-        "COGNITO_USER_POOLS"
-      ]
-    },
     "Sb": {
       "type": "list",
       "member": {}
@@ -3805,9 +3755,7 @@
       "members": {
         "id": {},
         "name": {},
-        "type": {
-          "shape": "Sa"
-        },
+        "type": {},
         "providerARNs": {
           "shape": "Sb"
         },
@@ -3828,19 +3776,6 @@
         "restApiId": {},
         "stage": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "enum": [
-        "0.5",
-        "1.6",
-        "6.1",
-        "13.5",
-        "28.4",
-        "58.2",
-        "118",
-        "237"
-      ]
     },
     "Sk": {
       "type": "map",
@@ -3880,34 +3815,12 @@
         "type"
       ],
       "members": {
-        "type": {
-          "shape": "St"
-        },
+        "type": {},
         "path": {},
         "method": {},
-        "statusCode": {
-          "type": "string",
-          "pattern": "^([1-5]\\d\\d|\\*|\\s*)$"
-        },
+        "statusCode": {},
         "name": {}
       }
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "API",
-        "AUTHORIZER",
-        "MODEL",
-        "RESOURCE",
-        "METHOD",
-        "PATH_PARAMETER",
-        "QUERY_PARAMETER",
-        "REQUEST_HEADER",
-        "REQUEST_BODY",
-        "RESPONSE",
-        "RESPONSE_HEADER",
-        "RESPONSE_BODY"
-      ]
     },
     "Sv": {
       "type": "structure",
@@ -3934,14 +3847,7 @@
       "members": {
         "types": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "REGIONAL",
-              "EDGE",
-              "PRIVATE"
-            ]
-          }
+          "member": {}
         }
       }
     },
@@ -4046,9 +3952,7 @@
     "S1d": {
       "type": "structure",
       "members": {
-        "statusCode": {
-          "shape": "S1e"
-        },
+        "statusCode": {},
         "responseParameters": {
           "shape": "S1b"
         },
@@ -4057,21 +3961,13 @@
         }
       }
     },
-    "S1e": {
-      "type": "string",
-      "pattern": "[1-5]\\d\\d"
-    },
     "S1f": {
       "type": "structure",
       "members": {
-        "type": {
-          "shape": "S1g"
-        },
+        "type": {},
         "httpMethod": {},
         "uri": {},
-        "connectionType": {
-          "shape": "S1h"
-        },
+        "connectionType": {},
         "connectionId": {},
         "credentials": {},
         "requestParameters": {
@@ -4081,9 +3977,7 @@
           "shape": "Sk"
         },
         "passthroughBehavior": {},
-        "contentHandling": {
-          "shape": "S1i"
-        },
+        "contentHandling": {},
         "timeoutInMillis": {
           "type": "integer"
         },
@@ -4100,36 +3994,10 @@
         }
       }
     },
-    "S1g": {
-      "type": "string",
-      "enum": [
-        "HTTP",
-        "AWS",
-        "MOCK",
-        "HTTP_PROXY",
-        "AWS_PROXY"
-      ]
-    },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "INTERNET",
-        "VPC_LINK"
-      ]
-    },
-    "S1i": {
-      "type": "string",
-      "enum": [
-        "CONVERT_TO_BINARY",
-        "CONVERT_TO_TEXT"
-      ]
-    },
     "S1l": {
       "type": "structure",
       "members": {
-        "statusCode": {
-          "shape": "S1e"
-        },
+        "statusCode": {},
         "selectionPattern": {},
         "responseParameters": {
           "shape": "Sk"
@@ -4137,17 +4005,8 @@
         "responseTemplates": {
           "shape": "Sk"
         },
-        "contentHandling": {
-          "shape": "S1i"
-        }
+        "contentHandling": {}
       }
-    },
-    "S1n": {
-      "type": "string",
-      "enum": [
-        "HEADER",
-        "AUTHORIZER"
-      ]
     },
     "S1o": {
       "type": "structure",
@@ -4168,9 +4027,7 @@
         "minimumCompressionSize": {
           "type": "integer"
         },
-        "apiKeySource": {
-          "shape": "S1n"
-        },
+        "apiKeySource": {},
         "endpointConfiguration": {
           "shape": "Sz"
         },
@@ -4202,19 +4059,8 @@
         "cacheClusterEnabled": {
           "type": "boolean"
         },
-        "cacheClusterSize": {
-          "shape": "Sj"
-        },
-        "cacheClusterStatus": {
-          "type": "string",
-          "enum": [
-            "CREATE_IN_PROGRESS",
-            "AVAILABLE",
-            "DELETE_IN_PROGRESS",
-            "NOT_AVAILABLE",
-            "FLUSH_IN_PROGRESS"
-          ]
-        },
+        "cacheClusterSize": {},
+        "cacheClusterStatus": {},
         "methodSettings": {
           "type": "map",
           "key": {},
@@ -4246,14 +4092,7 @@
               "requireAuthorizationForCacheControl": {
                 "type": "boolean"
               },
-              "unauthorizedCacheControlHeaderStrategy": {
-                "type": "string",
-                "enum": [
-                  "FAIL_WITH_403",
-                  "SUCCEED_WITH_RESPONSE_HEADER",
-                  "SUCCEED_WITHOUT_RESPONSE_HEADER"
-                ]
-              }
+              "unauthorizedCacheControlHeaderStrategy": {}
             }
           }
         },
@@ -4322,14 +4161,7 @@
         "offset": {
           "type": "integer"
         },
-        "period": {
-          "type": "string",
-          "enum": [
-            "DAY",
-            "WEEK",
-            "MONTH"
-          ]
-        }
+        "period": {}
       }
     },
     "S24": {
@@ -4368,42 +4200,9 @@
         "targetArns": {
           "shape": "S8"
         },
-        "status": {
-          "type": "string",
-          "enum": [
-            "AVAILABLE",
-            "PENDING",
-            "DELETING",
-            "FAILED"
-          ]
-        },
+        "status": {},
         "statusMessage": {}
       }
-    },
-    "S2j": {
-      "type": "string",
-      "enum": [
-        "DEFAULT_4XX",
-        "DEFAULT_5XX",
-        "RESOURCE_NOT_FOUND",
-        "UNAUTHORIZED",
-        "INVALID_API_KEY",
-        "ACCESS_DENIED",
-        "AUTHORIZER_FAILURE",
-        "AUTHORIZER_CONFIGURATION_ERROR",
-        "INVALID_SIGNATURE",
-        "EXPIRED_TOKEN",
-        "MISSING_AUTHENTICATION_TOKEN",
-        "INTEGRATION_FAILURE",
-        "INTEGRATION_TIMEOUT",
-        "API_CONFIGURATION_ERROR",
-        "UNSUPPORTED_MEDIA_TYPE",
-        "BAD_REQUEST_PARAMETERS",
-        "BAD_REQUEST_BODY",
-        "REQUEST_TOO_LARGE",
-        "THROTTLED",
-        "QUOTA_EXCEEDED"
-      ]
     },
     "S2z": {
       "type": "structure",
@@ -4435,12 +4234,8 @@
     "S43": {
       "type": "structure",
       "members": {
-        "responseType": {
-          "shape": "S2j"
-        },
-        "statusCode": {
-          "shape": "S1e"
-        },
+        "responseType": {},
+        "statusCode": {},
         "responseParameters": {
           "shape": "Sk"
         },
@@ -4498,13 +4293,6 @@
         }
       }
     },
-    "S5u": {
-      "type": "string",
-      "enum": [
-        "merge",
-        "overwrite"
-      ]
-    },
     "S65": {
       "type": "map",
       "key": {},
@@ -4515,17 +4303,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "op": {
-            "type": "string",
-            "enum": [
-              "add",
-              "remove",
-              "replace",
-              "move",
-              "copy",
-              "test"
-            ]
-          },
+          "op": {},
           "path": {},
           "value": {},
           "from": {}

--- a/apis/application-autoscaling-2016-02-06.min.json
+++ b/apis/application-autoscaling-2016-02-06.min.json
@@ -23,18 +23,10 @@
           "ScalableDimension"
         ],
         "members": {
-          "PolicyName": {
-            "shape": "S2"
-          },
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          }
+          "PolicyName": {},
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {}
         }
       },
       "output": {
@@ -51,18 +43,10 @@
           "ResourceId"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ScheduledActionName": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          }
+          "ServiceNamespace": {},
+          "ScheduledActionName": {},
+          "ResourceId": {},
+          "ScalableDimension": {}
         }
       },
       "output": {
@@ -79,15 +63,9 @@
           "ScalableDimension"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          }
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {}
         }
       },
       "output": {
@@ -102,21 +80,15 @@
           "ServiceNamespace"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
+          "ServiceNamespace": {},
           "ResourceIds": {
             "shape": "Sb"
           },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ScalableDimension": {},
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -136,33 +108,23 @@
                 "CreationTime"
               ],
               "members": {
-                "ServiceNamespace": {
-                  "shape": "S3"
-                },
-                "ResourceId": {
-                  "shape": "S2"
-                },
-                "ScalableDimension": {
-                  "shape": "S4"
-                },
+                "ServiceNamespace": {},
+                "ResourceId": {},
+                "ScalableDimension": {},
                 "MinCapacity": {
                   "type": "integer"
                 },
                 "MaxCapacity": {
                   "type": "integer"
                 },
-                "RoleARN": {
-                  "shape": "S2"
-                },
+                "RoleARN": {},
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -173,21 +135,13 @@
           "ServiceNamespace"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -208,53 +162,25 @@
                 "StatusCode"
               ],
               "members": {
-                "ActivityId": {
-                  "shape": "Sn"
-                },
-                "ServiceNamespace": {
-                  "shape": "S3"
-                },
-                "ResourceId": {
-                  "shape": "S2"
-                },
-                "ScalableDimension": {
-                  "shape": "S4"
-                },
-                "Description": {
-                  "shape": "Sd"
-                },
-                "Cause": {
-                  "shape": "Sd"
-                },
+                "ActivityId": {},
+                "ServiceNamespace": {},
+                "ResourceId": {},
+                "ScalableDimension": {},
+                "Description": {},
+                "Cause": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "StatusCode": {
-                  "type": "string",
-                  "enum": [
-                    "Pending",
-                    "InProgress",
-                    "Successful",
-                    "Overridden",
-                    "Unfulfilled",
-                    "Failed"
-                  ]
-                },
-                "StatusMessage": {
-                  "shape": "Sd"
-                },
-                "Details": {
-                  "shape": "Sd"
-                }
+                "StatusCode": {},
+                "StatusMessage": {},
+                "Details": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -268,21 +194,13 @@
           "PolicyNames": {
             "shape": "Sb"
           },
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -302,24 +220,12 @@
                 "CreationTime"
               ],
               "members": {
-                "PolicyARN": {
-                  "shape": "S2"
-                },
-                "PolicyName": {
-                  "shape": "St"
-                },
-                "ServiceNamespace": {
-                  "shape": "S3"
-                },
-                "ResourceId": {
-                  "shape": "S2"
-                },
-                "ScalableDimension": {
-                  "shape": "S4"
-                },
-                "PolicyType": {
-                  "shape": "Su"
-                },
+                "PolicyARN": {},
+                "PolicyName": {},
+                "ServiceNamespace": {},
+                "ResourceId": {},
+                "ScalableDimension": {},
+                "PolicyType": {},
                 "StepScalingPolicyConfiguration": {
                   "shape": "Sv"
                 },
@@ -335,9 +241,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -351,21 +255,13 @@
           "ScheduledActionNames": {
             "shape": "Sb"
           },
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -384,24 +280,12 @@
                 "CreationTime"
               ],
               "members": {
-                "ScheduledActionName": {
-                  "shape": "S1o"
-                },
-                "ScheduledActionARN": {
-                  "shape": "S2"
-                },
-                "ServiceNamespace": {
-                  "shape": "S3"
-                },
-                "Schedule": {
-                  "shape": "S2"
-                },
-                "ResourceId": {
-                  "shape": "S2"
-                },
-                "ScalableDimension": {
-                  "shape": "S4"
-                },
+                "ScheduledActionName": {},
+                "ScheduledActionARN": {},
+                "ServiceNamespace": {},
+                "Schedule": {},
+                "ResourceId": {},
+                "ScalableDimension": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -417,9 +301,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sd"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -433,21 +315,11 @@
           "ScalableDimension"
         ],
         "members": {
-          "PolicyName": {
-            "shape": "St"
-          },
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
-          "PolicyType": {
-            "shape": "Su"
-          },
+          "PolicyName": {},
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
+          "PolicyType": {},
           "StepScalingPolicyConfiguration": {
             "shape": "Sv"
           },
@@ -462,9 +334,7 @@
           "PolicyARN"
         ],
         "members": {
-          "PolicyARN": {
-            "shape": "S2"
-          },
+          "PolicyARN": {},
           "Alarms": {
             "shape": "S1i"
           }
@@ -480,21 +350,11 @@
           "ResourceId"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "Schedule": {
-            "shape": "S2"
-          },
-          "ScheduledActionName": {
-            "shape": "S1o"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ServiceNamespace": {},
+          "Schedule": {},
+          "ScheduledActionName": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -520,24 +380,16 @@
           "ScalableDimension"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "S3"
-          },
-          "ResourceId": {
-            "shape": "S2"
-          },
-          "ScalableDimension": {
-            "shape": "S4"
-          },
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "MinCapacity": {
             "type": "integer"
           },
           "MaxCapacity": {
             "type": "integer"
           },
-          "RoleARN": {
-            "shape": "S2"
-          }
+          "RoleARN": {}
         }
       },
       "output": {
@@ -547,79 +399,14 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S3": {
-      "type": "string",
-      "enum": [
-        "ecs",
-        "elasticmapreduce",
-        "ec2",
-        "appstream",
-        "dynamodb",
-        "rds",
-        "sagemaker",
-        "custom-resource"
-      ]
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "elasticmapreduce:instancegroup:InstanceCount",
-        "appstream:fleet:DesiredCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
-        "dynamodb:index:ReadCapacityUnits",
-        "dynamodb:index:WriteCapacityUnits",
-        "rds:cluster:ReadReplicaCount",
-        "sagemaker:variant:DesiredInstanceCount",
-        "custom-resource:ResourceType:Property"
-      ]
-    },
     "Sb": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
-    },
-    "Sd": {
-      "type": "string",
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "Sn": {
-      "type": "string",
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "St": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "\\p{Print}+"
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "StepScaling",
-        "TargetTrackingScaling"
-      ]
+      "member": {}
     },
     "Sv": {
       "type": "structure",
       "members": {
-        "AdjustmentType": {
-          "type": "string",
-          "enum": [
-            "ChangeInCapacity",
-            "PercentChangeInCapacity",
-            "ExactCapacity"
-          ]
-        },
+        "AdjustmentType": {},
         "StepAdjustments": {
           "type": "list",
           "member": {
@@ -646,14 +433,7 @@
         "Cooldown": {
           "type": "integer"
         },
-        "MetricAggregationType": {
-          "type": "string",
-          "enum": [
-            "Average",
-            "Minimum",
-            "Maximum"
-          ]
-        }
+        "MetricAggregationType": {}
       }
     },
     "S14": {
@@ -671,27 +451,8 @@
             "PredefinedMetricType"
           ],
           "members": {
-            "PredefinedMetricType": {
-              "type": "string",
-              "enum": [
-                "DynamoDBReadCapacityUtilization",
-                "DynamoDBWriteCapacityUtilization",
-                "ALBRequestCountPerTarget",
-                "RDSReaderAverageCPUUtilization",
-                "RDSReaderAverageDatabaseConnections",
-                "EC2SpotFleetRequestAverageCPUUtilization",
-                "EC2SpotFleetRequestAverageNetworkIn",
-                "EC2SpotFleetRequestAverageNetworkOut",
-                "SageMakerVariantInvocationsPerInstance",
-                "ECSServiceAverageCPUUtilization",
-                "ECSServiceAverageMemoryUtilization"
-              ]
-            },
-            "ResourceLabel": {
-              "type": "string",
-              "max": 1023,
-              "min": 1
-            }
+            "PredefinedMetricType": {},
+            "ResourceLabel": {}
           }
         },
         "CustomizedMetricSpecification": {
@@ -718,16 +479,7 @@
                 }
               }
             },
-            "Statistic": {
-              "type": "string",
-              "enum": [
-                "Average",
-                "Minimum",
-                "Maximum",
-                "SampleCount",
-                "Sum"
-              ]
-            },
+            "Statistic": {},
             "Unit": {}
           }
         },
@@ -751,20 +503,10 @@
           "AlarmARN"
         ],
         "members": {
-          "AlarmName": {
-            "shape": "Sn"
-          },
-          "AlarmARN": {
-            "shape": "Sn"
-          }
+          "AlarmName": {},
+          "AlarmARN": {}
         }
       }
-    },
-    "S1o": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "(?!((^[ ]+.*)|(.*([\\u0000-\\u001f]|[\\u007f-\\u009f]|[:/|])+.*)|(.*[ ]+$))).+"
     },
     "S1p": {
       "type": "structure",

--- a/apis/appstream-2016-12-01.min.json
+++ b/apis/appstream-2016-12-01.min.json
@@ -21,12 +21,8 @@
           "StackName"
         ],
         "members": {
-          "FleetName": {
-            "shape": "S2"
-          },
-          "StackName": {
-            "shape": "S2"
-          }
+          "FleetName": {},
+          "StackName": {}
         }
       },
       "output": {
@@ -43,28 +39,16 @@
           "DestinationRegion"
         ],
         "members": {
-          "SourceImageName": {
-            "shape": "S5"
-          },
-          "DestinationImageName": {
-            "shape": "S5"
-          },
-          "DestinationRegion": {
-            "type": "string",
-            "max": 32,
-            "min": 1
-          },
-          "DestinationImageDescription": {
-            "shape": "S7"
-          }
+          "SourceImageName": {},
+          "DestinationImageName": {},
+          "DestinationRegion": {},
+          "DestinationImageDescription": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DestinationImageName": {
-            "shape": "S5"
-          }
+          "DestinationImageName": {}
         }
       }
     },
@@ -104,21 +88,11 @@
           "ComputeCapacity"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
-          "ImageName": {
-            "shape": "S2"
-          },
-          "ImageArn": {
-            "shape": "Sk"
-          },
-          "InstanceType": {
-            "shape": "S2"
-          },
-          "FleetType": {
-            "shape": "Sl"
-          },
+          "Name": {},
+          "ImageName": {},
+          "ImageArn": {},
+          "InstanceType": {},
+          "FleetType": {},
           "ComputeCapacity": {
             "shape": "Sm"
           },
@@ -131,12 +105,8 @@
           "DisconnectTimeoutInSeconds": {
             "type": "integer"
           },
-          "Description": {
-            "shape": "S7"
-          },
-          "DisplayName": {
-            "shape": "Sr"
-          },
+          "Description": {},
+          "DisplayName": {},
           "EnableDefaultInternetAccess": {
             "type": "boolean"
           },
@@ -162,24 +132,12 @@
           "InstanceType"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
-          "ImageName": {
-            "shape": "S2"
-          },
-          "ImageArn": {
-            "shape": "Sk"
-          },
-          "InstanceType": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S7"
-          },
-          "DisplayName": {
-            "shape": "Sr"
-          },
+          "Name": {},
+          "ImageName": {},
+          "ImageArn": {},
+          "InstanceType": {},
+          "Description": {},
+          "DisplayName": {},
           "VpcConfig": {
             "shape": "So"
           },
@@ -189,9 +147,7 @@
           "DomainJoinInfo": {
             "shape": "St"
           },
-          "AppstreamAgentVersion": {
-            "shape": "S12"
-          }
+          "AppstreamAgentVersion": {}
         }
       },
       "output": {
@@ -210,9 +166,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "Validity": {
             "type": "long"
           }
@@ -221,9 +175,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "StreamingURL": {
-            "shape": "S2"
-          },
+          "StreamingURL": {},
           "Expires": {
             "type": "timestamp"
           }
@@ -237,24 +189,14 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
-          "Description": {
-            "shape": "S7"
-          },
-          "DisplayName": {
-            "shape": "Sr"
-          },
+          "Name": {},
+          "Description": {},
+          "DisplayName": {},
           "StorageConnectors": {
             "shape": "S1f"
           },
-          "RedirectURL": {
-            "shape": "S1l"
-          },
-          "FeedbackURL": {
-            "shape": "S1m"
-          },
+          "RedirectURL": {},
+          "FeedbackURL": {},
           "UserSettings": {
             "shape": "S1n"
           },
@@ -281,35 +223,20 @@
           "UserId"
         ],
         "members": {
-          "StackName": {
-            "shape": "S2"
-          },
-          "FleetName": {
-            "shape": "S2"
-          },
-          "UserId": {
-            "type": "string",
-            "max": 32,
-            "min": 2,
-            "pattern": "[\\w+=,.@-]*"
-          },
-          "ApplicationId": {
-            "shape": "S2"
-          },
+          "StackName": {},
+          "FleetName": {},
+          "UserId": {},
+          "ApplicationId": {},
           "Validity": {
             "type": "long"
           },
-          "SessionContext": {
-            "shape": "S2"
-          }
+          "SessionContext": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamingURL": {
-            "shape": "S2"
-          },
+          "StreamingURL": {},
           "Expires": {
             "type": "timestamp"
           }
@@ -338,9 +265,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -355,9 +280,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -376,9 +299,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -398,12 +319,8 @@
           "SharedAccountId"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
-          "SharedAccountId": {
-            "shape": "S2l"
-          }
+          "Name": {},
+          "SharedAccountId": {}
         }
       },
       "output": {
@@ -418,9 +335,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -439,9 +354,7 @@
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -453,9 +366,7 @@
               "shape": "Sh"
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -466,9 +377,7 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -480,9 +389,7 @@
               "shape": "Sv"
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -496,9 +403,7 @@
           "MaxResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -510,9 +415,7 @@
               "shape": "S14"
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -523,33 +426,21 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
+          "Name": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 500,
-            "min": 0
+            "type": "integer"
           },
           "SharedAwsAccountIds": {
             "type": "list",
-            "member": {
-              "shape": "S2l"
-            },
-            "max": 5,
-            "min": 1
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
+          "Name": {},
           "SharedImagePermissionsList": {
             "type": "list",
             "member": {
@@ -559,18 +450,14 @@
                 "imagePermissions"
               ],
               "members": {
-                "sharedAccountId": {
-                  "shape": "S2l"
-                },
+                "sharedAccountId": {},
                 "imagePermissions": {
                   "shape": "S2h"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -583,20 +470,12 @@
           },
           "Arns": {
             "type": "list",
-            "member": {
-              "shape": "Sk"
-            }
+            "member": {}
           },
-          "Type": {
-            "shape": "S2b"
-          },
-          "NextToken": {
-            "shape": "S2"
-          },
+          "Type": {},
+          "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 25,
-            "min": 0
+            "type": "integer"
           }
         }
       },
@@ -609,9 +488,7 @@
               "shape": "S29"
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -623,24 +500,14 @@
           "FleetName"
         ],
         "members": {
-          "StackName": {
-            "shape": "S2"
-          },
-          "FleetName": {
-            "shape": "S2"
-          },
-          "UserId": {
-            "shape": "S3c"
-          },
-          "NextToken": {
-            "shape": "S2"
-          },
+          "StackName": {},
+          "FleetName": {},
+          "UserId": {},
+          "NextToken": {},
           "Limit": {
             "type": "integer"
           },
-          "AuthenticationType": {
-            "shape": "S3d"
-          }
+          "AuthenticationType": {}
         }
       },
       "output": {
@@ -658,46 +525,23 @@
                 "State"
               ],
               "members": {
-                "Id": {
-                  "shape": "S2"
-                },
-                "UserId": {
-                  "shape": "S3c"
-                },
-                "StackName": {
-                  "shape": "S2"
-                },
-                "FleetName": {
-                  "shape": "S2"
-                },
-                "State": {
-                  "type": "string",
-                  "enum": [
-                    "ACTIVE",
-                    "PENDING",
-                    "EXPIRED"
-                  ]
-                },
-                "AuthenticationType": {
-                  "shape": "S3d"
-                },
+                "Id": {},
+                "UserId": {},
+                "StackName": {},
+                "FleetName": {},
+                "State": {},
+                "AuthenticationType": {},
                 "NetworkAccessConfiguration": {
                   "type": "structure",
                   "members": {
-                    "EniPrivateIpAddress": {
-                      "shape": "S2"
-                    },
-                    "EniId": {
-                      "shape": "S2"
-                    }
+                    "EniPrivateIpAddress": {},
+                    "EniId": {}
                   }
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -708,9 +552,7 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -722,9 +564,7 @@
               "shape": "S1v"
             }
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -736,12 +576,8 @@
           "StackName"
         ],
         "members": {
-          "FleetName": {
-            "shape": "S2"
-          },
-          "StackName": {
-            "shape": "S2"
-          }
+          "FleetName": {},
+          "StackName": {}
         }
       },
       "output": {
@@ -756,9 +592,7 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {
-            "shape": "S2"
-          }
+          "SessionId": {}
         }
       },
       "output": {
@@ -773,12 +607,8 @@
           "StackName"
         ],
         "members": {
-          "StackName": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "StackName": {},
+          "NextToken": {}
         }
       },
       "output": {
@@ -787,9 +617,7 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -800,12 +628,8 @@
           "FleetName"
         ],
         "members": {
-          "FleetName": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "FleetName": {},
+          "NextToken": {}
         }
       },
       "output": {
@@ -814,9 +638,7 @@
           "Names": {
             "shape": "S2u"
           },
-          "NextToken": {
-            "shape": "S2"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -827,9 +649,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "Sk"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -848,9 +668,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -865,12 +683,8 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "AppstreamAgentVersion": {
-            "shape": "S12"
-          }
+          "Name": {},
+          "AppstreamAgentVersion": {}
         }
       },
       "output": {
@@ -889,9 +703,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -906,9 +718,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -928,9 +738,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "Sk"
-          },
+          "ResourceArn": {},
           "Tags": {
             "shape": "S3w"
           }
@@ -949,16 +757,10 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "Sk"
-          },
+          "ResourceArn": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S3x"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -996,18 +798,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "ImageName": {
-            "shape": "S2"
-          },
-          "ImageArn": {
-            "shape": "Sk"
-          },
-          "Name": {
-            "shape": "S2"
-          },
-          "InstanceType": {
-            "shape": "S2"
-          },
+          "ImageName": {},
+          "ImageArn": {},
+          "Name": {},
+          "InstanceType": {},
           "ComputeCapacity": {
             "shape": "Sm"
           },
@@ -1024,12 +818,8 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "Description": {
-            "shape": "S7"
-          },
-          "DisplayName": {
-            "shape": "Sr"
-          },
+          "Description": {},
+          "DisplayName": {},
           "EnableDefaultInternetAccess": {
             "type": "boolean"
           },
@@ -1038,14 +828,7 @@
           },
           "AttributesToDelete": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "VPC_CONFIGURATION",
-                "VPC_CONFIGURATION_SECURITY_GROUP_IDS",
-                "DOMAIN_JOIN_INFO"
-              ]
-            }
+            "member": {}
           }
         }
       },
@@ -1067,12 +850,8 @@
           "ImagePermissions"
         ],
         "members": {
-          "Name": {
-            "shape": "S5"
-          },
-          "SharedAccountId": {
-            "shape": "S2l"
-          },
+          "Name": {},
+          "SharedAccountId": {},
           "ImagePermissions": {
             "shape": "S2h"
           }
@@ -1090,15 +869,9 @@
           "Name"
         ],
         "members": {
-          "DisplayName": {
-            "shape": "Sr"
-          },
-          "Description": {
-            "shape": "S7"
-          },
-          "Name": {
-            "shape": "S2"
-          },
+          "DisplayName": {},
+          "Description": {},
+          "Name": {},
           "StorageConnectors": {
             "shape": "S1f"
           },
@@ -1106,27 +879,11 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "RedirectURL": {
-            "shape": "S1l"
-          },
-          "FeedbackURL": {
-            "shape": "S1m"
-          },
+          "RedirectURL": {},
+          "FeedbackURL": {},
           "AttributesToDelete": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "STORAGE_CONNECTORS",
-                "STORAGE_CONNECTOR_HOMEFOLDERS",
-                "STORAGE_CONNECTOR_GOOGLE_DRIVE",
-                "STORAGE_CONNECTOR_ONE_DRIVE",
-                "REDIRECT_URL",
-                "FEEDBACK_URL",
-                "THEME_NAME",
-                "USER_SETTINGS"
-              ]
-            }
+            "member": {}
           },
           "UserSettings": {
             "shape": "S1n"
@@ -1147,27 +904,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,100}$"
-    },
-    "S7": {
-      "type": "string",
-      "max": 256
-    },
     "Sb": {
       "type": "list",
-      "member": {
-        "shape": "Sc"
-      }
-    },
-    "Sc": {
-      "type": "string",
-      "max": 2000
+      "member": {}
     },
     "Sd": {
       "type": "structure",
@@ -1178,13 +917,10 @@
       "members": {
         "AccountName": {
           "type": "string",
-          "min": 1,
           "sensitive": true
         },
         "AccountPassword": {
           "type": "string",
-          "max": 127,
-          "min": 1,
           "sensitive": true
         }
       }
@@ -1207,17 +943,6 @@
         }
       }
     },
-    "Sk": {
-      "type": "string",
-      "pattern": "^arn:aws:[A-Za-z0-9][A-Za-z0-9_/.-]{0,62}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-Za-z0-9:_/+=,@.-]{0,1023}$"
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "ALWAYS_ON",
-        "ON_DEMAND"
-      ]
-    },
     "Sm": {
       "type": "structure",
       "required": [
@@ -1234,30 +959,19 @@
       "members": {
         "SubnetIds": {
           "type": "list",
-          "member": {
-            "shape": "S2"
-          }
+          "member": {}
         },
         "SecurityGroupIds": {
           "type": "list",
-          "member": {
-            "shape": "S2"
-          },
-          "max": 5
+          "member": {}
         }
       }
-    },
-    "Sr": {
-      "type": "string",
-      "max": 100
     },
     "St": {
       "type": "structure",
       "members": {
         "DirectoryName": {},
-        "OrganizationalUnitDistinguishedName": {
-          "shape": "Sc"
-        }
+        "OrganizationalUnitDistinguishedName": {}
       }
     },
     "Sv": {
@@ -1270,30 +984,14 @@
         "State"
       ],
       "members": {
-        "Arn": {
-          "shape": "Sk"
-        },
-        "Name": {
-          "shape": "S2"
-        },
-        "DisplayName": {
-          "shape": "S2"
-        },
-        "Description": {
-          "shape": "S2"
-        },
-        "ImageName": {
-          "shape": "S2"
-        },
-        "ImageArn": {
-          "shape": "Sk"
-        },
-        "InstanceType": {
-          "shape": "S2"
-        },
-        "FleetType": {
-          "shape": "Sl"
-        },
+        "Arn": {},
+        "Name": {},
+        "DisplayName": {},
+        "Description": {},
+        "ImageName": {},
+        "ImageArn": {},
+        "InstanceType": {},
+        "FleetType": {},
         "ComputeCapacityStatus": {
           "type": "structure",
           "required": [
@@ -1320,15 +1018,7 @@
         "DisconnectTimeoutInSeconds": {
           "type": "integer"
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "STARTING",
-            "RUNNING",
-            "STOPPING",
-            "STOPPED"
-          ]
-        },
+        "State": {},
         "VpcConfig": {
           "shape": "So"
         },
@@ -1340,12 +1030,8 @@
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {
-                "shape": "S10"
-              },
-              "ErrorMessage": {
-                "shape": "S2"
-              }
+              "ErrorCode": {},
+              "ErrorMessage": {}
             }
           }
         },
@@ -1357,99 +1043,28 @@
         }
       }
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION",
-        "IAM_SERVICE_ROLE_MISSING_ENI_CREATE_ACTION",
-        "IAM_SERVICE_ROLE_MISSING_ENI_DELETE_ACTION",
-        "NETWORK_INTERFACE_LIMIT_EXCEEDED",
-        "INTERNAL_SERVICE_ERROR",
-        "IAM_SERVICE_ROLE_IS_MISSING",
-        "SUBNET_HAS_INSUFFICIENT_IP_ADDRESSES",
-        "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SUBNET_ACTION",
-        "SUBNET_NOT_FOUND",
-        "IMAGE_NOT_FOUND",
-        "INVALID_SUBNET_CONFIGURATION",
-        "SECURITY_GROUPS_NOT_FOUND",
-        "IGW_NOT_ATTACHED",
-        "IAM_SERVICE_ROLE_MISSING_DESCRIBE_SECURITY_GROUPS_ACTION",
-        "DOMAIN_JOIN_ERROR_FILE_NOT_FOUND",
-        "DOMAIN_JOIN_ERROR_ACCESS_DENIED",
-        "DOMAIN_JOIN_ERROR_LOGON_FAILURE",
-        "DOMAIN_JOIN_ERROR_INVALID_PARAMETER",
-        "DOMAIN_JOIN_ERROR_MORE_DATA",
-        "DOMAIN_JOIN_ERROR_NO_SUCH_DOMAIN",
-        "DOMAIN_JOIN_ERROR_NOT_SUPPORTED",
-        "DOMAIN_JOIN_NERR_INVALID_WORKGROUP_NAME",
-        "DOMAIN_JOIN_NERR_WORKSTATION_NOT_STARTED",
-        "DOMAIN_JOIN_ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED",
-        "DOMAIN_JOIN_NERR_PASSWORD_EXPIRED",
-        "DOMAIN_JOIN_INTERNAL_SERVICE_ERROR"
-      ]
-    },
-    "S12": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
     "S14": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
-        "Arn": {
-          "shape": "Sk"
-        },
-        "ImageArn": {
-          "shape": "Sk"
-        },
-        "Description": {
-          "shape": "S2"
-        },
-        "DisplayName": {
-          "shape": "S2"
-        },
+        "Name": {},
+        "Arn": {},
+        "ImageArn": {},
+        "Description": {},
+        "DisplayName": {},
         "VpcConfig": {
           "shape": "So"
         },
-        "InstanceType": {
-          "shape": "S2"
-        },
-        "Platform": {
-          "shape": "S15"
-        },
-        "State": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "UPDATING_AGENT",
-            "RUNNING",
-            "STOPPING",
-            "STOPPED",
-            "REBOOTING",
-            "SNAPSHOTTING",
-            "DELETING",
-            "FAILED"
-          ]
-        },
+        "InstanceType": {},
+        "Platform": {},
+        "State": {},
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {
-              "type": "string",
-              "enum": [
-                "INTERNAL_ERROR",
-                "IMAGE_UNAVAILABLE"
-              ]
-            },
-            "Message": {
-              "shape": "S2"
-            }
+            "Code": {},
+            "Message": {}
           }
         },
         "CreatedTime": {
@@ -1466,28 +1081,16 @@
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {
-                "shape": "S10"
-              },
-              "ErrorMessage": {
-                "shape": "S2"
-              },
+              "ErrorCode": {},
+              "ErrorMessage": {},
               "ErrorTimestamp": {
                 "type": "timestamp"
               }
             }
           }
         },
-        "AppstreamAgentVersion": {
-          "shape": "S12"
-        }
+        "AppstreamAgentVersion": {}
       }
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "WINDOWS"
-      ]
     },
     "S1f": {
       "type": "list",
@@ -1497,36 +1100,14 @@
           "ConnectorType"
         ],
         "members": {
-          "ConnectorType": {
-            "type": "string",
-            "enum": [
-              "HOMEFOLDERS",
-              "GOOGLE_DRIVE",
-              "ONE_DRIVE"
-            ]
-          },
-          "ResourceIdentifier": {
-            "type": "string",
-            "min": 1
-          },
+          "ConnectorType": {},
+          "ResourceIdentifier": {},
           "Domains": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 64
-            },
-            "max": 10
+            "member": {}
           }
         }
       }
-    },
-    "S1l": {
-      "type": "string",
-      "max": 1000
-    },
-    "S1m": {
-      "type": "string",
-      "max": 1000
     },
     "S1n": {
       "type": "list",
@@ -1537,26 +1118,10 @@
           "Permission"
         ],
         "members": {
-          "Action": {
-            "type": "string",
-            "enum": [
-              "CLIPBOARD_COPY_FROM_LOCAL_DEVICE",
-              "CLIPBOARD_COPY_TO_LOCAL_DEVICE",
-              "FILE_UPLOAD",
-              "FILE_DOWNLOAD",
-              "PRINTING_TO_LOCAL_DEVICE"
-            ]
-          },
-          "Permission": {
-            "type": "string",
-            "enum": [
-              "ENABLED",
-              "DISABLED"
-            ]
-          }
+          "Action": {},
+          "Permission": {}
         }
-      },
-      "min": 1
+      }
     },
     "S1r": {
       "type": "structure",
@@ -1567,14 +1132,8 @@
         "Enabled": {
           "type": "boolean"
         },
-        "SettingsGroup": {
-          "shape": "S1t"
-        }
+        "SettingsGroup": {}
       }
-    },
-    "S1t": {
-      "type": "string",
-      "max": 100
     },
     "S1v": {
       "type": "structure",
@@ -1582,45 +1141,25 @@
         "Name"
       ],
       "members": {
-        "Arn": {
-          "shape": "Sk"
-        },
-        "Name": {
-          "shape": "S2"
-        },
-        "Description": {
-          "shape": "S2"
-        },
-        "DisplayName": {
-          "shape": "S2"
-        },
+        "Arn": {},
+        "Name": {},
+        "Description": {},
+        "DisplayName": {},
         "CreatedTime": {
           "type": "timestamp"
         },
         "StorageConnectors": {
           "shape": "S1f"
         },
-        "RedirectURL": {
-          "shape": "S1l"
-        },
-        "FeedbackURL": {
-          "shape": "S1m"
-        },
+        "RedirectURL": {},
+        "FeedbackURL": {},
         "StackErrors": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "ErrorCode": {
-                "type": "string",
-                "enum": [
-                  "STORAGE_CONNECTOR_ERROR",
-                  "INTERNAL_SERVICE_ERROR"
-                ]
-              },
-              "ErrorMessage": {
-                "shape": "S2"
-              }
+              "ErrorCode": {},
+              "ErrorMessage": {}
             }
           }
         },
@@ -1633,12 +1172,8 @@
             "Enabled": {
               "type": "boolean"
             },
-            "SettingsGroup": {
-              "shape": "S1t"
-            },
-            "S3BucketName": {
-              "shape": "S2"
-            }
+            "SettingsGroup": {},
+            "S3BucketName": {}
           }
         }
       }
@@ -1649,54 +1184,22 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
-        "Arn": {
-          "shape": "Sk"
-        },
-        "BaseImageArn": {
-          "shape": "Sk"
-        },
-        "DisplayName": {
-          "shape": "S2"
-        },
-        "State": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "AVAILABLE",
-            "FAILED",
-            "COPYING",
-            "DELETING"
-          ]
-        },
-        "Visibility": {
-          "shape": "S2b"
-        },
+        "Name": {},
+        "Arn": {},
+        "BaseImageArn": {},
+        "DisplayName": {},
+        "State": {},
+        "Visibility": {},
         "ImageBuilderSupported": {
           "type": "boolean"
         },
-        "Platform": {
-          "shape": "S15"
-        },
-        "Description": {
-          "shape": "S2"
-        },
+        "Platform": {},
+        "Description": {},
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {
-              "type": "string",
-              "enum": [
-                "INTERNAL_ERROR",
-                "IMAGE_BUILDER_NOT_AVAILABLE",
-                "IMAGE_COPY_FAILURE"
-              ]
-            },
-            "Message": {
-              "shape": "S2"
-            }
+            "Code": {},
+            "Message": {}
           }
         },
         "Applications": {
@@ -1704,32 +1207,18 @@
           "member": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "S2"
-              },
-              "DisplayName": {
-                "shape": "S2"
-              },
-              "IconURL": {
-                "shape": "S2"
-              },
-              "LaunchPath": {
-                "shape": "S2"
-              },
-              "LaunchParameters": {
-                "shape": "S2"
-              },
+              "Name": {},
+              "DisplayName": {},
+              "IconURL": {},
+              "LaunchPath": {},
+              "LaunchParameters": {},
               "Enabled": {
                 "type": "boolean"
               },
               "Metadata": {
                 "type": "map",
-                "key": {
-                  "shape": "S2"
-                },
-                "value": {
-                  "shape": "S2"
-                }
+                "key": {},
+                "value": {}
               }
             }
           }
@@ -1740,21 +1229,11 @@
         "PublicBaseImageReleasedDate": {
           "type": "timestamp"
         },
-        "AppstreamAgentVersion": {
-          "shape": "S12"
-        },
+        "AppstreamAgentVersion": {},
         "ImagePermissions": {
           "shape": "S2h"
         }
       }
-    },
-    "S2b": {
-      "type": "string",
-      "enum": [
-        "PUBLIC",
-        "PRIVATE",
-        "SHARED"
-      ]
     },
     "S2h": {
       "type": "structure",
@@ -1767,48 +1246,14 @@
         }
       }
     },
-    "S2l": {
-      "type": "string",
-      "pattern": "^\\d+$"
-    },
     "S2u": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
-    },
-    "S3c": {
-      "type": "string",
-      "max": 32,
-      "min": 2
-    },
-    "S3d": {
-      "type": "string",
-      "enum": [
-        "API",
-        "SAML",
-        "USERPOOL"
-      ]
+      "member": {}
     },
     "S3w": {
       "type": "map",
-      "key": {
-        "shape": "S3x"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "min": 0,
-        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-      },
-      "max": 50,
-      "min": 1
-    },
-    "S3x": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^(^(?!aws:).[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/appsync-2017-07-25.min.json
+++ b/apis/appsync-2017-07-25.min.json
@@ -58,13 +58,9 @@
             "location": "uri",
             "locationName": "apiId"
           },
-          "name": {
-            "shape": "S7"
-          },
+          "name": {},
           "description": {},
-          "type": {
-            "shape": "S8"
-          },
+          "type": {},
           "serviceRoleArn": {},
           "dynamodbConfig": {
             "shape": "S9"
@@ -104,9 +100,7 @@
           "logConfig": {
             "shape": "Sh"
           },
-          "authenticationType": {
-            "shape": "Sj"
-          },
+          "authenticationType": {},
           "userPoolConfig": {
             "shape": "Sk"
           },
@@ -143,22 +137,13 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
-          "fieldName": {
-            "shape": "S7"
-          },
-          "dataSourceName": {
-            "shape": "S7"
-          },
-          "requestMappingTemplate": {
-            "shape": "Sr"
-          },
-          "responseMappingTemplate": {
-            "shape": "Sr"
-          }
+          "fieldName": {},
+          "dataSourceName": {},
+          "requestMappingTemplate": {},
+          "responseMappingTemplate": {}
         }
       },
       "output": {
@@ -187,9 +172,7 @@
             "locationName": "apiId"
           },
           "definition": {},
-          "format": {
-            "shape": "Sv"
-          }
+          "format": {}
         }
       },
       "output": {
@@ -245,7 +228,6 @@
             "locationName": "apiId"
           },
           "name": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           }
@@ -296,12 +278,10 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           }
@@ -329,7 +309,6 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           }
@@ -357,7 +336,6 @@
             "locationName": "apiId"
           },
           "name": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           }
@@ -416,12 +394,7 @@
           },
           "format": {
             "location": "querystring",
-            "locationName": "format",
-            "type": "string",
-            "enum": [
-              "SDL",
-              "JSON"
-            ]
+            "locationName": "format"
           }
         }
       },
@@ -453,12 +426,10 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           }
@@ -493,9 +464,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "shape": "S1k"
-          },
+          "status": {},
           "details": {}
         }
       }
@@ -518,12 +487,10 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "format": {
-            "shape": "Sv",
             "location": "querystring",
             "locationName": "format"
           }
@@ -554,14 +521,13 @@
             "locationName": "apiId"
           },
           "nextToken": {
-            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -574,9 +540,7 @@
               "shape": "S5"
             }
           },
-          "nextToken": {
-            "shape": "S1o"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -596,14 +560,13 @@
             "locationName": "apiId"
           },
           "nextToken": {
-            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -616,9 +579,7 @@
               "shape": "Sf"
             }
           },
-          "nextToken": {
-            "shape": "S1o"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -631,14 +592,13 @@
         "type": "structure",
         "members": {
           "nextToken": {
-            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -651,9 +611,7 @@
               "shape": "So"
             }
           },
-          "nextToken": {
-            "shape": "S1o"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -678,14 +636,13 @@
             "locationName": "typeName"
           },
           "nextToken": {
-            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -698,9 +655,7 @@
               "shape": "St"
             }
           },
-          "nextToken": {
-            "shape": "S1o"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -721,19 +676,17 @@
             "locationName": "apiId"
           },
           "format": {
-            "shape": "Sv",
             "location": "querystring",
             "locationName": "format"
           },
           "nextToken": {
-            "shape": "S1o",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1p",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -746,9 +699,7 @@
               "shape": "Sx"
             }
           },
-          "nextToken": {
-            "shape": "S1o"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -775,9 +726,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "shape": "S1k"
-          }
+          "status": {}
         }
       }
     },
@@ -832,14 +781,11 @@
             "locationName": "apiId"
           },
           "name": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "name"
           },
           "description": {},
-          "type": {
-            "shape": "S8"
-          },
+          "type": {},
           "serviceRoleArn": {},
           "dynamodbConfig": {
             "shape": "S9"
@@ -883,9 +829,7 @@
           "logConfig": {
             "shape": "Sh"
           },
-          "authenticationType": {
-            "shape": "Sj"
-          },
+          "authenticationType": {},
           "userPoolConfig": {
             "shape": "Sk"
           },
@@ -922,24 +866,16 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "fieldName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "fieldName"
           },
-          "dataSourceName": {
-            "shape": "S7"
-          },
-          "requestMappingTemplate": {
-            "shape": "Sr"
-          },
-          "responseMappingTemplate": {
-            "shape": "Sr"
-          }
+          "dataSourceName": {},
+          "requestMappingTemplate": {},
+          "responseMappingTemplate": {}
         }
       },
       "output": {
@@ -968,14 +904,11 @@
             "locationName": "apiId"
           },
           "typeName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "typeName"
           },
           "definition": {},
-          "format": {
-            "shape": "Sv"
-          }
+          "format": {}
         }
       },
       "output": {
@@ -998,20 +931,6 @@
           "type": "long"
         }
       }
-    },
-    "S7": {
-      "type": "string",
-      "pattern": "[_A-Za-z][_0-9A-Za-z]*"
-    },
-    "S8": {
-      "type": "string",
-      "enum": [
-        "AWS_LAMBDA",
-        "AMAZON_DYNAMODB",
-        "AMAZON_ELASTICSEARCH",
-        "NONE",
-        "HTTP"
-      ]
     },
     "S9": {
       "type": "structure",
@@ -1057,13 +976,9 @@
       "type": "structure",
       "members": {
         "dataSourceArn": {},
-        "name": {
-          "shape": "S7"
-        },
+        "name": {},
         "description": {},
-        "type": {
-          "shape": "S8"
-        },
+        "type": {},
         "serviceRoleArn": {},
         "dynamodbConfig": {
           "shape": "S9"
@@ -1086,25 +1001,9 @@
         "cloudWatchLogsRoleArn"
       ],
       "members": {
-        "fieldLogLevel": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "ERROR",
-            "ALL"
-          ]
-        },
+        "fieldLogLevel": {},
         "cloudWatchLogsRoleArn": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "enum": [
-        "API_KEY",
-        "AWS_IAM",
-        "AMAZON_COGNITO_USER_POOLS",
-        "OPENID_CONNECT"
-      ]
     },
     "Sk": {
       "type": "structure",
@@ -1116,13 +1015,7 @@
       "members": {
         "userPoolId": {},
         "awsRegion": {},
-        "defaultAction": {
-          "type": "string",
-          "enum": [
-            "ALLOW",
-            "DENY"
-          ]
-        },
+        "defaultAction": {},
         "appIdClientRegex": {}
       }
     },
@@ -1145,13 +1038,9 @@
     "So": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S7"
-        },
+        "name": {},
         "apiId": {},
-        "authenticationType": {
-          "shape": "Sj"
-        },
+        "authenticationType": {},
         "logConfig": {
           "shape": "Sh"
         },
@@ -1169,69 +1058,26 @@
         }
       }
     },
-    "Sr": {
-      "type": "string",
-      "max": 65536,
-      "min": 1
-    },
     "St": {
       "type": "structure",
       "members": {
-        "typeName": {
-          "shape": "S7"
-        },
-        "fieldName": {
-          "shape": "S7"
-        },
-        "dataSourceName": {
-          "shape": "S7"
-        },
+        "typeName": {},
+        "fieldName": {},
+        "dataSourceName": {},
         "resolverArn": {},
-        "requestMappingTemplate": {
-          "shape": "Sr"
-        },
-        "responseMappingTemplate": {
-          "shape": "Sr"
-        }
+        "requestMappingTemplate": {},
+        "responseMappingTemplate": {}
       }
-    },
-    "Sv": {
-      "type": "string",
-      "enum": [
-        "SDL",
-        "JSON"
-      ]
     },
     "Sx": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S7"
-        },
+        "name": {},
         "description": {},
         "arn": {},
         "definition": {},
-        "format": {
-          "shape": "Sv"
-        }
+        "format": {}
       }
-    },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "PROCESSING",
-        "ACTIVE",
-        "DELETING"
-      ]
-    },
-    "S1o": {
-      "type": "string",
-      "pattern": "[\\\\S]+"
-    },
-    "S1p": {
-      "type": "integer",
-      "max": 25,
-      "min": 0
     }
   }
 }

--- a/apis/athena-2017-05-18.min.json
+++ b/apis/athena-2017-05-18.min.json
@@ -39,9 +39,7 @@
               "type": "structure",
               "members": {
                 "NamedQueryId": {},
-                "ErrorCode": {
-                  "shape": "Sd"
-                },
+                "ErrorCode": {},
                 "ErrorMessage": {}
               }
             }
@@ -76,9 +74,7 @@
               "type": "structure",
               "members": {
                 "QueryExecutionId": {},
-                "ErrorCode": {
-                  "shape": "Sd"
-                },
+                "ErrorCode": {},
                 "ErrorMessage": {}
               }
             }
@@ -95,20 +91,11 @@
           "QueryString"
         ],
         "members": {
-          "Name": {
-            "shape": "S7"
-          },
-          "Description": {
-            "shape": "S8"
-          },
-          "Database": {
-            "shape": "S9"
-          },
-          "QueryString": {
-            "shape": "Sa"
-          },
+          "Name": {},
+          "Description": {},
+          "Database": {},
+          "QueryString": {},
           "ClientRequestToken": {
-            "shape": "Sy",
             "idempotencyToken": true
           }
         }
@@ -187,9 +174,7 @@
           "QueryExecutionId": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 1000,
-            "min": 0
+            "type": "integer"
           }
         }
       },
@@ -240,14 +225,7 @@
                         "Scale": {
                           "type": "integer"
                         },
-                        "Nullable": {
-                          "type": "string",
-                          "enum": [
-                            "NOT_NULL",
-                            "NULLABLE",
-                            "UNKNOWN"
-                          ]
-                        },
+                        "Nullable": {},
                         "CaseSensitive": {
                           "type": "boolean"
                         }
@@ -268,9 +246,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 0
+            "type": "integer"
           }
         }
       },
@@ -290,9 +266,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 0
+            "type": "integer"
           }
         }
       },
@@ -314,11 +288,8 @@
           "ResultConfiguration"
         ],
         "members": {
-          "QueryString": {
-            "shape": "Sa"
-          },
+          "QueryString": {},
           "ClientRequestToken": {
-            "shape": "Sy",
             "idempotencyToken": true
           },
           "QueryExecutionContext": {
@@ -359,9 +330,7 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {},
-      "max": 50,
-      "min": 1
+      "member": {}
     },
     "S6": {
       "type": "structure",
@@ -371,59 +340,22 @@
         "QueryString"
       ],
       "members": {
-        "Name": {
-          "shape": "S7"
-        },
-        "Description": {
-          "shape": "S8"
-        },
-        "Database": {
-          "shape": "S9"
-        },
-        "QueryString": {
-          "shape": "Sa"
-        },
+        "Name": {},
+        "Description": {},
+        "Database": {},
+        "QueryString": {},
         "NamedQueryId": {}
       }
     },
-    "S7": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S8": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S9": {
-      "type": "string",
-      "max": 32,
-      "min": 1
-    },
-    "Sa": {
-      "type": "string",
-      "max": 262144,
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
     "Sg": {
       "type": "list",
-      "member": {},
-      "max": 50,
-      "min": 1
+      "member": {}
     },
     "Sk": {
       "type": "structure",
       "members": {
         "QueryExecutionId": {},
-        "Query": {
-          "shape": "Sa"
-        },
+        "Query": {},
         "ResultConfiguration": {
           "shape": "Sl"
         },
@@ -433,16 +365,7 @@
         "Status": {
           "type": "structure",
           "members": {
-            "State": {
-              "type": "string",
-              "enum": [
-                "QUEUED",
-                "RUNNING",
-                "SUCCEEDED",
-                "FAILED",
-                "CANCELLED"
-              ]
-            },
+            "State": {},
             "StateChangeReason": {},
             "SubmissionDateTime": {
               "type": "timestamp"
@@ -478,14 +401,7 @@
             "EncryptionOption"
           ],
           "members": {
-            "EncryptionOption": {
-              "type": "string",
-              "enum": [
-                "SSE_S3",
-                "SSE_KMS",
-                "CSE_KMS"
-              ]
-            },
+            "EncryptionOption": {},
             "KmsKey": {}
           }
         }
@@ -494,15 +410,8 @@
     "Sp": {
       "type": "structure",
       "members": {
-        "Database": {
-          "shape": "S9"
-        }
+        "Database": {}
       }
-    },
-    "Sy": {
-      "type": "string",
-      "max": 128,
-      "min": 32
     }
   }
 }

--- a/apis/autoscaling-2011-01-01.min.json
+++ b/apis/autoscaling-2011-01-01.min.json
@@ -21,9 +21,7 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          }
+          "AutoScalingGroupName": {}
         }
       }
     },
@@ -35,9 +33,7 @@
           "TargetGroupARNs"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "TargetGroupARNs": {
             "shape": "S6"
           }
@@ -57,9 +53,7 @@
           "LoadBalancerNames"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "LoadBalancerNames": {
             "shape": "Sa"
           }
@@ -79,9 +73,7 @@
           "ScheduledActionNames"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ScheduledActionNames": {
             "shape": "Se"
           }
@@ -105,9 +97,7 @@
           "ScheduledUpdateGroupActions"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ScheduledUpdateGroupActions": {
             "type": "list",
             "member": {
@@ -116,18 +106,14 @@
                 "ScheduledActionName"
               ],
               "members": {
-                "ScheduledActionName": {
-                  "shape": "Sb"
-                },
+                "ScheduledActionName": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "Recurrence": {
-                  "shape": "Sb"
-                },
+                "Recurrence": {},
                 "MinSize": {
                   "type": "integer"
                 },
@@ -161,19 +147,11 @@
           "LifecycleActionResult"
         ],
         "members": {
-          "LifecycleHookName": {
-            "shape": "St"
-          },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "LifecycleActionToken": {
-            "shape": "Su"
-          },
+          "LifecycleHookName": {},
+          "AutoScalingGroupName": {},
+          "LifecycleActionToken": {},
           "LifecycleActionResult": {},
-          "InstanceId": {
-            "shape": "S3"
-          }
+          "InstanceId": {}
         }
       },
       "output": {
@@ -191,18 +169,12 @@
           "MaxSize"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "Sb"
-          },
-          "LaunchConfigurationName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
+          "LaunchConfigurationName": {},
           "LaunchTemplate": {
             "shape": "Sy"
           },
-          "InstanceId": {
-            "shape": "S3"
-          },
+          "InstanceId": {},
           "MinSize": {
             "type": "integer"
           },
@@ -224,18 +196,12 @@
           "TargetGroupARNs": {
             "shape": "S6"
           },
-          "HealthCheckType": {
-            "shape": "S12"
-          },
+          "HealthCheckType": {},
           "HealthCheckGracePeriod": {
             "type": "integer"
           },
-          "PlacementGroup": {
-            "shape": "Sb"
-          },
-          "VPCZoneIdentifier": {
-            "shape": "S14"
-          },
+          "PlacementGroup": {},
+          "VPCZoneIdentifier": {},
           "TerminationPolicies": {
             "shape": "S15"
           },
@@ -251,32 +217,22 @@
                 "LifecycleTransition"
               ],
               "members": {
-                "LifecycleHookName": {
-                  "shape": "St"
-                },
+                "LifecycleHookName": {},
                 "LifecycleTransition": {},
-                "NotificationMetadata": {
-                  "shape": "S1b"
-                },
+                "NotificationMetadata": {},
                 "HeartbeatTimeout": {
                   "type": "integer"
                 },
                 "DefaultResult": {},
-                "NotificationTargetARN": {
-                  "shape": "S1d"
-                },
-                "RoleARN": {
-                  "shape": "S4"
-                }
+                "NotificationTargetARN": {},
+                "RoleARN": {}
               }
             }
           },
           "Tags": {
             "shape": "S1e"
           },
-          "ServiceLinkedRoleARN": {
-            "shape": "S4"
-          }
+          "ServiceLinkedRoleARN": {}
         }
       }
     },
@@ -287,60 +243,36 @@
           "LaunchConfigurationName"
         ],
         "members": {
-          "LaunchConfigurationName": {
-            "shape": "Sb"
-          },
-          "ImageId": {
-            "shape": "Sb"
-          },
-          "KeyName": {
-            "shape": "Sb"
-          },
+          "LaunchConfigurationName": {},
+          "ImageId": {},
+          "KeyName": {},
           "SecurityGroups": {
             "shape": "S1k"
           },
-          "ClassicLinkVPCId": {
-            "shape": "Sb"
-          },
+          "ClassicLinkVPCId": {},
           "ClassicLinkVPCSecurityGroups": {
             "shape": "S1l"
           },
-          "UserData": {
-            "shape": "S1m"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          },
-          "InstanceType": {
-            "shape": "Sb"
-          },
-          "KernelId": {
-            "shape": "Sb"
-          },
-          "RamdiskId": {
-            "shape": "Sb"
-          },
+          "UserData": {},
+          "InstanceId": {},
+          "InstanceType": {},
+          "KernelId": {},
+          "RamdiskId": {},
           "BlockDeviceMappings": {
             "shape": "S1n"
           },
           "InstanceMonitoring": {
             "shape": "S1w"
           },
-          "SpotPrice": {
-            "shape": "S1y"
-          },
-          "IamInstanceProfile": {
-            "shape": "S16"
-          },
+          "SpotPrice": {},
+          "IamInstanceProfile": {},
           "EbsOptimized": {
             "type": "boolean"
           },
           "AssociatePublicIpAddress": {
             "type": "boolean"
           },
-          "PlacementTenancy": {
-            "shape": "Si"
-          }
+          "PlacementTenancy": {}
         }
       }
     },
@@ -364,9 +296,7 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ForceDelete": {
             "type": "boolean"
           }
@@ -380,9 +310,7 @@
           "LaunchConfigurationName"
         ],
         "members": {
-          "LaunchConfigurationName": {
-            "shape": "S4"
-          }
+          "LaunchConfigurationName": {}
         }
       }
     },
@@ -394,12 +322,8 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {
-            "shape": "St"
-          },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          }
+          "LifecycleHookName": {},
+          "AutoScalingGroupName": {}
         }
       },
       "output": {
@@ -416,12 +340,8 @@
           "TopicARN"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "TopicARN": {
-            "shape": "S4"
-          }
+          "AutoScalingGroupName": {},
+          "TopicARN": {}
         }
       }
     },
@@ -432,12 +352,8 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "PolicyName": {
-            "shape": "S4"
-          }
+          "AutoScalingGroupName": {},
+          "PolicyName": {}
         }
       }
     },
@@ -449,12 +365,8 @@
           "ScheduledActionName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "ScheduledActionName": {
-            "shape": "S4"
-          }
+          "AutoScalingGroupName": {},
+          "ScheduledActionName": {}
         }
       }
     },
@@ -501,9 +413,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "AdjustmentType": {
-                  "shape": "Sb"
-                }
+                "AdjustmentType": {}
               }
             }
           }
@@ -517,9 +427,7 @@
           "AutoScalingGroupNames": {
             "shape": "S2k"
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -547,15 +455,9 @@
                 "CreatedTime"
               ],
               "members": {
-                "AutoScalingGroupName": {
-                  "shape": "Sb"
-                },
-                "AutoScalingGroupARN": {
-                  "shape": "S4"
-                },
-                "LaunchConfigurationName": {
-                  "shape": "Sb"
-                },
+                "AutoScalingGroupName": {},
+                "AutoScalingGroupARN": {},
+                "LaunchConfigurationName": {},
                 "LaunchTemplate": {
                   "shape": "Sy"
                 },
@@ -580,9 +482,7 @@
                 "TargetGroupARNs": {
                   "shape": "S6"
                 },
-                "HealthCheckType": {
-                  "shape": "S12"
-                },
+                "HealthCheckType": {},
                 "HealthCheckGracePeriod": {
                   "type": "integer"
                 },
@@ -598,36 +498,11 @@
                       "ProtectedFromScaleIn"
                     ],
                     "members": {
-                      "InstanceId": {
-                        "shape": "S3"
-                      },
-                      "AvailabilityZone": {
-                        "shape": "Sb"
-                      },
-                      "LifecycleState": {
-                        "type": "string",
-                        "enum": [
-                          "Pending",
-                          "Pending:Wait",
-                          "Pending:Proceed",
-                          "Quarantined",
-                          "InService",
-                          "Terminating",
-                          "Terminating:Wait",
-                          "Terminating:Proceed",
-                          "Terminated",
-                          "Detaching",
-                          "Detached",
-                          "EnteringStandby",
-                          "Standby"
-                        ]
-                      },
-                      "HealthStatus": {
-                        "shape": "S12"
-                      },
-                      "LaunchConfigurationName": {
-                        "shape": "Sb"
-                      },
+                      "InstanceId": {},
+                      "AvailabilityZone": {},
+                      "LifecycleState": {},
+                      "HealthStatus": {},
+                      "LaunchConfigurationName": {},
                       "LaunchTemplate": {
                         "shape": "Sy"
                       },
@@ -645,38 +520,24 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ProcessName": {
-                        "shape": "Sb"
-                      },
-                      "SuspensionReason": {
-                        "shape": "Sb"
-                      }
+                      "ProcessName": {},
+                      "SuspensionReason": {}
                     }
                   }
                 },
-                "PlacementGroup": {
-                  "shape": "Sb"
-                },
-                "VPCZoneIdentifier": {
-                  "shape": "S14"
-                },
+                "PlacementGroup": {},
+                "VPCZoneIdentifier": {},
                 "EnabledMetrics": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Metric": {
-                        "shape": "Sb"
-                      },
-                      "Granularity": {
-                        "shape": "Sb"
-                      }
+                      "Metric": {},
+                      "Granularity": {}
                     }
                   }
                 },
-                "Status": {
-                  "shape": "Sb"
-                },
+                "Status": {},
                 "Tags": {
                   "shape": "S2w"
                 },
@@ -686,15 +547,11 @@
                 "NewInstancesProtectedFromScaleIn": {
                   "type": "boolean"
                 },
-                "ServiceLinkedRoleARN": {
-                  "shape": "S4"
-                }
+                "ServiceLinkedRoleARN": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -708,9 +565,7 @@
           "MaxRecords": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -730,24 +585,12 @@
                 "ProtectedFromScaleIn"
               ],
               "members": {
-                "InstanceId": {
-                  "shape": "S3"
-                },
-                "AutoScalingGroupName": {
-                  "shape": "Sb"
-                },
-                "AvailabilityZone": {
-                  "shape": "Sb"
-                },
-                "LifecycleState": {
-                  "shape": "S12"
-                },
-                "HealthStatus": {
-                  "shape": "S12"
-                },
-                "LaunchConfigurationName": {
-                  "shape": "Sb"
-                },
+                "InstanceId": {},
+                "AutoScalingGroupName": {},
+                "AvailabilityZone": {},
+                "LifecycleState": {},
+                "HealthStatus": {},
+                "LaunchConfigurationName": {},
                 "LaunchTemplate": {
                   "shape": "Sy"
                 },
@@ -757,9 +600,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -780,13 +621,9 @@
         "members": {
           "LaunchConfigurationNames": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -810,51 +647,29 @@
                 "CreatedTime"
               ],
               "members": {
-                "LaunchConfigurationName": {
-                  "shape": "Sb"
-                },
-                "LaunchConfigurationARN": {
-                  "shape": "S4"
-                },
-                "ImageId": {
-                  "shape": "Sb"
-                },
-                "KeyName": {
-                  "shape": "Sb"
-                },
+                "LaunchConfigurationName": {},
+                "LaunchConfigurationARN": {},
+                "ImageId": {},
+                "KeyName": {},
                 "SecurityGroups": {
                   "shape": "S1k"
                 },
-                "ClassicLinkVPCId": {
-                  "shape": "Sb"
-                },
+                "ClassicLinkVPCId": {},
                 "ClassicLinkVPCSecurityGroups": {
                   "shape": "S1l"
                 },
-                "UserData": {
-                  "shape": "S1m"
-                },
-                "InstanceType": {
-                  "shape": "Sb"
-                },
-                "KernelId": {
-                  "shape": "Sb"
-                },
-                "RamdiskId": {
-                  "shape": "Sb"
-                },
+                "UserData": {},
+                "InstanceType": {},
+                "KernelId": {},
+                "RamdiskId": {},
                 "BlockDeviceMappings": {
                   "shape": "S1n"
                 },
                 "InstanceMonitoring": {
                   "shape": "S1w"
                 },
-                "SpotPrice": {
-                  "shape": "S1y"
-                },
-                "IamInstanceProfile": {
-                  "shape": "S16"
-                },
+                "SpotPrice": {},
+                "IamInstanceProfile": {},
                 "CreatedTime": {
                   "type": "timestamp"
                 },
@@ -864,15 +679,11 @@
                 "AssociatePublicIpAddress": {
                   "type": "boolean"
                 },
-                "PlacementTenancy": {
-                  "shape": "Si"
-                }
+                "PlacementTenancy": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -894,15 +705,10 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "LifecycleHookNames": {
             "type": "list",
-            "member": {
-              "shape": "St"
-            },
-            "max": 50
+            "member": {}
           }
         }
       },
@@ -915,22 +721,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "LifecycleHookName": {
-                  "shape": "St"
-                },
-                "AutoScalingGroupName": {
-                  "shape": "S4"
-                },
+                "LifecycleHookName": {},
+                "AutoScalingGroupName": {},
                 "LifecycleTransition": {},
-                "NotificationTargetARN": {
-                  "shape": "S4"
-                },
-                "RoleARN": {
-                  "shape": "S4"
-                },
-                "NotificationMetadata": {
-                  "shape": "S1b"
-                },
+                "NotificationTargetARN": {},
+                "RoleARN": {},
+                "NotificationMetadata": {},
                 "HeartbeatTimeout": {
                   "type": "integer"
                 },
@@ -951,12 +747,8 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "AutoScalingGroupName": {},
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -971,18 +763,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "LoadBalancerTargetGroupARN": {
-                  "shape": "S7"
-                },
-                "State": {
-                  "shape": "Sb"
-                }
+                "LoadBalancerTargetGroupARN": {},
+                "State": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -993,12 +779,8 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "AutoScalingGroupName": {},
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -1013,18 +795,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "LoadBalancerName": {
-                  "shape": "Sb"
-                },
-                "State": {
-                  "shape": "Sb"
-                }
+                "LoadBalancerName": {},
+                "State": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1038,9 +814,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Metric": {
-                  "shape": "Sb"
-                }
+                "Metric": {}
               }
             }
           },
@@ -1049,9 +823,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Granularity": {
-                  "shape": "Sb"
-                }
+                "Granularity": {}
               }
             }
           }
@@ -1065,9 +837,7 @@
           "AutoScalingGroupNames": {
             "shape": "S2k"
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -1085,21 +855,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {
-                  "shape": "S4"
-                },
-                "TopicARN": {
-                  "shape": "S4"
-                },
-                "NotificationType": {
-                  "shape": "Sb"
-                }
+                "AutoScalingGroupName": {},
+                "TopicARN": {},
+                "NotificationType": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1107,24 +869,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "PolicyNames": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            }
+            "member": {}
           },
           "PolicyTypes": {
             "type": "list",
-            "member": {
-              "shape": "Si"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -1139,21 +893,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {
-                  "shape": "Sb"
-                },
-                "PolicyName": {
-                  "shape": "Sb"
-                },
-                "PolicyARN": {
-                  "shape": "S4"
-                },
-                "PolicyType": {
-                  "shape": "Si"
-                },
-                "AdjustmentType": {
-                  "shape": "Sb"
-                },
+                "AutoScalingGroupName": {},
+                "PolicyName": {},
+                "PolicyARN": {},
+                "PolicyType": {},
+                "AdjustmentType": {},
                 "MinAdjustmentStep": {
                   "shape": "S43"
                 },
@@ -1169,9 +913,7 @@
                 "StepAdjustments": {
                   "shape": "S46"
                 },
-                "MetricAggregationType": {
-                  "shape": "S12"
-                },
+                "MetricAggregationType": {},
                 "EstimatedInstanceWarmup": {
                   "type": "integer"
                 },
@@ -1184,9 +926,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1196,19 +936,13 @@
         "members": {
           "ActivityIds": {
             "type": "list",
-            "member": {
-              "shape": "Sj"
-            }
+            "member": {}
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "MaxRecords": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1221,9 +955,7 @@
           "Activities": {
             "shape": "S4s"
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1240,9 +972,7 @@
                 "ProcessName"
               ],
               "members": {
-                "ProcessName": {
-                  "shape": "Sb"
-                }
+                "ProcessName": {}
               }
             }
           }
@@ -1253,9 +983,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ScheduledActionNames": {
             "shape": "Se"
           },
@@ -1265,9 +993,7 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -1282,15 +1008,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutoScalingGroupName": {
-                  "shape": "Sb"
-                },
-                "ScheduledActionName": {
-                  "shape": "Sb"
-                },
-                "ScheduledActionARN": {
-                  "shape": "S4"
-                },
+                "AutoScalingGroupName": {},
+                "ScheduledActionName": {},
+                "ScheduledActionARN": {},
                 "Time": {
                   "type": "timestamp"
                 },
@@ -1300,9 +1020,7 @@
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "Recurrence": {
-                  "shape": "Sb"
-                },
+                "Recurrence": {},
                 "MinSize": {
                   "type": "integer"
                 },
@@ -1315,9 +1033,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1330,21 +1046,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "Sj"
-                },
+                "Name": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "shape": "Sj"
-                  }
+                  "member": {}
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "Sj"
-          },
+          "NextToken": {},
           "MaxRecords": {
             "type": "integer"
           }
@@ -1357,9 +1067,7 @@
           "Tags": {
             "shape": "S2w"
           },
-          "NextToken": {
-            "shape": "Sj"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1385,9 +1093,7 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1411,9 +1117,7 @@
           "TargetGroupARNs"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "TargetGroupARNs": {
             "shape": "S6"
           }
@@ -1433,9 +1137,7 @@
           "LoadBalancerNames"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "LoadBalancerNames": {
             "shape": "Sa"
           }
@@ -1454,9 +1156,7 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "Metrics": {
             "shape": "S5h"
           }
@@ -1471,15 +1171,11 @@
           "Granularity"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "Metrics": {
             "shape": "S5h"
           },
-          "Granularity": {
-            "shape": "Sb"
-          }
+          "Granularity": {}
         }
       }
     },
@@ -1494,9 +1190,7 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1519,12 +1213,8 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "PolicyName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
+          "PolicyName": {},
           "HonorCooldown": {
             "type": "boolean"
           },
@@ -1547,9 +1237,7 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          }
+          "AutoScalingGroupName": {}
         }
       },
       "output": {
@@ -1570,22 +1258,12 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {
-            "shape": "St"
-          },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "LifecycleHookName": {},
+          "AutoScalingGroupName": {},
           "LifecycleTransition": {},
-          "RoleARN": {
-            "shape": "S4"
-          },
-          "NotificationTargetARN": {
-            "shape": "S1d"
-          },
-          "NotificationMetadata": {
-            "shape": "S1b"
-          },
+          "RoleARN": {},
+          "NotificationTargetARN": {},
+          "NotificationMetadata": {},
           "HeartbeatTimeout": {
             "type": "integer"
           },
@@ -1607,12 +1285,8 @@
           "NotificationTypes"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "TopicARN": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
+          "TopicARN": {},
           "NotificationTypes": {
             "shape": "S33"
           }
@@ -1627,18 +1301,10 @@
           "PolicyName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "PolicyName": {
-            "shape": "Sb"
-          },
-          "PolicyType": {
-            "shape": "Si"
-          },
-          "AdjustmentType": {
-            "shape": "Sb"
-          },
+          "AutoScalingGroupName": {},
+          "PolicyName": {},
+          "PolicyType": {},
+          "AdjustmentType": {},
           "MinAdjustmentStep": {
             "shape": "S43"
           },
@@ -1651,9 +1317,7 @@
           "Cooldown": {
             "type": "integer"
           },
-          "MetricAggregationType": {
-            "shape": "S12"
-          },
+          "MetricAggregationType": {},
           "StepAdjustments": {
             "shape": "S46"
           },
@@ -1669,9 +1333,7 @@
         "resultWrapper": "PutScalingPolicyResult",
         "type": "structure",
         "members": {
-          "PolicyARN": {
-            "shape": "S4"
-          },
+          "PolicyARN": {},
           "Alarms": {
             "shape": "S4a"
           }
@@ -1686,12 +1348,8 @@
           "ScheduledActionName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "ScheduledActionName": {
-            "shape": "Sb"
-          },
+          "AutoScalingGroupName": {},
+          "ScheduledActionName": {},
           "Time": {
             "type": "timestamp"
           },
@@ -1701,9 +1359,7 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "Recurrence": {
-            "shape": "Sb"
-          },
+          "Recurrence": {},
           "MinSize": {
             "type": "integer"
           },
@@ -1724,18 +1380,10 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "LifecycleHookName": {
-            "shape": "St"
-          },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "LifecycleActionToken": {
-            "shape": "Su"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          }
+          "LifecycleHookName": {},
+          "AutoScalingGroupName": {},
+          "LifecycleActionToken": {},
+          "InstanceId": {}
         }
       },
       "output": {
@@ -1757,9 +1405,7 @@
           "DesiredCapacity"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "DesiredCapacity": {
             "type": "integer"
           },
@@ -1777,12 +1423,8 @@
           "HealthStatus"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "S3"
-          },
-          "HealthStatus": {
-            "shape": "S12"
-          },
+          "InstanceId": {},
+          "HealthStatus": {},
           "ShouldRespectGracePeriod": {
             "type": "boolean"
           }
@@ -1801,9 +1443,7 @@
           "InstanceIds": {
             "shape": "S2"
           },
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
           "ProtectedFromScaleIn": {
             "type": "boolean"
           }
@@ -1828,9 +1468,7 @@
           "ShouldDecrementDesiredCapacity"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "S3"
-          },
+          "InstanceId": {},
           "ShouldDecrementDesiredCapacity": {
             "type": "boolean"
           }
@@ -1853,12 +1491,8 @@
           "AutoScalingGroupName"
         ],
         "members": {
-          "AutoScalingGroupName": {
-            "shape": "S4"
-          },
-          "LaunchConfigurationName": {
-            "shape": "S4"
-          },
+          "AutoScalingGroupName": {},
+          "LaunchConfigurationName": {},
           "LaunchTemplate": {
             "shape": "Sy"
           },
@@ -1877,27 +1511,19 @@
           "AvailabilityZones": {
             "shape": "S11"
           },
-          "HealthCheckType": {
-            "shape": "S12"
-          },
+          "HealthCheckType": {},
           "HealthCheckGracePeriod": {
             "type": "integer"
           },
-          "PlacementGroup": {
-            "shape": "Sb"
-          },
-          "VPCZoneIdentifier": {
-            "shape": "S14"
-          },
+          "PlacementGroup": {},
+          "VPCZoneIdentifier": {},
           "TerminationPolicies": {
             "shape": "S15"
           },
           "NewInstancesProtectedFromScaleIn": {
             "type": "boolean"
           },
-          "ServiceLinkedRoleARN": {
-            "shape": "S4"
-          }
+          "ServiceLinkedRoleARN": {}
         }
       }
     }
@@ -1905,51 +1531,19 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
-    },
-    "S3": {
-      "type": "string",
-      "max": 19,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S4": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "S6": {
       "type": "list",
-      "member": {
-        "shape": "S7"
-      }
-    },
-    "S7": {
-      "type": "string",
-      "max": 511,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "Sa": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      }
-    },
-    "Sb": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "Se": {
       "type": "list",
-      "member": {
-        "shape": "S4"
-      }
+      "member": {}
     },
     "Sg": {
       "type": "list",
@@ -1959,98 +1553,27 @@
           "ScheduledActionName"
         ],
         "members": {
-          "ScheduledActionName": {
-            "shape": "Sb"
-          },
-          "ErrorCode": {
-            "shape": "Si"
-          },
-          "ErrorMessage": {
-            "shape": "Sj"
-          }
+          "ScheduledActionName": {},
+          "ErrorCode": {},
+          "ErrorMessage": {}
         }
       }
-    },
-    "Si": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "St": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[A-Za-z0-9\\-_\\/]+"
-    },
-    "Su": {
-      "type": "string",
-      "max": 36,
-      "min": 36
     },
     "Sy": {
       "type": "structure",
       "members": {
-        "LaunchTemplateId": {
-          "shape": "Sb"
-        },
-        "LaunchTemplateName": {
-          "type": "string",
-          "max": 128,
-          "min": 3,
-          "pattern": "[a-zA-Z0-9\\(\\)\\.-/_]+"
-        },
-        "Version": {
-          "shape": "Sb"
-        }
+        "LaunchTemplateId": {},
+        "LaunchTemplateName": {},
+        "Version": {}
       }
     },
     "S11": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      },
-      "min": 1
-    },
-    "S12": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S14": {
-      "type": "string",
-      "max": 2047,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "S15": {
       "type": "list",
-      "member": {
-        "shape": "S16"
-      }
-    },
-    "S16": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S1b": {
-      "type": "string",
-      "max": 1023,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S1d": {
-      "type": "string",
-      "max": 1600,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "S1e": {
       "type": "list",
@@ -2060,52 +1583,23 @@
           "Key"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sj"
-          },
-          "ResourceType": {
-            "shape": "Sj"
-          },
-          "Key": {
-            "shape": "S1g"
-          },
-          "Value": {
-            "shape": "S1h"
-          },
+          "ResourceId": {},
+          "ResourceType": {},
+          "Key": {},
+          "Value": {},
           "PropagateAtLaunch": {
             "type": "boolean"
           }
         }
       }
     },
-    "S1g": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S1h": {
-      "type": "string",
-      "max": 256,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S1k": {
       "type": "list",
-      "member": {
-        "shape": "Sj"
-      }
+      "member": {}
     },
     "S1l": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      }
-    },
-    "S1m": {
-      "type": "string",
-      "max": 21847,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      "member": {}
     },
     "S1n": {
       "type": "list",
@@ -2115,35 +1609,21 @@
           "DeviceName"
         ],
         "members": {
-          "VirtualName": {
-            "shape": "Sb"
-          },
-          "DeviceName": {
-            "shape": "Sb"
-          },
+          "VirtualName": {},
+          "DeviceName": {},
           "Ebs": {
             "type": "structure",
             "members": {
-              "SnapshotId": {
-                "shape": "Sb"
-              },
+              "SnapshotId": {},
               "VolumeSize": {
-                "type": "integer",
-                "max": 16384,
-                "min": 1
+                "type": "integer"
               },
-              "VolumeType": {
-                "type": "string",
-                "max": 255,
-                "min": 1
-              },
+              "VolumeType": {},
               "DeleteOnTermination": {
                 "type": "boolean"
               },
               "Iops": {
-                "type": "integer",
-                "max": 20000,
-                "min": 100
+                "type": "integer"
               },
               "Encrypted": {
                 "type": "boolean"
@@ -2164,34 +1644,19 @@
         }
       }
     },
-    "S1y": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
     "S2k": {
       "type": "list",
-      "member": {
-        "shape": "S4"
-      }
+      "member": {}
     },
     "S2w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "Sj"
-          },
-          "ResourceType": {
-            "shape": "Sj"
-          },
-          "Key": {
-            "shape": "S1g"
-          },
-          "Value": {
-            "shape": "S1h"
-          },
+          "ResourceId": {},
+          "ResourceType": {},
+          "Key": {},
+          "Value": {},
           "PropagateAtLaunch": {
             "type": "boolean"
           }
@@ -2200,9 +1665,7 @@
     },
     "S33": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      }
+      "member": {}
     },
     "S43": {
       "type": "integer",
@@ -2233,12 +1696,8 @@
       "member": {
         "type": "structure",
         "members": {
-          "AlarmName": {
-            "shape": "Sb"
-          },
-          "AlarmARN": {
-            "shape": "S4"
-          }
+          "AlarmName": {},
+          "AlarmARN": {}
         }
       }
     },
@@ -2254,18 +1713,8 @@
             "PredefinedMetricType"
           ],
           "members": {
-            "PredefinedMetricType": {
-              "type": "string",
-              "enum": [
-                "ASGAverageCPUUtilization",
-                "ASGAverageNetworkIn",
-                "ASGAverageNetworkOut",
-                "ALBRequestCountPerTarget"
-              ]
-            },
-            "ResourceLabel": {
-              "shape": "S1b"
-            }
+            "PredefinedMetricType": {},
+            "ResourceLabel": {}
           }
         },
         "CustomizedMetricSpecification": {
@@ -2292,16 +1741,7 @@
                 }
               }
             },
-            "Statistic": {
-              "type": "string",
-              "enum": [
-                "Average",
-                "Minimum",
-                "Maximum",
-                "SampleCount",
-                "Sum"
-              ]
-            },
+            "Statistic": {},
             "Unit": {}
           }
         },
@@ -2329,57 +1769,27 @@
         "StatusCode"
       ],
       "members": {
-        "ActivityId": {
-          "shape": "Sj"
-        },
-        "AutoScalingGroupName": {
-          "shape": "Sb"
-        },
-        "Description": {
-          "shape": "Sj"
-        },
-        "Cause": {
-          "shape": "S1b"
-        },
+        "ActivityId": {},
+        "AutoScalingGroupName": {},
+        "Description": {},
+        "Cause": {},
         "StartTime": {
           "type": "timestamp"
         },
         "EndTime": {
           "type": "timestamp"
         },
-        "StatusCode": {
-          "type": "string",
-          "enum": [
-            "PendingSpotBidPlacement",
-            "WaitingForSpotInstanceRequestId",
-            "WaitingForSpotInstanceId",
-            "WaitingForInstanceId",
-            "PreInService",
-            "InProgress",
-            "WaitingForELBConnectionDraining",
-            "MidLifecycleAction",
-            "WaitingForInstanceWarmup",
-            "Successful",
-            "Failed",
-            "Cancelled"
-          ]
-        },
-        "StatusMessage": {
-          "shape": "Sb"
-        },
+        "StatusCode": {},
+        "StatusMessage": {},
         "Progress": {
           "type": "integer"
         },
-        "Details": {
-          "shape": "Sj"
-        }
+        "Details": {}
       }
     },
     "S5h": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      }
+      "member": {}
     },
     "S5x": {
       "type": "structure",
@@ -2387,14 +1797,10 @@
         "AutoScalingGroupName"
       ],
       "members": {
-        "AutoScalingGroupName": {
-          "shape": "S4"
-        },
+        "AutoScalingGroupName": {},
         "ScalingProcesses": {
           "type": "list",
-          "member": {
-            "shape": "Sb"
-          }
+          "member": {}
         }
       }
     }

--- a/apis/autoscaling-plans-2018-01-06.min.json
+++ b/apis/autoscaling-plans-2018-01-06.min.json
@@ -22,9 +22,7 @@
           "ScalingInstructions"
         ],
         "members": {
-          "ScalingPlanName": {
-            "shape": "S2"
-          },
+          "ScalingPlanName": {},
           "ApplicationSource": {
             "shape": "S3"
           },
@@ -53,9 +51,7 @@
           "ScalingPlanVersion"
         ],
         "members": {
-          "ScalingPlanName": {
-            "shape": "S2"
-          },
+          "ScalingPlanName": {},
           "ScalingPlanVersion": {
             "type": "long"
           }
@@ -74,9 +70,7 @@
           "ScalingPlanVersion"
         ],
         "members": {
-          "ScalingPlanName": {
-            "shape": "S2"
-          },
+          "ScalingPlanName": {},
           "ScalingPlanVersion": {
             "type": "long"
           },
@@ -102,21 +96,13 @@
                 "ScalingStatusCode"
               ],
               "members": {
-                "ScalingPlanName": {
-                  "shape": "S2"
-                },
+                "ScalingPlanName": {},
                 "ScalingPlanVersion": {
                   "type": "long"
                 },
-                "ServiceNamespace": {
-                  "shape": "Sc"
-                },
-                "ResourceId": {
-                  "shape": "Sd"
-                },
-                "ScalableDimension": {
-                  "shape": "Se"
-                },
+                "ServiceNamespace": {},
+                "ResourceId": {},
+                "ScalableDimension": {},
                 "ScalingPolicies": {
                   "type": "list",
                   "member": {
@@ -126,35 +112,16 @@
                       "PolicyType"
                     ],
                     "members": {
-                      "PolicyName": {
-                        "type": "string",
-                        "max": 256,
-                        "min": 1,
-                        "pattern": "\\p{Print}+"
-                      },
-                      "PolicyType": {
-                        "type": "string",
-                        "enum": [
-                          "TargetTrackingScaling"
-                        ]
-                      },
+                      "PolicyName": {},
+                      "PolicyType": {},
                       "TargetTrackingConfiguration": {
                         "shape": "Sh"
                       }
                     }
                   }
                 },
-                "ScalingStatusCode": {
-                  "type": "string",
-                  "enum": [
-                    "Inactive",
-                    "PartiallyActive",
-                    "Active"
-                  ]
-                },
-                "ScalingStatusMessage": {
-                  "shape": "S4"
-                }
+                "ScalingStatusCode": {},
+                "ScalingStatusMessage": {}
               }
             }
           },
@@ -168,9 +135,7 @@
         "members": {
           "ScalingPlanNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           },
           "ScalingPlanVersion": {
             "type": "long"
@@ -202,9 +167,7 @@
                 "StatusCode"
               ],
               "members": {
-                "ScalingPlanName": {
-                  "shape": "S2"
-                },
+                "ScalingPlanName": {},
                 "ScalingPlanVersion": {
                   "type": "long"
                 },
@@ -214,22 +177,8 @@
                 "ScalingInstructions": {
                   "shape": "Sa"
                 },
-                "StatusCode": {
-                  "type": "string",
-                  "enum": [
-                    "Active",
-                    "ActiveWithProblems",
-                    "CreationInProgress",
-                    "CreationFailed",
-                    "DeletionInProgress",
-                    "DeletionFailed",
-                    "UpdateInProgress",
-                    "UpdateFailed"
-                  ]
-                },
-                "StatusMessage": {
-                  "shape": "S4"
-                },
+                "StatusCode": {},
+                "StatusMessage": {},
                 "StatusStartTime": {
                   "type": "timestamp"
                 },
@@ -254,9 +203,7 @@
           "ApplicationSource": {
             "shape": "S3"
           },
-          "ScalingPlanName": {
-            "shape": "S2"
-          },
+          "ScalingPlanName": {},
           "ScalingInstructions": {
             "shape": "Sa"
           },
@@ -272,46 +219,24 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\p{Print}&&[^|:/]]+"
-    },
     "S3": {
       "type": "structure",
       "members": {
-        "CloudFormationStackARN": {
-          "shape": "S4"
-        },
+        "CloudFormationStackARN": {},
         "TagFilters": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Key": {
-                "type": "string",
-                "max": 128,
-                "min": 1,
-                "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-              },
+              "Key": {},
               "Values": {
                 "type": "list",
-                "member": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1,
-                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-                }
+                "member": {}
               }
             }
           }
         }
       }
-    },
-    "S4": {
-      "type": "string",
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sa": {
       "type": "list",
@@ -326,15 +251,9 @@
           "TargetTrackingConfigurations"
         ],
         "members": {
-          "ServiceNamespace": {
-            "shape": "Sc"
-          },
-          "ResourceId": {
-            "shape": "Sd"
-          },
-          "ScalableDimension": {
-            "shape": "Se"
-          },
+          "ServiceNamespace": {},
+          "ResourceId": {},
+          "ScalableDimension": {},
           "MinCapacity": {
             "type": "integer"
           },
@@ -350,35 +269,6 @@
         }
       }
     },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "autoscaling",
-        "ecs",
-        "ec2",
-        "rds",
-        "dynamodb"
-      ]
-    },
-    "Sd": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "rds:cluster:ReadReplicaCount",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
-        "dynamodb:index:ReadCapacityUnits",
-        "dynamodb:index:WriteCapacityUnits"
-      ]
-    },
     "Sh": {
       "type": "structure",
       "required": [
@@ -391,29 +281,8 @@
             "PredefinedScalingMetricType"
           ],
           "members": {
-            "PredefinedScalingMetricType": {
-              "type": "string",
-              "enum": [
-                "ASGAverageCPUUtilization",
-                "ASGAverageNetworkIn",
-                "ASGAverageNetworkOut",
-                "DynamoDBReadCapacityUtilization",
-                "DynamoDBWriteCapacityUtilization",
-                "ECSServiceAverageCPUUtilization",
-                "ECSServiceAverageMemoryUtilization",
-                "ALBRequestCountPerTarget",
-                "RDSReaderAverageCPUUtilization",
-                "RDSReaderAverageDatabaseConnections",
-                "EC2SpotFleetRequestAverageCPUUtilization",
-                "EC2SpotFleetRequestAverageNetworkIn",
-                "EC2SpotFleetRequestAverageNetworkOut"
-              ]
-            },
-            "ResourceLabel": {
-              "type": "string",
-              "max": 1023,
-              "min": 1
-            }
+            "PredefinedScalingMetricType": {},
+            "ResourceLabel": {}
           }
         },
         "CustomizedScalingMetricSpecification": {
@@ -440,16 +309,7 @@
                 }
               }
             },
-            "Statistic": {
-              "type": "string",
-              "enum": [
-                "Average",
-                "Minimum",
-                "Maximum",
-                "SampleCount",
-                "Sum"
-              ]
-            },
+            "Statistic": {},
             "Unit": {}
           }
         },

--- a/apis/batch-2016-08-10.min.json
+++ b/apis/batch-2016-08-10.min.json
@@ -45,12 +45,8 @@
         ],
         "members": {
           "computeEnvironmentName": {},
-          "type": {
-            "shape": "S5"
-          },
-          "state": {
-            "shape": "S6"
-          },
+          "type": {},
+          "state": {},
           "computeResources": {
             "shape": "S7"
           },
@@ -78,9 +74,7 @@
         ],
         "members": {
           "jobQueueName": {},
-          "state": {
-            "shape": "Se"
-          },
+          "state": {},
           "priority": {
             "type": "integer"
           },
@@ -187,23 +181,9 @@
                 "computeEnvironmentName": {},
                 "computeEnvironmentArn": {},
                 "ecsClusterArn": {},
-                "type": {
-                  "shape": "S5"
-                },
-                "state": {
-                  "shape": "S6"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "CREATING",
-                    "UPDATING",
-                    "DELETING",
-                    "DELETED",
-                    "VALID",
-                    "INVALID"
-                  ]
-                },
+                "type": {},
+                "state": {},
+                "status": {},
                 "statusReason": {},
                 "computeResources": {
                   "shape": "S7"
@@ -307,20 +287,8 @@
               "members": {
                 "jobQueueName": {},
                 "jobQueueArn": {},
-                "state": {
-                  "shape": "Se"
-                },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "CREATING",
-                    "UPDATING",
-                    "DELETING",
-                    "DELETED",
-                    "VALID",
-                    "INVALID"
-                  ]
-                },
+                "state": {},
+                "status": {},
                 "statusReason": {},
                 "priority": {
                   "type": "integer"
@@ -369,9 +337,7 @@
                 "jobName": {},
                 "jobId": {},
                 "jobQueue": {},
-                "status": {
-                  "shape": "S1k"
-                },
+                "status": {},
                 "attempts": {
                   "type": "list",
                   "member": {
@@ -497,9 +463,7 @@
         "members": {
           "jobQueue": {},
           "arrayJobId": {},
-          "jobStatus": {
-            "shape": "S1k"
-          },
+          "jobStatus": {},
           "maxResults": {
             "type": "integer"
           },
@@ -526,9 +490,7 @@
                 "createdAt": {
                   "type": "long"
                 },
-                "status": {
-                  "shape": "S1k"
-                },
+                "status": {},
                 "statusReason": {},
                 "startedAt": {
                   "type": "long"
@@ -575,12 +537,7 @@
         ],
         "members": {
           "jobDefinitionName": {},
-          "type": {
-            "type": "string",
-            "enum": [
-              "container"
-            ]
-          },
+          "type": {},
           "parameters": {
             "shape": "Sx"
           },
@@ -708,9 +665,7 @@
         ],
         "members": {
           "computeEnvironment": {},
-          "state": {
-            "shape": "S6"
-          },
+          "state": {},
           "computeResources": {
             "type": "structure",
             "members": {
@@ -747,9 +702,7 @@
         ],
         "members": {
           "jobQueue": {},
-          "state": {
-            "shape": "Se"
-          },
+          "state": {},
           "priority": {
             "type": "integer"
           },
@@ -768,20 +721,6 @@
     }
   },
   "shapes": {
-    "S5": {
-      "type": "string",
-      "enum": [
-        "MANAGED",
-        "UNMANAGED"
-      ]
-    },
-    "S6": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
-    },
     "S7": {
       "type": "structure",
       "required": [
@@ -794,13 +733,7 @@
         "instanceRole"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "EC2",
-            "SPOT"
-          ]
-        },
+        "type": {},
         "minvCpus": {
           "type": "integer"
         },
@@ -836,13 +769,6 @@
     "Sa": {
       "type": "list",
       "member": {}
-    },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
     },
     "Sf": {
       "type": "list",
@@ -979,31 +905,13 @@
         }
       }
     },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "SUBMITTED",
-        "PENDING",
-        "RUNNABLE",
-        "STARTING",
-        "RUNNING",
-        "SUCCEEDED",
-        "FAILED"
-      ]
-    },
     "S1p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "jobId": {},
-          "type": {
-            "type": "string",
-            "enum": [
-              "N_TO_N",
-              "SEQUENTIAL"
-            ]
-          }
+          "type": {}
         }
       }
     }

--- a/apis/budgets-2016-10-20.min.json
+++ b/apis/budgets-2016-10-20.min.json
@@ -21,9 +21,7 @@
           "Budget"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
+          "AccountId": {},
           "Budget": {
             "shape": "S3"
           },
@@ -43,8 +41,7 @@
                   "shape": "Sp"
                 }
               }
-            },
-            "max": 5
+            }
           }
         }
       },
@@ -63,12 +60,8 @@
           "Subscribers"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           },
@@ -92,12 +85,8 @@
           "Subscriber"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           },
@@ -119,12 +108,8 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          }
+          "AccountId": {},
+          "BudgetName": {}
         }
       },
       "output": {
@@ -141,12 +126,8 @@
           "Notification"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           }
@@ -167,12 +148,8 @@
           "Subscriber"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           },
@@ -194,12 +171,8 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          }
+          "AccountId": {},
+          "BudgetName": {}
         }
       },
       "output": {
@@ -218,11 +191,9 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
+          "AccountId": {},
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -248,14 +219,10 @@
           "BudgetName"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -282,17 +249,13 @@
           "Notification"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           },
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -315,9 +278,7 @@
           "NewBudget"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
+          "AccountId": {},
           "NewBudget": {
             "shape": "S3"
           }
@@ -338,12 +299,8 @@
           "NewNotification"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "OldNotification": {
             "shape": "Sk"
           },
@@ -368,12 +325,8 @@
           "NewSubscriber"
         ],
         "members": {
-          "AccountId": {
-            "shape": "S2"
-          },
-          "BudgetName": {
-            "shape": "S4"
-          },
+          "AccountId": {},
+          "BudgetName": {},
           "Notification": {
             "shape": "Sk"
           },
@@ -392,11 +345,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 12,
-      "min": 12
-    },
     "S3": {
       "type": "structure",
       "required": [
@@ -405,9 +353,7 @@
         "BudgetType"
       ],
       "members": {
-        "BudgetName": {
-          "shape": "S4"
-        },
+        "BudgetName": {},
         "BudgetLimit": {
           "shape": "S5"
         },
@@ -457,15 +403,7 @@
             }
           }
         },
-        "TimeUnit": {
-          "type": "string",
-          "enum": [
-            "DAILY",
-            "MONTHLY",
-            "QUARTERLY",
-            "ANNUALLY"
-          ]
-        },
+        "TimeUnit": {},
         "TimePeriod": {
           "type": "structure",
           "members": {
@@ -491,21 +429,8 @@
             }
           }
         },
-        "BudgetType": {
-          "type": "string",
-          "enum": [
-            "USAGE",
-            "COST",
-            "RI_UTILIZATION",
-            "RI_COVERAGE"
-          ]
-        }
+        "BudgetType": {}
       }
-    },
-    "S4": {
-      "type": "string",
-      "max": 100,
-      "pattern": "[^:\\\\]+"
     },
     "S5": {
       "type": "structure",
@@ -514,14 +439,8 @@
         "Unit"
       ],
       "members": {
-        "Amount": {
-          "type": "string",
-          "pattern": "([0-9]*\\.)?[0-9]+"
-        },
-        "Unit": {
-          "type": "string",
-          "min": 1
-        }
+        "Amount": {},
+        "Unit": {}
       }
     },
     "Sk": {
@@ -532,42 +451,19 @@
         "Threshold"
       ],
       "members": {
-        "NotificationType": {
-          "type": "string",
-          "enum": [
-            "ACTUAL",
-            "FORECASTED"
-          ]
-        },
-        "ComparisonOperator": {
-          "type": "string",
-          "enum": [
-            "GREATER_THAN",
-            "LESS_THAN",
-            "EQUAL_TO"
-          ]
-        },
+        "NotificationType": {},
+        "ComparisonOperator": {},
         "Threshold": {
-          "type": "double",
-          "max": 1000000000,
-          "min": 0.1
+          "type": "double"
         },
-        "ThresholdType": {
-          "type": "string",
-          "enum": [
-            "PERCENTAGE",
-            "ABSOLUTE_VALUE"
-          ]
-        }
+        "ThresholdType": {}
       }
     },
     "Sp": {
       "type": "list",
       "member": {
         "shape": "Sq"
-      },
-      "max": 11,
-      "min": 1
+      }
     },
     "Sq": {
       "type": "structure",
@@ -576,23 +472,9 @@
         "Address"
       ],
       "members": {
-        "SubscriptionType": {
-          "type": "string",
-          "enum": [
-            "SNS",
-            "EMAIL"
-          ]
-        },
-        "Address": {
-          "type": "string",
-          "min": 1
-        }
+        "SubscriptionType": {},
+        "Address": {}
       }
-    },
-    "S17": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     }
   }
 }

--- a/apis/ce-2017-10-25.min.json
+++ b/apis/ce-2017-10-25.min.json
@@ -21,9 +21,7 @@
           "TimePeriod": {
             "shape": "S2"
           },
-          "Granularity": {
-            "shape": "S4"
-          },
+          "Granularity": {},
           "Filter": {
             "shape": "S5"
           },
@@ -91,16 +89,8 @@
           "TimePeriod": {
             "shape": "S2"
           },
-          "Dimension": {
-            "shape": "S8"
-          },
-          "Context": {
-            "type": "string",
-            "enum": [
-              "COST_AND_USAGE",
-              "RESERVATIONS"
-            ]
-          },
+          "Dimension": {},
+          "Context": {},
           "NextPageToken": {}
         }
       },
@@ -147,9 +137,7 @@
           "GroupBy": {
             "shape": "Sf"
           },
-          "Granularity": {
-            "shape": "S4"
-          },
+          "Granularity": {},
           "Filter": {
             "shape": "S5"
           },
@@ -206,24 +194,15 @@
         "members": {
           "AccountId": {},
           "Service": {},
-          "AccountScope": {
-            "shape": "S1k"
-          },
-          "LookbackPeriodInDays": {
-            "shape": "S1l"
-          },
-          "TermInYears": {
-            "shape": "S1m"
-          },
-          "PaymentOption": {
-            "shape": "S1n"
-          },
+          "AccountScope": {},
+          "LookbackPeriodInDays": {},
+          "TermInYears": {},
+          "PaymentOption": {},
           "ServiceSpecification": {
             "shape": "S1o"
           },
           "PageSize": {
-            "type": "integer",
-            "min": 0
+            "type": "integer"
           },
           "NextPageToken": {}
         }
@@ -243,18 +222,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "AccountScope": {
-                  "shape": "S1k"
-                },
-                "LookbackPeriodInDays": {
-                  "shape": "S1l"
-                },
-                "TermInYears": {
-                  "shape": "S1m"
-                },
-                "PaymentOption": {
-                  "shape": "S1n"
-                },
+                "AccountScope": {},
+                "LookbackPeriodInDays": {},
+                "TermInYears": {},
+                "PaymentOption": {},
                 "ServiceSpecification": {
                   "shape": "S1o"
                 },
@@ -394,9 +365,7 @@
           "GroupBy": {
             "shape": "Sf"
           },
-          "Granularity": {
-            "shape": "S4"
-          },
+          "Granularity": {},
           "Filter": {
             "shape": "S5"
           },
@@ -492,24 +461,9 @@
         "End"
       ],
       "members": {
-        "Start": {
-          "shape": "S3"
-        },
-        "End": {
-          "shape": "S3"
-        }
+        "Start": {},
+        "End": {}
       }
-    },
-    "S3": {
-      "type": "string",
-      "pattern": "\\d{4}-\\d{2}-\\d{2}"
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "DAILY",
-        "MONTHLY"
-      ]
     },
     "S5": {
       "type": "structure",
@@ -526,9 +480,7 @@
         "Dimensions": {
           "type": "structure",
           "members": {
-            "Key": {
-              "shape": "S8"
-            },
+            "Key": {},
             "Values": {
               "shape": "S9"
             }
@@ -551,31 +503,6 @@
         "shape": "S5"
       }
     },
-    "S8": {
-      "type": "string",
-      "enum": [
-        "AZ",
-        "INSTANCE_TYPE",
-        "LINKED_ACCOUNT",
-        "OPERATION",
-        "PURCHASE_TYPE",
-        "REGION",
-        "SERVICE",
-        "USAGE_TYPE",
-        "USAGE_TYPE_GROUP",
-        "RECORD_TYPE",
-        "OPERATING_SYSTEM",
-        "TENANCY",
-        "SCOPE",
-        "PLATFORM",
-        "SUBSCRIPTION_ID",
-        "LEGAL_ENTITY_NAME",
-        "DEPLOYMENT_OPTION",
-        "DATABASE_ENGINE",
-        "CACHE_ENGINE",
-        "INSTANCE_TYPE_FAMILY"
-      ]
-    },
     "S9": {
       "type": "list",
       "member": {}
@@ -585,13 +512,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "DIMENSION",
-              "TAG"
-            ]
-          },
+          "Type": {},
           "Key": {}
         }
       }
@@ -626,52 +547,13 @@
         }
       }
     },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "PAYER",
-        "LINKED"
-      ]
-    },
-    "S1l": {
-      "type": "string",
-      "enum": [
-        "SEVEN_DAYS",
-        "THIRTY_DAYS",
-        "SIXTY_DAYS"
-      ]
-    },
-    "S1m": {
-      "type": "string",
-      "enum": [
-        "ONE_YEAR",
-        "THREE_YEARS"
-      ]
-    },
-    "S1n": {
-      "type": "string",
-      "enum": [
-        "NO_UPFRONT",
-        "PARTIAL_UPFRONT",
-        "ALL_UPFRONT",
-        "LIGHT_UTILIZATION",
-        "MEDIUM_UTILIZATION",
-        "HEAVY_UTILIZATION"
-      ]
-    },
     "S1o": {
       "type": "structure",
       "members": {
         "EC2Specification": {
           "type": "structure",
           "members": {
-            "OfferingClass": {
-              "type": "string",
-              "enum": [
-                "STANDARD",
-                "CONVERTIBLE"
-              ]
-            }
+            "OfferingClass": {}
           }
         }
       }

--- a/apis/cloud9-2017-09-23.min.json
+++ b/apis/cloud9-2017-09-23.min.json
@@ -20,42 +20,21 @@
           "instanceType"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S3"
-          },
-          "clientRequestToken": {
-            "type": "string",
-            "pattern": "[\\x20-\\x7E]{10,128}"
-          },
-          "instanceType": {
-            "type": "string",
-            "max": 20,
-            "min": 5,
-            "pattern": "^[a-z][1-9][.][a-z0-9]+$"
-          },
-          "subnetId": {
-            "type": "string",
-            "max": 30,
-            "min": 5
-          },
+          "name": {},
+          "description": {},
+          "clientRequestToken": {},
+          "instanceType": {},
+          "subnetId": {},
           "automaticStopTimeMinutes": {
-            "type": "integer",
-            "max": 20160
+            "type": "integer"
           },
-          "ownerArn": {
-            "shape": "S8"
-          }
+          "ownerArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          }
+          "environmentId": {}
         }
       },
       "idempotent": true
@@ -69,15 +48,9 @@
           "permissions"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          },
-          "userArn": {
-            "shape": "S8"
-          },
-          "permissions": {
-            "shape": "Sc"
-          }
+          "environmentId": {},
+          "userArn": {},
+          "permissions": {}
         }
       },
       "output": {
@@ -97,9 +70,7 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          }
+          "environmentId": {}
         }
       },
       "output": {
@@ -116,12 +87,8 @@
           "userArn"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          },
-          "userArn": {
-            "shape": "S8"
-          }
+          "environmentId": {},
+          "userArn": {}
         }
       },
       "output": {
@@ -134,21 +101,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "userArn": {
-            "shape": "S8"
-          },
-          "environmentId": {
-            "shape": "Sa"
-          },
+          "userArn": {},
+          "environmentId": {},
           "permissions": {
             "type": "list",
-            "member": {
-              "shape": "Sf"
-            }
+            "member": {}
           },
           "nextToken": {},
           "maxResults": {
-            "shape": "So"
+            "type": "integer"
           }
         }
       },
@@ -172,26 +133,13 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          }
+          "environmentId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "error",
-              "creating",
-              "connecting",
-              "ready",
-              "stopping",
-              "stopped",
-              "deleting"
-            ]
-          },
+          "status": {},
           "message": {}
         }
       }
@@ -205,11 +153,7 @@
         "members": {
           "environmentIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -221,22 +165,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {
-                  "shape": "Sa"
-                },
-                "name": {
-                  "shape": "S2"
-                },
-                "description": {
-                  "shape": "S3"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "ssh",
-                    "ec2"
-                  ]
-                },
+                "id": {},
+                "name": {},
+                "description": {},
+                "type": {},
                 "arn": {},
                 "ownerArn": {}
               }
@@ -251,7 +183,7 @@
         "members": {
           "nextToken": {},
           "maxResults": {
-            "shape": "So"
+            "type": "integer"
           }
         }
       },
@@ -261,9 +193,7 @@
           "nextToken": {},
           "environmentIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa"
-            }
+            "member": {}
           }
         }
       }
@@ -275,15 +205,9 @@
           "environmentId"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          },
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S3"
-          }
+          "environmentId": {},
+          "name": {},
+          "description": {}
         }
       },
       "output": {
@@ -301,15 +225,9 @@
           "permissions"
         ],
         "members": {
-          "environmentId": {
-            "shape": "Sa"
-          },
-          "userArn": {
-            "shape": "S8"
-          },
-          "permissions": {
-            "shape": "Sc"
-          }
+          "environmentId": {},
+          "userArn": {},
+          "permissions": {}
         }
       },
       "output": {
@@ -324,60 +242,17 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 60,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "max": 200
-    },
-    "S8": {
-      "type": "string",
-      "pattern": "arn:aws:(iam|sts)::\\d+:\\S+"
-    },
-    "Sa": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9]{8,32}$"
-    },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "read-write",
-        "read-only"
-      ]
-    },
     "Se": {
       "type": "structure",
       "members": {
-        "permissions": {
-          "shape": "Sf"
-        },
+        "permissions": {},
         "userId": {},
-        "userArn": {
-          "shape": "S8"
-        },
-        "environmentId": {
-          "shape": "Sa"
-        },
+        "userArn": {},
+        "environmentId": {},
         "lastAccess": {
           "type": "timestamp"
         }
       }
-    },
-    "Sf": {
-      "type": "string",
-      "enum": [
-        "owner",
-        "read-write",
-        "read-only"
-      ]
-    },
-    "So": {
-      "type": "integer",
-      "max": 25,
-      "min": 0
     }
   }
 }

--- a/apis/clouddirectory-2016-05-10.min.json
+++ b/apis/clouddirectory-2016-05-10.min.json
@@ -98,9 +98,7 @@
           "ChildReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -249,7 +247,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     },
                     "FacetFilter": {
                       "shape": "S3"
@@ -267,7 +265,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -282,7 +280,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -297,7 +295,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -342,7 +340,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -357,7 +355,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -372,7 +370,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -389,7 +387,7 @@
                       "shape": "Sf"
                     },
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     },
                     "NextToken": {}
                   }
@@ -411,7 +409,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -432,7 +430,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -455,7 +453,6 @@
             }
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -592,24 +589,7 @@
                 "ExceptionResponse": {
                   "type": "structure",
                   "members": {
-                    "Type": {
-                      "type": "string",
-                      "enum": [
-                        "ValidationException",
-                        "InvalidArnException",
-                        "ResourceNotFoundException",
-                        "InvalidNextTokenException",
-                        "AccessDeniedException",
-                        "NotNodeException",
-                        "FacetValidationException",
-                        "CannotListParentOfRootException",
-                        "NotIndexException",
-                        "NotPolicyException",
-                        "DirectoryNotEnabledException",
-                        "LimitExceededException",
-                        "InternalServiceException"
-                      ]
-                    },
+                    "Type": {},
                     "Message": {}
                   }
                 }
@@ -657,9 +637,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -677,9 +655,7 @@
                     "ChildReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    }
+                    "LinkName": {}
                   }
                 },
                 "DetachObject": {
@@ -692,9 +668,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -804,9 +778,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -999,9 +971,7 @@
           "SchemaArn"
         ],
         "members": {
-          "Name": {
-            "shape": "S3y"
-          },
+          "Name": {},
           "SchemaArn": {
             "location": "header",
             "locationName": "x-amz-data-partition"
@@ -1018,9 +988,7 @@
         ],
         "members": {
           "DirectoryArn": {},
-          "Name": {
-            "shape": "S3y"
-          },
+          "Name": {},
           "ObjectIdentifier": {},
           "AppliedSchemaArn": {}
         }
@@ -1044,15 +1012,11 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "Attributes": {
             "shape": "S42"
           },
-          "ObjectType": {
-            "shape": "S4f"
-          }
+          "ObjectType": {}
         }
       },
       "output": {
@@ -1087,9 +1051,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1125,9 +1087,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1149,9 +1109,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S4m"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1186,9 +1144,7 @@
               "IdentityAttributeOrder"
             ],
             "members": {
-              "Name": {
-                "shape": "Su"
-              },
+              "Name": {},
               "Attributes": {
                 "shape": "S4q"
               },
@@ -1249,9 +1205,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1328,9 +1282,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1392,9 +1344,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1580,9 +1530,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1591,12 +1539,8 @@
           "Facet": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "S4"
-              },
-              "ObjectType": {
-                "shape": "S4f"
-              }
+              "Name": {},
+              "ObjectType": {}
             }
           }
         }
@@ -1625,9 +1569,7 @@
           "AttributeNames": {
             "shape": "S1a"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -1661,7 +1603,6 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -1702,7 +1643,6 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1738,9 +1678,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S4m"
-          },
+          "Name": {},
           "Document": {}
         }
       }
@@ -1761,9 +1699,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1790,7 +1726,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1825,10 +1761,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1854,7 +1789,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1878,11 +1813,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "state": {
-            "shape": "S5j"
-          }
+          "state": {}
         }
       },
       "output": {
@@ -1917,12 +1850,10 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1953,7 +1884,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1962,9 +1893,7 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -1997,11 +1926,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -2037,11 +1964,10 @@
             "shape": "Sf"
           },
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "NextToken": {},
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2078,10 +2004,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -2121,10 +2046,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2161,7 +2085,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2196,10 +2120,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2211,9 +2134,7 @@
           "Parents": {
             "type": "map",
             "key": {},
-            "value": {
-              "shape": "Sl"
-            }
+            "value": {}
           },
           "NextToken": {}
         }
@@ -2240,10 +2161,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2286,11 +2206,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -2324,10 +2242,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2354,7 +2271,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2382,8 +2299,7 @@
           "ResourceArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "min": 50
+            "type": "integer"
           }
         }
       },
@@ -2413,12 +2329,10 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          },
+          "Name": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2449,7 +2363,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2458,9 +2372,7 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {
-              "shape": "Su"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -2487,7 +2399,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2518,15 +2430,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Version": {
-            "shape": "S7e"
-          },
-          "MinorVersion": {
-            "shape": "S7e"
-          },
-          "Name": {
-            "shape": "S4m"
-          }
+          "Version": {},
+          "MinorVersion": {},
+          "Name": {}
         }
       },
       "output": {
@@ -2660,9 +2566,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2671,15 +2575,11 @@
                 "Attribute": {
                   "shape": "S43"
                 },
-                "Action": {
-                  "shape": "S2y"
-                }
+                "Action": {}
               }
             }
           },
-          "ObjectType": {
-            "shape": "S4f"
-          }
+          "ObjectType": {}
         }
       },
       "output": {
@@ -2767,9 +2667,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4m"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -2798,9 +2696,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          },
+          "Name": {},
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2813,9 +2709,7 @@
                 "Attribute": {
                   "shape": "S4r"
                 },
-                "Action": {
-                  "shape": "S2y"
-                }
+                "Action": {}
               }
             }
           },
@@ -2873,9 +2767,7 @@
         "members": {
           "DevelopmentSchemaArn": {},
           "PublishedSchemaArn": {},
-          "MinorVersion": {
-            "shape": "S7e"
-          },
+          "MinorVersion": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -2894,16 +2786,8 @@
       "type": "structure",
       "members": {
         "SchemaArn": {},
-        "FacetName": {
-          "shape": "S4"
-        }
+        "FacetName": {}
       }
-    },
-    "S4": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S5": {
       "type": "list",
@@ -2932,19 +2816,9 @@
       ],
       "members": {
         "SchemaArn": {},
-        "FacetName": {
-          "shape": "S4"
-        },
-        "Name": {
-          "shape": "S8"
-        }
+        "FacetName": {},
+        "Name": {}
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S9": {
       "type": "structure",
@@ -2968,12 +2842,6 @@
         "Selector": {}
       }
     },
-    "Sl": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[^\\/\\[\\]\\(\\):\\{\\}#@!?\\s\\\\;]+"
-    },
     "St": {
       "type": "structure",
       "required": [
@@ -2982,14 +2850,8 @@
       ],
       "members": {
         "SchemaArn": {},
-        "TypedLinkName": {
-          "shape": "Su"
-        }
+        "TypedLinkName": {}
       }
-    },
-    "Su": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "Sv": {
       "type": "list",
@@ -3000,9 +2862,7 @@
           "Value"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S8"
-          },
+          "AttributeName": {},
           "Value": {
             "shape": "S9"
           }
@@ -3032,15 +2892,9 @@
         }
       }
     },
-    "S14": {
-      "type": "integer",
-      "min": 1
-    },
     "S1a": {
       "type": "list",
-      "member": {
-        "shape": "S8"
-      }
+      "member": {}
     },
     "S1f": {
       "type": "list",
@@ -3063,29 +2917,15 @@
         "EndMode"
       ],
       "members": {
-        "StartMode": {
-          "shape": "S1i"
-        },
+        "StartMode": {},
         "StartValue": {
           "shape": "S9"
         },
-        "EndMode": {
-          "shape": "S1i"
-        },
+        "EndMode": {},
         "EndValue": {
           "shape": "S9"
         }
       }
-    },
-    "S1i": {
-      "type": "string",
-      "enum": [
-        "FIRST",
-        "LAST",
-        "LAST_BEFORE_MISSING_VALUES",
-        "INCLUSIVE",
-        "EXCLUSIVE"
-      ]
     },
     "S1k": {
       "type": "list",
@@ -3095,27 +2935,16 @@
           "Range"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S8"
-          },
+          "AttributeName": {},
           "Range": {
             "shape": "S1h"
           }
         }
       }
     },
-    "S1o": {
-      "type": "string",
-      "enum": [
-        "SERIALIZABLE",
-        "EVENTUAL"
-      ]
-    },
     "S1v": {
       "type": "map",
-      "key": {
-        "shape": "Sl"
-      },
+      "key": {},
       "value": {}
     },
     "S1x": {
@@ -3189,9 +3018,7 @@
           "ObjectAttributeAction": {
             "type": "structure",
             "members": {
-              "ObjectAttributeActionType": {
-                "shape": "S2y"
-              },
+              "ObjectAttributeActionType": {},
               "ObjectAttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3199,13 +3026,6 @@
           }
         }
       }
-    },
-    "S2y": {
-      "type": "string",
-      "enum": [
-        "CREATE_OR_UPDATE",
-        "DELETE"
-      ]
     },
     "S35": {
       "type": "list",
@@ -3224,9 +3044,7 @@
           "AttributeAction": {
             "type": "structure",
             "members": {
-              "AttributeActionType": {
-                "shape": "S2y"
-              },
+              "AttributeActionType": {},
               "AttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3234,12 +3052,6 @@
           }
         }
       }
-    },
-    "S3y": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S42": {
       "type": "list",
@@ -3253,18 +3065,14 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S8"
-        },
+        "Name": {},
         "AttributeDefinition": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {
-              "shape": "S45"
-            },
+            "Type": {},
             "DefaultValue": {
               "shape": "S9"
             },
@@ -3283,49 +3091,20 @@
             "TargetAttributeName"
           ],
           "members": {
-            "TargetFacetName": {
-              "shape": "S4"
-            },
-            "TargetAttributeName": {
-              "shape": "S8"
-            }
+            "TargetFacetName": {},
+            "TargetAttributeName": {}
           }
         },
-        "RequiredBehavior": {
-          "shape": "S4e"
-        }
+        "RequiredBehavior": {}
       }
-    },
-    "S45": {
-      "type": "string",
-      "enum": [
-        "STRING",
-        "BINARY",
-        "BOOLEAN",
-        "NUMBER",
-        "DATETIME"
-      ]
     },
     "S46": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 64,
-        "min": 1,
-        "pattern": "^[a-zA-Z0-9._-]*$"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "BINARY_LENGTH",
-              "NUMBER_COMPARISON",
-              "STRING_FROM_SET",
-              "STRING_LENGTH"
-            ]
-          },
+          "Type": {},
           "Parameters": {
             "type": "map",
             "key": {},
@@ -3333,28 +3112,6 @@
           }
         }
       }
-    },
-    "S4e": {
-      "type": "string",
-      "enum": [
-        "REQUIRED_ALWAYS",
-        "NOT_REQUIRED"
-      ]
-    },
-    "S4f": {
-      "type": "string",
-      "enum": [
-        "NODE",
-        "LEAF_NODE",
-        "POLICY",
-        "INDEX"
-      ]
-    },
-    "S4m": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S4q": {
       "type": "list",
@@ -3370,12 +3127,8 @@
         "RequiredBehavior"
       ],
       "members": {
-        "Name": {
-          "shape": "S8"
-        },
-        "Type": {
-          "shape": "S45"
-        },
+        "Name": {},
+        "Type": {},
         "DefaultValue": {
           "shape": "S9"
         },
@@ -3385,33 +3138,19 @@
         "Rules": {
           "shape": "S46"
         },
-        "RequiredBehavior": {
-          "shape": "S4e"
-        }
+        "RequiredBehavior": {}
       }
     },
     "S5i": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3y"
-        },
+        "Name": {},
         "DirectoryArn": {},
-        "State": {
-          "shape": "S5j"
-        },
+        "State": {},
         "CreationDateTime": {
           "type": "timestamp"
         }
       }
-    },
-    "S5j": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED",
-        "DELETED"
-      ]
     },
     "S61": {
       "type": "list",
@@ -3426,12 +3165,6 @@
           "Value": {}
         }
       }
-    },
-    "S7e": {
-      "type": "string",
-      "max": 10,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     }
   }
 }

--- a/apis/clouddirectory-2017-01-11.min.json
+++ b/apis/clouddirectory-2017-01-11.min.json
@@ -98,9 +98,7 @@
           "ChildReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -249,7 +247,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     },
                     "FacetFilter": {
                       "shape": "S3"
@@ -267,7 +265,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -282,7 +280,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -297,7 +295,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -342,7 +340,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -357,7 +355,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -372,7 +370,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -389,7 +387,7 @@
                       "shape": "Sf"
                     },
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     },
                     "NextToken": {}
                   }
@@ -411,7 +409,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -432,7 +430,7 @@
                     },
                     "NextToken": {},
                     "MaxResults": {
-                      "shape": "S14"
+                      "type": "integer"
                     }
                   }
                 },
@@ -455,7 +453,6 @@
             }
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -592,24 +589,7 @@
                 "ExceptionResponse": {
                   "type": "structure",
                   "members": {
-                    "Type": {
-                      "type": "string",
-                      "enum": [
-                        "ValidationException",
-                        "InvalidArnException",
-                        "ResourceNotFoundException",
-                        "InvalidNextTokenException",
-                        "AccessDeniedException",
-                        "NotNodeException",
-                        "FacetValidationException",
-                        "CannotListParentOfRootException",
-                        "NotIndexException",
-                        "NotPolicyException",
-                        "DirectoryNotEnabledException",
-                        "LimitExceededException",
-                        "InternalServiceException"
-                      ]
-                    },
+                    "Type": {},
                     "Message": {}
                   }
                 }
@@ -657,9 +637,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -677,9 +655,7 @@
                     "ChildReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    }
+                    "LinkName": {}
                   }
                 },
                 "DetachObject": {
@@ -692,9 +668,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -804,9 +778,7 @@
                     "ParentReference": {
                       "shape": "Sf"
                     },
-                    "LinkName": {
-                      "shape": "Sl"
-                    },
+                    "LinkName": {},
                     "BatchReferenceName": {}
                   }
                 },
@@ -999,9 +971,7 @@
           "SchemaArn"
         ],
         "members": {
-          "Name": {
-            "shape": "S3y"
-          },
+          "Name": {},
           "SchemaArn": {
             "location": "header",
             "locationName": "x-amz-data-partition"
@@ -1018,9 +988,7 @@
         ],
         "members": {
           "DirectoryArn": {},
-          "Name": {
-            "shape": "S3y"
-          },
+          "Name": {},
           "ObjectIdentifier": {},
           "AppliedSchemaArn": {}
         }
@@ -1043,18 +1011,12 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "Attributes": {
             "shape": "S42"
           },
-          "ObjectType": {
-            "shape": "S4f"
-          },
-          "FacetStyle": {
-            "shape": "S4g"
-          }
+          "ObjectType": {},
+          "FacetStyle": {}
         }
       },
       "output": {
@@ -1089,9 +1051,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1127,9 +1087,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1151,9 +1109,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S4n"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1188,9 +1144,7 @@
               "IdentityAttributeOrder"
             ],
             "members": {
-              "Name": {
-                "shape": "Su"
-              },
+              "Name": {},
               "Attributes": {
                 "shape": "S4r"
               },
@@ -1251,9 +1205,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1330,9 +1282,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1394,9 +1344,7 @@
           "ParentReference": {
             "shape": "Sf"
           },
-          "LinkName": {
-            "shape": "Sl"
-          }
+          "LinkName": {}
         }
       },
       "output": {
@@ -1582,9 +1530,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1593,15 +1539,9 @@
           "Facet": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "S4"
-              },
-              "ObjectType": {
-                "shape": "S4f"
-              },
-              "FacetStyle": {
-                "shape": "S4g"
-              }
+              "Name": {},
+              "ObjectType": {},
+              "FacetStyle": {}
             }
           }
         }
@@ -1630,9 +1570,7 @@
           "AttributeNames": {
             "shape": "S1a"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -1666,7 +1604,6 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -1707,7 +1644,6 @@
             "shape": "Sf"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1743,9 +1679,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S4n"
-          },
+          "Name": {},
           "Document": {}
         }
       }
@@ -1766,9 +1700,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1795,7 +1727,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1830,10 +1762,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -1859,7 +1790,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1883,11 +1814,9 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "state": {
-            "shape": "S5k"
-          }
+          "state": {}
         }
       },
       "output": {
@@ -1922,12 +1851,10 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1958,7 +1885,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -1967,9 +1894,7 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -2002,11 +1927,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -2042,11 +1965,10 @@
             "shape": "Sf"
           },
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "NextToken": {},
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2073,7 +1995,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2108,10 +2030,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           },
@@ -2151,10 +2072,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2191,7 +2111,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2226,10 +2146,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2241,9 +2160,7 @@
           "Parents": {
             "type": "map",
             "key": {},
-            "value": {
-              "shape": "Sl"
-            }
+            "value": {}
           },
           "NextToken": {}
         }
@@ -2270,10 +2187,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2316,11 +2232,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "ConsistencyLevel": {
-            "shape": "S1o"
-          }
+          "ConsistencyLevel": {}
         }
       },
       "output": {
@@ -2354,10 +2268,9 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           },
           "ConsistencyLevel": {
-            "shape": "S1o",
             "location": "header",
             "locationName": "x-amz-consistency-level"
           }
@@ -2384,7 +2297,7 @@
           "SchemaArn": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2412,8 +2325,7 @@
           "ResourceArn": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "min": 50
+            "type": "integer"
           }
         }
       },
@@ -2443,12 +2355,10 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          },
+          "Name": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2479,7 +2389,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2488,9 +2398,7 @@
         "members": {
           "FacetNames": {
             "type": "list",
-            "member": {
-              "shape": "Su"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -2517,7 +2425,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S14"
+            "type": "integer"
           }
         }
       },
@@ -2548,15 +2456,9 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Version": {
-            "shape": "S7h"
-          },
-          "MinorVersion": {
-            "shape": "S7h"
-          },
-          "Name": {
-            "shape": "S4n"
-          }
+          "Version": {},
+          "MinorVersion": {},
+          "Name": {}
         }
       },
       "output": {
@@ -2690,9 +2592,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2701,15 +2601,11 @@
                 "Attribute": {
                   "shape": "S43"
                 },
-                "Action": {
-                  "shape": "S2y"
-                }
+                "Action": {}
               }
             }
           },
-          "ObjectType": {
-            "shape": "S4f"
-          }
+          "ObjectType": {}
         }
       },
       "output": {
@@ -2797,9 +2693,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "S4n"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -2828,9 +2722,7 @@
             "location": "header",
             "locationName": "x-amz-data-partition"
           },
-          "Name": {
-            "shape": "Su"
-          },
+          "Name": {},
           "AttributeUpdates": {
             "type": "list",
             "member": {
@@ -2843,9 +2735,7 @@
                 "Attribute": {
                   "shape": "S4s"
                 },
-                "Action": {
-                  "shape": "S2y"
-                }
+                "Action": {}
               }
             }
           },
@@ -2903,9 +2793,7 @@
         "members": {
           "DevelopmentSchemaArn": {},
           "PublishedSchemaArn": {},
-          "MinorVersion": {
-            "shape": "S7h"
-          },
+          "MinorVersion": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -2924,16 +2812,8 @@
       "type": "structure",
       "members": {
         "SchemaArn": {},
-        "FacetName": {
-          "shape": "S4"
-        }
+        "FacetName": {}
       }
-    },
-    "S4": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S5": {
       "type": "list",
@@ -2962,19 +2842,9 @@
       ],
       "members": {
         "SchemaArn": {},
-        "FacetName": {
-          "shape": "S4"
-        },
-        "Name": {
-          "shape": "S8"
-        }
+        "FacetName": {},
+        "Name": {}
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S9": {
       "type": "structure",
@@ -2998,12 +2868,6 @@
         "Selector": {}
       }
     },
-    "Sl": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[^\\/\\[\\]\\(\\):\\{\\}#@!?\\s\\\\;]+"
-    },
     "St": {
       "type": "structure",
       "required": [
@@ -3012,14 +2876,8 @@
       ],
       "members": {
         "SchemaArn": {},
-        "TypedLinkName": {
-          "shape": "Su"
-        }
+        "TypedLinkName": {}
       }
-    },
-    "Su": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "Sv": {
       "type": "list",
@@ -3030,9 +2888,7 @@
           "Value"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S8"
-          },
+          "AttributeName": {},
           "Value": {
             "shape": "S9"
           }
@@ -3062,15 +2918,9 @@
         }
       }
     },
-    "S14": {
-      "type": "integer",
-      "min": 1
-    },
     "S1a": {
       "type": "list",
-      "member": {
-        "shape": "S8"
-      }
+      "member": {}
     },
     "S1f": {
       "type": "list",
@@ -3093,29 +2943,15 @@
         "EndMode"
       ],
       "members": {
-        "StartMode": {
-          "shape": "S1i"
-        },
+        "StartMode": {},
         "StartValue": {
           "shape": "S9"
         },
-        "EndMode": {
-          "shape": "S1i"
-        },
+        "EndMode": {},
         "EndValue": {
           "shape": "S9"
         }
       }
-    },
-    "S1i": {
-      "type": "string",
-      "enum": [
-        "FIRST",
-        "LAST",
-        "LAST_BEFORE_MISSING_VALUES",
-        "INCLUSIVE",
-        "EXCLUSIVE"
-      ]
     },
     "S1k": {
       "type": "list",
@@ -3125,27 +2961,16 @@
           "Range"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S8"
-          },
+          "AttributeName": {},
           "Range": {
             "shape": "S1h"
           }
         }
       }
     },
-    "S1o": {
-      "type": "string",
-      "enum": [
-        "SERIALIZABLE",
-        "EVENTUAL"
-      ]
-    },
     "S1v": {
       "type": "map",
-      "key": {
-        "shape": "Sl"
-      },
+      "key": {},
       "value": {}
     },
     "S1x": {
@@ -3219,9 +3044,7 @@
           "ObjectAttributeAction": {
             "type": "structure",
             "members": {
-              "ObjectAttributeActionType": {
-                "shape": "S2y"
-              },
+              "ObjectAttributeActionType": {},
               "ObjectAttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3229,13 +3052,6 @@
           }
         }
       }
-    },
-    "S2y": {
-      "type": "string",
-      "enum": [
-        "CREATE_OR_UPDATE",
-        "DELETE"
-      ]
     },
     "S35": {
       "type": "list",
@@ -3254,9 +3070,7 @@
           "AttributeAction": {
             "type": "structure",
             "members": {
-              "AttributeActionType": {
-                "shape": "S2y"
-              },
+              "AttributeActionType": {},
               "AttributeUpdateValue": {
                 "shape": "S9"
               }
@@ -3264,12 +3078,6 @@
           }
         }
       }
-    },
-    "S3y": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S42": {
       "type": "list",
@@ -3283,18 +3091,14 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S8"
-        },
+        "Name": {},
         "AttributeDefinition": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {
-              "shape": "S45"
-            },
+            "Type": {},
             "DefaultValue": {
               "shape": "S9"
             },
@@ -3313,50 +3117,20 @@
             "TargetAttributeName"
           ],
           "members": {
-            "TargetFacetName": {
-              "shape": "S4"
-            },
-            "TargetAttributeName": {
-              "shape": "S8"
-            }
+            "TargetFacetName": {},
+            "TargetAttributeName": {}
           }
         },
-        "RequiredBehavior": {
-          "shape": "S4e"
-        }
+        "RequiredBehavior": {}
       }
-    },
-    "S45": {
-      "type": "string",
-      "enum": [
-        "STRING",
-        "BINARY",
-        "BOOLEAN",
-        "NUMBER",
-        "DATETIME",
-        "VARIANT"
-      ]
     },
     "S46": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 64,
-        "min": 1,
-        "pattern": "^[a-zA-Z0-9._-]*$"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "BINARY_LENGTH",
-              "NUMBER_COMPARISON",
-              "STRING_FROM_SET",
-              "STRING_LENGTH"
-            ]
-          },
+          "Type": {},
           "Parameters": {
             "type": "map",
             "key": {},
@@ -3364,35 +3138,6 @@
           }
         }
       }
-    },
-    "S4e": {
-      "type": "string",
-      "enum": [
-        "REQUIRED_ALWAYS",
-        "NOT_REQUIRED"
-      ]
-    },
-    "S4f": {
-      "type": "string",
-      "enum": [
-        "NODE",
-        "LEAF_NODE",
-        "POLICY",
-        "INDEX"
-      ]
-    },
-    "S4g": {
-      "type": "string",
-      "enum": [
-        "STATIC",
-        "DYNAMIC"
-      ]
-    },
-    "S4n": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     },
     "S4r": {
       "type": "list",
@@ -3408,12 +3153,8 @@
         "RequiredBehavior"
       ],
       "members": {
-        "Name": {
-          "shape": "S8"
-        },
-        "Type": {
-          "shape": "S45"
-        },
+        "Name": {},
+        "Type": {},
         "DefaultValue": {
           "shape": "S9"
         },
@@ -3423,33 +3164,19 @@
         "Rules": {
           "shape": "S46"
         },
-        "RequiredBehavior": {
-          "shape": "S4e"
-        }
+        "RequiredBehavior": {}
       }
     },
     "S5j": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3y"
-        },
+        "Name": {},
         "DirectoryArn": {},
-        "State": {
-          "shape": "S5k"
-        },
+        "State": {},
         "CreationDateTime": {
           "type": "timestamp"
         }
       }
-    },
-    "S5k": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED",
-        "DELETED"
-      ]
     },
     "S62": {
       "type": "list",
@@ -3464,12 +3191,6 @@
           "Value": {}
         }
       }
-    },
-    "S7h": {
-      "type": "string",
-      "max": 10,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9._-]*$"
     }
   }
 }

--- a/apis/cloudformation-2010-05-15.min.json
+++ b/apis/cloudformation-2010-05-15.min.json
@@ -19,9 +19,7 @@
         ],
         "members": {
           "StackName": {},
-          "ClientRequestToken": {
-            "shape": "S3"
-          }
+          "ClientRequestToken": {}
         }
       }
     },
@@ -32,22 +30,13 @@
           "StackName"
         ],
         "members": {
-          "StackName": {
-            "shape": "S5"
-          },
-          "RoleARN": {
-            "shape": "S6"
-          },
+          "StackName": {},
+          "RoleARN": {},
           "ResourcesToSkip": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "pattern": "[a-zA-Z0-9]+|[a-zA-Z][-a-zA-Z0-9]*\\.[a-zA-Z0-9]+"
-            }
+            "member": {}
           },
-          "ClientRequestToken": {
-            "shape": "S3"
-          }
+          "ClientRequestToken": {}
         }
       },
       "output": {
@@ -64,15 +53,9 @@
           "ChangeSetName"
         ],
         "members": {
-          "StackName": {
-            "shape": "S5"
-          },
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "StackName": {},
+          "TemplateBody": {},
+          "TemplateURL": {},
           "UsePreviousTemplate": {
             "type": "boolean"
           },
@@ -85,9 +68,7 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {
-            "shape": "S6"
-          },
+          "RoleARN": {},
           "RollbackConfiguration": {
             "shape": "Sn"
           },
@@ -97,33 +78,17 @@
           "Tags": {
             "shape": "Sv"
           },
-          "ChangeSetName": {
-            "shape": "Sz"
-          },
-          "ClientToken": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          },
-          "Description": {
-            "shape": "S11"
-          },
-          "ChangeSetType": {
-            "type": "string",
-            "enum": [
-              "CREATE",
-              "UPDATE"
-            ]
-          }
+          "ChangeSetName": {},
+          "ClientToken": {},
+          "Description": {},
+          "ChangeSetType": {}
         }
       },
       "output": {
         "resultWrapper": "CreateChangeSetResult",
         "type": "structure",
         "members": {
-          "Id": {
-            "shape": "S14"
-          },
+          "Id": {},
           "StackId": {}
         }
       }
@@ -136,12 +101,8 @@
         ],
         "members": {
           "StackName": {},
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "TemplateBody": {},
+          "TemplateURL": {},
           "Parameters": {
             "shape": "Se"
           },
@@ -152,7 +113,7 @@
             "shape": "Sn"
           },
           "TimeoutInMinutes": {
-            "shape": "S18"
+            "type": "integer"
           },
           "NotificationARNs": {
             "shape": "St"
@@ -163,29 +124,14 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {
-            "shape": "S6"
-          },
-          "OnFailure": {
-            "type": "string",
-            "enum": [
-              "DO_NOTHING",
-              "ROLLBACK",
-              "DELETE"
-            ]
-          },
-          "StackPolicyBody": {
-            "shape": "S1a"
-          },
-          "StackPolicyURL": {
-            "shape": "S1b"
-          },
+          "RoleARN": {},
+          "OnFailure": {},
+          "StackPolicyBody": {},
+          "StackPolicyURL": {},
           "Tags": {
             "shape": "Sv"
           },
-          "ClientRequestToken": {
-            "shape": "S3"
-          },
+          "ClientRequestToken": {},
           "EnableTerminationProtection": {
             "type": "boolean"
           }
@@ -222,7 +168,6 @@
             "shape": "S1k"
           },
           "OperationId": {
-            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -231,9 +176,7 @@
         "resultWrapper": "CreateStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -245,15 +188,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "Description": {
-            "shape": "S11"
-          },
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "Description": {},
+          "TemplateBody": {},
+          "TemplateURL": {},
           "Parameters": {
             "shape": "Se"
           },
@@ -263,14 +200,9 @@
           "Tags": {
             "shape": "Sv"
           },
-          "AdministrationRoleARN": {
-            "shape": "S6"
-          },
-          "ExecutionRoleName": {
-            "shape": "S1r"
-          },
+          "AdministrationRoleARN": {},
+          "ExecutionRoleName": {},
           "ClientRequestToken": {
-            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -290,12 +222,8 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {
-            "shape": "S1v"
-          },
-          "StackName": {
-            "shape": "S5"
-          }
+          "ChangeSetName": {},
+          "StackName": {}
         }
       },
       "output": {
@@ -316,12 +244,8 @@
             "type": "list",
             "member": {}
           },
-          "RoleARN": {
-            "shape": "S6"
-          },
-          "ClientRequestToken": {
-            "shape": "S3"
-          }
+          "RoleARN": {},
+          "ClientRequestToken": {}
         }
       }
     },
@@ -349,7 +273,6 @@
             "type": "boolean"
           },
           "OperationId": {
-            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -358,9 +281,7 @@
         "resultWrapper": "DeleteStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -384,9 +305,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -405,9 +324,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -418,44 +335,28 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {
-            "shape": "S1v"
-          },
-          "StackName": {
-            "shape": "S5"
-          },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "ChangeSetName": {},
+          "StackName": {},
+          "NextToken": {}
         }
       },
       "output": {
         "resultWrapper": "DescribeChangeSetResult",
         "type": "structure",
         "members": {
-          "ChangeSetName": {
-            "shape": "Sz"
-          },
-          "ChangeSetId": {
-            "shape": "S14"
-          },
+          "ChangeSetName": {},
+          "ChangeSetId": {},
           "StackId": {},
           "StackName": {},
-          "Description": {
-            "shape": "S11"
-          },
+          "Description": {},
           "Parameters": {
             "shape": "Se"
           },
           "CreationTime": {
             "type": "timestamp"
           },
-          "ExecutionStatus": {
-            "shape": "S2f"
-          },
-          "Status": {
-            "shape": "S2g"
-          },
+          "ExecutionStatus": {},
+          "Status": {},
           "StatusReason": {},
           "NotificationARNs": {
             "shape": "St"
@@ -474,41 +375,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "Resource"
-                  ]
-                },
+                "Type": {},
                 "ResourceChange": {
                   "type": "structure",
                   "members": {
-                    "Action": {
-                      "type": "string",
-                      "enum": [
-                        "Add",
-                        "Modify",
-                        "Remove"
-                      ]
-                    },
+                    "Action": {},
                     "LogicalResourceId": {},
                     "PhysicalResourceId": {},
-                    "ResourceType": {
-                      "shape": "Sm"
-                    },
-                    "Replacement": {
-                      "type": "string",
-                      "enum": [
-                        "True",
-                        "False",
-                        "Conditional"
-                      ]
-                    },
+                    "ResourceType": {},
+                    "Replacement": {},
                     "Scope": {
                       "type": "list",
-                      "member": {
-                        "shape": "S2q"
-                      }
+                      "member": {}
                     },
                     "Details": {
                       "type": "list",
@@ -518,37 +396,13 @@
                           "Target": {
                             "type": "structure",
                             "members": {
-                              "Attribute": {
-                                "shape": "S2q"
-                              },
+                              "Attribute": {},
                               "Name": {},
-                              "RequiresRecreation": {
-                                "type": "string",
-                                "enum": [
-                                  "Never",
-                                  "Conditionally",
-                                  "Always"
-                                ]
-                              }
+                              "RequiresRecreation": {}
                             }
                           },
-                          "Evaluation": {
-                            "type": "string",
-                            "enum": [
-                              "Static",
-                              "Dynamic"
-                            ]
-                          },
-                          "ChangeSource": {
-                            "type": "string",
-                            "enum": [
-                              "ResourceReference",
-                              "ParameterReference",
-                              "ResourceAttribute",
-                              "DirectModification",
-                              "Automatic"
-                            ]
-                          },
+                          "Evaluation": {},
+                          "ChangeSource": {},
                           "CausingEntity": {}
                         }
                       }
@@ -558,9 +412,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -569,9 +421,7 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -594,26 +444,18 @@
                 "StackName": {},
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {
-                  "shape": "Sm"
-                },
+                "ResourceType": {},
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {
-                  "shape": "S35"
-                },
+                "ResourceStatus": {},
                 "ResourceStatusReason": {},
                 "ResourceProperties": {},
-                "ClientRequestToken": {
-                  "shape": "S3"
-                }
+                "ClientRequestToken": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -627,9 +469,7 @@
         ],
         "members": {
           "StackSetName": {},
-          "StackInstanceAccount": {
-            "shape": "S1h"
-          },
+          "StackInstanceAccount": {},
           "StackInstanceRegion": {}
         }
       },
@@ -642,16 +482,12 @@
             "members": {
               "StackSetId": {},
               "Region": {},
-              "Account": {
-                "shape": "S1h"
-              },
+              "Account": {},
               "StackId": {},
               "ParameterOverrides": {
                 "shape": "Se"
               },
-              "Status": {
-                "shape": "S3b"
-              },
+              "Status": {},
               "StatusReason": {}
             }
           }
@@ -687,19 +523,13 @@
               "StackId": {},
               "LogicalResourceId": {},
               "PhysicalResourceId": {},
-              "ResourceType": {
-                "shape": "Sm"
-              },
+              "ResourceType": {},
               "LastUpdatedTimestamp": {
                 "type": "timestamp"
               },
-              "ResourceStatus": {
-                "shape": "S35"
-              },
+              "ResourceStatus": {},
               "ResourceStatusReason": {},
-              "Description": {
-                "shape": "S11"
-              },
+              "Description": {},
               "Metadata": {}
             }
           }
@@ -734,19 +564,13 @@
                 "StackId": {},
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {
-                  "shape": "Sm"
-                },
+                "ResourceType": {},
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {
-                  "shape": "S35"
-                },
+                "ResourceStatus": {},
                 "ResourceStatusReason": {},
-                "Description": {
-                  "shape": "S11"
-                }
+                "Description": {}
               }
             }
           }
@@ -772,15 +596,9 @@
             "members": {
               "StackSetName": {},
               "StackSetId": {},
-              "Description": {
-                "shape": "S11"
-              },
-              "Status": {
-                "shape": "S3o"
-              },
-              "TemplateBody": {
-                "shape": "Sb"
-              },
+              "Description": {},
+              "Status": {},
+              "TemplateBody": {},
               "Parameters": {
                 "shape": "Se"
               },
@@ -791,12 +609,8 @@
                 "shape": "Sv"
               },
               "StackSetARN": {},
-              "AdministrationRoleARN": {
-                "shape": "S6"
-              },
-              "ExecutionRoleName": {
-                "shape": "S1r"
-              }
+              "AdministrationRoleARN": {},
+              "ExecutionRoleName": {}
             }
           }
         }
@@ -811,9 +625,7 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       },
       "output": {
@@ -823,28 +635,18 @@
           "StackSetOperation": {
             "type": "structure",
             "members": {
-              "OperationId": {
-                "shape": "S3"
-              },
+              "OperationId": {},
               "StackSetId": {},
-              "Action": {
-                "shape": "S3t"
-              },
-              "Status": {
-                "shape": "S3u"
-              },
+              "Action": {},
+              "Status": {},
               "OperationPreferences": {
                 "shape": "S1k"
               },
               "RetainStacks": {
                 "type": "boolean"
               },
-              "AdministrationRoleARN": {
-                "shape": "S6"
-              },
-              "ExecutionRoleName": {
-                "shape": "S1r"
-              },
+              "AdministrationRoleARN": {},
+              "ExecutionRoleName": {},
               "CreationTimestamp": {
                 "type": "timestamp"
               },
@@ -861,9 +663,7 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -882,12 +682,8 @@
               "members": {
                 "StackId": {},
                 "StackName": {},
-                "ChangeSetId": {
-                  "shape": "S14"
-                },
-                "Description": {
-                  "shape": "S11"
-                },
+                "ChangeSetId": {},
+                "Description": {},
                 "Parameters": {
                   "shape": "Se"
                 },
@@ -903,9 +699,7 @@
                 "RollbackConfiguration": {
                   "shape": "Sn"
                 },
-                "StackStatus": {
-                  "shape": "S42"
-                },
+                "StackStatus": {},
                 "StackStatusReason": {},
                 "DisableRollback": {
                   "type": "boolean"
@@ -914,7 +708,7 @@
                   "shape": "St"
                 },
                 "TimeoutInMinutes": {
-                  "shape": "S18"
+                  "type": "integer"
                 },
                 "Capabilities": {
                   "shape": "Sj"
@@ -926,16 +720,12 @@
                     "members": {
                       "OutputKey": {},
                       "OutputValue": {},
-                      "Description": {
-                        "shape": "S11"
-                      },
+                      "Description": {},
                       "ExportName": {}
                     }
                   }
                 },
-                "RoleARN": {
-                  "shape": "S6"
-                },
+                "RoleARN": {},
                 "Tags": {
                   "shape": "Sv"
                 },
@@ -947,9 +737,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -957,12 +745,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "TemplateBody": {},
+          "TemplateURL": {},
           "Parameters": {
             "shape": "Se"
           }
@@ -983,15 +767,9 @@
           "ChangeSetName"
         ],
         "members": {
-          "ChangeSetName": {
-            "shape": "S1v"
-          },
-          "StackName": {
-            "shape": "S5"
-          },
-          "ClientRequestToken": {
-            "shape": "S3"
-          }
+          "ChangeSetName": {},
+          "StackName": {},
+          "ClientRequestToken": {}
         }
       },
       "output": {
@@ -1014,9 +792,7 @@
         "resultWrapper": "GetStackPolicyResult",
         "type": "structure",
         "members": {
-          "StackPolicyBody": {
-            "shape": "S1a"
-          }
+          "StackPolicyBody": {}
         }
       }
     },
@@ -1025,26 +801,18 @@
         "type": "structure",
         "members": {
           "StackName": {},
-          "ChangeSetName": {
-            "shape": "S1v"
-          },
-          "TemplateStage": {
-            "shape": "S4h"
-          }
+          "ChangeSetName": {},
+          "TemplateStage": {}
         }
       },
       "output": {
         "resultWrapper": "GetTemplateResult",
         "type": "structure",
         "members": {
-          "TemplateBody": {
-            "shape": "Sb"
-          },
+          "TemplateBody": {},
           "StagesAvailable": {
             "type": "list",
-            "member": {
-              "shape": "S4h"
-            }
+            "member": {}
           }
         }
       }
@@ -1053,18 +821,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
-          "StackName": {
-            "shape": "S5"
-          },
-          "StackSetName": {
-            "shape": "S4l"
-          }
+          "TemplateBody": {},
+          "TemplateURL": {},
+          "StackName": {},
+          "StackSetName": {}
         }
       },
       "output": {
@@ -1082,9 +842,7 @@
                 "NoEcho": {
                   "type": "boolean"
                 },
-                "Description": {
-                  "shape": "S11"
-                },
+                "Description": {},
                 "ParameterConstraints": {
                   "type": "structure",
                   "members": {
@@ -1097,9 +855,7 @@
               }
             }
           },
-          "Description": {
-            "shape": "S11"
-          },
+          "Description": {},
           "Capabilities": {
             "shape": "Sj"
           },
@@ -1122,12 +878,8 @@
           "StackName"
         ],
         "members": {
-          "StackName": {
-            "shape": "S5"
-          },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "StackName": {},
+          "NextToken": {}
         }
       },
       "output": {
@@ -1141,31 +893,19 @@
               "members": {
                 "StackId": {},
                 "StackName": {},
-                "ChangeSetId": {
-                  "shape": "S14"
-                },
-                "ChangeSetName": {
-                  "shape": "Sz"
-                },
-                "ExecutionStatus": {
-                  "shape": "S2f"
-                },
-                "Status": {
-                  "shape": "S2g"
-                },
+                "ChangeSetId": {},
+                "ChangeSetName": {},
+                "ExecutionStatus": {},
+                "Status": {},
                 "StatusReason": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
-                "Description": {
-                  "shape": "S11"
-                }
+                "Description": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1173,9 +913,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1193,9 +931,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1207,9 +943,7 @@
         ],
         "members": {
           "ExportName": {},
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1220,9 +954,7 @@
             "type": "list",
             "member": {}
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1234,15 +966,11 @@
         ],
         "members": {
           "StackSetName": {},
-          "NextToken": {
-            "shape": "S26"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S5b"
+            "type": "integer"
           },
-          "StackInstanceAccount": {
-            "shape": "S1h"
-          },
+          "StackInstanceAccount": {},
           "StackInstanceRegion": {}
         }
       },
@@ -1257,20 +985,14 @@
               "members": {
                 "StackSetId": {},
                 "Region": {},
-                "Account": {
-                  "shape": "S1h"
-                },
+                "Account": {},
                 "StackId": {},
-                "Status": {
-                  "shape": "S3b"
-                },
+                "Status": {},
                 "StatusReason": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1282,9 +1004,7 @@
         ],
         "members": {
           "StackName": {},
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1304,22 +1024,16 @@
               "members": {
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {
-                  "shape": "Sm"
-                },
+                "ResourceType": {},
                 "LastUpdatedTimestamp": {
                   "type": "timestamp"
                 },
-                "ResourceStatus": {
-                  "shape": "S35"
-                },
+                "ResourceStatus": {},
                 "ResourceStatusReason": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1332,14 +1046,10 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {
-            "shape": "S3"
-          },
-          "NextToken": {
-            "shape": "S26"
-          },
+          "OperationId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S5b"
+            "type": "integer"
           }
         }
       },
@@ -1352,41 +1062,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "Account": {
-                  "shape": "S1h"
-                },
+                "Account": {},
                 "Region": {},
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "PENDING",
-                    "RUNNING",
-                    "SUCCEEDED",
-                    "FAILED",
-                    "CANCELLED"
-                  ]
-                },
+                "Status": {},
                 "StatusReason": {},
                 "AccountGateResult": {
                   "type": "structure",
                   "members": {
-                    "Status": {
-                      "type": "string",
-                      "enum": [
-                        "SUCCEEDED",
-                        "FAILED",
-                        "SKIPPED"
-                      ]
-                    },
+                    "Status": {},
                     "StatusReason": {}
                   }
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1398,11 +1088,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "NextToken": {
-            "shape": "S26"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S5b"
+            "type": "integer"
           }
         }
       },
@@ -1415,15 +1103,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "OperationId": {
-                  "shape": "S3"
-                },
-                "Action": {
-                  "shape": "S3t"
-                },
-                "Status": {
-                  "shape": "S3u"
-                },
+                "OperationId": {},
+                "Action": {},
+                "Status": {},
                 "CreationTimestamp": {
                   "type": "timestamp"
                 },
@@ -1433,9 +1115,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1443,15 +1123,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S26"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S5b"
+            "type": "integer"
           },
-          "Status": {
-            "shape": "S3o"
-          }
+          "Status": {}
         }
       },
       "output": {
@@ -1465,18 +1141,12 @@
               "members": {
                 "StackSetName": {},
                 "StackSetId": {},
-                "Description": {
-                  "shape": "S11"
-                },
-                "Status": {
-                  "shape": "S3o"
-                }
+                "Description": {},
+                "Status": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1484,14 +1154,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S26"
-          },
+          "NextToken": {},
           "StackStatusFilter": {
             "type": "list",
-            "member": {
-              "shape": "S42"
-            }
+            "member": {}
           }
         }
       },
@@ -1521,18 +1187,14 @@
                 "DeletionTime": {
                   "type": "timestamp"
                 },
-                "StackStatus": {
-                  "shape": "S42"
-                },
+                "StackStatus": {},
                 "StackStatusReason": {},
                 "ParentId": {},
                 "RootId": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1544,12 +1206,8 @@
         ],
         "members": {
           "StackName": {},
-          "StackPolicyBody": {
-            "shape": "S1a"
-          },
-          "StackPolicyURL": {
-            "shape": "S1b"
-          }
+          "StackPolicyBody": {},
+          "StackPolicyURL": {}
         }
       }
     },
@@ -1563,22 +1221,10 @@
           "Status"
         ],
         "members": {
-          "StackName": {
-            "shape": "S5"
-          },
+          "StackName": {},
           "LogicalResourceId": {},
-          "UniqueId": {
-            "type": "string",
-            "max": 64,
-            "min": 1
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILURE"
-            ]
-          }
+          "UniqueId": {},
+          "Status": {}
         }
       }
     },
@@ -1591,9 +1237,7 @@
         ],
         "members": {
           "StackSetName": {},
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       },
       "output": {
@@ -1610,25 +1254,13 @@
         ],
         "members": {
           "StackName": {},
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "TemplateBody": {},
+          "TemplateURL": {},
           "UsePreviousTemplate": {
             "type": "boolean"
           },
-          "StackPolicyDuringUpdateBody": {
-            "type": "string",
-            "max": 16384,
-            "min": 1
-          },
-          "StackPolicyDuringUpdateURL": {
-            "type": "string",
-            "max": 1350,
-            "min": 1
-          },
+          "StackPolicyDuringUpdateBody": {},
+          "StackPolicyDuringUpdateURL": {},
           "Parameters": {
             "shape": "Se"
           },
@@ -1638,27 +1270,19 @@
           "ResourceTypes": {
             "shape": "Sl"
           },
-          "RoleARN": {
-            "shape": "S6"
-          },
+          "RoleARN": {},
           "RollbackConfiguration": {
             "shape": "Sn"
           },
-          "StackPolicyBody": {
-            "shape": "S1a"
-          },
-          "StackPolicyURL": {
-            "shape": "S1b"
-          },
+          "StackPolicyBody": {},
+          "StackPolicyURL": {},
           "NotificationARNs": {
             "shape": "St"
           },
           "Tags": {
             "shape": "Sv"
           },
-          "ClientRequestToken": {
-            "shape": "S3"
-          }
+          "ClientRequestToken": {}
         }
       },
       "output": {
@@ -1678,9 +1302,7 @@
           "Regions"
         ],
         "members": {
-          "StackSetName": {
-            "shape": "S4l"
-          },
+          "StackSetName": {},
           "Accounts": {
             "shape": "S1g"
           },
@@ -1694,7 +1316,6 @@
             "shape": "S1k"
           },
           "OperationId": {
-            "shape": "S3",
             "idempotencyToken": true
           }
         }
@@ -1703,9 +1324,7 @@
         "resultWrapper": "UpdateStackInstancesResult",
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -1717,15 +1336,9 @@
         ],
         "members": {
           "StackSetName": {},
-          "Description": {
-            "shape": "S11"
-          },
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          },
+          "Description": {},
+          "TemplateBody": {},
+          "TemplateURL": {},
           "UsePreviousTemplate": {
             "type": "boolean"
           },
@@ -1741,14 +1354,9 @@
           "OperationPreferences": {
             "shape": "S1k"
           },
-          "AdministrationRoleARN": {
-            "shape": "S6"
-          },
-          "ExecutionRoleName": {
-            "shape": "S1r"
-          },
+          "AdministrationRoleARN": {},
+          "ExecutionRoleName": {},
           "OperationId": {
-            "shape": "S3",
             "idempotencyToken": true
           },
           "Accounts": {
@@ -1763,9 +1371,7 @@
         "resultWrapper": "UpdateStackSetResult",
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -1780,9 +1386,7 @@
           "EnableTerminationProtection": {
             "type": "boolean"
           },
-          "StackName": {
-            "shape": "S5"
-          }
+          "StackName": {}
         }
       },
       "output": {
@@ -1797,12 +1401,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "TemplateBody": {
-            "shape": "Sb"
-          },
-          "TemplateURL": {
-            "shape": "Sc"
-          }
+          "TemplateBody": {},
+          "TemplateURL": {}
         }
       },
       "output": {
@@ -1819,15 +1419,11 @@
                 "NoEcho": {
                   "type": "boolean"
                 },
-                "Description": {
-                  "shape": "S11"
-                }
+                "Description": {}
               }
             }
           },
-          "Description": {
-            "shape": "S11"
-          },
+          "Description": {},
           "Capabilities": {
             "shape": "Sj"
           },
@@ -1840,31 +1436,6 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9][-a-zA-Z0-9]*"
-    },
-    "S5": {
-      "type": "string",
-      "min": 1,
-      "pattern": "([a-zA-Z][-a-zA-Z0-9]*)|(arn:\\b(aws|aws-us-gov|aws-cn)\\b:[-a-zA-Z0-9:/._+]*)"
-    },
-    "S6": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "Sb": {
-      "type": "string",
-      "min": 1
-    },
-    "Sc": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
     "Se": {
       "type": "list",
       "member": {
@@ -1881,24 +1452,11 @@
     },
     "Sj": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "CAPABILITY_IAM",
-          "CAPABILITY_NAMED_IAM"
-        ]
-      }
+      "member": {}
     },
     "Sl": {
       "type": "list",
-      "member": {
-        "shape": "Sm"
-      }
-    },
-    "Sm": {
-      "type": "string",
-      "max": 256,
-      "min": 1
+      "member": {}
     },
     "Sn": {
       "type": "structure",
@@ -1915,20 +1473,16 @@
               "Arn": {},
               "Type": {}
             }
-          },
-          "max": 5
+          }
         },
         "MonitoringTimeInMinutes": {
-          "type": "integer",
-          "max": 180,
-          "min": 0
+          "type": "integer"
         }
       }
     },
     "St": {
       "type": "list",
-      "member": {},
-      "max": 5
+      "member": {}
     },
     "Sv": {
       "type": "list",
@@ -1939,59 +1493,14 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 50
-    },
-    "Sz": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z][-a-zA-Z0-9]*"
-    },
-    "S11": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S14": {
-      "type": "string",
-      "min": 1,
-      "pattern": "arn:[-a-zA-Z0-9:/]*"
-    },
-    "S18": {
-      "type": "integer",
-      "min": 1
-    },
-    "S1a": {
-      "type": "string",
-      "max": 16384,
-      "min": 1
-    },
-    "S1b": {
-      "type": "string",
-      "max": 1350,
-      "min": 1
+      }
     },
     "S1g": {
       "type": "list",
-      "member": {
-        "shape": "S1h"
-      }
-    },
-    "S1h": {
-      "type": "string",
-      "pattern": "[0-9]{12}"
+      "member": {}
     },
     "S1i": {
       "type": "list",
@@ -2004,163 +1513,22 @@
           "shape": "S1i"
         },
         "FailureToleranceCount": {
-          "type": "integer",
-          "min": 0
+          "type": "integer"
         },
         "FailureTolerancePercentage": {
-          "type": "integer",
-          "max": 100,
-          "min": 0
+          "type": "integer"
         },
         "MaxConcurrentCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "MaxConcurrentPercentage": {
-          "type": "integer",
-          "max": 100,
-          "min": 1
+          "type": "integer"
         }
       }
-    },
-    "S1r": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z_0-9+=,.@-]+"
-    },
-    "S1v": {
-      "type": "string",
-      "max": 1600,
-      "min": 1,
-      "pattern": "[a-zA-Z][-a-zA-Z0-9]*|arn:[-a-zA-Z0-9:/]*"
-    },
-    "S26": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S2f": {
-      "type": "string",
-      "enum": [
-        "UNAVAILABLE",
-        "AVAILABLE",
-        "EXECUTE_IN_PROGRESS",
-        "EXECUTE_COMPLETE",
-        "EXECUTE_FAILED",
-        "OBSOLETE"
-      ]
-    },
-    "S2g": {
-      "type": "string",
-      "enum": [
-        "CREATE_PENDING",
-        "CREATE_IN_PROGRESS",
-        "CREATE_COMPLETE",
-        "DELETE_COMPLETE",
-        "FAILED"
-      ]
-    },
-    "S2q": {
-      "type": "string",
-      "enum": [
-        "Properties",
-        "Metadata",
-        "CreationPolicy",
-        "UpdatePolicy",
-        "DeletionPolicy",
-        "Tags"
-      ]
-    },
-    "S35": {
-      "type": "string",
-      "enum": [
-        "CREATE_IN_PROGRESS",
-        "CREATE_FAILED",
-        "CREATE_COMPLETE",
-        "DELETE_IN_PROGRESS",
-        "DELETE_FAILED",
-        "DELETE_COMPLETE",
-        "DELETE_SKIPPED",
-        "UPDATE_IN_PROGRESS",
-        "UPDATE_FAILED",
-        "UPDATE_COMPLETE"
-      ]
-    },
-    "S3b": {
-      "type": "string",
-      "enum": [
-        "CURRENT",
-        "OUTDATED",
-        "INOPERABLE"
-      ]
-    },
-    "S3o": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "DELETED"
-      ]
-    },
-    "S3t": {
-      "type": "string",
-      "enum": [
-        "CREATE",
-        "UPDATE",
-        "DELETE"
-      ]
-    },
-    "S3u": {
-      "type": "string",
-      "enum": [
-        "RUNNING",
-        "SUCCEEDED",
-        "FAILED",
-        "STOPPING",
-        "STOPPED"
-      ]
-    },
-    "S42": {
-      "type": "string",
-      "enum": [
-        "CREATE_IN_PROGRESS",
-        "CREATE_FAILED",
-        "CREATE_COMPLETE",
-        "ROLLBACK_IN_PROGRESS",
-        "ROLLBACK_FAILED",
-        "ROLLBACK_COMPLETE",
-        "DELETE_IN_PROGRESS",
-        "DELETE_FAILED",
-        "DELETE_COMPLETE",
-        "UPDATE_IN_PROGRESS",
-        "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
-        "UPDATE_COMPLETE",
-        "UPDATE_ROLLBACK_IN_PROGRESS",
-        "UPDATE_ROLLBACK_FAILED",
-        "UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS",
-        "UPDATE_ROLLBACK_COMPLETE",
-        "REVIEW_IN_PROGRESS"
-      ]
-    },
-    "S4h": {
-      "type": "string",
-      "enum": [
-        "Original",
-        "Processed"
-      ]
-    },
-    "S4l": {
-      "type": "string",
-      "pattern": "[a-zA-Z][-a-zA-Z0-9]*(?::[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12})?"
     },
     "S4w": {
       "type": "list",
       "member": {}
-    },
-    "S5b": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     }
   }
 }

--- a/apis/cloudfront-2016-11-25.min.json
+++ b/apis/cloudfront-2016-11-25.min.json
@@ -835,9 +835,7 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {
-                      "shape": "S1h"
-                    },
+                    "PriceClass": {},
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -862,7 +860,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -894,7 +891,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -922,7 +918,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3q",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -936,7 +931,6 @@
               "Items": {
                 "type": "list",
                 "member": {
-                  "shape": "S24",
                   "locationName": "Key"
                 }
               }
@@ -1152,9 +1146,7 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {
-          "shape": "S1h"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         },
@@ -1165,9 +1157,7 @@
           "shape": "S1m"
         },
         "WebACLId": {},
-        "HttpVersion": {
-          "shape": "S1q"
-        },
+        "HttpVersion": {},
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1261,14 +1251,7 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {
-                    "type": "string",
-                    "enum": [
-                      "http-only",
-                      "match-viewer",
-                      "https-only"
-                    ]
-                  },
+                  "OriginProtocolPolicy": {},
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1282,14 +1265,7 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol",
-                          "type": "string",
-                          "enum": [
-                            "SSLv3",
-                            "TLSv1",
-                            "TLSv1.1",
-                            "TLSv1.2"
-                          ]
+                          "locationName": "SslProtocol"
                         }
                       }
                     }
@@ -1297,8 +1273,7 @@
                 }
               }
             }
-          },
-          "min": 1
+          }
         }
       }
     },
@@ -1319,9 +1294,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {
-          "shape": "S10"
-        },
+        "ViewerProtocolPolicy": {},
         "MinTTL": {
           "type": "long"
         },
@@ -1361,14 +1334,7 @@
             "Forward"
           ],
           "members": {
-            "Forward": {
-              "type": "string",
-              "enum": [
-                "none",
-                "whitelist",
-                "all"
-              ]
-            },
+            "Forward": {},
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -1445,14 +1411,6 @@
         }
       }
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "allow-all",
-        "https-only",
-        "redirect-to-https"
-      ]
-    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1486,17 +1444,7 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method",
-        "type": "string",
-        "enum": [
-          "GET",
-          "HEAD",
-          "POST",
-          "PUT",
-          "PATCH",
-          "OPTIONS",
-          "DELETE"
-        ]
+        "locationName": "Method"
       }
     },
     "S16": {
@@ -1515,15 +1463,7 @@
             "type": "structure",
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {
-                "type": "string",
-                "enum": [
-                  "viewer-request",
-                  "viewer-response",
-                  "origin-request",
-                  "origin-response"
-                ]
-              }
+              "EventType": {}
             }
           }
         }
@@ -1560,9 +1500,7 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {
-                "shape": "S10"
-              },
+              "ViewerProtocolPolicy": {},
               "MinTTL": {
                 "type": "long"
               },
@@ -1620,14 +1558,6 @@
         }
       }
     },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "PriceClass_100",
-        "PriceClass_200",
-        "PriceClass_All"
-      ]
-    },
     "S1i": {
       "type": "structure",
       "members": {
@@ -1636,31 +1566,13 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {
-          "type": "string",
-          "enum": [
-            "sni-only",
-            "vip"
-          ]
-        },
-        "MinimumProtocolVersion": {
-          "type": "string",
-          "enum": [
-            "SSLv3",
-            "TLSv1"
-          ]
-        },
+        "SSLSupportMethod": {},
+        "MinimumProtocolVersion": {},
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true,
-          "type": "string",
-          "enum": [
-            "cloudfront",
-            "iam",
-            "acm"
-          ]
+          "deprecated": true
         }
       }
     },
@@ -1677,14 +1589,7 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {
-              "type": "string",
-              "enum": [
-                "blacklist",
-                "whitelist",
-                "none"
-              ]
-            },
+            "RestrictionType": {},
             "Quantity": {
               "type": "integer"
             },
@@ -1697,13 +1602,6 @@
           }
         }
       }
-    },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "http1.1",
-        "http2"
-      ]
     },
     "S1s": {
       "type": "structure",
@@ -1790,25 +1688,12 @@
               "Key"
             ],
             "members": {
-              "Key": {
-                "shape": "S24"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "min": 0,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
           }
         }
       }
-    },
-    "S24": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S28": {
       "type": "structure",
@@ -1892,9 +1777,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {
-          "shape": "S1h"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         }
@@ -2006,9 +1889,7 @@
                 "shape": "S1d"
               },
               "Comment": {},
-              "PriceClass": {
-                "shape": "S1h"
-              },
+              "PriceClass": {},
               "Enabled": {
                 "type": "boolean"
               },
@@ -2019,9 +1900,7 @@
                 "shape": "S1m"
               },
               "WebACLId": {},
-              "HttpVersion": {
-                "shape": "S1q"
-              },
+              "HttpVersion": {},
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2029,10 +1908,6 @@
           }
         }
       }
-    },
-    "S3q": {
-      "type": "string",
-      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2017-03-25.min.json
+++ b/apis/cloudfront-2017-03-25.min.json
@@ -854,9 +854,7 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {
-                      "shape": "S1h"
-                    },
+                    "PriceClass": {},
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -881,7 +879,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -913,7 +910,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -941,7 +937,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S3r",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -955,7 +950,6 @@
               "Items": {
                 "type": "list",
                 "member": {
-                  "shape": "S24",
                   "locationName": "Key"
                 }
               }
@@ -1171,9 +1165,7 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {
-          "shape": "S1h"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         },
@@ -1184,9 +1176,7 @@
           "shape": "S1m"
         },
         "WebACLId": {},
-        "HttpVersion": {
-          "shape": "S1q"
-        },
+        "HttpVersion": {},
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1280,14 +1270,7 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {
-                    "type": "string",
-                    "enum": [
-                      "http-only",
-                      "match-viewer",
-                      "https-only"
-                    ]
-                  },
+                  "OriginProtocolPolicy": {},
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1301,14 +1284,7 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol",
-                          "type": "string",
-                          "enum": [
-                            "SSLv3",
-                            "TLSv1",
-                            "TLSv1.1",
-                            "TLSv1.2"
-                          ]
+                          "locationName": "SslProtocol"
                         }
                       }
                     }
@@ -1322,8 +1298,7 @@
                 }
               }
             }
-          },
-          "min": 1
+          }
         }
       }
     },
@@ -1344,9 +1319,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {
-          "shape": "S10"
-        },
+        "ViewerProtocolPolicy": {},
         "MinTTL": {
           "type": "long"
         },
@@ -1386,14 +1359,7 @@
             "Forward"
           ],
           "members": {
-            "Forward": {
-              "type": "string",
-              "enum": [
-                "none",
-                "whitelist",
-                "all"
-              ]
-            },
+            "Forward": {},
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -1470,14 +1436,6 @@
         }
       }
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "allow-all",
-        "https-only",
-        "redirect-to-https"
-      ]
-    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1511,17 +1469,7 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method",
-        "type": "string",
-        "enum": [
-          "GET",
-          "HEAD",
-          "POST",
-          "PUT",
-          "PATCH",
-          "OPTIONS",
-          "DELETE"
-        ]
+        "locationName": "Method"
       }
     },
     "S16": {
@@ -1540,15 +1488,7 @@
             "type": "structure",
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {
-                "type": "string",
-                "enum": [
-                  "viewer-request",
-                  "viewer-response",
-                  "origin-request",
-                  "origin-response"
-                ]
-              }
+              "EventType": {}
             }
           }
         }
@@ -1585,9 +1525,7 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {
-                "shape": "S10"
-              },
+              "ViewerProtocolPolicy": {},
               "MinTTL": {
                 "type": "long"
               },
@@ -1645,14 +1583,6 @@
         }
       }
     },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "PriceClass_100",
-        "PriceClass_200",
-        "PriceClass_All"
-      ]
-    },
     "S1i": {
       "type": "structure",
       "members": {
@@ -1661,34 +1591,13 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {
-          "type": "string",
-          "enum": [
-            "sni-only",
-            "vip"
-          ]
-        },
-        "MinimumProtocolVersion": {
-          "type": "string",
-          "enum": [
-            "SSLv3",
-            "TLSv1",
-            "TLSv1_2016",
-            "TLSv1.1_2016",
-            "TLSv1.2_2018"
-          ]
-        },
+        "SSLSupportMethod": {},
+        "MinimumProtocolVersion": {},
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true,
-          "type": "string",
-          "enum": [
-            "cloudfront",
-            "iam",
-            "acm"
-          ]
+          "deprecated": true
         }
       }
     },
@@ -1705,14 +1614,7 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {
-              "type": "string",
-              "enum": [
-                "blacklist",
-                "whitelist",
-                "none"
-              ]
-            },
+            "RestrictionType": {},
             "Quantity": {
               "type": "integer"
             },
@@ -1725,13 +1627,6 @@
           }
         }
       }
-    },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "http1.1",
-        "http2"
-      ]
     },
     "S1s": {
       "type": "structure",
@@ -1818,25 +1713,12 @@
               "Key"
             ],
             "members": {
-              "Key": {
-                "shape": "S24"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "min": 0,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
           }
         }
       }
-    },
-    "S24": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S28": {
       "type": "structure",
@@ -1920,9 +1802,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {
-          "shape": "S1h"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         }
@@ -2034,9 +1914,7 @@
                 "shape": "S1d"
               },
               "Comment": {},
-              "PriceClass": {
-                "shape": "S1h"
-              },
+              "PriceClass": {},
               "Enabled": {
                 "type": "boolean"
               },
@@ -2047,9 +1925,7 @@
                 "shape": "S1m"
               },
               "WebACLId": {},
-              "HttpVersion": {
-                "shape": "S1q"
-              },
+              "HttpVersion": {},
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2057,10 +1933,6 @@
           }
         }
       }
-    },
-    "S3r": {
-      "type": "string",
-      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2017-10-30.min.json
+++ b/apis/cloudfront-2017-10-30.min.json
@@ -1400,9 +1400,7 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {
-                      "shape": "S1i"
-                    },
+                    "PriceClass": {},
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -1427,7 +1425,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -1459,7 +1456,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1487,7 +1483,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1501,7 +1496,6 @@
               "Items": {
                 "type": "list",
                 "member": {
-                  "shape": "S25",
                   "locationName": "Key"
                 }
               }
@@ -1849,9 +1843,7 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {
-          "shape": "S1i"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         },
@@ -1862,9 +1854,7 @@
           "shape": "S1n"
         },
         "WebACLId": {},
-        "HttpVersion": {
-          "shape": "S1r"
-        },
+        "HttpVersion": {},
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1958,14 +1948,7 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {
-                    "type": "string",
-                    "enum": [
-                      "http-only",
-                      "match-viewer",
-                      "https-only"
-                    ]
-                  },
+                  "OriginProtocolPolicy": {},
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1979,14 +1962,7 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol",
-                          "type": "string",
-                          "enum": [
-                            "SSLv3",
-                            "TLSv1",
-                            "TLSv1.1",
-                            "TLSv1.2"
-                          ]
+                          "locationName": "SslProtocol"
                         }
                       }
                     }
@@ -2000,8 +1976,7 @@
                 }
               }
             }
-          },
-          "min": 1
+          }
         }
       }
     },
@@ -2022,9 +1997,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {
-          "shape": "S10"
-        },
+        "ViewerProtocolPolicy": {},
         "MinTTL": {
           "type": "long"
         },
@@ -2065,14 +2038,7 @@
             "Forward"
           ],
           "members": {
-            "Forward": {
-              "type": "string",
-              "enum": [
-                "none",
-                "whitelist",
-                "all"
-              ]
-            },
+            "Forward": {},
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -2149,14 +2115,6 @@
         }
       }
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "allow-all",
-        "https-only",
-        "redirect-to-https"
-      ]
-    },
     "S12": {
       "type": "structure",
       "required": [
@@ -2190,17 +2148,7 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method",
-        "type": "string",
-        "enum": [
-          "GET",
-          "HEAD",
-          "POST",
-          "PUT",
-          "PATCH",
-          "OPTIONS",
-          "DELETE"
-        ]
+        "locationName": "Method"
       }
     },
     "S16": {
@@ -2223,15 +2171,7 @@
             ],
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {
-                "type": "string",
-                "enum": [
-                  "viewer-request",
-                  "viewer-response",
-                  "origin-request",
-                  "origin-response"
-                ]
-              }
+              "EventType": {}
             }
           }
         }
@@ -2268,9 +2208,7 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {
-                "shape": "S10"
-              },
+              "ViewerProtocolPolicy": {},
               "MinTTL": {
                 "type": "long"
               },
@@ -2329,14 +2267,6 @@
         }
       }
     },
-    "S1i": {
-      "type": "string",
-      "enum": [
-        "PriceClass_100",
-        "PriceClass_200",
-        "PriceClass_All"
-      ]
-    },
     "S1j": {
       "type": "structure",
       "members": {
@@ -2345,34 +2275,13 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {
-          "type": "string",
-          "enum": [
-            "sni-only",
-            "vip"
-          ]
-        },
-        "MinimumProtocolVersion": {
-          "type": "string",
-          "enum": [
-            "SSLv3",
-            "TLSv1",
-            "TLSv1_2016",
-            "TLSv1.1_2016",
-            "TLSv1.2_2018"
-          ]
-        },
+        "SSLSupportMethod": {},
+        "MinimumProtocolVersion": {},
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true,
-          "type": "string",
-          "enum": [
-            "cloudfront",
-            "iam",
-            "acm"
-          ]
+          "deprecated": true
         }
       }
     },
@@ -2389,14 +2298,7 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {
-              "type": "string",
-              "enum": [
-                "blacklist",
-                "whitelist",
-                "none"
-              ]
-            },
+            "RestrictionType": {},
             "Quantity": {
               "type": "integer"
             },
@@ -2409,13 +2311,6 @@
           }
         }
       }
-    },
-    "S1r": {
-      "type": "string",
-      "enum": [
-        "http1.1",
-        "http2"
-      ]
     },
     "S1t": {
       "type": "structure",
@@ -2502,25 +2397,12 @@
               "Key"
             ],
             "members": {
-              "Key": {
-                "shape": "S25"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "min": 0,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
           }
         }
       }
-    },
-    "S25": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S29": {
       "type": "structure",
@@ -2603,12 +2485,7 @@
                   "ContentType"
                 ],
                 "members": {
-                  "Format": {
-                    "type": "string",
-                    "enum": [
-                      "URLEncoded"
-                    ]
-                  },
+                  "Format": {},
                   "ProfileId": {},
                   "ContentType": {}
                 }
@@ -2825,9 +2702,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {
-          "shape": "S1i"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         }
@@ -2939,9 +2814,7 @@
                 "shape": "S1e"
               },
               "Comment": {},
-              "PriceClass": {
-                "shape": "S1i"
-              },
+              "PriceClass": {},
               "Enabled": {
                 "type": "boolean"
               },
@@ -2952,9 +2825,7 @@
                 "shape": "S1n"
               },
               "WebACLId": {},
-              "HttpVersion": {
-                "shape": "S1r"
-              },
+              "HttpVersion": {},
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2962,10 +2833,6 @@
           }
         }
       }
-    },
-    "S5b": {
-      "type": "string",
-      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudfront-2018-06-18.min.json
+++ b/apis/cloudfront-2018-06-18.min.json
@@ -1400,9 +1400,7 @@
                       "shape": "Sy"
                     },
                     "Comment": {},
-                    "PriceClass": {
-                      "shape": "S1i"
-                    },
+                    "PriceClass": {},
                     "Enabled": {
                       "type": "boolean"
                     }
@@ -1427,7 +1425,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           }
@@ -1459,7 +1456,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1487,7 +1483,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "S5b",
             "location": "querystring",
             "locationName": "Resource"
           },
@@ -1501,7 +1496,6 @@
               "Items": {
                 "type": "list",
                 "member": {
-                  "shape": "S25",
                   "locationName": "Key"
                 }
               }
@@ -1849,9 +1843,7 @@
             "Prefix": {}
           }
         },
-        "PriceClass": {
-          "shape": "S1i"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         },
@@ -1862,9 +1854,7 @@
           "shape": "S1n"
         },
         "WebACLId": {},
-        "HttpVersion": {
-          "shape": "S1r"
-        },
+        "HttpVersion": {},
         "IsIPV6Enabled": {
           "type": "boolean"
         }
@@ -1958,14 +1948,7 @@
                   "HTTPSPort": {
                     "type": "integer"
                   },
-                  "OriginProtocolPolicy": {
-                    "type": "string",
-                    "enum": [
-                      "http-only",
-                      "match-viewer",
-                      "https-only"
-                    ]
-                  },
+                  "OriginProtocolPolicy": {},
                   "OriginSslProtocols": {
                     "type": "structure",
                     "required": [
@@ -1979,14 +1962,7 @@
                       "Items": {
                         "type": "list",
                         "member": {
-                          "locationName": "SslProtocol",
-                          "type": "string",
-                          "enum": [
-                            "SSLv3",
-                            "TLSv1",
-                            "TLSv1.1",
-                            "TLSv1.2"
-                          ]
+                          "locationName": "SslProtocol"
                         }
                       }
                     }
@@ -2000,8 +1976,7 @@
                 }
               }
             }
-          },
-          "min": 1
+          }
         }
       }
     },
@@ -2022,9 +1997,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "ViewerProtocolPolicy": {
-          "shape": "S10"
-        },
+        "ViewerProtocolPolicy": {},
         "MinTTL": {
           "type": "long"
         },
@@ -2065,14 +2038,7 @@
             "Forward"
           ],
           "members": {
-            "Forward": {
-              "type": "string",
-              "enum": [
-                "none",
-                "whitelist",
-                "all"
-              ]
-            },
+            "Forward": {},
             "WhitelistedNames": {
               "type": "structure",
               "required": [
@@ -2149,14 +2115,6 @@
         }
       }
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "allow-all",
-        "https-only",
-        "redirect-to-https"
-      ]
-    },
     "S12": {
       "type": "structure",
       "required": [
@@ -2190,17 +2148,7 @@
     "S13": {
       "type": "list",
       "member": {
-        "locationName": "Method",
-        "type": "string",
-        "enum": [
-          "GET",
-          "HEAD",
-          "POST",
-          "PUT",
-          "PATCH",
-          "OPTIONS",
-          "DELETE"
-        ]
+        "locationName": "Method"
       }
     },
     "S16": {
@@ -2223,15 +2171,7 @@
             ],
             "members": {
               "LambdaFunctionARN": {},
-              "EventType": {
-                "type": "string",
-                "enum": [
-                  "viewer-request",
-                  "viewer-response",
-                  "origin-request",
-                  "origin-response"
-                ]
-              },
+              "EventType": {},
               "IncludeBody": {
                 "type": "boolean"
               }
@@ -2271,9 +2211,7 @@
               "TrustedSigners": {
                 "shape": "Sy"
               },
-              "ViewerProtocolPolicy": {
-                "shape": "S10"
-              },
+              "ViewerProtocolPolicy": {},
               "MinTTL": {
                 "type": "long"
               },
@@ -2332,14 +2270,6 @@
         }
       }
     },
-    "S1i": {
-      "type": "string",
-      "enum": [
-        "PriceClass_100",
-        "PriceClass_200",
-        "PriceClass_All"
-      ]
-    },
     "S1j": {
       "type": "structure",
       "members": {
@@ -2348,34 +2278,13 @@
         },
         "IAMCertificateId": {},
         "ACMCertificateArn": {},
-        "SSLSupportMethod": {
-          "type": "string",
-          "enum": [
-            "sni-only",
-            "vip"
-          ]
-        },
-        "MinimumProtocolVersion": {
-          "type": "string",
-          "enum": [
-            "SSLv3",
-            "TLSv1",
-            "TLSv1_2016",
-            "TLSv1.1_2016",
-            "TLSv1.2_2018"
-          ]
-        },
+        "SSLSupportMethod": {},
+        "MinimumProtocolVersion": {},
         "Certificate": {
           "deprecated": true
         },
         "CertificateSource": {
-          "deprecated": true,
-          "type": "string",
-          "enum": [
-            "cloudfront",
-            "iam",
-            "acm"
-          ]
+          "deprecated": true
         }
       }
     },
@@ -2392,14 +2301,7 @@
             "Quantity"
           ],
           "members": {
-            "RestrictionType": {
-              "type": "string",
-              "enum": [
-                "blacklist",
-                "whitelist",
-                "none"
-              ]
-            },
+            "RestrictionType": {},
             "Quantity": {
               "type": "integer"
             },
@@ -2412,13 +2314,6 @@
           }
         }
       }
-    },
-    "S1r": {
-      "type": "string",
-      "enum": [
-        "http1.1",
-        "http2"
-      ]
     },
     "S1t": {
       "type": "structure",
@@ -2505,25 +2400,12 @@
               "Key"
             ],
             "members": {
-              "Key": {
-                "shape": "S25"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "min": 0,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
           }
         }
       }
-    },
-    "S25": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S29": {
       "type": "structure",
@@ -2606,12 +2488,7 @@
                   "ContentType"
                 ],
                 "members": {
-                  "Format": {
-                    "type": "string",
-                    "enum": [
-                      "URLEncoded"
-                    ]
-                  },
+                  "Format": {},
                   "ProfileId": {},
                   "ContentType": {}
                 }
@@ -2828,9 +2705,7 @@
         "TrustedSigners": {
           "shape": "Sy"
         },
-        "PriceClass": {
-          "shape": "S1i"
-        },
+        "PriceClass": {},
         "Enabled": {
           "type": "boolean"
         }
@@ -2942,9 +2817,7 @@
                 "shape": "S1e"
               },
               "Comment": {},
-              "PriceClass": {
-                "shape": "S1i"
-              },
+              "PriceClass": {},
               "Enabled": {
                 "type": "boolean"
               },
@@ -2955,9 +2828,7 @@
                 "shape": "S1n"
               },
               "WebACLId": {},
-              "HttpVersion": {
-                "shape": "S1r"
-              },
+              "HttpVersion": {},
               "IsIPV6Enabled": {
                 "type": "boolean"
               }
@@ -2965,10 +2836,6 @@
           }
         }
       }
-    },
-    "S5b": {
-      "type": "string",
-      "pattern": "arn:aws:cloudfront::[0-9]+:.*"
     }
   }
 }

--- a/apis/cloudhsm-2014-05-30.min.json
+++ b/apis/cloudhsm-2014-05-30.min.json
@@ -21,9 +21,7 @@
           "TagList"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          },
+          "ResourceArn": {},
           "TagList": {
             "shape": "S3"
           }
@@ -35,9 +33,7 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "shape": "S2"
-          }
+          "Status": {}
         }
       }
     },
@@ -48,17 +44,13 @@
           "Label"
         ],
         "members": {
-          "Label": {
-            "shape": "S9"
-          }
+          "Label": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          }
+          "HapgArn": {}
         }
       }
     },
@@ -73,36 +65,27 @@
         ],
         "members": {
           "SubnetId": {
-            "shape": "Sd",
             "locationName": "SubnetId"
           },
           "SshKey": {
-            "shape": "Se",
             "locationName": "SshKey"
           },
           "EniIp": {
-            "shape": "Sf",
             "locationName": "EniIp"
           },
           "IamRoleArn": {
-            "shape": "Sg",
             "locationName": "IamRoleArn"
           },
           "ExternalId": {
-            "shape": "Sh",
             "locationName": "ExternalId"
           },
           "SubscriptionType": {
-            "shape": "Si",
             "locationName": "SubscriptionType"
           },
           "ClientToken": {
-            "locationName": "ClientToken",
-            "type": "string",
-            "pattern": "[a-zA-Z0-9]{1,64}"
+            "locationName": "ClientToken"
           },
           "SyslogIp": {
-            "shape": "Sf",
             "locationName": "SyslogIp"
           }
         },
@@ -111,9 +94,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {
-            "shape": "Sl"
-          }
+          "HsmArn": {}
         }
       }
     },
@@ -124,21 +105,14 @@
           "Certificate"
         ],
         "members": {
-          "Label": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9_.-]{2,64}"
-          },
-          "Certificate": {
-            "shape": "So"
-          }
+          "Label": {},
+          "Certificate": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          }
+          "ClientArn": {}
         }
       }
     },
@@ -149,9 +123,7 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          }
+          "HapgArn": {}
         }
       },
       "output": {
@@ -160,9 +132,7 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "shape": "S2"
-          }
+          "Status": {}
         }
       }
     },
@@ -174,7 +144,6 @@
         ],
         "members": {
           "HsmArn": {
-            "shape": "Sl",
             "locationName": "HsmArn"
           }
         },
@@ -186,9 +155,7 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "shape": "S2"
-          }
+          "Status": {}
         }
       }
     },
@@ -199,9 +166,7 @@
           "ClientArn"
         ],
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          }
+          "ClientArn": {}
         }
       },
       "output": {
@@ -210,9 +175,7 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "shape": "S2"
-          }
+          "Status": {}
         }
       }
     },
@@ -223,20 +186,14 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          }
+          "HapgArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          },
-          "HapgSerial": {
-            "shape": "S2"
-          },
+          "HapgArn": {},
+          "HapgSerial": {},
           "HsmsLastActionFailed": {
             "shape": "Sz"
           },
@@ -246,23 +203,12 @@
           "HsmsPendingRegistration": {
             "shape": "Sz"
           },
-          "Label": {
-            "shape": "S9"
-          },
-          "LastModifiedTimestamp": {
-            "shape": "S10"
-          },
+          "Label": {},
+          "LastModifiedTimestamp": {},
           "PartitionSerialList": {
             "shape": "S11"
           },
-          "State": {
-            "type": "string",
-            "enum": [
-              "READY",
-              "UPDATING",
-              "DEGRADED"
-            ]
-          }
+          "State": {}
         }
       }
     },
@@ -270,94 +216,36 @@
       "input": {
         "type": "structure",
         "members": {
-          "HsmArn": {
-            "shape": "Sl"
-          },
-          "HsmSerialNumber": {
-            "shape": "S15"
-          }
+          "HsmArn": {},
+          "HsmSerialNumber": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {
-            "shape": "Sl"
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "PENDING",
-              "RUNNING",
-              "UPDATING",
-              "SUSPENDED",
-              "TERMINATING",
-              "TERMINATED",
-              "DEGRADED"
-            ]
-          },
-          "StatusDetails": {
-            "shape": "S2"
-          },
-          "AvailabilityZone": {
-            "shape": "S18"
-          },
-          "EniId": {
-            "type": "string",
-            "pattern": "eni-[0-9a-f]{8}"
-          },
-          "EniIp": {
-            "shape": "Sf"
-          },
-          "SubscriptionType": {
-            "shape": "Si"
-          },
-          "SubscriptionStartDate": {
-            "shape": "S10"
-          },
-          "SubscriptionEndDate": {
-            "shape": "S10"
-          },
-          "VpcId": {
-            "type": "string",
-            "pattern": "vpc-[0-9a-f]{8}"
-          },
-          "SubnetId": {
-            "shape": "Sd"
-          },
-          "IamRoleArn": {
-            "shape": "Sg"
-          },
-          "SerialNumber": {
-            "shape": "S15"
-          },
-          "VendorName": {
-            "shape": "S2"
-          },
-          "HsmType": {
-            "shape": "S2"
-          },
-          "SoftwareVersion": {
-            "shape": "S2"
-          },
-          "SshPublicKey": {
-            "shape": "Se"
-          },
-          "SshKeyLastUpdated": {
-            "shape": "S10"
-          },
-          "ServerCertUri": {
-            "shape": "S2"
-          },
-          "ServerCertLastUpdated": {
-            "shape": "S10"
-          },
+          "HsmArn": {},
+          "Status": {},
+          "StatusDetails": {},
+          "AvailabilityZone": {},
+          "EniId": {},
+          "EniIp": {},
+          "SubscriptionType": {},
+          "SubscriptionStartDate": {},
+          "SubscriptionEndDate": {},
+          "VpcId": {},
+          "SubnetId": {},
+          "IamRoleArn": {},
+          "SerialNumber": {},
+          "VendorName": {},
+          "HsmType": {},
+          "SoftwareVersion": {},
+          "SshPublicKey": {},
+          "SshKeyLastUpdated": {},
+          "ServerCertUri": {},
+          "ServerCertLastUpdated": {},
           "Partitions": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hsm-[0-9a-f]{8}/partition-[0-9]{6,12}"
-            }
+            "member": {}
           }
         }
       }
@@ -366,32 +254,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          },
-          "CertificateFingerprint": {
-            "shape": "S1e"
-          }
+          "ClientArn": {},
+          "CertificateFingerprint": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          },
-          "Certificate": {
-            "shape": "So"
-          },
-          "CertificateFingerprint": {
-            "shape": "S1e"
-          },
-          "LastModifiedTimestamp": {
-            "shape": "S10"
-          },
-          "Label": {
-            "shape": "S9"
-          }
+          "ClientArn": {},
+          "Certificate": {},
+          "CertificateFingerprint": {},
+          "LastModifiedTimestamp": {},
+          "Label": {}
         }
       }
     },
@@ -404,16 +278,8 @@
           "HapgList"
         ],
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          },
-          "ClientVersion": {
-            "type": "string",
-            "enum": [
-              "5.1",
-              "5.3"
-            ]
-          },
+          "ClientArn": {},
+          "ClientVersion": {},
           "HapgList": {
             "shape": "S1i"
           }
@@ -422,15 +288,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ConfigType": {
-            "shape": "S2"
-          },
-          "ConfigFile": {
-            "shape": "S2"
-          },
-          "ConfigCred": {
-            "shape": "S2"
-          }
+          "ConfigType": {},
+          "ConfigFile": {},
+          "ConfigCred": {}
         }
       }
     },
@@ -444,9 +304,7 @@
         "members": {
           "AZList": {
             "type": "list",
-            "member": {
-              "shape": "S18"
-            }
+            "member": {}
           }
         }
       }
@@ -455,9 +313,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -469,9 +325,7 @@
           "HapgList": {
             "shape": "S1i"
           },
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -479,9 +333,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -490,9 +342,7 @@
           "HsmList": {
             "shape": "Sz"
           },
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -500,9 +350,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -513,13 +361,9 @@
         "members": {
           "ClientList": {
             "type": "list",
-            "member": {
-              "shape": "Sq"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S1o"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -530,9 +374,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -554,12 +396,8 @@
           "HapgArn"
         ],
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          },
-          "Label": {
-            "shape": "S9"
-          },
+          "HapgArn": {},
+          "Label": {},
           "PartitionSerialList": {
             "shape": "S11"
           }
@@ -568,9 +406,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "HapgArn": {
-            "shape": "Sb"
-          }
+          "HapgArn": {}
         }
       }
     },
@@ -582,27 +418,21 @@
         ],
         "members": {
           "HsmArn": {
-            "shape": "Sl",
             "locationName": "HsmArn"
           },
           "SubnetId": {
-            "shape": "Sd",
             "locationName": "SubnetId"
           },
           "EniIp": {
-            "shape": "Sf",
             "locationName": "EniIp"
           },
           "IamRoleArn": {
-            "shape": "Sg",
             "locationName": "IamRoleArn"
           },
           "ExternalId": {
-            "shape": "Sh",
             "locationName": "ExternalId"
           },
           "SyslogIp": {
-            "shape": "Sf",
             "locationName": "SyslogIp"
           }
         },
@@ -611,9 +441,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "HsmArn": {
-            "shape": "Sl"
-          }
+          "HsmArn": {}
         }
       }
     },
@@ -625,20 +453,14 @@
           "Certificate"
         ],
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          },
-          "Certificate": {
-            "shape": "So"
-          }
+          "ClientArn": {},
+          "Certificate": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClientArn": {
-            "shape": "Sq"
-          }
+          "ClientArn": {}
         }
       }
     },
@@ -650,14 +472,10 @@
           "TagKeyList"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          },
+          "ResourceArn": {},
           "TagKeyList": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            }
+            "member": {}
           }
         }
       },
@@ -667,18 +485,12 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "shape": "S2"
-          }
+          "Status": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "[\\w :+=./\\\\-]*"
-    },
     "S3": {
       "type": "list",
       "member": {
@@ -688,108 +500,22 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S5"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0
-          }
+          "Key": {},
+          "Value": {}
         }
       }
     },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S9": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9_.-]{1,64}"
-    },
-    "Sb": {
-      "type": "string",
-      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hapg-[0-9a-f]{8}"
-    },
-    "Sd": {
-      "type": "string",
-      "pattern": "subnet-[0-9a-f]{8}"
-    },
-    "Se": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9+/= ._:\\\\@-]*"
-    },
-    "Sf": {
-      "type": "string",
-      "pattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
-    },
-    "Sg": {
-      "type": "string",
-      "pattern": "arn:aws(-iso)?:iam::[0-9]{12}:role/[a-zA-Z0-9_\\+=,\\.\\-@]{1,64}"
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "[\\w :+=./-]*"
-    },
-    "Si": {
-      "type": "string",
-      "enum": [
-        "PRODUCTION"
-      ]
-    },
-    "Sl": {
-      "type": "string",
-      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:hsm-[0-9a-f]{8}"
-    },
-    "So": {
-      "type": "string",
-      "max": 2400,
-      "min": 600,
-      "pattern": "[\\w :+=./\\n-]*"
-    },
-    "Sq": {
-      "type": "string",
-      "pattern": "arn:aws(-iso)?:cloudhsm:[a-zA-Z0-9\\-]*:[0-9]{12}:client-[0-9a-f]{8}"
-    },
     "Sz": {
       "type": "list",
-      "member": {
-        "shape": "Sl"
-      }
-    },
-    "S10": {
-      "type": "string",
-      "pattern": "\\d*"
+      "member": {}
     },
     "S11": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "pattern": "\\d{6,12}"
-      }
-    },
-    "S15": {
-      "type": "string",
-      "pattern": "\\d{1,16}"
-    },
-    "S18": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9\\-]*"
-    },
-    "S1e": {
-      "type": "string",
-      "pattern": "([0-9a-fA-F][0-9a-fA-F]:){15}[0-9a-fA-F][0-9a-fA-F]"
+      "member": {}
     },
     "S1i": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      }
-    },
-    "S1o": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9+/]*"
+      "member": {}
     }
   }
 }

--- a/apis/cloudhsmv2-2017-04-28.min.json
+++ b/apis/cloudhsmv2-2017-04-28.min.json
@@ -22,12 +22,8 @@
           "BackupId"
         ],
         "members": {
-          "DestinationRegion": {
-            "shape": "S2"
-          },
-          "BackupId": {
-            "shape": "S3"
-          }
+          "DestinationRegion": {},
+          "BackupId": {}
         }
       },
       "output": {
@@ -39,15 +35,9 @@
               "CreateTimestamp": {
                 "type": "timestamp"
               },
-              "SourceRegion": {
-                "shape": "S2"
-              },
-              "SourceBackup": {
-                "shape": "S3"
-              },
-              "SourceCluster": {
-                "shape": "S7"
-              }
+              "SourceRegion": {},
+              "SourceBackup": {},
+              "SourceCluster": {}
             }
           }
         }
@@ -63,18 +53,10 @@
         "members": {
           "SubnetIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa"
-            },
-            "max": 10,
-            "min": 1
+            "member": {}
           },
-          "HsmType": {
-            "shape": "Sb"
-          },
-          "SourceBackupId": {
-            "shape": "S3"
-          }
+          "HsmType": {},
+          "SourceBackupId": {}
         }
       },
       "output": {
@@ -94,15 +76,9 @@
           "AvailabilityZone"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S7"
-          },
-          "AvailabilityZone": {
-            "shape": "Sh"
-          },
-          "IpAddress": {
-            "shape": "Sj"
-          }
+          "ClusterId": {},
+          "AvailabilityZone": {},
+          "IpAddress": {}
         }
       },
       "output": {
@@ -121,9 +97,7 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {
-            "shape": "S3"
-          }
+          "BackupId": {}
         }
       },
       "output": {
@@ -142,9 +116,7 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S7"
-          }
+          "ClusterId": {}
         }
       },
       "output": {
@@ -163,26 +135,16 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S7"
-          },
-          "HsmId": {
-            "shape": "Sk"
-          },
-          "EniId": {
-            "shape": "Si"
-          },
-          "EniIp": {
-            "shape": "Sj"
-          }
+          "ClusterId": {},
+          "HsmId": {},
+          "EniId": {},
+          "EniIp": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HsmId": {
-            "shape": "Sk"
-          }
+          "HsmId": {}
         }
       }
     },
@@ -190,11 +152,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S16"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S18"
@@ -213,9 +173,7 @@
               "shape": "Sz"
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -226,11 +184,9 @@
           "Filters": {
             "shape": "S18"
           },
-          "NextToken": {
-            "shape": "S16"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           }
         }
       },
@@ -243,9 +199,7 @@
               "shape": "Sd"
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -258,26 +212,16 @@
           "TrustAnchor"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S7"
-          },
-          "SignedCert": {
-            "shape": "Su"
-          },
-          "TrustAnchor": {
-            "shape": "Su"
-          }
+          "ClusterId": {},
+          "SignedCert": {},
+          "TrustAnchor": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "State": {
-            "shape": "Sp"
-          },
-          "StateMessage": {
-            "shape": "Sq"
-          }
+          "State": {},
+          "StateMessage": {}
         }
       }
     },
@@ -288,14 +232,10 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "S7"
-          },
-          "NextToken": {
-            "shape": "S16"
-          },
+          "ResourceId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S17"
+            "type": "integer"
           }
         }
       },
@@ -308,9 +248,7 @@
           "TagList": {
             "shape": "S1l"
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -321,9 +259,7 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {
-            "shape": "S3"
-          }
+          "BackupId": {}
         }
       },
       "output": {
@@ -343,9 +279,7 @@
           "TagList"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "S7"
-          },
+          "ResourceId": {},
           "TagList": {
             "shape": "S1l"
           }
@@ -364,16 +298,10 @@
           "TagKeyList"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "S7"
-          },
+          "ResourceId": {},
           "TagKeyList": {
             "type": "list",
-            "member": {
-              "shape": "S1n"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -384,38 +312,11 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\\d"
-    },
-    "S3": {
-      "type": "string",
-      "pattern": "backup-[2-7a-zA-Z]{11,16}"
-    },
-    "S7": {
-      "type": "string",
-      "pattern": "cluster-[2-7a-zA-Z]{11,16}"
-    },
-    "Sa": {
-      "type": "string",
-      "pattern": "subnet-[0-9a-fA-F]{8,17}"
-    },
-    "Sb": {
-      "type": "string",
-      "pattern": "(hsm1\\.medium)"
-    },
     "Sd": {
       "type": "structure",
       "members": {
-        "BackupPolicy": {
-          "type": "string",
-          "enum": [
-            "DEFAULT"
-          ]
-        },
-        "ClusterId": {
-          "shape": "S7"
-        },
+        "BackupPolicy": {},
+        "ClusterId": {},
         "CreateTimestamp": {
           "type": "timestamp"
         },
@@ -425,58 +326,26 @@
             "shape": "Sg"
           }
         },
-        "HsmType": {
-          "shape": "Sb"
-        },
-        "PreCoPassword": {
-          "type": "string",
-          "max": 32,
-          "min": 7
-        },
-        "SecurityGroup": {
-          "type": "string",
-          "pattern": "sg-[0-9a-fA-F]"
-        },
-        "SourceBackupId": {
-          "shape": "S3"
-        },
-        "State": {
-          "shape": "Sp"
-        },
-        "StateMessage": {
-          "shape": "Sq"
-        },
+        "HsmType": {},
+        "PreCoPassword": {},
+        "SecurityGroup": {},
+        "SourceBackupId": {},
+        "State": {},
+        "StateMessage": {},
         "SubnetMapping": {
           "type": "map",
-          "key": {
-            "shape": "Sh"
-          },
-          "value": {
-            "shape": "Sa"
-          }
+          "key": {},
+          "value": {}
         },
-        "VpcId": {
-          "type": "string",
-          "pattern": "vpc-[0-9a-fA-F]"
-        },
+        "VpcId": {},
         "Certificates": {
           "type": "structure",
           "members": {
-            "ClusterCsr": {
-              "shape": "Su"
-            },
-            "HsmCertificate": {
-              "shape": "Su"
-            },
-            "AwsHardwareCertificate": {
-              "shape": "Su"
-            },
-            "ManufacturerHardwareCertificate": {
-              "shape": "Su"
-            },
-            "ClusterCertificate": {
-              "shape": "Su"
-            }
+            "ClusterCsr": {},
+            "HsmCertificate": {},
+            "AwsHardwareCertificate": {},
+            "ManufacturerHardwareCertificate": {},
+            "ClusterCertificate": {}
           }
         }
       }
@@ -487,76 +356,15 @@
         "HsmId"
       ],
       "members": {
-        "AvailabilityZone": {
-          "shape": "Sh"
-        },
-        "ClusterId": {
-          "shape": "S7"
-        },
-        "SubnetId": {
-          "shape": "Sa"
-        },
-        "EniId": {
-          "shape": "Si"
-        },
-        "EniIp": {
-          "shape": "Sj"
-        },
-        "HsmId": {
-          "shape": "Sk"
-        },
-        "State": {
-          "type": "string",
-          "enum": [
-            "CREATE_IN_PROGRESS",
-            "ACTIVE",
-            "DEGRADED",
-            "DELETE_IN_PROGRESS",
-            "DELETED"
-          ]
-        },
+        "AvailabilityZone": {},
+        "ClusterId": {},
+        "SubnetId": {},
+        "EniId": {},
+        "EniIp": {},
+        "HsmId": {},
+        "State": {},
         "StateMessage": {}
       }
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "[a-z]{2}(-(gov))?-(east|west|north|south|central){1,2}-\\d[a-z]"
-    },
-    "Si": {
-      "type": "string",
-      "pattern": "eni-[0-9a-fA-F]{8,17}"
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}"
-    },
-    "Sk": {
-      "type": "string",
-      "pattern": "hsm-[2-7a-zA-Z]{11,16}"
-    },
-    "Sp": {
-      "type": "string",
-      "enum": [
-        "CREATE_IN_PROGRESS",
-        "UNINITIALIZED",
-        "INITIALIZE_IN_PROGRESS",
-        "INITIALIZED",
-        "ACTIVE",
-        "UPDATE_IN_PROGRESS",
-        "DELETE_IN_PROGRESS",
-        "DELETED",
-        "DEGRADED"
-      ]
-    },
-    "Sq": {
-      "type": "string",
-      "max": 300,
-      "pattern": ".*"
-    },
-    "Su": {
-      "type": "string",
-      "max": 5000,
-      "pattern": "[a-zA-Z0-9+-/=\\s]*"
     },
     "Sz": {
       "type": "structure",
@@ -564,57 +372,26 @@
         "BackupId"
       ],
       "members": {
-        "BackupId": {
-          "shape": "S3"
-        },
-        "BackupState": {
-          "type": "string",
-          "enum": [
-            "CREATE_IN_PROGRESS",
-            "READY",
-            "DELETED",
-            "PENDING_DELETION"
-          ]
-        },
-        "ClusterId": {
-          "shape": "S7"
-        },
+        "BackupId": {},
+        "BackupState": {},
+        "ClusterId": {},
         "CreateTimestamp": {
           "type": "timestamp"
         },
         "CopyTimestamp": {
           "type": "timestamp"
         },
-        "SourceRegion": {
-          "shape": "S2"
-        },
-        "SourceBackup": {
-          "shape": "S3"
-        },
-        "SourceCluster": {
-          "shape": "S7"
-        },
+        "SourceRegion": {},
+        "SourceBackup": {},
+        "SourceCluster": {},
         "DeleteTimestamp": {
           "type": "timestamp"
         }
       }
     },
-    "S16": {
-      "type": "string",
-      "max": 256,
-      "pattern": ".*"
-    },
-    "S17": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
     "S18": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "pattern": "[a-zA-Z0-9_-]+"
-      },
+      "key": {},
       "value": {
         "type": "list",
         "member": {}
@@ -629,25 +406,10 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S1n"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 50,
-      "min": 1
-    },
-    "S1n": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
     }
   }
 }

--- a/apis/cloudsearch-2011-02-01.min.json
+++ b/apis/cloudsearch-2011-02-01.min.json
@@ -16,9 +16,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -39,9 +37,7 @@
           "IndexField"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "IndexField": {
             "shape": "Sf"
           }
@@ -68,9 +64,7 @@
           "RankExpression"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "RankExpression": {
             "shape": "S12"
           }
@@ -96,9 +90,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -119,12 +111,8 @@
           "IndexFieldName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "IndexFieldName": {
-            "shape": "Sg"
-          }
+          "DomainName": {},
+          "IndexFieldName": {}
         }
       },
       "output": {
@@ -148,12 +136,8 @@
           "RankName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "RankName": {
-            "shape": "Sg"
-          }
+          "DomainName": {},
+          "RankName": {}
         }
       },
       "output": {
@@ -176,9 +160,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -198,9 +180,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -222,9 +202,7 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           }
         }
       },
@@ -251,9 +229,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "FieldNames": {
             "shape": "S1o"
           }
@@ -282,9 +258,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "RankNames": {
             "shape": "S1o"
           }
@@ -313,9 +287,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -338,9 +310,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -363,9 +333,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -388,9 +356,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -413,9 +379,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -436,9 +400,7 @@
           "MultiAZ"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "MultiAZ": {
             "type": "boolean"
           }
@@ -462,9 +424,7 @@
           "DefaultSearchField"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "DefaultSearchField": {}
         }
       },
@@ -489,9 +449,7 @@
           "AccessPolicies"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AccessPolicies": {}
         }
       },
@@ -516,9 +474,7 @@
           "Stems"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Stems": {}
         }
       },
@@ -543,9 +499,7 @@
           "Stopwords"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Stopwords": {}
         }
       },
@@ -570,9 +524,7 @@
           "Synonyms"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Synonyms": {}
         }
       },
@@ -591,12 +543,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 3,
-      "max": 28,
-      "pattern": "[a-z][a-z0-9\\-]+"
-    },
     "S4": {
       "type": "structure",
       "required": [
@@ -605,14 +551,8 @@
         "RequiresIndexDocuments"
       ],
       "members": {
-        "DomainId": {
-          "type": "string",
-          "min": 1,
-          "max": 64
-        },
-        "DomainName": {
-          "shape": "S2"
-        },
+        "DomainId": {},
+        "DomainName": {},
         "Created": {
           "type": "boolean"
         },
@@ -620,8 +560,7 @@
           "type": "boolean"
         },
         "NumSearchableDocs": {
-          "type": "long",
-          "min": 0
+          "type": "long"
         },
         "DocService": {
           "shape": "S8"
@@ -637,12 +576,10 @@
         },
         "SearchInstanceType": {},
         "SearchPartitionCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "SearchInstanceCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -660,31 +597,20 @@
         "IndexFieldType"
       ],
       "members": {
-        "IndexFieldName": {
-          "shape": "Sg"
-        },
-        "IndexFieldType": {
-          "type": "string",
-          "enum": [
-            "uint",
-            "literal",
-            "text"
-          ]
-        },
+        "IndexFieldName": {},
+        "IndexFieldType": {},
         "UIntOptions": {
           "type": "structure",
           "members": {
             "DefaultValue": {
-              "shape": "Sj"
+              "type": "integer"
             }
           }
         },
         "LiteralOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "Sl"
-            },
+            "DefaultValue": {},
             "SearchEnabled": {
               "type": "boolean"
             },
@@ -699,18 +625,14 @@
         "TextOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "Sl"
-            },
+            "DefaultValue": {},
             "FacetEnabled": {
               "type": "boolean"
             },
             "ResultEnabled": {
               "type": "boolean"
             },
-            "TextProcessor": {
-              "shape": "Sg"
-            }
+            "TextProcessor": {}
           }
         },
         "SourceAttributes": {
@@ -721,26 +643,15 @@
               "SourceDataFunction"
             ],
             "members": {
-              "SourceDataFunction": {
-                "type": "string",
-                "enum": [
-                  "Copy",
-                  "TrimTitle",
-                  "Map"
-                ]
-              },
+              "SourceDataFunction": {},
               "SourceDataCopy": {
                 "type": "structure",
                 "required": [
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {
-                    "shape": "Sg"
-                  },
-                  "DefaultValue": {
-                    "shape": "Sl"
-                  }
+                  "SourceName": {},
+                  "DefaultValue": {}
                 }
               },
               "SourceDataTrimTitle": {
@@ -749,17 +660,10 @@
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {
-                    "shape": "Sg"
-                  },
-                  "DefaultValue": {
-                    "shape": "Sl"
-                  },
+                  "SourceName": {},
+                  "DefaultValue": {},
                   "Separator": {},
-                  "Language": {
-                    "type": "string",
-                    "pattern": "[a-zA-Z]{2,8}(?:-[a-zA-Z]{2,8})*"
-                  }
+                  "Language": {}
                 }
               },
               "SourceDataMap": {
@@ -768,20 +672,12 @@
                   "SourceName"
                 ],
                 "members": {
-                  "SourceName": {
-                    "shape": "Sg"
-                  },
-                  "DefaultValue": {
-                    "shape": "Sl"
-                  },
+                  "SourceName": {},
+                  "DefaultValue": {},
                   "Cases": {
                     "type": "map",
-                    "key": {
-                      "shape": "Sl"
-                    },
-                    "value": {
-                      "shape": "Sl"
-                    }
+                    "key": {},
+                    "value": {}
                   }
                 }
               }
@@ -789,21 +685,6 @@
           }
         }
       }
-    },
-    "Sg": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "[a-z][a-z0-9_]*"
-    },
-    "Sj": {
-      "type": "integer",
-      "min": 0
-    },
-    "Sl": {
-      "type": "string",
-      "min": 0,
-      "max": 1024
     },
     "Sx": {
       "type": "structure",
@@ -835,16 +716,9 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "shape": "Sj"
+          "type": "integer"
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "RequiresIndexDocuments",
-            "Processing",
-            "Active"
-          ]
-        },
+        "State": {},
         "PendingDeletion": {
           "type": "boolean"
         }
@@ -857,14 +731,8 @@
         "RankExpression"
       ],
       "members": {
-        "RankName": {
-          "shape": "Sg"
-        },
-        "RankExpression": {
-          "type": "string",
-          "min": 1,
-          "max": 10240
-        }
+        "RankName": {},
+        "RankExpression": {}
       }
     },
     "S15": {
@@ -904,9 +772,7 @@
         "Status"
       ],
       "members": {
-        "Options": {
-          "shape": "Sg"
-        },
+        "Options": {},
         "Status": {
           "shape": "Sy"
         }
@@ -914,9 +780,7 @@
     },
     "S1o": {
       "type": "list",
-      "member": {
-        "shape": "Sg"
-      }
+      "member": {}
     },
     "S1w": {
       "type": "structure",

--- a/apis/cloudsearch-2013-01-01.min.json
+++ b/apis/cloudsearch-2013-01-01.min.json
@@ -18,9 +18,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -40,9 +38,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -63,9 +59,7 @@
           "AnalysisScheme"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AnalysisScheme": {
             "shape": "Sl"
           }
@@ -92,9 +86,7 @@
           "Expression"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Expression": {
             "shape": "Sy"
           }
@@ -121,9 +113,7 @@
           "IndexField"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "IndexField": {
             "shape": "S13"
           }
@@ -150,9 +140,7 @@
           "Suggester"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Suggester": {
             "shape": "S1p"
           }
@@ -179,12 +167,8 @@
           "AnalysisSchemeName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "AnalysisSchemeName": {
-            "shape": "Sm"
-          }
+          "DomainName": {},
+          "AnalysisSchemeName": {}
         }
       },
       "output": {
@@ -207,9 +191,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -230,12 +212,8 @@
           "ExpressionName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "ExpressionName": {
-            "shape": "Sm"
-          }
+          "DomainName": {},
+          "ExpressionName": {}
         }
       },
       "output": {
@@ -259,12 +237,8 @@
           "IndexFieldName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "IndexFieldName": {
-            "shape": "S14"
-          }
+          "DomainName": {},
+          "IndexFieldName": {}
         }
       },
       "output": {
@@ -288,12 +262,8 @@
           "SuggesterName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "SuggesterName": {
-            "shape": "Sm"
-          }
+          "DomainName": {},
+          "SuggesterName": {}
         }
       },
       "output": {
@@ -316,9 +286,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AnalysisSchemeNames": {
             "shape": "S25"
           },
@@ -350,9 +318,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Deployed": {
             "type": "boolean"
           }
@@ -374,9 +340,7 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           }
         }
       },
@@ -403,9 +367,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "ExpressionNames": {
             "shape": "S25"
           },
@@ -437,14 +399,10 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "FieldNames": {
             "type": "list",
-            "member": {
-              "shape": "S14"
-            }
+            "member": {}
           },
           "Deployed": {
             "type": "boolean"
@@ -474,9 +432,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -499,9 +455,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Deployed": {
             "type": "boolean"
           }
@@ -527,9 +481,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "SuggesterNames": {
             "shape": "S25"
           },
@@ -561,9 +513,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -583,9 +533,7 @@
         "members": {
           "DomainNames": {
             "type": "map",
-            "key": {
-              "shape": "S2"
-            },
+            "key": {},
             "value": {}
           }
         }
@@ -599,9 +547,7 @@
           "MultiAZ"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "MultiAZ": {
             "type": "boolean"
           }
@@ -625,9 +571,7 @@
           "ScalingParameters"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "ScalingParameters": {
             "shape": "S2q"
           }
@@ -654,9 +598,7 @@
           "AccessPolicies"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AccessPolicies": {}
         }
       },
@@ -675,23 +617,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 3,
-      "max": 28,
-      "pattern": "[a-z][a-z0-9\\-]+"
-    },
     "S4": {
       "type": "list",
-      "member": {
-        "shape": "S5"
-      }
-    },
-    "S5": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "[a-z][a-z0-9_]*"
+      "member": {}
     },
     "S8": {
       "type": "structure",
@@ -701,14 +629,8 @@
         "RequiresIndexDocuments"
       ],
       "members": {
-        "DomainId": {
-          "type": "string",
-          "min": 1,
-          "max": 64
-        },
-        "DomainName": {
-          "shape": "S2"
-        },
+        "DomainId": {},
+        "DomainName": {},
         "ARN": {},
         "Created": {
           "type": "boolean"
@@ -730,12 +652,10 @@
         },
         "SearchInstanceType": {},
         "SearchPartitionCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "SearchInstanceCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "Limits": {
           "type": "structure",
@@ -745,12 +665,10 @@
           ],
           "members": {
             "MaximumReplicationCount": {
-              "type": "integer",
-              "min": 1
+              "type": "integer"
             },
             "MaximumPartitionCount": {
-              "type": "integer",
-              "min": 1
+              "type": "integer"
             }
           }
         }
@@ -769,49 +687,8 @@
         "AnalysisSchemeLanguage"
       ],
       "members": {
-        "AnalysisSchemeName": {
-          "shape": "Sm"
-        },
-        "AnalysisSchemeLanguage": {
-          "type": "string",
-          "enum": [
-            "ar",
-            "bg",
-            "ca",
-            "cs",
-            "da",
-            "de",
-            "el",
-            "en",
-            "es",
-            "eu",
-            "fa",
-            "fi",
-            "fr",
-            "ga",
-            "gl",
-            "he",
-            "hi",
-            "hu",
-            "hy",
-            "id",
-            "it",
-            "ja",
-            "ko",
-            "lv",
-            "mul",
-            "nl",
-            "no",
-            "pt",
-            "ro",
-            "ru",
-            "sv",
-            "th",
-            "tr",
-            "zh-Hans",
-            "zh-Hant"
-          ]
-        },
+        "AnalysisSchemeName": {},
+        "AnalysisSchemeLanguage": {},
         "AnalysisOptions": {
           "type": "structure",
           "members": {
@@ -819,24 +696,10 @@
             "Stopwords": {},
             "StemmingDictionary": {},
             "JapaneseTokenizationDictionary": {},
-            "AlgorithmicStemming": {
-              "type": "string",
-              "enum": [
-                "none",
-                "minimal",
-                "light",
-                "full"
-              ]
-            }
+            "AlgorithmicStemming": {}
           }
         }
       }
-    },
-    "Sm": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "[a-z][a-z0-9_]*"
     },
     "Ss": {
       "type": "structure",
@@ -868,25 +731,13 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "shape": "Sv"
+          "type": "integer"
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "RequiresIndexDocuments",
-            "Processing",
-            "Active",
-            "FailedToValidate"
-          ]
-        },
+        "State": {},
         "PendingDeletion": {
           "type": "boolean"
         }
       }
-    },
-    "Sv": {
-      "type": "integer",
-      "min": 0
     },
     "Sy": {
       "type": "structure",
@@ -895,14 +746,8 @@
         "ExpressionValue"
       ],
       "members": {
-        "ExpressionName": {
-          "shape": "Sm"
-        },
-        "ExpressionValue": {
-          "type": "string",
-          "min": 1,
-          "max": 10240
-        }
+        "ExpressionName": {},
+        "ExpressionValue": {}
       }
     },
     "S11": {
@@ -927,34 +772,15 @@
         "IndexFieldType"
       ],
       "members": {
-        "IndexFieldName": {
-          "shape": "S14"
-        },
-        "IndexFieldType": {
-          "type": "string",
-          "enum": [
-            "int",
-            "double",
-            "literal",
-            "text",
-            "date",
-            "latlon",
-            "int-array",
-            "double-array",
-            "literal-array",
-            "text-array",
-            "date-array"
-          ]
-        },
+        "IndexFieldName": {},
+        "IndexFieldType": {},
         "IntOptions": {
           "type": "structure",
           "members": {
             "DefaultValue": {
               "type": "long"
             },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "SourceField": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -975,9 +801,7 @@
             "DefaultValue": {
               "type": "double"
             },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "SourceField": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -995,12 +819,8 @@
         "LiteralOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "DefaultValue": {},
+            "SourceField": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1018,12 +838,8 @@
         "TextOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "DefaultValue": {},
+            "SourceField": {},
             "ReturnEnabled": {
               "type": "boolean"
             },
@@ -1033,20 +849,14 @@
             "HighlightEnabled": {
               "type": "boolean"
             },
-            "AnalysisScheme": {
-              "shape": "S1d"
-            }
+            "AnalysisScheme": {}
           }
         },
         "DateOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "DefaultValue": {},
+            "SourceField": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1064,12 +874,8 @@
         "LatLonOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceField": {
-              "shape": "S5"
-            },
+            "DefaultValue": {},
+            "SourceField": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1090,9 +896,7 @@
             "DefaultValue": {
               "type": "long"
             },
-            "SourceFields": {
-              "shape": "S1h"
-            },
+            "SourceFields": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1110,9 +914,7 @@
             "DefaultValue": {
               "type": "double"
             },
-            "SourceFields": {
-              "shape": "S1h"
-            },
+            "SourceFields": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1127,12 +929,8 @@
         "LiteralArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceFields": {
-              "shape": "S1h"
-            },
+            "DefaultValue": {},
+            "SourceFields": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1147,32 +945,22 @@
         "TextArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceFields": {
-              "shape": "S1h"
-            },
+            "DefaultValue": {},
+            "SourceFields": {},
             "ReturnEnabled": {
               "type": "boolean"
             },
             "HighlightEnabled": {
               "type": "boolean"
             },
-            "AnalysisScheme": {
-              "shape": "S1d"
-            }
+            "AnalysisScheme": {}
           }
         },
         "DateArrayOptions": {
           "type": "structure",
           "members": {
-            "DefaultValue": {
-              "shape": "S1b"
-            },
-            "SourceFields": {
-              "shape": "S1h"
-            },
+            "DefaultValue": {},
+            "SourceFields": {},
             "FacetEnabled": {
               "type": "boolean"
             },
@@ -1185,25 +973,6 @@
           }
         }
       }
-    },
-    "S14": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "([a-z][a-z0-9_]*\\*?|\\*[a-z0-9_]*)"
-    },
-    "S1b": {
-      "type": "string",
-      "min": 0,
-      "max": 1024
-    },
-    "S1d": {
-      "type": "string",
-      "pattern": "[\\S]+"
-    },
-    "S1h": {
-      "type": "string",
-      "pattern": "\\s*[a-z*][a-z0-9_]*\\*?\\s*(,\\s*[a-z*][a-z0-9_]*\\*?\\s*)*"
     },
     "S1n": {
       "type": "structure",
@@ -1227,26 +996,15 @@
         "DocumentSuggesterOptions"
       ],
       "members": {
-        "SuggesterName": {
-          "shape": "Sm"
-        },
+        "SuggesterName": {},
         "DocumentSuggesterOptions": {
           "type": "structure",
           "required": [
             "SourceField"
           ],
           "members": {
-            "SourceField": {
-              "shape": "S5"
-            },
-            "FuzzyMatching": {
-              "type": "string",
-              "enum": [
-                "none",
-                "low",
-                "high"
-              ]
-            },
+            "SourceField": {},
+            "FuzzyMatching": {},
             "SortExpression": {}
           }
         }
@@ -1269,9 +1027,7 @@
     },
     "S25": {
       "type": "list",
-      "member": {
-        "shape": "Sm"
-      }
+      "member": {}
     },
     "S2a": {
       "type": "structure",
@@ -1306,24 +1062,12 @@
     "S2q": {
       "type": "structure",
       "members": {
-        "DesiredInstanceType": {
-          "type": "string",
-          "enum": [
-            "search.m1.small",
-            "search.m1.large",
-            "search.m2.xlarge",
-            "search.m2.2xlarge",
-            "search.m3.medium",
-            "search.m3.large",
-            "search.m3.xlarge",
-            "search.m3.2xlarge"
-          ]
-        },
+        "DesiredInstanceType": {},
         "DesiredReplicationCount": {
-          "shape": "Sv"
+          "type": "integer"
         },
         "DesiredPartitionCount": {
-          "shape": "Sv"
+          "type": "integer"
         }
       }
     },

--- a/apis/cloudsearchdomain-2013-01-01.min.json
+++ b/apis/cloudsearchdomain-2013-01-01.min.json
@@ -58,14 +58,7 @@
           },
           "queryParser": {
             "location": "querystring",
-            "locationName": "q.parser",
-            "type": "string",
-            "enum": [
-              "simple",
-              "structured",
-              "lucene",
-              "dismax"
-            ]
+            "locationName": "q.parser"
           },
           "return": {
             "location": "querystring",
@@ -274,12 +267,7 @@
           },
           "contentType": {
             "location": "header",
-            "locationName": "Content-Type",
-            "type": "string",
-            "enum": [
-              "application/json",
-              "application/xml"
-            ]
+            "locationName": "Content-Type"
           }
         },
         "payload": "documents"

--- a/apis/cloudtrail-2013-11-01.min.json
+++ b/apis/cloudtrail-2013-11-01.min.json
@@ -308,17 +308,7 @@
                 "AttributeValue"
               ],
               "members": {
-                "AttributeKey": {
-                  "type": "string",
-                  "enum": [
-                    "EventId",
-                    "EventName",
-                    "Username",
-                    "ResourceType",
-                    "ResourceName",
-                    "EventSource"
-                  ]
-                },
+                "AttributeKey": {},
                 "AttributeValue": {}
               }
             }
@@ -330,9 +320,7 @@
             "type": "timestamp"
           },
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -519,14 +507,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "ReadWriteType": {
-            "type": "string",
-            "enum": [
-              "ReadOnly",
-              "WriteOnly",
-              "All"
-            ]
-          },
+          "ReadWriteType": {},
           "IncludeManagementEvents": {
             "type": "boolean"
           },

--- a/apis/codebuild-2016-10-06.min.json
+++ b/apis/codebuild-2016-10-06.min.json
@@ -35,9 +35,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {
-                  "shape": "S3"
-                },
+                "id": {},
                 "statusCode": {}
               }
             }
@@ -110,12 +108,8 @@
           "serviceRole"
         ],
         "members": {
-          "name": {
-            "shape": "S1i"
-          },
-          "description": {
-            "shape": "S1j"
-          },
+          "name": {},
+          "description": {},
           "source": {
             "shape": "Sk"
           },
@@ -134,15 +128,11 @@
           "environment": {
             "shape": "Sx"
           },
-          "serviceRole": {
-            "shape": "S3"
-          },
+          "serviceRole": {},
           "timeoutInMinutes": {
-            "shape": "S1p"
+            "type": "integer"
           },
-          "encryptionKey": {
-            "shape": "S3"
-          },
+          "encryptionKey": {},
           "tags": {
             "shape": "S1q"
           },
@@ -173,9 +163,7 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S1i"
-          },
+          "projectName": {},
           "branchFilter": {}
         }
       },
@@ -195,9 +183,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S3"
-          }
+          "name": {}
         }
       },
       "output": {
@@ -212,9 +198,7 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S1i"
-          }
+          "projectName": {}
         }
       },
       "output": {
@@ -229,9 +213,7 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S3"
-          }
+          "projectName": {}
         }
       },
       "output": {
@@ -243,9 +225,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "sortOrder": {
-            "shape": "S28"
-          },
+          "sortOrder": {},
           "nextToken": {}
         }
       },
@@ -266,12 +246,8 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S3"
-          },
-          "sortOrder": {
-            "shape": "S28"
-          },
+          "projectName": {},
+          "sortOrder": {},
           "nextToken": {}
         }
       },
@@ -298,34 +274,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "platform": {
-                  "type": "string",
-                  "enum": [
-                    "DEBIAN",
-                    "AMAZON_LINUX",
-                    "UBUNTU",
-                    "WINDOWS_SERVER"
-                  ]
-                },
+                "platform": {},
                 "languages": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "language": {
-                        "type": "string",
-                        "enum": [
-                          "JAVA",
-                          "PYTHON",
-                          "NODE_JS",
-                          "RUBY",
-                          "GOLANG",
-                          "DOCKER",
-                          "ANDROID",
-                          "DOTNET",
-                          "BASE"
-                        ]
-                      },
+                      "language": {},
                       "images": {
                         "type": "list",
                         "member": {
@@ -353,20 +308,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "sortBy": {
-            "type": "string",
-            "enum": [
-              "NAME",
-              "CREATED_TIME",
-              "LAST_MODIFIED_TIME"
-            ]
-          },
-          "sortOrder": {
-            "shape": "S28"
-          },
-          "nextToken": {
-            "shape": "S3"
-          }
+          "sortBy": {},
+          "sortOrder": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -386,9 +330,7 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S3"
-          },
+          "projectName": {},
           "secondarySourcesOverride": {
             "shape": "Sq"
           },
@@ -405,15 +347,13 @@
           "environmentVariablesOverride": {
             "shape": "S10"
           },
-          "sourceTypeOverride": {
-            "shape": "Sl"
-          },
+          "sourceTypeOverride": {},
           "sourceLocationOverride": {},
           "sourceAuthOverride": {
             "shape": "Sn"
           },
           "gitCloneDepthOverride": {
-            "shape": "Sm"
+            "type": "integer"
           },
           "buildspecOverride": {},
           "insecureSslOverride": {
@@ -422,27 +362,19 @@
           "reportBuildStatusOverride": {
             "type": "boolean"
           },
-          "environmentTypeOverride": {
-            "shape": "Sy"
-          },
-          "imageOverride": {
-            "shape": "S3"
-          },
-          "computeTypeOverride": {
-            "shape": "Sz"
-          },
+          "environmentTypeOverride": {},
+          "imageOverride": {},
+          "computeTypeOverride": {},
           "certificateOverride": {},
           "cacheOverride": {
             "shape": "Sv"
           },
-          "serviceRoleOverride": {
-            "shape": "S3"
-          },
+          "serviceRoleOverride": {},
           "privilegedModeOverride": {
             "type": "boolean"
           },
           "timeoutInMinutesOverride": {
-            "shape": "S1p"
+            "type": "integer"
           },
           "idempotencyToken": {},
           "logsConfigOverride": {
@@ -466,9 +398,7 @@
           "id"
         ],
         "members": {
-          "id": {
-            "shape": "S3"
-          }
+          "id": {}
         }
       },
       "output": {
@@ -487,12 +417,8 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S1j"
-          },
+          "name": {},
+          "description": {},
           "source": {
             "shape": "Sk"
           },
@@ -511,15 +437,11 @@
           "environment": {
             "shape": "Sx"
           },
-          "serviceRole": {
-            "shape": "S3"
-          },
+          "serviceRole": {},
           "timeoutInMinutes": {
-            "shape": "S1p"
+            "type": "integer"
           },
-          "encryptionKey": {
-            "shape": "S3"
-          },
+          "encryptionKey": {},
           "tags": {
             "shape": "S1q"
           },
@@ -550,9 +472,7 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S1i"
-          },
+          "projectName": {},
           "branchFilter": {},
           "rotateSecret": {
             "type": "boolean"
@@ -572,25 +492,13 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "min": 1
+      "member": {}
     },
     "Sb": {
       "type": "structure",
       "members": {
-        "id": {
-          "shape": "S3"
-        },
-        "arn": {
-          "shape": "S3"
-        },
+        "id": {},
+        "arn": {},
         "startTime": {
           "type": "timestamp"
         },
@@ -598,38 +506,16 @@
           "type": "timestamp"
         },
         "currentPhase": {},
-        "buildStatus": {
-          "shape": "Sd"
-        },
-        "sourceVersion": {
-          "shape": "S3"
-        },
-        "projectName": {
-          "shape": "S3"
-        },
+        "buildStatus": {},
+        "sourceVersion": {},
+        "projectName": {},
         "phases": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "phaseType": {
-                "type": "string",
-                "enum": [
-                  "SUBMITTED",
-                  "PROVISIONING",
-                  "DOWNLOAD_SOURCE",
-                  "INSTALL",
-                  "PRE_BUILD",
-                  "BUILD",
-                  "POST_BUILD",
-                  "UPLOAD_ARTIFACTS",
-                  "FINALIZING",
-                  "COMPLETED"
-                ]
-              },
-              "phaseStatus": {
-                "shape": "Sd"
-              },
+              "phaseType": {},
+              "phaseStatus": {},
               "startTime": {
                 "type": "timestamp"
               },
@@ -668,9 +554,7 @@
           "type": "list",
           "member": {
             "shape": "St"
-          },
-          "max": 12,
-          "min": 0
+          }
         },
         "cache": {
           "shape": "Sv"
@@ -678,9 +562,7 @@
         "environment": {
           "shape": "Sx"
         },
-        "serviceRole": {
-          "shape": "S3"
-        },
+        "serviceRole": {},
         "logs": {
           "type": "structure",
           "members": {
@@ -709,29 +591,12 @@
         "networkInterface": {
           "type": "structure",
           "members": {
-            "subnetId": {
-              "shape": "S3"
-            },
-            "networkInterfaceId": {
-              "shape": "S3"
-            }
+            "subnetId": {},
+            "networkInterfaceId": {}
           }
         },
-        "encryptionKey": {
-          "shape": "S3"
-        }
+        "encryptionKey": {}
       }
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "SUCCEEDED",
-        "FAILED",
-        "FAULT",
-        "TIMED_OUT",
-        "IN_PROGRESS",
-        "STOPPED"
-      ]
     },
     "Sk": {
       "type": "structure",
@@ -739,12 +604,10 @@
         "type"
       ],
       "members": {
-        "type": {
-          "shape": "Sl"
-        },
+        "type": {},
         "location": {},
         "gitCloneDepth": {
-          "shape": "Sm"
+          "type": "integer"
         },
         "buildspec": {},
         "auth": {
@@ -759,34 +622,13 @@
         "sourceIdentifier": {}
       }
     },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "CODECOMMIT",
-        "CODEPIPELINE",
-        "GITHUB",
-        "S3",
-        "BITBUCKET",
-        "GITHUB_ENTERPRISE",
-        "NO_SOURCE"
-      ]
-    },
-    "Sm": {
-      "type": "integer",
-      "min": 0
-    },
     "Sn": {
       "type": "structure",
       "required": [
         "type"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "OAUTH"
-          ]
-        },
+        "type": {},
         "resource": {}
       }
     },
@@ -794,9 +636,7 @@
       "type": "list",
       "member": {
         "shape": "Sk"
-      },
-      "max": 12,
-      "min": 0
+      }
     },
     "Sr": {
       "type": "list",
@@ -810,9 +650,7 @@
           "sourceIdentifier": {},
           "sourceVersion": {}
         }
-      },
-      "max": 12,
-      "min": 0
+      }
     },
     "St": {
       "type": "structure",
@@ -835,13 +673,7 @@
         "type"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "NO_CACHE",
-            "S3"
-          ]
-        },
+        "type": {},
         "location": {}
       }
     },
@@ -853,15 +685,9 @@
         "computeType"
       ],
       "members": {
-        "type": {
-          "shape": "Sy"
-        },
-        "image": {
-          "shape": "S3"
-        },
-        "computeType": {
-          "shape": "Sz"
-        },
+        "type": {},
+        "image": {},
+        "computeType": {},
         "environmentVariables": {
           "shape": "S10"
         },
@@ -870,21 +696,6 @@
         },
         "certificate": {}
       }
-    },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "WINDOWS_CONTAINER",
-        "LINUX_CONTAINER"
-      ]
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "BUILD_GENERAL1_SMALL",
-        "BUILD_GENERAL1_MEDIUM",
-        "BUILD_GENERAL1_LARGE"
-      ]
     },
     "S10": {
       "type": "list",
@@ -895,17 +706,9 @@
           "value"
         ],
         "members": {
-          "name": {
-            "shape": "S3"
-          },
+          "name": {},
           "value": {},
-          "type": {
-            "type": "string",
-            "enum": [
-              "PLAINTEXT",
-              "PARAMETER_STORE"
-            ]
-          }
+          "type": {}
         }
       }
     },
@@ -915,19 +718,10 @@
         "status"
       ],
       "members": {
-        "status": {
-          "shape": "S15"
-        },
+        "status": {},
         "groupName": {},
         "streamName": {}
       }
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
     },
     "S16": {
       "type": "structure",
@@ -935,52 +729,34 @@
         "status"
       ],
       "members": {
-        "status": {
-          "shape": "S15"
-        },
+        "status": {},
         "location": {}
       }
     },
     "S19": {
       "type": "structure",
       "members": {
-        "vpcId": {
-          "shape": "S3"
-        },
+        "vpcId": {},
         "subnets": {
           "type": "list",
-          "member": {
-            "shape": "S3"
-          },
-          "max": 16
+          "member": {}
         },
         "securityGroupIds": {
           "type": "list",
-          "member": {
-            "shape": "S3"
-          },
-          "max": 5
+          "member": {}
         }
       }
     },
     "S1e": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 100,
-      "min": 1
+      "member": {}
     },
     "S1h": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S1i"
-        },
+        "name": {},
         "arn": {},
-        "description": {
-          "shape": "S1j"
-        },
+        "description": {},
         "source": {
           "shape": "Sk"
         },
@@ -999,15 +775,11 @@
         "environment": {
           "shape": "Sx"
         },
-        "serviceRole": {
-          "shape": "S3"
-        },
+        "serviceRole": {},
         "timeoutInMinutes": {
-          "shape": "S1p"
+          "type": "integer"
         },
-        "encryptionKey": {
-          "shape": "S3"
-        },
+        "encryptionKey": {},
         "tags": {
           "shape": "S1q"
         },
@@ -1037,48 +809,18 @@
         }
       }
     },
-    "S1i": {
-      "type": "string",
-      "max": 255,
-      "min": 2,
-      "pattern": "[A-Za-z0-9][A-Za-z0-9\\-_]{1,254}"
-    },
-    "S1j": {
-      "type": "string",
-      "max": 255,
-      "min": 0
-    },
     "S1k": {
       "type": "structure",
       "required": [
         "type"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "CODEPIPELINE",
-            "S3",
-            "NO_ARTIFACTS"
-          ]
-        },
+        "type": {},
         "location": {},
         "path": {},
-        "namespaceType": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "BUILD_ID"
-          ]
-        },
+        "namespaceType": {},
         "name": {},
-        "packaging": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "ZIP"
-          ]
-        },
+        "packaging": {},
         "overrideArtifactName": {
           "type": "boolean"
         },
@@ -1092,49 +834,24 @@
       "type": "list",
       "member": {
         "shape": "S1k"
-      },
-      "max": 12,
-      "min": 0
-    },
-    "S1p": {
-      "type": "integer",
-      "max": 480,
-      "min": 5
+      }
     },
     "S1q": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "key": {
-            "type": "string",
-            "max": 127,
-            "min": 1,
-            "pattern": "^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=@+\\\\-]*)$"
-          },
-          "value": {
-            "type": "string",
-            "max": 255,
-            "min": 1,
-            "pattern": "^([\\\\p{L}\\\\p{Z}\\\\p{N}_.:/=@+\\\\-]*)$"
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "max": 50,
-      "min": 0
+      }
     },
     "S1u": {
       "type": "structure",
       "members": {
-        "url": {
-          "shape": "S3"
-        },
-        "payloadUrl": {
-          "shape": "S3"
-        },
-        "secret": {
-          "shape": "S3"
-        },
+        "url": {},
+        "payloadUrl": {},
+        "secret": {},
         "branchFilter": {},
         "lastModifiedSecret": {
           "type": "timestamp"
@@ -1151,13 +868,6 @@
           "shape": "S16"
         }
       }
-    },
-    "S28": {
-      "type": "string",
-      "enum": [
-        "ASCENDING",
-        "DESCENDING"
-      ]
     }
   }
 }

--- a/apis/codecommit-2015-04-13.min.json
+++ b/apis/codecommit-2015-04-13.min.json
@@ -22,9 +22,7 @@
         "members": {
           "repositoryNames": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           }
         }
       },
@@ -39,9 +37,7 @@
           },
           "repositoriesNotFound": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           }
         }
       }
@@ -55,12 +51,8 @@
           "commitId"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "branchName": {
-            "shape": "Sa"
-          },
+          "repositoryName": {},
+          "branchName": {},
           "commitId": {}
         }
       }
@@ -73,12 +65,8 @@
           "targets"
         ],
         "members": {
-          "title": {
-            "shape": "Sk"
-          },
-          "description": {
-            "shape": "Sl"
-          },
+          "title": {},
+          "description": {},
           "targets": {
             "type": "list",
             "member": {
@@ -88,9 +76,7 @@
                 "sourceReference"
               ],
               "members": {
-                "repositoryName": {
-                  "shape": "S3"
-                },
+                "repositoryName": {},
                 "sourceReference": {},
                 "destinationReference": {}
               }
@@ -120,12 +106,8 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "repositoryDescription": {
-            "shape": "S9"
-          }
+          "repositoryName": {},
+          "repositoryDescription": {}
         }
       },
       "output": {
@@ -145,12 +127,8 @@
           "branchName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "branchName": {
-            "shape": "Sa"
-          }
+          "repositoryName": {},
+          "branchName": {}
         }
       },
       "output": {
@@ -188,9 +166,7 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "repositoryName": {}
         }
       },
       "output": {
@@ -208,9 +184,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "pullRequestEventType": {
-            "shape": "S1c"
-          },
+          "pullRequestEventType": {},
           "actorArn": {},
           "nextToken": {},
           "maxResults": {
@@ -233,16 +207,12 @@
                 "eventDate": {
                   "type": "timestamp"
                 },
-                "pullRequestEventType": {
-                  "shape": "S1c"
-                },
+                "pullRequestEventType": {},
                 "actorArn": {},
                 "pullRequestCreatedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {
-                      "shape": "S3"
-                    },
+                    "repositoryName": {},
                     "sourceCommitId": {},
                     "destinationCommitId": {},
                     "mergeBase": {}
@@ -251,17 +221,13 @@
                 "pullRequestStatusChangedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "pullRequestStatus": {
-                      "shape": "St"
-                    }
+                    "pullRequestStatus": {}
                   }
                 },
                 "pullRequestSourceReferenceUpdatedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {
-                      "shape": "S3"
-                    },
+                    "repositoryName": {},
                     "beforeCommitId": {},
                     "afterCommitId": {},
                     "mergeBase": {}
@@ -270,9 +236,7 @@
                 "pullRequestMergedStateChangedEventMetadata": {
                   "type": "structure",
                   "members": {
-                    "repositoryName": {
-                      "shape": "S3"
-                    },
+                    "repositoryName": {},
                     "destinationReference": {},
                     "mergeMetadata": {
                       "shape": "Sw"
@@ -294,9 +258,7 @@
           "blobId"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "blobId": {}
         }
       },
@@ -316,12 +278,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "branchName": {
-            "shape": "Sa"
-          }
+          "repositoryName": {},
+          "branchName": {}
         }
       },
       "output": {
@@ -360,9 +318,7 @@
           "afterCommitId"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitId": {},
           "afterCommitId": {},
           "nextToken": {},
@@ -379,9 +335,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "repositoryName": {
-                  "shape": "S3"
-                },
+                "repositoryName": {},
                 "beforeCommitId": {},
                 "afterCommitId": {},
                 "beforeBlobId": {},
@@ -407,9 +361,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitId": {},
           "afterCommitId": {},
           "nextToken": {},
@@ -427,9 +379,7 @@
               "type": "structure",
               "members": {
                 "pullRequestId": {},
-                "repositoryName": {
-                  "shape": "S3"
-                },
+                "repositoryName": {},
                 "beforeCommitId": {},
                 "afterCommitId": {},
                 "beforeBlobId": {},
@@ -455,9 +405,7 @@
           "commitId"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "commitId": {}
         }
       },
@@ -497,9 +445,7 @@
           "afterCommitSpecifier"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitSpecifier": {},
           "afterCommitSpecifier": {},
           "beforePath": {},
@@ -524,14 +470,7 @@
                 "afterBlob": {
                   "shape": "S2o"
                 },
-                "changeType": {
-                  "type": "string",
-                  "enum": [
-                    "A",
-                    "M",
-                    "D"
-                  ]
-                }
+                "changeType": {}
               }
             }
           },
@@ -549,17 +488,10 @@
           "mergeOption"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "destinationCommitSpecifier": {},
           "sourceCommitSpecifier": {},
-          "mergeOption": {
-            "type": "string",
-            "enum": [
-              "FAST_FORWARD_MERGE"
-            ]
-          }
+          "mergeOption": {}
         }
       },
       "output": {
@@ -607,9 +539,7 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "repositoryName": {}
         }
       },
       "output": {
@@ -628,9 +558,7 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "repositoryName": {}
         }
       },
       "output": {
@@ -650,9 +578,7 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "nextToken": {}
         }
       },
@@ -673,13 +599,9 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "authorArn": {},
-          "pullRequestStatus": {
-            "shape": "St"
-          },
+          "pullRequestStatus": {},
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -705,20 +627,8 @@
         "type": "structure",
         "members": {
           "nextToken": {},
-          "sortBy": {
-            "type": "string",
-            "enum": [
-              "repositoryName",
-              "lastModifiedDate"
-            ]
-          },
-          "order": {
-            "type": "string",
-            "enum": [
-              "ascending",
-              "descending"
-            ]
-          }
+          "sortBy": {},
+          "order": {}
         }
       },
       "output": {
@@ -729,9 +639,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "repositoryName": {
-                  "shape": "S3"
-                },
+                "repositoryName": {},
                 "repositoryId": {}
               }
             }
@@ -749,9 +657,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "sourceCommitId": {}
         }
       },
@@ -773,9 +679,7 @@
           "content"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitId": {},
           "afterCommitId": {},
           "location": {
@@ -790,9 +694,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitId": {},
           "afterCommitId": {},
           "beforeBlobId": {},
@@ -819,9 +721,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "beforeCommitId": {},
           "afterCommitId": {},
           "location": {
@@ -836,9 +736,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "pullRequestId": {},
           "beforeCommitId": {},
           "afterCommitId": {},
@@ -889,25 +787,13 @@
           "filePath"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "branchName": {
-            "shape": "Sa"
-          },
+          "repositoryName": {},
+          "branchName": {},
           "fileContent": {
-            "type": "blob",
-            "max": 6291456
+            "type": "blob"
           },
           "filePath": {},
-          "fileMode": {
-            "type": "string",
-            "enum": [
-              "EXECUTABLE",
-              "NORMAL",
-              "SYMLINK"
-            ]
-          },
+          "fileMode": {},
           "parentCommitId": {},
           "commitMessage": {},
           "name": {},
@@ -936,9 +822,7 @@
           "triggers"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "triggers": {
             "shape": "S32"
           }
@@ -959,9 +843,7 @@
           "triggers"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "repositoryName": {},
           "triggers": {
             "shape": "S32"
           }
@@ -1016,12 +898,8 @@
           "defaultBranchName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "defaultBranchName": {
-            "shape": "Sa"
-          }
+          "repositoryName": {},
+          "defaultBranchName": {}
         }
       }
     },
@@ -1034,9 +912,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "description": {
-            "shape": "Sl"
-          }
+          "description": {}
         }
       },
       "output": {
@@ -1060,9 +936,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "pullRequestStatus": {
-            "shape": "St"
-          }
+          "pullRequestStatus": {}
         }
       },
       "output": {
@@ -1086,9 +960,7 @@
         ],
         "members": {
           "pullRequestId": {},
-          "title": {
-            "shape": "Sk"
-          }
+          "title": {}
         }
       },
       "output": {
@@ -1110,12 +982,8 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "repositoryDescription": {
-            "shape": "S9"
-          }
+          "repositoryName": {},
+          "repositoryDescription": {}
         }
       }
     },
@@ -1127,37 +995,21 @@
           "newName"
         ],
         "members": {
-          "oldName": {
-            "shape": "S3"
-          },
-          "newName": {
-            "shape": "S3"
-          }
+          "oldName": {},
+          "newName": {}
         }
       }
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[\\w\\.-]+"
-    },
     "S6": {
       "type": "structure",
       "members": {
         "accountId": {},
         "repositoryId": {},
-        "repositoryName": {
-          "shape": "S3"
-        },
-        "repositoryDescription": {
-          "shape": "S9"
-        },
-        "defaultBranch": {
-          "shape": "Sa"
-        },
+        "repositoryName": {},
+        "repositoryDescription": {},
+        "defaultBranch": {},
         "lastModifiedDate": {
           "type": "timestamp"
         },
@@ -1169,51 +1021,26 @@
         "Arn": {}
       }
     },
-    "S9": {
-      "type": "string",
-      "max": 1000
-    },
-    "Sa": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "Sk": {
-      "type": "string",
-      "max": 150
-    },
-    "Sl": {
-      "type": "string",
-      "max": 10240
-    },
     "Sr": {
       "type": "structure",
       "members": {
         "pullRequestId": {},
-        "title": {
-          "shape": "Sk"
-        },
-        "description": {
-          "shape": "Sl"
-        },
+        "title": {},
+        "description": {},
         "lastActivityDate": {
           "type": "timestamp"
         },
         "creationDate": {
           "type": "timestamp"
         },
-        "pullRequestStatus": {
-          "shape": "St"
-        },
+        "pullRequestStatus": {},
         "authorArn": {},
         "pullRequestTargets": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "repositoryName": {
-                "shape": "S3"
-              },
+              "repositoryName": {},
               "sourceReference": {},
               "destinationReference": {},
               "destinationCommit": {},
@@ -1228,13 +1055,6 @@
         "clientRequestToken": {}
       }
     },
-    "St": {
-      "type": "string",
-      "enum": [
-        "OPEN",
-        "CLOSED"
-      ]
-    },
     "Sw": {
       "type": "structure",
       "members": {
@@ -1247,9 +1067,7 @@
     "S12": {
       "type": "structure",
       "members": {
-        "branchName": {
-          "shape": "Sa"
-        },
+        "branchName": {},
         "commitId": {}
       }
     },
@@ -1272,15 +1090,6 @@
         "clientRequestToken": {}
       }
     },
-    "S1c": {
-      "type": "string",
-      "enum": [
-        "PULL_REQUEST_CREATED",
-        "PULL_REQUEST_STATUS_CHANGED",
-        "PULL_REQUEST_SOURCE_REFERENCE_UPDATED",
-        "PULL_REQUEST_MERGE_STATE_CHANGED"
-      ]
-    },
     "S1z": {
       "type": "structure",
       "members": {
@@ -1288,13 +1097,7 @@
         "filePosition": {
           "type": "long"
         },
-        "relativeFileVersion": {
-          "type": "string",
-          "enum": [
-            "BEFORE",
-            "AFTER"
-          ]
-        }
+        "relativeFileVersion": {}
       }
     },
     "S23": {
@@ -1337,24 +1140,14 @@
           },
           "events": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "all",
-                "updateReference",
-                "createReference",
-                "deleteReference"
-              ]
-            }
+            "member": {}
           }
         }
       }
     },
     "S36": {
       "type": "list",
-      "member": {
-        "shape": "Sa"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/codedeploy-2014-10-06.min.json
+++ b/apis/codedeploy-2014-10-06.min.json
@@ -39,9 +39,7 @@
           "revisions"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "revisions": {
             "shape": "Sa"
           }
@@ -50,9 +48,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "errorMessage": {},
           "revisions": {
             "type": "list",
@@ -103,9 +99,7 @@
           "deploymentGroupNames"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "deploymentGroupNames": {
             "shape": "Sv"
           }
@@ -214,12 +208,8 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "computePlatform": {
-            "shape": "S16"
-          }
+          "applicationName": {},
+          "computePlatform": {}
         }
       },
       "output": {
@@ -236,18 +226,12 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "deploymentGroupName": {
-            "shape": "Sw"
-          },
+          "applicationName": {},
+          "deploymentGroupName": {},
           "revision": {
             "shape": "Sb"
           },
-          "deploymentConfigName": {
-            "shape": "S1c"
-          },
+          "deploymentConfigName": {},
           "description": {},
           "ignoreApplicationStopFailures": {
             "type": "boolean"
@@ -261,9 +245,7 @@
           "updateOutdatedInstancesOnly": {
             "type": "boolean"
           },
-          "fileExistsBehavior": {
-            "shape": "S3l"
-          }
+          "fileExistsBehavior": {}
         }
       },
       "output": {
@@ -280,18 +262,14 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {
-            "shape": "S1c"
-          },
+          "deploymentConfigName": {},
           "minimumHealthyHosts": {
             "shape": "S40"
           },
           "trafficRoutingConfig": {
             "shape": "S43"
           },
-          "computePlatform": {
-            "shape": "S16"
-          }
+          "computePlatform": {}
         }
       },
       "output": {
@@ -310,15 +288,9 @@
           "serviceRoleArn"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "deploymentGroupName": {
-            "shape": "Sw"
-          },
-          "deploymentConfigName": {
-            "shape": "S1c"
-          },
+          "applicationName": {},
+          "deploymentGroupName": {},
+          "deploymentConfigName": {},
           "ec2TagFilters": {
             "shape": "S1d"
           },
@@ -369,9 +341,7 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          }
+          "applicationName": {}
         }
       }
     },
@@ -382,9 +352,7 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {
-            "shape": "S1c"
-          }
+          "deploymentConfigName": {}
         }
       }
     },
@@ -396,12 +364,8 @@
           "deploymentGroupName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "deploymentGroupName": {
-            "shape": "Sw"
-          }
+          "applicationName": {},
+          "deploymentGroupName": {}
         }
       },
       "output": {
@@ -445,9 +409,7 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          }
+          "applicationName": {}
         }
       },
       "output": {
@@ -467,9 +429,7 @@
           "revision"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "revision": {
             "shape": "Sb"
           }
@@ -478,9 +438,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "revision": {
             "shape": "Sb"
           },
@@ -516,9 +474,7 @@
           "deploymentConfigName"
         ],
         "members": {
-          "deploymentConfigName": {
-            "shape": "S1c"
-          }
+          "deploymentConfigName": {}
         }
       },
       "output": {
@@ -528,18 +484,14 @@
             "type": "structure",
             "members": {
               "deploymentConfigId": {},
-              "deploymentConfigName": {
-                "shape": "S1c"
-              },
+              "deploymentConfigName": {},
               "minimumHealthyHosts": {
                 "shape": "S40"
               },
               "createTime": {
                 "type": "timestamp"
               },
-              "computePlatform": {
-                "shape": "S16"
-              },
+              "computePlatform": {},
               "trafficRoutingConfig": {
                 "shape": "S43"
               }
@@ -556,12 +508,8 @@
           "deploymentGroupName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "deploymentGroupName": {
-            "shape": "Sw"
-          }
+          "applicationName": {},
+          "deploymentGroupName": {}
         }
       },
       "output": {
@@ -620,34 +568,12 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "sortBy": {
-            "type": "string",
-            "enum": [
-              "registerTime",
-              "firstUsedTime",
-              "lastUsedTime"
-            ]
-          },
-          "sortOrder": {
-            "type": "string",
-            "enum": [
-              "ascending",
-              "descending"
-            ]
-          },
+          "applicationName": {},
+          "sortBy": {},
+          "sortOrder": {},
           "s3Bucket": {},
           "s3KeyPrefix": {},
-          "deployed": {
-            "type": "string",
-            "enum": [
-              "include",
-              "exclude",
-              "ignore"
-            ]
-          },
+          "deployed": {},
           "nextToken": {}
         }
       },
@@ -690,9 +616,7 @@
         "members": {
           "deploymentConfigsList": {
             "type": "list",
-            "member": {
-              "shape": "S1c"
-            }
+            "member": {}
           },
           "nextToken": {}
         }
@@ -705,18 +629,14 @@
           "applicationName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "nextToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "deploymentGroups": {
             "shape": "Sv"
           },
@@ -735,15 +655,11 @@
           "nextToken": {},
           "instanceStatusFilter": {
             "type": "list",
-            "member": {
-              "shape": "S2w"
-            }
+            "member": {}
           },
           "instanceTypeFilter": {
             "type": "list",
-            "member": {
-              "shape": "S36"
-            }
+            "member": {}
           }
         }
       },
@@ -761,17 +677,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "deploymentGroupName": {
-            "shape": "Sw"
-          },
+          "applicationName": {},
+          "deploymentGroupName": {},
           "includeOnlyStatuses": {
             "type": "list",
-            "member": {
-              "shape": "S2l"
-            }
+            "member": {}
           },
           "createTimeRange": {
             "type": "structure",
@@ -819,13 +729,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "registrationStatus": {
-            "type": "string",
-            "enum": [
-              "Registered",
-              "Deregistered"
-            ]
-          },
+          "registrationStatus": {},
           "tagFilters": {
             "shape": "S1g"
           },
@@ -848,9 +752,7 @@
         "members": {
           "deploymentId": {},
           "lifecycleEventHookExecutionId": {},
-          "status": {
-            "shape": "S35"
-          }
+          "status": {}
         }
       },
       "output": {
@@ -868,9 +770,7 @@
           "revision"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
+          "applicationName": {},
           "description": {},
           "revision": {
             "shape": "Sb"
@@ -932,13 +832,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "Pending",
-              "Succeeded"
-            ]
-          },
+          "status": {},
           "statusMessage": {}
         }
       }
@@ -947,12 +841,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "newApplicationName": {
-            "shape": "S9"
-          }
+          "applicationName": {},
+          "newApplicationName": {}
         }
       }
     },
@@ -964,18 +854,10 @@
           "currentDeploymentGroupName"
         ],
         "members": {
-          "applicationName": {
-            "shape": "S9"
-          },
-          "currentDeploymentGroupName": {
-            "shape": "Sw"
-          },
-          "newDeploymentGroupName": {
-            "shape": "Sw"
-          },
-          "deploymentConfigName": {
-            "shape": "S1c"
-          },
+          "applicationName": {},
+          "currentDeploymentGroupName": {},
+          "newDeploymentGroupName": {},
+          "deploymentConfigName": {},
           "ec2TagFilters": {
             "shape": "S1d"
           },
@@ -1037,11 +919,6 @@
       "type": "list",
       "member": {}
     },
-    "S9": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
     "Sa": {
       "type": "list",
       "member": {
@@ -1051,29 +928,13 @@
     "Sb": {
       "type": "structure",
       "members": {
-        "revisionType": {
-          "type": "string",
-          "enum": [
-            "S3",
-            "GitHub",
-            "String"
-          ]
-        },
+        "revisionType": {},
         "s3Location": {
           "type": "structure",
           "members": {
             "bucket": {},
             "key": {},
-            "bundleType": {
-              "type": "string",
-              "enum": [
-                "tar",
-                "tgz",
-                "zip",
-                "YAML",
-                "JSON"
-              ]
-            },
+            "bundleType": {},
             "version": {},
             "eTag": {}
           }
@@ -1114,28 +975,17 @@
     },
     "Sv": {
       "type": "list",
-      "member": {
-        "shape": "Sw"
-      }
-    },
-    "Sw": {
-      "type": "string",
-      "max": 100,
-      "min": 1
+      "member": {}
     },
     "Sz": {
       "type": "list",
-      "member": {
-        "shape": "S9"
-      }
+      "member": {}
     },
     "S12": {
       "type": "structure",
       "members": {
         "applicationId": {},
-        "applicationName": {
-          "shape": "S9"
-        },
+        "applicationName": {},
         "createTime": {
           "type": "timestamp"
         },
@@ -1143,31 +993,16 @@
           "type": "boolean"
         },
         "gitHubAccountName": {},
-        "computePlatform": {
-          "shape": "S16"
-        }
+        "computePlatform": {}
       }
-    },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "Server",
-        "Lambda"
-      ]
     },
     "S1a": {
       "type": "structure",
       "members": {
-        "applicationName": {
-          "shape": "S9"
-        },
+        "applicationName": {},
         "deploymentGroupId": {},
-        "deploymentGroupName": {
-          "shape": "Sw"
-        },
-        "deploymentConfigName": {
-          "shape": "S1c"
-        },
+        "deploymentGroupName": {},
+        "deploymentConfigName": {},
         "ec2TagFilters": {
           "shape": "S1d"
         },
@@ -1211,15 +1046,8 @@
         "onPremisesTagSet": {
           "shape": "S2o"
         },
-        "computePlatform": {
-          "shape": "S16"
-        }
+        "computePlatform": {}
       }
-    },
-    "S1c": {
-      "type": "string",
-      "max": 100,
-      "min": 1
     },
     "S1d": {
       "type": "list",
@@ -1228,14 +1056,7 @@
         "members": {
           "Key": {},
           "Value": {},
-          "Type": {
-            "type": "string",
-            "enum": [
-              "KEY_ONLY",
-              "VALUE_ONLY",
-              "KEY_AND_VALUE"
-            ]
-          }
+          "Type": {}
         }
       }
     },
@@ -1246,14 +1067,7 @@
         "members": {
           "Key": {},
           "Value": {},
-          "Type": {
-            "type": "string",
-            "enum": [
-              "KEY_ONLY",
-              "VALUE_ONLY",
-              "KEY_AND_VALUE"
-            ]
-          }
+          "Type": {}
         }
       }
     },
@@ -1276,21 +1090,7 @@
           "triggerTargetArn": {},
           "triggerEvents": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "DeploymentStart",
-                "DeploymentSuccess",
-                "DeploymentFailure",
-                "DeploymentStop",
-                "DeploymentRollback",
-                "DeploymentReady",
-                "InstanceStart",
-                "InstanceSuccess",
-                "InstanceFailure",
-                "InstanceReady"
-              ]
-            }
+            "member": {}
           }
         }
       }
@@ -1323,34 +1123,15 @@
         },
         "events": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "DEPLOYMENT_FAILURE",
-              "DEPLOYMENT_STOP_ON_ALARM",
-              "DEPLOYMENT_STOP_ON_REQUEST"
-            ]
-          }
+          "member": {}
         }
       }
     },
     "S21": {
       "type": "structure",
       "members": {
-        "deploymentType": {
-          "type": "string",
-          "enum": [
-            "IN_PLACE",
-            "BLUE_GREEN"
-          ]
-        },
-        "deploymentOption": {
-          "type": "string",
-          "enum": [
-            "WITH_TRAFFIC_CONTROL",
-            "WITHOUT_TRAFFIC_CONTROL"
-          ]
-        }
+        "deploymentType": {},
+        "deploymentOption": {}
       }
     },
     "S24": {
@@ -1359,13 +1140,7 @@
         "terminateBlueInstancesOnDeploymentSuccess": {
           "type": "structure",
           "members": {
-            "action": {
-              "type": "string",
-              "enum": [
-                "TERMINATE",
-                "KEEP_ALIVE"
-              ]
-            },
+            "action": {},
             "terminationWaitTimeInMinutes": {
               "type": "integer"
             }
@@ -1374,13 +1149,7 @@
         "deploymentReadyOption": {
           "type": "structure",
           "members": {
-            "actionOnTimeout": {
-              "type": "string",
-              "enum": [
-                "CONTINUE_DEPLOYMENT",
-                "STOP_DEPLOYMENT"
-              ]
-            },
+            "actionOnTimeout": {},
             "waitTimeInMinutes": {
               "type": "integer"
             }
@@ -1389,13 +1158,7 @@
         "greenFleetProvisioningOption": {
           "type": "structure",
           "members": {
-            "action": {
-              "type": "string",
-              "enum": [
-                "DISCOVER_EXISTING",
-                "COPY_AUTO_SCALING_GROUP"
-              ]
-            }
+            "action": {}
           }
         }
       }
@@ -1427,9 +1190,7 @@
       "type": "structure",
       "members": {
         "deploymentId": {},
-        "status": {
-          "shape": "S2l"
-        },
+        "status": {},
         "endTime": {
           "type": "timestamp"
         },
@@ -1437,18 +1198,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S2l": {
-      "type": "string",
-      "enum": [
-        "Created",
-        "Queued",
-        "InProgress",
-        "Succeeded",
-        "Failed",
-        "Stopped",
-        "Ready"
-      ]
     },
     "S2m": {
       "type": "structure",
@@ -1481,9 +1230,7 @@
       "members": {
         "deploymentId": {},
         "instanceId": {},
-        "status": {
-          "shape": "S2w"
-        },
+        "status": {},
         "lastUpdatedAt": {
           "type": "timestamp"
         },
@@ -1496,17 +1243,7 @@
               "diagnostics": {
                 "type": "structure",
                 "members": {
-                  "errorCode": {
-                    "type": "string",
-                    "enum": [
-                      "Success",
-                      "ScriptMissing",
-                      "ScriptNotExecutable",
-                      "ScriptTimedOut",
-                      "ScriptFailed",
-                      "UnknownError"
-                    ]
-                  },
+                  "errorCode": {},
                   "scriptName": {},
                   "message": {},
                   "logTail": {}
@@ -1518,46 +1255,12 @@
               "endTime": {
                 "type": "timestamp"
               },
-              "status": {
-                "shape": "S35"
-              }
+              "status": {}
             }
           }
         },
-        "instanceType": {
-          "shape": "S36"
-        }
+        "instanceType": {}
       }
-    },
-    "S2w": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "InProgress",
-        "Succeeded",
-        "Failed",
-        "Skipped",
-        "Unknown",
-        "Ready"
-      ]
-    },
-    "S35": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "InProgress",
-        "Succeeded",
-        "Failed",
-        "Skipped",
-        "Unknown"
-      ]
-    },
-    "S36": {
-      "type": "string",
-      "enum": [
-        "Blue",
-        "Green"
-      ]
     },
     "S38": {
       "type": "list",
@@ -1566,15 +1269,9 @@
     "S3b": {
       "type": "structure",
       "members": {
-        "applicationName": {
-          "shape": "S9"
-        },
-        "deploymentGroupName": {
-          "shape": "Sw"
-        },
-        "deploymentConfigName": {
-          "shape": "S1c"
-        },
+        "applicationName": {},
+        "deploymentGroupName": {},
+        "deploymentConfigName": {},
         "deploymentId": {},
         "previousRevision": {
           "shape": "Sb"
@@ -1582,43 +1279,11 @@
         "revision": {
           "shape": "Sb"
         },
-        "status": {
-          "shape": "S2l"
-        },
+        "status": {},
         "errorInformation": {
           "type": "structure",
           "members": {
-            "code": {
-              "type": "string",
-              "enum": [
-                "DEPLOYMENT_GROUP_MISSING",
-                "APPLICATION_MISSING",
-                "REVISION_MISSING",
-                "IAM_ROLE_MISSING",
-                "IAM_ROLE_PERMISSIONS",
-                "NO_EC2_SUBSCRIPTION",
-                "OVER_MAX_INSTANCES",
-                "NO_INSTANCES",
-                "TIMEOUT",
-                "HEALTH_CONSTRAINTS_INVALID",
-                "HEALTH_CONSTRAINTS",
-                "INTERNAL_ERROR",
-                "THROTTLED",
-                "ALARM_ACTIVE",
-                "AGENT_ISSUE",
-                "AUTO_SCALING_IAM_ROLE_PERMISSIONS",
-                "AUTO_SCALING_CONFIGURATION",
-                "MANUAL_STOP",
-                "MISSING_BLUE_GREEN_DEPLOYMENT_CONFIGURATION",
-                "MISSING_ELB_INFORMATION",
-                "MISSING_GITHUB_TOKEN",
-                "ELASTIC_LOAD_BALANCING_INVALID",
-                "ELB_INVALID_INSTANCE",
-                "INVALID_LAMBDA_CONFIGURATION",
-                "INVALID_LAMBDA_FUNCTION",
-                "HOOK_EXECUTION_FAILURE"
-              ]
-            },
+            "code": {},
             "message": {}
           }
         },
@@ -1655,14 +1320,7 @@
           }
         },
         "description": {},
-        "creator": {
-          "type": "string",
-          "enum": [
-            "user",
-            "autoscaling",
-            "codeDeployRollback"
-          ]
-        },
+        "creator": {},
         "ignoreApplicationStopFailures": {
           "type": "boolean"
         },
@@ -1699,16 +1357,12 @@
           "type": "string",
           "deprecated": true
         },
-        "fileExistsBehavior": {
-          "shape": "S3l"
-        },
+        "fileExistsBehavior": {},
         "deploymentStatusMessages": {
           "type": "list",
           "member": {}
         },
-        "computePlatform": {
-          "shape": "S16"
-        }
+        "computePlatform": {}
       }
     },
     "S3i": {
@@ -1728,14 +1382,6 @@
     "S3j": {
       "type": "list",
       "member": {}
-    },
-    "S3l": {
-      "type": "string",
-      "enum": [
-        "DISALLOW",
-        "OVERWRITE",
-        "RETAIN"
-      ]
     },
     "S3q": {
       "type": "structure",
@@ -1761,26 +1407,13 @@
         "value": {
           "type": "integer"
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "HOST_COUNT",
-            "FLEET_PERCENT"
-          ]
-        }
+        "type": {}
       }
     },
     "S43": {
       "type": "structure",
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "TimeBasedCanary",
-            "TimeBasedLinear",
-            "AllAtOnce"
-          ]
-        },
+        "type": {},
         "timeBasedCanary": {
           "type": "structure",
           "members": {

--- a/apis/codepipeline-2015-07-09.min.json
+++ b/apis/codepipeline-2015-07-09.min.json
@@ -21,20 +21,14 @@
           "nonce"
         ],
         "members": {
-          "jobId": {
-            "shape": "S2"
-          },
-          "nonce": {
-            "shape": "S3"
-          }
+          "jobId": {},
+          "nonce": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "shape": "S5"
-          }
+          "status": {}
         }
       }
     },
@@ -47,23 +41,15 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {
-            "shape": "S7"
-          },
-          "nonce": {
-            "shape": "S3"
-          },
-          "clientToken": {
-            "shape": "S8"
-          }
+          "jobId": {},
+          "nonce": {},
+          "clientToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "status": {
-            "shape": "S5"
-          }
+          "status": {}
         }
       }
     },
@@ -78,15 +64,9 @@
           "outputArtifactDetails"
         ],
         "members": {
-          "category": {
-            "shape": "Sb"
-          },
-          "provider": {
-            "shape": "Sc"
-          },
-          "version": {
-            "shape": "Sd"
-          },
+          "category": {},
+          "provider": {},
+          "version": {},
           "settings": {
             "shape": "Se"
           },
@@ -143,15 +123,9 @@
           "version"
         ],
         "members": {
-          "category": {
-            "shape": "Sb"
-          },
-          "provider": {
-            "shape": "Sc"
-          },
-          "version": {
-            "shape": "Sd"
-          }
+          "category": {},
+          "provider": {},
+          "version": {}
         }
       }
     },
@@ -162,9 +136,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "Sw"
-          }
+          "name": {}
         }
       }
     },
@@ -175,9 +147,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S1r"
-          }
+          "name": {}
         }
       },
       "output": {
@@ -189,9 +159,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "webhookName": {
-            "shape": "S1r"
-          }
+          "webhookName": {}
         }
       },
       "output": {
@@ -209,18 +177,10 @@
           "reason"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "stageName": {
-            "shape": "S16"
-          },
-          "transitionType": {
-            "shape": "S1w"
-          },
-          "reason": {
-            "shape": "S1x"
-          }
+          "pipelineName": {},
+          "stageName": {},
+          "transitionType": {},
+          "reason": {}
         }
       }
     },
@@ -233,15 +193,9 @@
           "transitionType"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "stageName": {
-            "shape": "S16"
-          },
-          "transitionType": {
-            "shape": "S1w"
-          }
+          "pipelineName": {},
+          "stageName": {},
+          "transitionType": {}
         }
       }
     },
@@ -252,9 +206,7 @@
           "jobId"
         ],
         "members": {
-          "jobId": {
-            "shape": "S2"
-          }
+          "jobId": {}
         }
       },
       "output": {
@@ -263,15 +215,11 @@
           "jobDetails": {
             "type": "structure",
             "members": {
-              "id": {
-                "shape": "S2"
-              },
+              "id": {},
               "data": {
                 "shape": "S22"
               },
-              "accountId": {
-                "shape": "S2k"
-              }
+              "accountId": {}
             }
           }
         }
@@ -284,11 +232,9 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "Sw"
-          },
+          "name": {},
           "version": {
-            "shape": "S1m"
+            "type": "integer"
           }
         }
       },
@@ -301,10 +247,7 @@
           "metadata": {
             "type": "structure",
             "members": {
-              "pipelineArn": {
-                "type": "string",
-                "pattern": "arn:aws(-[\\w]+)*:codepipeline:.+:[0-9]{12}:.+"
-              },
+              "pipelineArn": {},
               "created": {
                 "type": "timestamp"
               },
@@ -324,12 +267,8 @@
           "pipelineExecutionId"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "pipelineExecutionId": {
-            "shape": "S2r"
-          }
+          "pipelineName": {},
+          "pipelineExecutionId": {}
         }
       },
       "output": {
@@ -338,41 +277,25 @@
           "pipelineExecution": {
             "type": "structure",
             "members": {
-              "pipelineName": {
-                "shape": "Sw"
-              },
+              "pipelineName": {},
               "pipelineVersion": {
-                "shape": "S1m"
+                "type": "integer"
               },
-              "pipelineExecutionId": {
-                "shape": "S2r"
-              },
-              "status": {
-                "shape": "S2u"
-              },
+              "pipelineExecutionId": {},
+              "status": {},
               "artifactRevisions": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "name": {
-                      "shape": "S1j"
-                    },
-                    "revisionId": {
-                      "shape": "S29"
-                    },
-                    "revisionChangeIdentifier": {
-                      "shape": "S2x"
-                    },
-                    "revisionSummary": {
-                      "shape": "S2y"
-                    },
+                    "name": {},
+                    "revisionId": {},
+                    "revisionChangeIdentifier": {},
+                    "revisionSummary": {},
                     "created": {
                       "type": "timestamp"
                     },
-                    "revisionUrl": {
-                      "shape": "Sf"
-                    }
+                    "revisionUrl": {}
                   }
                 }
               }
@@ -388,28 +311,22 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "Sw"
-          }
+          "name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
+          "pipelineName": {},
           "pipelineVersion": {
-            "shape": "S1m"
+            "type": "integer"
           },
           "stageStates": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "stageName": {
-                  "shape": "S16"
-                },
+                "stageName": {},
                 "inboundTransitionState": {
                   "type": "structure",
                   "members": {
@@ -420,9 +337,7 @@
                     "lastChangedAt": {
                       "type": "timestamp"
                     },
-                    "disabledReason": {
-                      "shape": "S1x"
-                    }
+                    "disabledReason": {}
                   }
                 },
                 "actionStates": {
@@ -430,57 +345,36 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "actionName": {
-                        "shape": "S1d"
-                      },
+                      "actionName": {},
                       "currentRevision": {
                         "shape": "S39"
                       },
                       "latestExecution": {
                         "type": "structure",
                         "members": {
-                          "status": {
-                            "type": "string",
-                            "enum": [
-                              "InProgress",
-                              "Succeeded",
-                              "Failed"
-                            ]
-                          },
-                          "summary": {
-                            "shape": "S3c"
-                          },
+                          "status": {},
+                          "summary": {},
                           "lastStatusChange": {
                             "type": "timestamp"
                           },
                           "token": {},
                           "lastUpdatedBy": {},
-                          "externalExecutionId": {
-                            "shape": "S3f"
-                          },
-                          "externalExecutionUrl": {
-                            "shape": "Sf"
-                          },
+                          "externalExecutionId": {},
+                          "externalExecutionUrl": {},
                           "percentComplete": {
-                            "shape": "S3g"
+                            "type": "integer"
                           },
                           "errorDetails": {
                             "type": "structure",
                             "members": {
                               "code": {},
-                              "message": {
-                                "shape": "S3j"
-                              }
+                              "message": {}
                             }
                           }
                         }
                       },
-                      "entityUrl": {
-                        "shape": "Sf"
-                      },
-                      "revisionUrl": {
-                        "shape": "Sf"
-                      }
+                      "entityUrl": {},
+                      "revisionUrl": {}
                     }
                   }
                 },
@@ -491,17 +385,8 @@
                     "status"
                   ],
                   "members": {
-                    "pipelineExecutionId": {
-                      "shape": "S2r"
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "InProgress",
-                        "Failed",
-                        "Succeeded"
-                      ]
-                    }
+                    "pipelineExecutionId": {},
+                    "status": {}
                   }
                 }
               }
@@ -524,12 +409,8 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {
-            "shape": "S7"
-          },
-          "clientToken": {
-            "shape": "S8"
-          }
+          "jobId": {},
+          "clientToken": {}
         }
       },
       "output": {
@@ -538,9 +419,7 @@
           "jobDetails": {
             "type": "structure",
             "members": {
-              "id": {
-                "shape": "S7"
-              },
+              "id": {},
               "data": {
                 "type": "structure",
                 "members": {
@@ -562,17 +441,13 @@
                   "artifactCredentials": {
                     "shape": "S2f"
                   },
-                  "continuationToken": {
-                    "shape": "S2j"
-                  },
+                  "continuationToken": {},
                   "encryptionKey": {
                     "shape": "S11"
                   }
                 }
               },
-              "nonce": {
-                "shape": "S3"
-              }
+              "nonce": {}
             }
           }
         }
@@ -582,12 +457,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "actionOwnerFilter": {
-            "shape": "St"
-          },
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "actionOwnerFilter": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -602,9 +473,7 @@
               "shape": "Sr"
             }
           },
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -615,15 +484,11 @@
           "pipelineName"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
+          "pipelineName": {},
           "maxResults": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -634,12 +499,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "pipelineExecutionId": {
-                  "shape": "S2r"
-                },
-                "status": {
-                  "shape": "S2u"
-                },
+                "pipelineExecutionId": {},
+                "status": {},
                 "startTime": {
                   "type": "timestamp"
                 },
@@ -654,27 +515,17 @@
                       "actionName"
                     ],
                     "members": {
-                      "actionName": {
-                        "shape": "S1d"
-                      },
-                      "revisionId": {
-                        "shape": "S29"
-                      },
-                      "revisionSummary": {
-                        "shape": "S2y"
-                      },
-                      "revisionUrl": {
-                        "shape": "Sf"
-                      }
+                      "actionName": {},
+                      "revisionId": {},
+                      "revisionSummary": {},
+                      "revisionUrl": {}
                     }
                   }
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -682,9 +533,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -695,11 +544,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {
-                  "shape": "Sw"
-                },
+                "name": {},
                 "version": {
-                  "shape": "S1m"
+                  "type": "integer"
                 },
                 "created": {
                   "type": "timestamp"
@@ -710,9 +557,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S3r"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -720,11 +565,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S3r"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S3v"
+            "type": "integer"
           }
         }
       },
@@ -737,9 +580,7 @@
               "shape": "S48"
             }
           },
-          "NextToken": {
-            "shape": "S3r"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -754,21 +595,12 @@
             "shape": "Ss"
           },
           "maxBatchSize": {
-            "shape": "S4o"
+            "type": "integer"
           },
           "queryParam": {
             "type": "map",
-            "key": {
-              "shape": "Sj"
-            },
-            "value": {
-              "type": "string",
-              "max": 50,
-              "min": 1,
-              "pattern": "[a-zA-Z0-9_-]+"
-            },
-            "max": 1,
-            "min": 0
+            "key": {},
+            "value": {}
           }
         }
       },
@@ -780,18 +612,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {
-                  "shape": "S2"
-                },
+                "id": {},
                 "data": {
                   "shape": "S22"
                 },
-                "nonce": {
-                  "shape": "S3"
-                },
-                "accountId": {
-                  "shape": "S2k"
-                }
+                "nonce": {},
+                "accountId": {}
               }
             }
           }
@@ -809,7 +635,7 @@
             "shape": "Ss"
           },
           "maxBatchSize": {
-            "shape": "S4o"
+            "type": "integer"
           }
         }
       },
@@ -821,13 +647,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "clientId": {
-                  "type": "string",
-                  "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-                },
-                "jobId": {
-                  "shape": "S2"
-                }
+                "clientId": {},
+                "jobId": {}
               }
             }
           }
@@ -844,15 +665,9 @@
           "actionRevision"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "stageName": {
-            "shape": "S16"
-          },
-          "actionName": {
-            "shape": "S1d"
-          },
+          "pipelineName": {},
+          "stageName": {},
+          "actionName": {},
           "actionRevision": {
             "shape": "S39"
           }
@@ -864,9 +679,7 @@
           "newRevision": {
             "type": "boolean"
           },
-          "pipelineExecutionId": {
-            "shape": "S2r"
-          }
+          "pipelineExecutionId": {}
         }
       }
     },
@@ -881,15 +694,9 @@
           "token"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "stageName": {
-            "shape": "S16"
-          },
-          "actionName": {
-            "shape": "S1d"
-          },
+          "pipelineName": {},
+          "stageName": {},
+          "actionName": {},
           "result": {
             "type": "structure",
             "required": [
@@ -897,24 +704,11 @@
               "status"
             ],
             "members": {
-              "summary": {
-                "type": "string",
-                "max": 512,
-                "min": 0
-              },
-              "status": {
-                "type": "string",
-                "enum": [
-                  "Approved",
-                  "Rejected"
-                ]
-              }
+              "summary": {},
+              "status": {}
             }
           },
-          "token": {
-            "type": "string",
-            "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-          }
+          "token": {}
         }
       },
       "output": {
@@ -934,9 +728,7 @@
           "failureDetails"
         ],
         "members": {
-          "jobId": {
-            "shape": "S2"
-          },
+          "jobId": {},
           "failureDetails": {
             "shape": "S58"
           }
@@ -950,15 +742,11 @@
           "jobId"
         ],
         "members": {
-          "jobId": {
-            "shape": "S2"
-          },
+          "jobId": {},
           "currentRevision": {
             "shape": "S5b"
           },
-          "continuationToken": {
-            "shape": "S2j"
-          },
+          "continuationToken": {},
           "executionDetails": {
             "shape": "S5d"
           }
@@ -974,12 +762,8 @@
           "failureDetails"
         ],
         "members": {
-          "jobId": {
-            "shape": "S7"
-          },
-          "clientToken": {
-            "shape": "S8"
-          },
+          "jobId": {},
+          "clientToken": {},
           "failureDetails": {
             "shape": "S58"
           }
@@ -994,18 +778,12 @@
           "clientToken"
         ],
         "members": {
-          "jobId": {
-            "shape": "S7"
-          },
-          "clientToken": {
-            "shape": "S8"
-          },
+          "jobId": {},
+          "clientToken": {},
           "currentRevision": {
             "shape": "S5b"
           },
-          "continuationToken": {
-            "shape": "S2j"
-          },
+          "continuationToken": {},
           "executionDetails": {
             "shape": "S5d"
           }
@@ -1037,9 +815,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "webhookName": {
-            "shape": "S1r"
-          }
+          "webhookName": {}
         }
       },
       "output": {
@@ -1057,29 +833,16 @@
           "retryMode"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sw"
-          },
-          "stageName": {
-            "shape": "S16"
-          },
-          "pipelineExecutionId": {
-            "shape": "S2r"
-          },
-          "retryMode": {
-            "type": "string",
-            "enum": [
-              "FAILED_ACTIONS"
-            ]
-          }
+          "pipelineName": {},
+          "stageName": {},
+          "pipelineExecutionId": {},
+          "retryMode": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineExecutionId": {
-            "shape": "S2r"
-          }
+          "pipelineExecutionId": {}
         }
       }
     },
@@ -1090,17 +853,13 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "Sw"
-          }
+          "name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "pipelineExecutionId": {
-            "shape": "S2r"
-          }
+          "pipelineExecutionId": {}
         }
       }
     },
@@ -1127,86 +886,14 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "S3": {
-      "type": "string",
-      "max": 50,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "enum": [
-        "Created",
-        "Queued",
-        "Dispatched",
-        "InProgress",
-        "TimedOut",
-        "Succeeded",
-        "Failed"
-      ]
-    },
-    "S7": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
-    "S8": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "Sb": {
-      "type": "string",
-      "enum": [
-        "Source",
-        "Build",
-        "Deploy",
-        "Test",
-        "Invoke",
-        "Approval"
-      ]
-    },
-    "Sc": {
-      "type": "string",
-      "max": 25,
-      "min": 1,
-      "pattern": "[0-9A-Za-z_-]+"
-    },
-    "Sd": {
-      "type": "string",
-      "max": 9,
-      "min": 1,
-      "pattern": "[0-9A-Za-z_-]+"
-    },
     "Se": {
       "type": "structure",
       "members": {
-        "thirdPartyConfigurationUrl": {
-          "shape": "Sf"
-        },
-        "entityUrlTemplate": {
-          "shape": "Sg"
-        },
-        "executionUrlTemplate": {
-          "shape": "Sg"
-        },
-        "revisionUrlTemplate": {
-          "shape": "Sg"
-        }
+        "thirdPartyConfigurationUrl": {},
+        "entityUrlTemplate": {},
+        "executionUrlTemplate": {},
+        "revisionUrlTemplate": {}
       }
-    },
-    "Sf": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "Sg": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
     },
     "Sh": {
       "type": "list",
@@ -1219,9 +906,7 @@
           "secret"
         ],
         "members": {
-          "name": {
-            "shape": "Sj"
-          },
+          "name": {},
           "required": {
             "type": "boolean"
           },
@@ -1234,27 +919,10 @@
           "queryable": {
             "type": "boolean"
           },
-          "description": {
-            "type": "string",
-            "max": 160,
-            "min": 1
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "String",
-              "Number",
-              "Boolean"
-            ]
-          }
+          "description": {},
+          "type": {}
         }
-      },
-      "max": 10
-    },
-    "Sj": {
-      "type": "string",
-      "max": 50,
-      "min": 1
+      }
     },
     "Sn": {
       "type": "structure",
@@ -1264,14 +932,10 @@
       ],
       "members": {
         "minimumCount": {
-          "type": "integer",
-          "max": 5,
-          "min": 0
+          "type": "integer"
         },
         "maximumCount": {
-          "type": "integer",
-          "max": 5,
-          "min": 0
+          "type": "integer"
         }
       }
     },
@@ -1309,27 +973,11 @@
         "version"
       ],
       "members": {
-        "category": {
-          "shape": "Sb"
-        },
-        "owner": {
-          "shape": "St"
-        },
-        "provider": {
-          "shape": "Sc"
-        },
-        "version": {
-          "shape": "Sd"
-        }
+        "category": {},
+        "owner": {},
+        "provider": {},
+        "version": {}
       }
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "AWS",
-        "ThirdParty",
-        "Custom"
-      ]
     },
     "Sv": {
       "type": "structure",
@@ -1340,12 +988,8 @@
         "stages"
       ],
       "members": {
-        "name": {
-          "shape": "Sw"
-        },
-        "roleArn": {
-          "shape": "Sx"
-        },
+        "name": {},
+        "roleArn": {},
         "artifactStore": {
           "type": "structure",
           "required": [
@@ -1353,18 +997,8 @@
             "location"
           ],
           "members": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "S3"
-              ]
-            },
-            "location": {
-              "type": "string",
-              "max": 63,
-              "min": 3,
-              "pattern": "[a-zA-Z0-9\\-\\.]+"
-            },
+            "type": {},
+            "location": {},
             "encryptionKey": {
               "shape": "S11"
             }
@@ -1379,9 +1013,7 @@
               "actions"
             ],
             "members": {
-              "name": {
-                "shape": "S16"
-              },
+              "name": {},
               "blockers": {
                 "type": "list",
                 "member": {
@@ -1391,17 +1023,8 @@
                     "type"
                   ],
                   "members": {
-                    "name": {
-                      "type": "string",
-                      "max": 100,
-                      "min": 1
-                    },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "Schedule"
-                      ]
-                    }
+                    "name": {},
+                    "type": {}
                   }
                 }
               },
@@ -1414,16 +1037,12 @@
                     "actionTypeId"
                   ],
                   "members": {
-                    "name": {
-                      "shape": "S1d"
-                    },
+                    "name": {},
                     "actionTypeId": {
                       "shape": "Ss"
                     },
                     "runOrder": {
-                      "type": "integer",
-                      "max": 999,
-                      "min": 1
+                      "type": "integer"
                     },
                     "configuration": {
                       "shape": "S1f"
@@ -1436,9 +1055,7 @@
                           "name"
                         ],
                         "members": {
-                          "name": {
-                            "shape": "S1j"
-                          }
+                          "name": {}
                         }
                       }
                     },
@@ -1450,15 +1067,11 @@
                           "name"
                         ],
                         "members": {
-                          "name": {
-                            "shape": "S1j"
-                          }
+                          "name": {}
                         }
                       }
                     },
-                    "roleArn": {
-                      "shape": "Sx"
-                    }
+                    "roleArn": {}
                   }
                 }
               }
@@ -1466,20 +1079,9 @@
           }
         },
         "version": {
-          "shape": "S1m"
+          "type": "integer"
         }
       }
-    },
-    "Sw": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[A-Za-z0-9.@\\-_]+"
-    },
-    "Sx": {
-      "type": "string",
-      "max": 1024,
-      "pattern": "arn:aws(-[\\w]+)*:iam::[0-9]{12}:role/.*"
     },
     "S11": {
       "type": "structure",
@@ -1488,70 +1090,14 @@
         "type"
       ],
       "members": {
-        "id": {
-          "type": "string",
-          "max": 100,
-          "min": 1
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "KMS"
-          ]
-        }
+        "id": {},
+        "type": {}
       }
-    },
-    "S16": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[A-Za-z0-9.@\\-_]+"
-    },
-    "S1d": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[A-Za-z0-9.@\\-_]+"
     },
     "S1f": {
       "type": "map",
-      "key": {
-        "shape": "Sj"
-      },
-      "value": {
-        "type": "string",
-        "max": 1000,
-        "min": 1
-      }
-    },
-    "S1j": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_\\-]+"
-    },
-    "S1m": {
-      "type": "integer",
-      "min": 1
-    },
-    "S1r": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[A-Za-z0-9.@\\-_]+"
-    },
-    "S1w": {
-      "type": "string",
-      "enum": [
-        "Inbound",
-        "Outbound"
-      ]
-    },
-    "S1x": {
-      "type": "string",
-      "max": 300,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9!@ \\(\\)\\.\\*\\?\\-]+"
+      "key": {},
+      "value": {}
     },
     "S22": {
       "type": "structure",
@@ -1574,9 +1120,7 @@
         "artifactCredentials": {
           "shape": "S2f"
         },
-        "continuationToken": {
-          "shape": "S2j"
-        },
+        "continuationToken": {},
         "encryptionKey": {
           "shape": "S11"
         }
@@ -1593,23 +1137,17 @@
     "S24": {
       "type": "structure",
       "members": {
-        "pipelineName": {
-          "shape": "Sw"
-        },
+        "pipelineName": {},
         "stage": {
           "type": "structure",
           "members": {
-            "name": {
-              "shape": "S16"
-            }
+            "name": {}
           }
         },
         "action": {
           "type": "structure",
           "members": {
-            "name": {
-              "shape": "S1d"
-            }
+            "name": {}
           }
         }
       }
@@ -1619,21 +1157,12 @@
       "member": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S1j"
-          },
-          "revision": {
-            "shape": "S29"
-          },
+          "name": {},
+          "revision": {},
           "location": {
             "type": "structure",
             "members": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "S3"
-                ]
-              },
+              "type": {},
               "s3Location": {
                 "type": "structure",
                 "required": [
@@ -1650,11 +1179,6 @@
         }
       }
     },
-    "S29": {
-      "type": "string",
-      "max": 1500,
-      "min": 1
-    },
     "S2f": {
       "type": "structure",
       "required": [
@@ -1669,38 +1193,6 @@
       },
       "sensitive": true
     },
-    "S2j": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S2k": {
-      "type": "string",
-      "pattern": "[0-9]{12}"
-    },
-    "S2r": {
-      "type": "string",
-      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "S2u": {
-      "type": "string",
-      "enum": [
-        "InProgress",
-        "Succeeded",
-        "Superseded",
-        "Failed"
-      ]
-    },
-    "S2x": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S2y": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
     "S39": {
       "type": "structure",
       "required": [
@@ -1709,46 +1201,12 @@
         "created"
       ],
       "members": {
-        "revisionId": {
-          "shape": "S29"
-        },
-        "revisionChangeId": {
-          "shape": "S2x"
-        },
+        "revisionId": {},
+        "revisionChangeId": {},
         "created": {
           "type": "timestamp"
         }
       }
-    },
-    "S3c": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S3f": {
-      "type": "string",
-      "max": 1500,
-      "min": 1
-    },
-    "S3g": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
-    },
-    "S3j": {
-      "type": "string",
-      "max": 5000,
-      "min": 1
-    },
-    "S3r": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S3v": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     },
     "S48": {
       "type": "structure",
@@ -1760,11 +1218,7 @@
         "definition": {
           "shape": "S49"
         },
-        "url": {
-          "type": "string",
-          "max": 1000,
-          "min": 1
-        },
+        "url": {},
         "errorMessage": {},
         "errorCode": {},
         "lastTriggered": {
@@ -1784,15 +1238,9 @@
         "authenticationConfiguration"
       ],
       "members": {
-        "name": {
-          "shape": "S1r"
-        },
-        "targetPipeline": {
-          "shape": "Sw"
-        },
-        "targetAction": {
-          "shape": "S1d"
-        },
+        "name": {},
+        "targetPipeline": {},
+        "targetAction": {},
         "filters": {
           "type": "list",
           "member": {
@@ -1801,48 +1249,20 @@
               "jsonPath"
             ],
             "members": {
-              "jsonPath": {
-                "type": "string",
-                "max": 150,
-                "min": 1
-              },
-              "matchEquals": {
-                "type": "string",
-                "max": 150,
-                "min": 1
-              }
+              "jsonPath": {},
+              "matchEquals": {}
             }
-          },
-          "max": 5
+          }
         },
-        "authentication": {
-          "type": "string",
-          "enum": [
-            "GITHUB_HMAC",
-            "IP",
-            "UNAUTHENTICATED"
-          ]
-        },
+        "authentication": {},
         "authenticationConfiguration": {
           "type": "structure",
           "members": {
-            "AllowedIPRange": {
-              "type": "string",
-              "max": 100,
-              "min": 1
-            },
-            "SecretToken": {
-              "type": "string",
-              "max": 100,
-              "min": 1
-            }
+            "AllowedIPRange": {},
+            "SecretToken": {}
           }
         }
       }
-    },
-    "S4o": {
-      "type": "integer",
-      "min": 1
     },
     "S58": {
       "type": "structure",
@@ -1851,23 +1271,9 @@
         "message"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "JobFailed",
-            "ConfigurationError",
-            "PermissionError",
-            "RevisionOutOfSync",
-            "RevisionUnavailable",
-            "SystemUnavailable"
-          ]
-        },
-        "message": {
-          "shape": "S3j"
-        },
-        "externalExecutionId": {
-          "shape": "S3f"
-        }
+        "type": {},
+        "message": {},
+        "externalExecutionId": {}
       }
     },
     "S5b": {
@@ -1877,31 +1283,21 @@
         "changeIdentifier"
       ],
       "members": {
-        "revision": {
-          "shape": "S29"
-        },
-        "changeIdentifier": {
-          "shape": "S2x"
-        },
+        "revision": {},
+        "changeIdentifier": {},
         "created": {
           "type": "timestamp"
         },
-        "revisionSummary": {
-          "shape": "S2y"
-        }
+        "revisionSummary": {}
       }
     },
     "S5d": {
       "type": "structure",
       "members": {
-        "summary": {
-          "shape": "S3c"
-        },
-        "externalExecutionId": {
-          "shape": "S3f"
-        },
+        "summary": {},
+        "externalExecutionId": {},
         "percentComplete": {
-          "shape": "S3g"
+          "type": "integer"
         }
       }
     }

--- a/apis/codestar-2017-04-19.min.json
+++ b/apis/codestar-2017-04-19.min.json
@@ -22,18 +22,10 @@
           "projectRole"
         ],
         "members": {
-          "projectId": {
-            "shape": "S2"
-          },
-          "clientRequestToken": {
-            "shape": "S3"
-          },
-          "userArn": {
-            "shape": "S4"
-          },
-          "projectRole": {
-            "shape": "S5"
-          },
+          "projectId": {},
+          "clientRequestToken": {},
+          "userArn": {},
+          "projectRole": {},
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -42,9 +34,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "clientRequestToken": {
-            "shape": "S3"
-          }
+          "clientRequestToken": {}
         }
       }
     },
@@ -59,15 +49,11 @@
           "name": {
             "shape": "S9"
           },
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "description": {
             "shape": "Sa"
           },
-          "clientRequestToken": {
-            "shape": "S3"
-          }
+          "clientRequestToken": {}
         }
       },
       "output": {
@@ -77,18 +63,10 @@
           "arn"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
-          "arn": {
-            "shape": "Sc"
-          },
-          "clientRequestToken": {
-            "shape": "S3"
-          },
-          "projectTemplateId": {
-            "shape": "Sd"
-          }
+          "id": {},
+          "arn": {},
+          "clientRequestToken": {},
+          "projectTemplateId": {}
         }
       }
     },
@@ -101,18 +79,12 @@
           "emailAddress"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "displayName": {
-            "shape": "Sf"
-          },
+          "userArn": {},
+          "displayName": {},
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {
-            "shape": "Sh"
-          }
+          "sshPublicKey": {}
         }
       },
       "output": {
@@ -121,18 +93,12 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "displayName": {
-            "shape": "Sf"
-          },
+          "userArn": {},
+          "displayName": {},
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {
-            "shape": "Sh"
-          },
+          "sshPublicKey": {},
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -149,12 +115,8 @@
           "id"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
-          "clientRequestToken": {
-            "shape": "S3"
-          },
+          "id": {},
+          "clientRequestToken": {},
           "deleteStack": {
             "type": "boolean"
           }
@@ -163,12 +125,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "stackId": {
-            "shape": "So"
-          },
-          "projectArn": {
-            "shape": "Sc"
-          }
+          "stackId": {},
+          "projectArn": {}
         }
       }
     },
@@ -179,9 +137,7 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          }
+          "userArn": {}
         }
       },
       "output": {
@@ -190,9 +146,7 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          }
+          "userArn": {}
         }
       }
     },
@@ -203,9 +157,7 @@
           "id"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          }
+          "id": {}
         }
       },
       "output": {
@@ -214,27 +166,17 @@
           "name": {
             "shape": "S9"
           },
-          "id": {
-            "shape": "S2"
-          },
-          "arn": {
-            "shape": "Sc"
-          },
+          "id": {},
+          "arn": {},
           "description": {
             "shape": "Sa"
           },
-          "clientRequestToken": {
-            "shape": "S3"
-          },
+          "clientRequestToken": {},
           "createdTimeStamp": {
             "type": "timestamp"
           },
-          "stackId": {
-            "shape": "So"
-          },
-          "projectTemplateId": {
-            "shape": "Sd"
-          }
+          "stackId": {},
+          "projectTemplateId": {}
         }
       }
     },
@@ -245,9 +187,7 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          }
+          "userArn": {}
         }
       },
       "output": {
@@ -258,18 +198,12 @@
           "lastModifiedTimestamp"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "displayName": {
-            "shape": "Sf"
-          },
+          "userArn": {},
+          "displayName": {},
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {
-            "shape": "Sh"
-          },
+          "sshPublicKey": {},
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -287,12 +221,8 @@
           "userArn"
         ],
         "members": {
-          "projectId": {
-            "shape": "S2"
-          },
-          "userArn": {
-            "shape": "S4"
-          }
+          "projectId": {},
+          "userArn": {}
         }
       },
       "output": {
@@ -304,11 +234,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "Sy"
-          },
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sz"
+            "type": "integer"
           }
         }
       },
@@ -323,18 +251,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "projectId": {
-                  "shape": "S2"
-                },
-                "projectArn": {
-                  "shape": "Sc"
-                }
+                "projectId": {},
+                "projectArn": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "Sy"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -345,14 +267,10 @@
           "projectId"
         ],
         "members": {
-          "projectId": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "Sy"
-          },
+          "projectId": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sz"
+            "type": "integer"
           }
         }
       },
@@ -367,17 +285,11 @@
                 "id"
               ],
               "members": {
-                "id": {
-                  "type": "string",
-                  "min": 11,
-                  "pattern": "^arn\\:aws\\:\\S.*\\:.*"
-                }
+                "id": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "Sy"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -388,14 +300,10 @@
           "id"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "Sy"
-          },
+          "id": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sz"
+            "type": "integer"
           }
         }
       },
@@ -405,9 +313,7 @@
           "tags": {
             "shape": "S1a"
           },
-          "nextToken": {
-            "shape": "Sy"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -418,14 +324,10 @@
           "projectId"
         ],
         "members": {
-          "projectId": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "Sy"
-          },
+          "projectId": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sz"
+            "type": "integer"
           }
         }
       },
@@ -444,21 +346,15 @@
                 "projectRole"
               ],
               "members": {
-                "userArn": {
-                  "shape": "S4"
-                },
-                "projectRole": {
-                  "shape": "S5"
-                },
+                "userArn": {},
+                "projectRole": {},
                 "remoteAccessAllowed": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "Sy"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -466,11 +362,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "Sy"
-          },
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sz"
+            "type": "integer"
           }
         }
       },
@@ -485,24 +379,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "userArn": {
-                  "shape": "S4"
-                },
-                "displayName": {
-                  "shape": "Sf"
-                },
+                "userArn": {},
+                "displayName": {},
                 "emailAddress": {
                   "shape": "Sg"
                 },
-                "sshPublicKey": {
-                  "shape": "Sh"
-                }
+                "sshPublicKey": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "Sy"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -514,9 +400,7 @@
           "tags"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "tags": {
             "shape": "S1a"
           }
@@ -539,14 +423,10 @@
           "tags"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "tags": {
             "type": "list",
-            "member": {
-              "shape": "S1b"
-            }
+            "member": {}
           }
         }
       },
@@ -562,9 +442,7 @@
           "id"
         ],
         "members": {
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "name": {
             "shape": "S9"
           },
@@ -586,15 +464,9 @@
           "userArn"
         ],
         "members": {
-          "projectId": {
-            "shape": "S2"
-          },
-          "userArn": {
-            "shape": "S4"
-          },
-          "projectRole": {
-            "shape": "S5"
-          },
+          "projectId": {},
+          "userArn": {},
+          "projectRole": {},
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -603,12 +475,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "projectRole": {
-            "shape": "S5"
-          },
+          "userArn": {},
+          "projectRole": {},
           "remoteAccessAllowed": {
             "type": "boolean"
           }
@@ -622,18 +490,12 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "displayName": {
-            "shape": "Sf"
-          },
+          "userArn": {},
+          "displayName": {},
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {
-            "shape": "Sh"
-          }
+          "sshPublicKey": {}
         }
       },
       "output": {
@@ -642,18 +504,12 @@
           "userArn"
         ],
         "members": {
-          "userArn": {
-            "shape": "S4"
-          },
-          "displayName": {
-            "shape": "Sf"
-          },
+          "userArn": {},
+          "displayName": {},
           "emailAddress": {
             "shape": "Sg"
           },
-          "sshPublicKey": {
-            "shape": "Sh"
-          },
+          "sshPublicKey": {},
           "createdTimestamp": {
             "type": "timestamp"
           },
@@ -665,99 +521,22 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 15,
-      "min": 2,
-      "pattern": "^[a-z][a-z0-9-]+$"
-    },
-    "S3": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^[\\w:/-]+$"
-    },
-    "S4": {
-      "type": "string",
-      "max": 95,
-      "min": 32,
-      "pattern": "^arn:aws:iam::\\d{12}:user(?:(\\u002F)|(\\u002F[\\u0021-\\u007E]+\\u002F))[\\w+=,.@-]+$"
-    },
-    "S5": {
-      "type": "string",
-      "pattern": "^(Owner|Viewer|Contributor)$"
-    },
     "S9": {
       "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^\\S(.*\\S)?$",
       "sensitive": true
     },
     "Sa": {
       "type": "string",
-      "max": 1024,
-      "pattern": "^$|^\\S(.*\\S)?$",
       "sensitive": true
-    },
-    "Sc": {
-      "type": "string",
-      "pattern": "^arn:aws[^:\\s]*:codestar:[^:\\s]+:[0-9]{12}:project\\/[a-z]([a-z0-9|-])+$"
-    },
-    "Sd": {
-      "type": "string",
-      "min": 1,
-      "pattern": "^arn:aws[^:\\s]{0,5}:codestar:[^:\\s]+::project-template\\/[a-z0-9-]+$"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^\\S(.*\\S)?$"
     },
     "Sg": {
       "type": "string",
-      "max": 128,
-      "min": 3,
-      "pattern": "^[\\w-.+]+@[\\w-.+]+$",
       "sensitive": true
-    },
-    "Sh": {
-      "type": "string",
-      "max": 16384,
-      "pattern": "^[\\t\\r\\n\\u0020-\\u00FF]*$"
-    },
-    "So": {
-      "type": "string",
-      "pattern": "^arn:aws[^:\\s]*:cloudformation:[^:\\s]+:[0-9]{12}:stack\\/[^:\\s]+\\/[^:\\s]+$"
-    },
-    "Sy": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "^[\\w/+=]+$"
-    },
-    "Sz": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     },
     "S1a": {
       "type": "map",
-      "key": {
-        "shape": "S1b"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-      }
-    },
-    "S1b": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/cognito-identity-2014-06-30.min.json
+++ b/apis/cognito-identity-2014-06-30.min.json
@@ -20,18 +20,14 @@
           "AllowUnauthenticatedIdentities"
         ],
         "members": {
-          "IdentityPoolName": {
-            "shape": "S2"
-          },
+          "IdentityPoolName": {},
           "AllowUnauthenticatedIdentities": {
             "type": "boolean"
           },
           "SupportedLoginProviders": {
             "shape": "S4"
           },
-          "DeveloperProviderName": {
-            "shape": "S7"
-          },
+          "DeveloperProviderName": {},
           "OpenIdConnectProviderARNs": {
             "shape": "S8"
           },
@@ -56,11 +52,7 @@
         "members": {
           "IdentityIdsToDelete": {
             "type": "list",
-            "member": {
-              "shape": "Sk"
-            },
-            "max": 60,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -72,19 +64,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "IdentityId": {
-                  "shape": "Sk"
-                },
-                "ErrorCode": {
-                  "type": "string",
-                  "enum": [
-                    "AccessDenied",
-                    "InternalServerError"
-                  ]
-                }
+                "IdentityId": {},
+                "ErrorCode": {}
               }
-            },
-            "max": 60
+            }
           }
         }
       }
@@ -96,9 +79,7 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          }
+          "IdentityPoolId": {}
         }
       }
     },
@@ -109,9 +90,7 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          }
+          "IdentityId": {}
         }
       },
       "output": {
@@ -125,9 +104,7 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          }
+          "IdentityPoolId": {}
         }
       },
       "output": {
@@ -141,23 +118,17 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Logins": {
             "shape": "Sw"
           },
-          "CustomRoleArn": {
-            "shape": "S9"
-          }
+          "CustomRoleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Credentials": {
             "type": "structure",
             "members": {
@@ -179,15 +150,8 @@
           "IdentityPoolId"
         ],
         "members": {
-          "AccountId": {
-            "type": "string",
-            "max": 15,
-            "min": 1,
-            "pattern": "\\d+"
-          },
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
+          "AccountId": {},
+          "IdentityPoolId": {},
           "Logins": {
             "shape": "Sw"
           }
@@ -196,9 +160,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          }
+          "IdentityId": {}
         }
       }
     },
@@ -209,17 +171,13 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          }
+          "IdentityPoolId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
+          "IdentityPoolId": {},
           "Roles": {
             "shape": "S18"
           },
@@ -236,9 +194,7 @@
           "IdentityId"
         ],
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Logins": {
             "shape": "Sw"
           }
@@ -247,9 +203,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Token": {}
         }
       }
@@ -262,28 +216,20 @@
           "Logins"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityPoolId": {},
+          "IdentityId": {},
           "Logins": {
             "shape": "Sw"
           },
           "TokenDuration": {
-            "type": "long",
-            "max": 86400,
-            "min": 1
+            "type": "long"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Token": {}
         }
       }
@@ -296,15 +242,11 @@
           "MaxResults"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
+          "IdentityPoolId": {},
           "MaxResults": {
-            "shape": "S1r"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1s"
-          },
+          "NextToken": {},
           "HideDisabled": {
             "type": "boolean"
           }
@@ -313,18 +255,14 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
+          "IdentityPoolId": {},
           "Identities": {
             "type": "list",
             "member": {
               "shape": "Sr"
             }
           },
-          "NextToken": {
-            "shape": "S1s"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -336,11 +274,9 @@
         ],
         "members": {
           "MaxResults": {
-            "shape": "S1r"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1s"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -351,18 +287,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "IdentityPoolId": {
-                  "shape": "Sh"
-                },
-                "IdentityPoolName": {
-                  "shape": "S2"
-                }
+                "IdentityPoolId": {},
+                "IdentityPoolName": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S1s"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -373,38 +303,24 @@
           "IdentityPoolId"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
-          "IdentityId": {
-            "shape": "Sk"
-          },
-          "DeveloperUserIdentifier": {
-            "shape": "S21"
-          },
+          "IdentityPoolId": {},
+          "IdentityId": {},
+          "DeveloperUserIdentifier": {},
           "MaxResults": {
-            "shape": "S1r"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1s"
-          }
+          "NextToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "DeveloperUserIdentifierList": {
             "type": "list",
-            "member": {
-              "shape": "S21"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S1s"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -418,26 +334,16 @@
           "IdentityPoolId"
         ],
         "members": {
-          "SourceUserIdentifier": {
-            "shape": "S21"
-          },
-          "DestinationUserIdentifier": {
-            "shape": "S21"
-          },
-          "DeveloperProviderName": {
-            "shape": "S7"
-          },
-          "IdentityPoolId": {
-            "shape": "Sh"
-          }
+          "SourceUserIdentifier": {},
+          "DestinationUserIdentifier": {},
+          "DeveloperProviderName": {},
+          "IdentityPoolId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          }
+          "IdentityId": {}
         }
       }
     },
@@ -449,9 +355,7 @@
           "Roles"
         ],
         "members": {
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
+          "IdentityPoolId": {},
           "Roles": {
             "shape": "S18"
           },
@@ -471,18 +375,10 @@
           "DeveloperUserIdentifier"
         ],
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
-          "IdentityPoolId": {
-            "shape": "Sh"
-          },
-          "DeveloperProviderName": {
-            "shape": "S7"
-          },
-          "DeveloperUserIdentifier": {
-            "shape": "S21"
-          }
+          "IdentityId": {},
+          "IdentityPoolId": {},
+          "DeveloperProviderName": {},
+          "DeveloperUserIdentifier": {}
         }
       }
     },
@@ -495,9 +391,7 @@
           "LoginsToRemove"
         ],
         "members": {
-          "IdentityId": {
-            "shape": "Sk"
-          },
+          "IdentityId": {},
           "Logins": {
             "shape": "Sw"
           },
@@ -517,64 +411,22 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w ]+"
-    },
     "S4": {
       "type": "map",
-      "key": {
-        "shape": "S5"
-      },
-      "value": {
-        "type": "string",
-        "max": 128,
-        "min": 1,
-        "pattern": "[\\w.;_/-]+"
-      },
-      "max": 10
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w._-]+"
+      "key": {},
+      "value": {}
     },
     "S8": {
       "type": "list",
-      "member": {
-        "shape": "S9"
-      }
-    },
-    "S9": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
+      "member": {}
     },
     "Sa": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ProviderName": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[\\w._:/-]+"
-          },
-          "ClientId": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[\\w_]+"
-          },
+          "ProviderName": {},
+          "ClientId": {},
           "ServerSideTokenCheck": {
             "type": "boolean"
           }
@@ -583,9 +435,7 @@
     },
     "Sf": {
       "type": "list",
-      "member": {
-        "shape": "S9"
-      }
+      "member": {}
     },
     "Sg": {
       "type": "structure",
@@ -595,21 +445,15 @@
         "AllowUnauthenticatedIdentities"
       ],
       "members": {
-        "IdentityPoolId": {
-          "shape": "Sh"
-        },
-        "IdentityPoolName": {
-          "shape": "S2"
-        },
+        "IdentityPoolId": {},
+        "IdentityPoolName": {},
         "AllowUnauthenticatedIdentities": {
           "type": "boolean"
         },
         "SupportedLoginProviders": {
           "shape": "S4"
         },
-        "DeveloperProviderName": {
-          "shape": "S7"
-        },
+        "DeveloperProviderName": {},
         "OpenIdConnectProviderARNs": {
           "shape": "S8"
         },
@@ -621,24 +465,10 @@
         }
       }
     },
-    "Sh": {
-      "type": "string",
-      "max": 55,
-      "min": 1,
-      "pattern": "[\\w-]+:[0-9a-f-]+"
-    },
-    "Sk": {
-      "type": "string",
-      "max": 55,
-      "min": 1,
-      "pattern": "[\\w-]+:[0-9a-f-]+"
-    },
     "Sr": {
       "type": "structure",
       "members": {
-        "IdentityId": {
-          "shape": "Sk"
-        },
+        "IdentityId": {},
         "Logins": {
           "shape": "Ss"
         },
@@ -652,58 +482,29 @@
     },
     "Ss": {
       "type": "list",
-      "member": {
-        "shape": "S5"
-      }
+      "member": {}
     },
     "Sw": {
       "type": "map",
-      "key": {
-        "shape": "S5"
-      },
-      "value": {
-        "type": "string",
-        "max": 50000,
-        "min": 1
-      },
-      "max": 10
+      "key": {},
+      "value": {}
     },
     "S18": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "pattern": "(un)?authenticated"
-      },
-      "value": {
-        "shape": "S9"
-      },
-      "max": 2
+      "key": {},
+      "value": {}
     },
     "S1a": {
       "type": "map",
-      "key": {
-        "shape": "S5"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "required": [
           "Type"
         ],
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "Token",
-              "Rules"
-            ]
-          },
-          "AmbiguousRoleResolution": {
-            "type": "string",
-            "enum": [
-              "AuthenticatedRole",
-              "Deny"
-            ]
-          },
+          "Type": {},
+          "AmbiguousRoleResolution": {},
           "RulesConfiguration": {
             "type": "structure",
             "required": [
@@ -721,54 +522,17 @@
                     "RoleARN"
                   ],
                   "members": {
-                    "Claim": {
-                      "type": "string",
-                      "max": 64,
-                      "min": 1,
-                      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
-                    },
-                    "MatchType": {
-                      "type": "string",
-                      "enum": [
-                        "Equals",
-                        "Contains",
-                        "StartsWith",
-                        "NotEqual"
-                      ]
-                    },
-                    "Value": {
-                      "type": "string",
-                      "max": 128,
-                      "min": 1
-                    },
-                    "RoleARN": {
-                      "shape": "S9"
-                    }
+                    "Claim": {},
+                    "MatchType": {},
+                    "Value": {},
+                    "RoleARN": {}
                   }
-                },
-                "max": 25,
-                "min": 1
+                }
               }
             }
           }
         }
-      },
-      "max": 10
-    },
-    "S1r": {
-      "type": "integer",
-      "max": 60,
-      "min": 1
-    },
-    "S1s": {
-      "type": "string",
-      "min": 1,
-      "pattern": "[\\S]+"
-    },
-    "S21": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
+      }
     }
   }
 }

--- a/apis/cognito-idp-2016-04-18.min.json
+++ b/apis/cognito-idp-2016-04-18.min.json
@@ -20,16 +20,12 @@
           "CustomAttributes"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "CustomAttributes": {
             "type": "list",
             "member": {
               "shape": "S4"
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -47,15 +43,11 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "GroupName": {
-            "shape": "Se"
-          }
+          "GroupName": {}
         }
       }
     },
@@ -67,9 +59,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -88,9 +78,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
@@ -106,18 +94,10 @@
           "ForceAliasCreation": {
             "type": "boolean"
           },
-          "MessageAction": {
-            "type": "string",
-            "enum": [
-              "RESEND",
-              "SUPPRESS"
-            ]
-          },
+          "MessageAction": {},
           "DesiredDeliveryMediums": {
             "type": "list",
-            "member": {
-              "shape": "Sq"
-            }
+            "member": {}
           }
         }
       },
@@ -138,9 +118,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -156,9 +134,7 @@
           "UserAttributeNames"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
@@ -199,9 +175,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -220,9 +194,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -242,15 +214,11 @@
           "DeviceKey"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "DeviceKey": {
-            "shape": "S1a"
-          }
+          "DeviceKey": {}
         }
       }
     },
@@ -263,12 +231,8 @@
           "Username"
         ],
         "members": {
-          "DeviceKey": {
-            "shape": "S1a"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "DeviceKey": {},
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -294,9 +258,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -323,9 +285,7 @@
           "Enabled": {
             "type": "boolean"
           },
-          "UserStatus": {
-            "shape": "Su"
-          },
+          "UserStatus": {},
           "MFAOptions": {
             "shape": "Sv"
           },
@@ -345,15 +305,11 @@
           "AuthFlow"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           },
-          "AuthFlow": {
-            "shape": "S1j"
-          },
+          "AuthFlow": {},
           "AuthParameters": {
             "shape": "S1k"
           },
@@ -371,12 +327,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {
-            "shape": "S1r"
-          },
-          "Session": {
-            "shape": "S1s"
-          },
+          "ChallengeName": {},
+          "Session": {},
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -417,18 +369,14 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          }
+          "PaginationToken": {}
         }
       },
       "output": {
@@ -437,9 +385,7 @@
           "Devices": {
             "shape": "S24"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          }
+          "PaginationToken": {}
         }
       }
     },
@@ -454,15 +400,11 @@
           "Username": {
             "shape": "Sd"
           },
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -471,9 +413,7 @@
           "Groups": {
             "shape": "S28"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -485,18 +425,14 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
           "MaxResults": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -508,43 +444,16 @@
               "type": "structure",
               "members": {
                 "EventId": {},
-                "EventType": {
-                  "type": "string",
-                  "enum": [
-                    "SignIn",
-                    "SignUp",
-                    "ForgotPassword"
-                  ]
-                },
+                "EventType": {},
                 "CreationDate": {
                   "type": "timestamp"
                 },
-                "EventResponse": {
-                  "type": "string",
-                  "enum": [
-                    "Success",
-                    "Failure"
-                  ]
-                },
+                "EventResponse": {},
                 "EventRisk": {
                   "type": "structure",
                   "members": {
-                    "RiskDecision": {
-                      "type": "string",
-                      "enum": [
-                        "NoRisk",
-                        "AccountTakeover",
-                        "Block"
-                      ]
-                    },
-                    "RiskLevel": {
-                      "type": "string",
-                      "enum": [
-                        "Low",
-                        "Medium",
-                        "High"
-                      ]
-                    }
+                    "RiskDecision": {},
+                    "RiskLevel": {}
                   }
                 },
                 "ChallengeResponses": {
@@ -552,20 +461,8 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ChallengeName": {
-                        "type": "string",
-                        "enum": [
-                          "Password",
-                          "Mfa"
-                        ]
-                      },
-                      "ChallengeResponse": {
-                        "type": "string",
-                        "enum": [
-                          "Success",
-                          "Failure"
-                        ]
-                      }
+                      "ChallengeName": {},
+                      "ChallengeResponse": {}
                     }
                   }
                 },
@@ -586,9 +483,7 @@
                     "Provider"
                   ],
                   "members": {
-                    "FeedbackValue": {
-                      "shape": "S2s"
-                    },
+                    "FeedbackValue": {},
                     "Provider": {},
                     "FeedbackDate": {
                       "type": "timestamp"
@@ -598,9 +493,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -613,15 +506,11 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "GroupName": {
-            "shape": "Se"
-          }
+          "GroupName": {}
         }
       }
     },
@@ -633,9 +522,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -655,21 +542,15 @@
           "ChallengeName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           },
-          "ChallengeName": {
-            "shape": "S1r"
-          },
+          "ChallengeName": {},
           "ChallengeResponses": {
             "shape": "S2x"
           },
-          "Session": {
-            "shape": "S1s"
-          },
+          "Session": {},
           "AnalyticsMetadata": {
             "shape": "S1m"
           },
@@ -681,12 +562,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {
-            "shape": "S1r"
-          },
-          "Session": {
-            "shape": "S1s"
-          },
+          "ChallengeName": {},
+          "Session": {},
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -713,9 +590,7 @@
           "Username": {
             "shape": "Sd"
           },
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -732,9 +607,7 @@
           "MFAOptions"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
@@ -758,18 +631,12 @@
           "FeedbackValue"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "EventId": {
-            "shape": "S36"
-          },
-          "FeedbackValue": {
-            "shape": "S2s"
-          }
+          "EventId": {},
+          "FeedbackValue": {}
         }
       },
       "output": {
@@ -786,18 +653,12 @@
           "DeviceKey"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "DeviceKey": {
-            "shape": "S1a"
-          },
-          "DeviceRememberedStatus": {
-            "shape": "S39"
-          }
+          "DeviceKey": {},
+          "DeviceRememberedStatus": {}
         }
       },
       "output": {
@@ -814,9 +675,7 @@
           "UserAttributes"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
@@ -838,9 +697,7 @@
           "Username"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           }
@@ -858,9 +715,7 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "Session": {
-            "shape": "S1s"
-          }
+          "Session": {}
         }
       },
       "output": {
@@ -868,13 +723,9 @@
         "members": {
           "SecretCode": {
             "type": "string",
-            "min": 16,
-            "pattern": "[A-Za-z0-9]+",
             "sensitive": true
           },
-          "Session": {
-            "shape": "S1s"
-          }
+          "Session": {}
         }
       }
     },
@@ -915,9 +766,7 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {
-            "shape": "S1a"
-          },
+          "DeviceKey": {},
           "DeviceSecretVerifierConfig": {
             "type": "structure",
             "members": {
@@ -925,11 +774,7 @@
               "Salt": {}
             }
           },
-          "DeviceName": {
-            "type": "string",
-            "max": 1024,
-            "min": 1
-          }
+          "DeviceName": {}
         }
       },
       "output": {
@@ -960,9 +805,7 @@
           "Username": {
             "shape": "Sd"
           },
-          "ConfirmationCode": {
-            "shape": "S3q"
-          },
+          "ConfirmationCode": {},
           "Password": {
             "shape": "Sm"
           },
@@ -998,9 +841,7 @@
           "Username": {
             "shape": "Sd"
           },
-          "ConfirmationCode": {
-            "shape": "S3q"
-          },
+          "ConfirmationCode": {},
           "ForceAliasCreation": {
             "type": "boolean"
           },
@@ -1026,20 +867,12 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {
-            "shape": "Se"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S2a"
-          },
-          "RoleArn": {
-            "shape": "S2b"
-          },
+          "GroupName": {},
+          "UserPoolId": {},
+          "Description": {},
+          "RoleArn": {},
           "Precedence": {
-            "shape": "S2c"
+            "type": "integer"
           }
         }
       },
@@ -1062,18 +895,9 @@
           "ProviderDetails"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "ProviderName": {
-            "type": "string",
-            "max": 32,
-            "min": 1,
-            "pattern": "[^_][\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}][^_]+"
-          },
-          "ProviderType": {
-            "shape": "S3z"
-          },
+          "UserPoolId": {},
+          "ProviderName": {},
+          "ProviderType": {},
           "ProviderDetails": {
             "shape": "S40"
           },
@@ -1106,15 +930,9 @@
           "Name"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Identifier": {
-            "shape": "S48"
-          },
-          "Name": {
-            "shape": "S49"
-          },
+          "UserPoolId": {},
+          "Identifier": {},
+          "Name": {},
           "Scopes": {
             "shape": "S4a"
           }
@@ -1141,15 +959,9 @@
           "CloudWatchLogsRoleArn"
         ],
         "members": {
-          "JobName": {
-            "shape": "S4h"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "CloudWatchLogsRoleArn": {
-            "shape": "S2b"
-          }
+          "JobName": {},
+          "UserPoolId": {},
+          "CloudWatchLogsRoleArn": {}
         }
       },
       "output": {
@@ -1168,9 +980,7 @@
           "PoolName"
         ],
         "members": {
-          "PoolName": {
-            "shape": "S4q"
-          },
+          "PoolName": {},
           "Policies": {
             "shape": "S4r"
           },
@@ -1186,24 +996,14 @@
           "UsernameAttributes": {
             "shape": "S4z"
           },
-          "SmsVerificationMessage": {
-            "shape": "S51"
-          },
-          "EmailVerificationMessage": {
-            "shape": "S52"
-          },
-          "EmailVerificationSubject": {
-            "shape": "S53"
-          },
+          "SmsVerificationMessage": {},
+          "EmailVerificationMessage": {},
+          "EmailVerificationSubject": {},
           "VerificationMessageTemplate": {
             "shape": "S54"
           },
-          "SmsAuthenticationMessage": {
-            "shape": "S51"
-          },
-          "MfaConfiguration": {
-            "shape": "S58"
-          },
+          "SmsAuthenticationMessage": {},
+          "MfaConfiguration": {},
           "DeviceConfiguration": {
             "shape": "S59"
           },
@@ -1244,17 +1044,13 @@
           "ClientName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "ClientName": {
-            "shape": "S5p"
-          },
+          "UserPoolId": {},
+          "ClientName": {},
           "GenerateSecret": {
             "type": "boolean"
           },
           "RefreshTokenValidity": {
-            "shape": "S5r"
+            "type": "integer"
           },
           "ReadAttributes": {
             "shape": "S5s"
@@ -1274,9 +1070,7 @@
           "LogoutURLs": {
             "shape": "S5z"
           },
-          "DefaultRedirectURI": {
-            "shape": "S5y"
-          },
+          "DefaultRedirectURI": {},
           "AllowedOAuthFlows": {
             "shape": "S60"
           },
@@ -1308,12 +1102,8 @@
           "UserPoolId"
         ],
         "members": {
-          "Domain": {
-            "shape": "S5n"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "Domain": {},
+          "UserPoolId": {},
           "CustomDomainConfig": {
             "shape": "S6a"
           }
@@ -1322,9 +1112,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "CloudFrontDomain": {
-            "shape": "S5n"
-          }
+          "CloudFrontDomain": {}
         }
       }
     },
@@ -1336,12 +1124,8 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {
-            "shape": "Se"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "GroupName": {},
+          "UserPoolId": {}
         }
       }
     },
@@ -1353,12 +1137,8 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "ProviderName": {
-            "shape": "S13"
-          }
+          "UserPoolId": {},
+          "ProviderName": {}
         }
       }
     },
@@ -1370,12 +1150,8 @@
           "Identifier"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Identifier": {
-            "shape": "S48"
-          }
+          "UserPoolId": {},
+          "Identifier": {}
         }
       }
     },
@@ -1422,9 +1198,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       }
     },
@@ -1436,9 +1210,7 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           }
@@ -1453,12 +1225,8 @@
           "UserPoolId"
         ],
         "members": {
-          "Domain": {
-            "shape": "S5n"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "Domain": {},
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -1474,12 +1242,8 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "ProviderName": {
-            "shape": "S13"
-          }
+          "UserPoolId": {},
+          "ProviderName": {}
         }
       },
       "output": {
@@ -1502,12 +1266,8 @@
           "Identifier"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Identifier": {
-            "shape": "S48"
-          }
+          "UserPoolId": {},
+          "Identifier": {}
         }
       },
       "output": {
@@ -1529,9 +1289,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           }
@@ -1557,12 +1315,8 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "JobId": {
-            "shape": "S4k"
-          }
+          "UserPoolId": {},
+          "JobId": {}
         }
       },
       "output": {
@@ -1581,9 +1335,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -1603,9 +1355,7 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           }
@@ -1627,9 +1377,7 @@
           "Domain"
         ],
         "members": {
-          "Domain": {
-            "shape": "S5n"
-          }
+          "Domain": {}
         }
       },
       "output": {
@@ -1638,35 +1386,13 @@
           "DomainDescription": {
             "type": "structure",
             "members": {
-              "UserPoolId": {
-                "shape": "S2"
-              },
+              "UserPoolId": {},
               "AWSAccountId": {},
-              "Domain": {
-                "shape": "S5n"
-              },
-              "S3Bucket": {
-                "type": "string",
-                "max": 1024,
-                "min": 3,
-                "pattern": "^[0-9A-Za-z\\.\\-_]*(?<!\\.)$"
-              },
+              "Domain": {},
+              "S3Bucket": {},
               "CloudFrontDistribution": {},
-              "Version": {
-                "type": "string",
-                "max": 20,
-                "min": 1
-              },
-              "Status": {
-                "type": "string",
-                "enum": [
-                  "CREATING",
-                  "DELETING",
-                  "UPDATING",
-                  "ACTIVE",
-                  "FAILED"
-                ]
-              },
+              "Version": {},
+              "Status": {},
               "CustomDomainConfig": {
                 "shape": "S6a"
               }
@@ -1685,9 +1411,7 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {
-            "shape": "S1a"
-          }
+          "DeviceKey": {}
         }
       }
     },
@@ -1733,17 +1457,13 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "CSVHeader": {
             "type": "list",
             "member": {}
@@ -1758,9 +1478,7 @@
           "DeviceKey"
         ],
         "members": {
-          "DeviceKey": {
-            "shape": "S1a"
-          },
+          "DeviceKey": {},
           "AccessToken": {
             "shape": "S1v"
           }
@@ -1786,12 +1504,8 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {
-            "shape": "Se"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "GroupName": {},
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -1811,12 +1525,8 @@
           "IdpIdentifier"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "IdpIdentifier": {
-            "shape": "S44"
-          }
+          "UserPoolId": {},
+          "IdpIdentifier": {}
         }
       },
       "output": {
@@ -1838,9 +1548,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -1857,9 +1565,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           }
@@ -1924,9 +1630,7 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "AttributeName": {
-            "shape": "Sk"
-          }
+          "AttributeName": {}
         }
       },
       "output": {
@@ -1946,9 +1650,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          }
+          "UserPoolId": {}
         }
       },
       "output": {
@@ -1960,9 +1662,7 @@
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {
-            "shape": "S58"
-          }
+          "MfaConfiguration": {}
         }
       }
     },
@@ -1991,9 +1691,7 @@
           "ClientId"
         ],
         "members": {
-          "AuthFlow": {
-            "shape": "S1j"
-          },
+          "AuthFlow": {},
           "AuthParameters": {
             "shape": "S1k"
           },
@@ -2014,12 +1712,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {
-            "shape": "S1r"
-          },
-          "Session": {
-            "shape": "S1s"
-          },
+          "ChallengeName": {},
+          "Session": {},
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -2040,11 +1734,9 @@
             "shape": "S1v"
           },
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          }
+          "PaginationToken": {}
         }
       },
       "output": {
@@ -2053,9 +1745,7 @@
           "Devices": {
             "shape": "S24"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          }
+          "PaginationToken": {}
         }
       }
     },
@@ -2066,15 +1756,11 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -2083,9 +1769,7 @@
           "Groups": {
             "shape": "S28"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2096,17 +1780,11 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 60,
-            "min": 1
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S8q"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -2120,12 +1798,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProviderName": {
-                  "shape": "S13"
-                },
-                "ProviderType": {
-                  "shape": "S3z"
-                },
+                "ProviderName": {},
+                "ProviderType": {},
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
@@ -2133,13 +1807,9 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 50,
-            "min": 0
+            }
           },
-          "NextToken": {
-            "shape": "S8q"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2150,17 +1820,11 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S8q"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -2175,9 +1839,7 @@
               "shape": "S4f"
             }
           },
-          "NextToken": {
-            "shape": "S8q"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2189,15 +1851,11 @@
           "MaxResults"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "MaxResults": {
-            "shape": "S8z"
+            "type": "integer"
           },
-          "PaginationToken": {
-            "shape": "S8q"
-          }
+          "PaginationToken": {}
         }
       },
       "output": {
@@ -2207,13 +1865,9 @@
             "type": "list",
             "member": {
               "shape": "S4j"
-            },
-            "max": 50,
-            "min": 1
+            }
           },
-          "PaginationToken": {
-            "shape": "S8q"
-          }
+          "PaginationToken": {}
         }
       }
     },
@@ -2224,17 +1878,11 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 60,
-            "min": 1
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -2248,18 +1896,12 @@
                 "ClientId": {
                   "shape": "S1i"
                 },
-                "UserPoolId": {
-                  "shape": "S2"
-                },
-                "ClientName": {
-                  "shape": "S5p"
-                }
+                "UserPoolId": {},
+                "ClientName": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2270,11 +1912,9 @@
           "MaxResults"
         ],
         "members": {
-          "NextToken": {
-            "shape": "S8q"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S8z"
+            "type": "integer"
           }
         }
       },
@@ -2286,18 +1926,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S4q"
-                },
+                "Id": {},
+                "Name": {},
                 "LambdaConfig": {
                   "shape": "S4u"
                 },
-                "Status": {
-                  "shape": "S5m"
-                },
+                "Status": {},
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
@@ -2307,9 +1941,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S8q"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2320,25 +1952,16 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "AttributesToGet": {
             "type": "list",
-            "member": {
-              "shape": "Sk"
-            }
+            "member": {}
           },
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          },
-          "Filter": {
-            "type": "string",
-            "max": 256
-          }
+          "PaginationToken": {},
+          "Filter": {}
         }
       },
       "output": {
@@ -2347,9 +1970,7 @@
           "Users": {
             "shape": "S9f"
           },
-          "PaginationToken": {
-            "shape": "S22"
-          }
+          "PaginationToken": {}
         }
       }
     },
@@ -2361,18 +1982,12 @@
           "GroupName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "GroupName": {
-            "shape": "Se"
-          },
+          "UserPoolId": {},
+          "GroupName": {},
           "Limit": {
-            "shape": "S21"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -2381,9 +1996,7 @@
           "Users": {
             "shape": "S9f"
           },
-          "NextToken": {
-            "shape": "S26"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -2433,12 +2046,8 @@
           "ClientId": {
             "shape": "S1i"
           },
-          "ChallengeName": {
-            "shape": "S1r"
-          },
-          "Session": {
-            "shape": "S1s"
-          },
+          "ChallengeName": {},
+          "Session": {},
           "ChallengeResponses": {
             "shape": "S2x"
           },
@@ -2453,12 +2062,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChallengeName": {
-            "shape": "S1r"
-          },
-          "Session": {
-            "shape": "S1s"
-          },
+          "ChallengeName": {},
+          "Session": {},
           "ChallengeParameters": {
             "shape": "S1t"
           },
@@ -2475,9 +2080,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           },
@@ -2511,9 +2114,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           },
@@ -2565,18 +2166,14 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "SmsMfaConfiguration": {
             "shape": "S8e"
           },
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {
-            "shape": "S58"
-          }
+          "MfaConfiguration": {}
         }
       },
       "output": {
@@ -2588,9 +2185,7 @@
           "SoftwareTokenMfaConfiguration": {
             "shape": "S8f"
           },
-          "MfaConfiguration": {
-            "shape": "S58"
-          }
+          "MfaConfiguration": {}
         }
       }
     },
@@ -2677,12 +2272,8 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "JobId": {
-            "shape": "S4k"
-          }
+          "UserPoolId": {},
+          "JobId": {}
         }
       },
       "output": {
@@ -2702,12 +2293,8 @@
           "JobId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "JobId": {
-            "shape": "S4k"
-          }
+          "UserPoolId": {},
+          "JobId": {}
         }
       },
       "output": {
@@ -2730,21 +2317,15 @@
           "FeedbackValue"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Username": {
             "shape": "Sd"
           },
-          "EventId": {
-            "shape": "S36"
-          },
+          "EventId": {},
           "FeedbackToken": {
             "shape": "S1v"
           },
-          "FeedbackValue": {
-            "shape": "S2s"
-          }
+          "FeedbackValue": {}
         }
       },
       "output": {
@@ -2763,12 +2344,8 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "DeviceKey": {
-            "shape": "S1a"
-          },
-          "DeviceRememberedStatus": {
-            "shape": "S39"
-          }
+          "DeviceKey": {},
+          "DeviceRememberedStatus": {}
         }
       },
       "output": {
@@ -2784,20 +2361,12 @@
           "UserPoolId"
         ],
         "members": {
-          "GroupName": {
-            "shape": "Se"
-          },
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S2a"
-          },
-          "RoleArn": {
-            "shape": "S2b"
-          },
+          "GroupName": {},
+          "UserPoolId": {},
+          "Description": {},
+          "RoleArn": {},
           "Precedence": {
-            "shape": "S2c"
+            "type": "integer"
           }
         }
       },
@@ -2818,12 +2387,8 @@
           "ProviderName"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "ProviderName": {
-            "shape": "S13"
-          },
+          "UserPoolId": {},
+          "ProviderName": {},
           "ProviderDetails": {
             "shape": "S40"
           },
@@ -2856,15 +2421,9 @@
           "Name"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
-          "Identifier": {
-            "shape": "S48"
-          },
-          "Name": {
-            "shape": "S49"
-          },
+          "UserPoolId": {},
+          "Identifier": {},
+          "Name": {},
           "Scopes": {
             "shape": "S4a"
           }
@@ -2918,9 +2477,7 @@
           "UserPoolId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "Policies": {
             "shape": "S4r"
           },
@@ -2930,24 +2487,14 @@
           "AutoVerifiedAttributes": {
             "shape": "S4v"
           },
-          "SmsVerificationMessage": {
-            "shape": "S51"
-          },
-          "EmailVerificationMessage": {
-            "shape": "S52"
-          },
-          "EmailVerificationSubject": {
-            "shape": "S53"
-          },
+          "SmsVerificationMessage": {},
+          "EmailVerificationMessage": {},
+          "EmailVerificationSubject": {},
           "VerificationMessageTemplate": {
             "shape": "S54"
           },
-          "SmsAuthenticationMessage": {
-            "shape": "S51"
-          },
-          "MfaConfiguration": {
-            "shape": "S58"
-          },
+          "SmsAuthenticationMessage": {},
+          "MfaConfiguration": {},
           "DeviceConfiguration": {
             "shape": "S59"
           },
@@ -2981,17 +2528,13 @@
           "ClientId"
         ],
         "members": {
-          "UserPoolId": {
-            "shape": "S2"
-          },
+          "UserPoolId": {},
           "ClientId": {
             "shape": "S1i"
           },
-          "ClientName": {
-            "shape": "S5p"
-          },
+          "ClientName": {},
           "RefreshTokenValidity": {
-            "shape": "S5r"
+            "type": "integer"
           },
           "ReadAttributes": {
             "shape": "S5s"
@@ -3011,9 +2554,7 @@
           "LogoutURLs": {
             "shape": "S5z"
           },
-          "DefaultRedirectURI": {
-            "shape": "S5y"
-          },
+          "DefaultRedirectURI": {},
           "AllowedOAuthFlows": {
             "shape": "S60"
           },
@@ -3047,31 +2588,16 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "Session": {
-            "shape": "S1s"
-          },
-          "UserCode": {
-            "type": "string",
-            "max": 6,
-            "min": 6,
-            "pattern": "[0-9]+"
-          },
+          "Session": {},
+          "UserCode": {},
           "FriendlyDeviceName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "ERROR"
-            ]
-          },
-          "Session": {
-            "shape": "S1s"
-          }
+          "Status": {},
+          "Session": {}
         }
       }
     },
@@ -3087,12 +2613,8 @@
           "AccessToken": {
             "shape": "S1v"
           },
-          "AttributeName": {
-            "shape": "Sk"
-          },
-          "Code": {
-            "shape": "S3q"
-          }
+          "AttributeName": {},
+          "Code": {}
         }
       },
       "output": {
@@ -3103,30 +2625,11 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 55,
-      "min": 1,
-      "pattern": "[\\w-]+_[0-9a-zA-Z]+"
-    },
     "S4": {
       "type": "structure",
       "members": {
-        "Name": {
-          "type": "string",
-          "max": 20,
-          "min": 1,
-          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
-        },
-        "AttributeDataType": {
-          "type": "string",
-          "enum": [
-            "String",
-            "Number",
-            "DateTime",
-            "Boolean"
-          ]
-        },
+        "Name": {},
+        "AttributeDataType": {},
         "DeveloperOnlyAttribute": {
           "type": "boolean"
         },
@@ -3154,16 +2657,7 @@
     },
     "Sd": {
       "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+",
       "sensitive": true
-    },
-    "Se": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
     },
     "Si": {
       "type": "list",
@@ -3173,36 +2667,17 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "Sk"
-          },
+          "Name": {},
           "Value": {
             "type": "string",
-            "max": 2048,
             "sensitive": true
           }
         }
       }
     },
-    "Sk": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
-    },
     "Sm": {
       "type": "string",
-      "max": 256,
-      "min": 6,
-      "pattern": "[\\S]+",
       "sensitive": true
-    },
-    "Sq": {
-      "type": "string",
-      "enum": [
-        "SMS",
-        "EMAIL"
-      ]
     },
     "Ss": {
       "type": "structure",
@@ -3222,74 +2697,38 @@
         "Enabled": {
           "type": "boolean"
         },
-        "UserStatus": {
-          "shape": "Su"
-        },
+        "UserStatus": {},
         "MFAOptions": {
           "shape": "Sv"
         }
       }
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "UNCONFIRMED",
-        "CONFIRMED",
-        "ARCHIVED",
-        "COMPROMISED",
-        "UNKNOWN",
-        "RESET_REQUIRED",
-        "FORCE_CHANGE_PASSWORD"
-      ]
     },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "DeliveryMedium": {
-            "shape": "Sq"
-          },
-          "AttributeName": {
-            "shape": "Sk"
-          }
+          "DeliveryMedium": {},
+          "AttributeName": {}
         }
       }
     },
     "Sz": {
       "type": "list",
-      "member": {
-        "shape": "Sk"
-      }
+      "member": {}
     },
     "S12": {
       "type": "structure",
       "members": {
-        "ProviderName": {
-          "shape": "S13"
-        },
+        "ProviderName": {},
         "ProviderAttributeName": {},
         "ProviderAttributeValue": {}
       }
     },
-    "S13": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
-    },
-    "S1a": {
-      "type": "string",
-      "max": 55,
-      "min": 1,
-      "pattern": "[\\w-]+_[0-9a-f-]+"
-    },
     "S1d": {
       "type": "structure",
       "members": {
-        "DeviceKey": {
-          "shape": "S1a"
-        },
+        "DeviceKey": {},
         "DeviceAttributes": {
           "shape": "Si"
         },
@@ -3310,21 +2749,7 @@
     },
     "S1i": {
       "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+]+",
       "sensitive": true
-    },
-    "S1j": {
-      "type": "string",
-      "enum": [
-        "USER_SRP_AUTH",
-        "REFRESH_TOKEN_AUTH",
-        "REFRESH_TOKEN",
-        "CUSTOM_AUTH",
-        "ADMIN_NO_SRP_AUTH",
-        "USER_PASSWORD_AUTH"
-      ]
     },
     "S1k": {
       "type": "map",
@@ -3367,26 +2792,6 @@
         "EncodedData": {}
       }
     },
-    "S1r": {
-      "type": "string",
-      "enum": [
-        "SMS_MFA",
-        "SOFTWARE_TOKEN_MFA",
-        "SELECT_MFA_TYPE",
-        "MFA_SETUP",
-        "PASSWORD_VERIFIER",
-        "CUSTOM_CHALLENGE",
-        "DEVICE_SRP_AUTH",
-        "DEVICE_PASSWORD_VERIFIER",
-        "ADMIN_NO_SRP_AUTH",
-        "NEW_PASSWORD_REQUIRED"
-      ]
-    },
-    "S1s": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
     "S1t": {
       "type": "map",
       "key": {},
@@ -3411,9 +2816,7 @@
         "NewDeviceMetadata": {
           "type": "structure",
           "members": {
-            "DeviceKey": {
-              "shape": "S1a"
-            },
+            "DeviceKey": {},
             "DeviceGroupKey": {}
           }
         }
@@ -3421,29 +2824,13 @@
     },
     "S1v": {
       "type": "string",
-      "pattern": "[A-Za-z0-9-_=.]+",
       "sensitive": true
-    },
-    "S21": {
-      "type": "integer",
-      "max": 60,
-      "min": 0
-    },
-    "S22": {
-      "type": "string",
-      "min": 1,
-      "pattern": "[\\S]+"
     },
     "S24": {
       "type": "list",
       "member": {
         "shape": "S1d"
       }
-    },
-    "S26": {
-      "type": "string",
-      "min": 1,
-      "pattern": "[\\S]+"
     },
     "S28": {
       "type": "list",
@@ -3454,20 +2841,12 @@
     "S29": {
       "type": "structure",
       "members": {
-        "GroupName": {
-          "shape": "Se"
-        },
-        "UserPoolId": {
-          "shape": "S2"
-        },
-        "Description": {
-          "shape": "S2a"
-        },
-        "RoleArn": {
-          "shape": "S2b"
-        },
+        "GroupName": {},
+        "UserPoolId": {},
+        "Description": {},
+        "RoleArn": {},
         "Precedence": {
-          "shape": "S2c"
+          "type": "integer"
         },
         "LastModifiedDate": {
           "type": "timestamp"
@@ -3476,27 +2855,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S2a": {
-      "type": "string",
-      "max": 2048
-    },
-    "S2b": {
-      "type": "string",
-      "max": 2048,
-      "min": 20,
-      "pattern": "arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:([\\w+=/,.@-]*)?:[0-9]+:[\\w+=/,.@-]+(:[\\w+=/,.@-]+)?(:[\\w+=/,.@-]+)?"
-    },
-    "S2c": {
-      "type": "integer",
-      "min": 0
-    },
-    "S2s": {
-      "type": "string",
-      "enum": [
-        "Valid",
-        "Invalid"
-      ]
     },
     "S2x": {
       "type": "map",
@@ -3525,47 +2883,15 @@
         }
       }
     },
-    "S36": {
-      "type": "string",
-      "max": 50,
-      "min": 1,
-      "pattern": "[\\w+-]+"
-    },
-    "S39": {
-      "type": "string",
-      "enum": [
-        "remembered",
-        "not_remembered"
-      ]
-    },
     "S3p": {
       "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=/]+",
       "sensitive": true
-    },
-    "S3q": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "[\\S]+"
     },
     "S3r": {
       "type": "structure",
       "members": {
         "EncodedData": {}
       }
-    },
-    "S3z": {
-      "type": "string",
-      "enum": [
-        "SAML",
-        "Facebook",
-        "Google",
-        "LoginWithAmazon",
-        "OIDC"
-      ]
     },
     "S40": {
       "type": "map",
@@ -3574,39 +2900,19 @@
     },
     "S41": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 32,
-        "min": 1
-      },
+      "key": {},
       "value": {}
     },
     "S43": {
       "type": "list",
-      "member": {
-        "shape": "S44"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "S44": {
-      "type": "string",
-      "max": 40,
-      "min": 1,
-      "pattern": "[\\w\\s+=.@-]+"
+      "member": {}
     },
     "S46": {
       "type": "structure",
       "members": {
-        "UserPoolId": {
-          "shape": "S2"
-        },
-        "ProviderName": {
-          "shape": "S13"
-        },
-        "ProviderType": {
-          "shape": "S3z"
-        },
+        "UserPoolId": {},
+        "ProviderName": {},
+        "ProviderType": {},
         "ProviderDetails": {
           "shape": "S40"
         },
@@ -3624,18 +2930,6 @@
         }
       }
     },
-    "S48": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\x21\\x23-\\x5B\\x5D-\\x7E]+"
-    },
-    "S49": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\w\\s+=,.@-]+"
-    },
     "S4a": {
       "type": "list",
       "member": {
@@ -3645,61 +2939,29 @@
           "ScopeDescription"
         ],
         "members": {
-          "ScopeName": {
-            "type": "string",
-            "max": 256,
-            "min": 1,
-            "pattern": "[\\x21\\x23-\\x2E\\x30-\\x5B\\x5D-\\x7E]+"
-          },
-          "ScopeDescription": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-          }
+          "ScopeName": {},
+          "ScopeDescription": {}
         }
-      },
-      "max": 25
+      }
     },
     "S4f": {
       "type": "structure",
       "members": {
-        "UserPoolId": {
-          "shape": "S2"
-        },
-        "Identifier": {
-          "shape": "S48"
-        },
-        "Name": {
-          "shape": "S49"
-        },
+        "UserPoolId": {},
+        "Identifier": {},
+        "Name": {},
         "Scopes": {
           "shape": "S4a"
         }
       }
     },
-    "S4h": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w\\s+=,.@-]+"
-    },
     "S4j": {
       "type": "structure",
       "members": {
-        "JobName": {
-          "shape": "S4h"
-        },
-        "JobId": {
-          "shape": "S4k"
-        },
-        "UserPoolId": {
-          "shape": "S2"
-        },
-        "PreSignedUrl": {
-          "type": "string",
-          "max": 2048,
-          "min": 0
-        },
+        "JobName": {},
+        "JobId": {},
+        "UserPoolId": {},
+        "PreSignedUrl": {},
         "CreationDate": {
           "type": "timestamp"
         },
@@ -3709,22 +2971,8 @@
         "CompletionDate": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "Created",
-            "Pending",
-            "InProgress",
-            "Stopping",
-            "Expired",
-            "Stopped",
-            "Failed",
-            "Succeeded"
-          ]
-        },
-        "CloudWatchLogsRoleArn": {
-          "shape": "S2b"
-        },
+        "Status": {},
+        "CloudWatchLogsRoleArn": {},
         "ImportedUsers": {
           "type": "long"
         },
@@ -3734,25 +2982,8 @@
         "FailedUsers": {
           "type": "long"
         },
-        "CompletionMessage": {
-          "type": "string",
-          "max": 128,
-          "min": 1,
-          "pattern": "[\\w]+"
-        }
+        "CompletionMessage": {}
       }
-    },
-    "S4k": {
-      "type": "string",
-      "max": 55,
-      "min": 1,
-      "pattern": "import-[0-9a-zA-Z-]+"
-    },
-    "S4q": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w\\s+=,.@-]+"
     },
     "S4r": {
       "type": "structure",
@@ -3761,9 +2992,7 @@
           "type": "structure",
           "members": {
             "MinimumLength": {
-              "type": "integer",
-              "max": 99,
-              "min": 6
+              "type": "integer"
             },
             "RequireUppercase": {
               "type": "boolean"
@@ -3784,127 +3013,40 @@
     "S4u": {
       "type": "structure",
       "members": {
-        "PreSignUp": {
-          "shape": "S2b"
-        },
-        "CustomMessage": {
-          "shape": "S2b"
-        },
-        "PostConfirmation": {
-          "shape": "S2b"
-        },
-        "PreAuthentication": {
-          "shape": "S2b"
-        },
-        "PostAuthentication": {
-          "shape": "S2b"
-        },
-        "DefineAuthChallenge": {
-          "shape": "S2b"
-        },
-        "CreateAuthChallenge": {
-          "shape": "S2b"
-        },
-        "VerifyAuthChallengeResponse": {
-          "shape": "S2b"
-        },
-        "PreTokenGeneration": {
-          "shape": "S2b"
-        },
-        "UserMigration": {
-          "shape": "S2b"
-        }
+        "PreSignUp": {},
+        "CustomMessage": {},
+        "PostConfirmation": {},
+        "PreAuthentication": {},
+        "PostAuthentication": {},
+        "DefineAuthChallenge": {},
+        "CreateAuthChallenge": {},
+        "VerifyAuthChallengeResponse": {},
+        "PreTokenGeneration": {},
+        "UserMigration": {}
       }
     },
     "S4v": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "phone_number",
-          "email"
-        ]
-      }
+      "member": {}
     },
     "S4x": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "phone_number",
-          "email",
-          "preferred_username"
-        ]
-      }
+      "member": {}
     },
     "S4z": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "phone_number",
-          "email"
-        ]
-      }
-    },
-    "S51": {
-      "type": "string",
-      "max": 140,
-      "min": 6,
-      "pattern": ".*\\{####\\}.*"
-    },
-    "S52": {
-      "type": "string",
-      "max": 20000,
-      "min": 6,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*\\{####\\}[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*"
-    },
-    "S53": {
-      "type": "string",
-      "max": 140,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
+      "member": {}
     },
     "S54": {
       "type": "structure",
       "members": {
-        "SmsMessage": {
-          "shape": "S51"
-        },
-        "EmailMessage": {
-          "shape": "S52"
-        },
-        "EmailSubject": {
-          "shape": "S53"
-        },
-        "EmailMessageByLink": {
-          "type": "string",
-          "max": 20000,
-          "min": 6,
-          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*\\{##[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*##\\}[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]*"
-        },
-        "EmailSubjectByLink": {
-          "type": "string",
-          "max": 140,
-          "min": 1,
-          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
-        },
-        "DefaultEmailOption": {
-          "type": "string",
-          "enum": [
-            "CONFIRM_WITH_LINK",
-            "CONFIRM_WITH_CODE"
-          ]
-        }
+        "SmsMessage": {},
+        "EmailMessage": {},
+        "EmailSubject": {},
+        "EmailMessageByLink": {},
+        "EmailSubjectByLink": {},
+        "DefaultEmailOption": {}
       }
-    },
-    "S58": {
-      "type": "string",
-      "enum": [
-        "OFF",
-        "ON",
-        "OPTIONAL"
-      ]
     },
     "S59": {
       "type": "structure",
@@ -3920,13 +3062,8 @@
     "S5a": {
       "type": "structure",
       "members": {
-        "SourceArn": {
-          "shape": "S2b"
-        },
-        "ReplyToEmailAddress": {
-          "type": "string",
-          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+@[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
-        }
+        "SourceArn": {},
+        "ReplyToEmailAddress": {}
       }
     },
     "S5c": {
@@ -3935,9 +3072,7 @@
         "SnsCallerArn"
       ],
       "members": {
-        "SnsCallerArn": {
-          "shape": "S2b"
-        },
+        "SnsCallerArn": {},
         "ExternalId": {}
       }
     },
@@ -3953,22 +3088,14 @@
           "type": "boolean"
         },
         "UnusedAccountValidityDays": {
-          "type": "integer",
-          "max": 365,
-          "min": 0
+          "type": "integer"
         },
         "InviteMessageTemplate": {
           "type": "structure",
           "members": {
-            "SMSMessage": {
-              "shape": "S51"
-            },
-            "EmailMessage": {
-              "shape": "S52"
-            },
-            "EmailSubject": {
-              "shape": "S53"
-            }
+            "SMSMessage": {},
+            "EmailMessage": {},
+            "EmailSubject": {}
           }
         }
       }
@@ -3977,9 +3104,7 @@
       "type": "list",
       "member": {
         "shape": "S4"
-      },
-      "max": 50,
-      "min": 1
+      }
     },
     "S5i": {
       "type": "structure",
@@ -3987,34 +3112,21 @@
         "AdvancedSecurityMode"
       ],
       "members": {
-        "AdvancedSecurityMode": {
-          "type": "string",
-          "enum": [
-            "OFF",
-            "AUDIT",
-            "ENFORCED"
-          ]
-        }
+        "AdvancedSecurityMode": {}
       }
     },
     "S5l": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S4q"
-        },
+        "Id": {},
+        "Name": {},
         "Policies": {
           "shape": "S4r"
         },
         "LambdaConfig": {
           "shape": "S4u"
         },
-        "Status": {
-          "shape": "S5m"
-        },
+        "Status": {},
         "LastModifiedDate": {
           "type": "timestamp"
         },
@@ -4033,24 +3145,14 @@
         "UsernameAttributes": {
           "shape": "S4z"
         },
-        "SmsVerificationMessage": {
-          "shape": "S51"
-        },
-        "EmailVerificationMessage": {
-          "shape": "S52"
-        },
-        "EmailVerificationSubject": {
-          "shape": "S53"
-        },
+        "SmsVerificationMessage": {},
+        "EmailVerificationMessage": {},
+        "EmailVerificationSubject": {},
         "VerificationMessageTemplate": {
           "shape": "S54"
         },
-        "SmsAuthenticationMessage": {
-          "shape": "S51"
-        },
-        "MfaConfiguration": {
-          "shape": "S58"
-        },
+        "SmsAuthenticationMessage": {},
+        "MfaConfiguration": {},
         "DeviceConfiguration": {
           "shape": "S59"
         },
@@ -4068,116 +3170,44 @@
         },
         "SmsConfigurationFailure": {},
         "EmailConfigurationFailure": {},
-        "Domain": {
-          "shape": "S5n"
-        },
-        "CustomDomain": {
-          "shape": "S5n"
-        },
+        "Domain": {},
+        "CustomDomain": {},
         "AdminCreateUserConfig": {
           "shape": "S5e"
         },
         "UserPoolAddOns": {
           "shape": "S5i"
         },
-        "Arn": {
-          "shape": "S2b"
-        }
+        "Arn": {}
       }
-    },
-    "S5m": {
-      "type": "string",
-      "enum": [
-        "Enabled",
-        "Disabled"
-      ]
-    },
-    "S5n": {
-      "type": "string",
-      "max": 63,
-      "min": 1,
-      "pattern": "^[a-z0-9](?:[a-z0-9\\-]{0,61}[a-z0-9])?$"
-    },
-    "S5p": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w\\s+=,.@-]+"
-    },
-    "S5r": {
-      "type": "integer",
-      "max": 3650,
-      "min": 0
     },
     "S5s": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 2048,
-        "min": 1
-      }
+      "member": {}
     },
     "S5u": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "ADMIN_NO_SRP_AUTH",
-          "CUSTOM_AUTH_FLOW_ONLY",
-          "USER_PASSWORD_AUTH"
-        ]
-      }
+      "member": {}
     },
     "S5w": {
       "type": "list",
-      "member": {
-        "shape": "S13"
-      }
+      "member": {}
     },
     "S5x": {
       "type": "list",
-      "member": {
-        "shape": "S5y"
-      },
-      "max": 100,
-      "min": 0
-    },
-    "S5y": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}]+"
+      "member": {}
     },
     "S5z": {
       "type": "list",
-      "member": {
-        "shape": "S5y"
-      },
-      "max": 100,
-      "min": 0
+      "member": {}
     },
     "S60": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "code",
-          "implicit",
-          "client_credentials"
-        ]
-      },
-      "max": 3,
-      "min": 0
+      "member": {}
     },
     "S62": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 256,
-        "min": 1,
-        "pattern": "[\\x21\\x23-\\x5B\\x5D-\\x7E]+"
-      },
-      "max": 25
+      "member": {}
     },
     "S64": {
       "type": "structure",
@@ -4187,13 +3217,8 @@
         "ExternalId"
       ],
       "members": {
-        "ApplicationId": {
-          "type": "string",
-          "pattern": "^[0-9a-fA-F]+$"
-        },
-        "RoleArn": {
-          "shape": "S2b"
-        },
+        "ApplicationId": {},
+        "RoleArn": {},
         "ExternalId": {},
         "UserDataShared": {
           "type": "boolean"
@@ -4203,20 +3228,13 @@
     "S67": {
       "type": "structure",
       "members": {
-        "UserPoolId": {
-          "shape": "S2"
-        },
-        "ClientName": {
-          "shape": "S5p"
-        },
+        "UserPoolId": {},
+        "ClientName": {},
         "ClientId": {
           "shape": "S1i"
         },
         "ClientSecret": {
           "type": "string",
-          "max": 64,
-          "min": 1,
-          "pattern": "[\\w+]+",
           "sensitive": true
         },
         "LastModifiedDate": {
@@ -4226,7 +3244,7 @@
           "type": "timestamp"
         },
         "RefreshTokenValidity": {
-          "shape": "S5r"
+          "type": "integer"
         },
         "ReadAttributes": {
           "shape": "S5s"
@@ -4246,9 +3264,7 @@
         "LogoutURLs": {
           "shape": "S5z"
         },
-        "DefaultRedirectURI": {
-          "shape": "S5y"
-        },
+        "DefaultRedirectURI": {},
         "AllowedOAuthFlows": {
           "shape": "S60"
         },
@@ -4269,17 +3285,13 @@
         "CertificateArn"
       ],
       "members": {
-        "CertificateArn": {
-          "shape": "S2b"
-        }
+        "CertificateArn": {}
       }
     },
     "S6s": {
       "type": "structure",
       "members": {
-        "UserPoolId": {
-          "shape": "S2"
-        },
+        "UserPoolId": {},
         "ClientId": {
           "shape": "S1i"
         },
@@ -4305,14 +3317,7 @@
       "members": {
         "EventFilter": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "SIGN_IN",
-              "PASSWORD_CHANGE",
-              "SIGN_UP"
-            ]
-          }
+          "member": {}
         },
         "Actions": {
           "type": "structure",
@@ -4320,13 +3325,7 @@
             "EventAction"
           ],
           "members": {
-            "EventAction": {
-              "type": "string",
-              "enum": [
-                "BLOCK",
-                "NO_ACTION"
-              ]
-            }
+            "EventAction": {}
           }
         }
       }
@@ -4345,9 +3344,7 @@
           "members": {
             "From": {},
             "ReplyTo": {},
-            "SourceArn": {
-              "shape": "S2b"
-            },
+            "SourceArn": {},
             "BlockEmail": {
               "shape": "S70"
             },
@@ -4381,25 +3378,10 @@
         "Subject"
       ],
       "members": {
-        "Subject": {
-          "type": "string",
-          "max": 140,
-          "min": 1,
-          "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s]+"
-        },
-        "HtmlBody": {
-          "shape": "S72"
-        },
-        "TextBody": {
-          "shape": "S72"
-        }
+        "Subject": {},
+        "HtmlBody": {},
+        "TextBody": {}
       }
-    },
-    "S72": {
-      "type": "string",
-      "max": 20000,
-      "min": 6,
-      "pattern": "[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\s*]+"
     },
     "S74": {
       "type": "structure",
@@ -4411,15 +3393,7 @@
         "Notify": {
           "type": "boolean"
         },
-        "EventAction": {
-          "type": "string",
-          "enum": [
-            "BLOCK",
-            "MFA_IF_CONFIGURED",
-            "MFA_REQUIRED",
-            "NO_ACTION"
-          ]
-        }
+        "EventAction": {}
       }
     },
     "S77": {
@@ -4427,13 +3401,11 @@
       "members": {
         "BlockedIPRangeList": {
           "type": "list",
-          "member": {},
-          "max": 20
+          "member": {}
         },
         "SkippedIPRangeList": {
           "type": "list",
-          "member": {},
-          "max": 20
+          "member": {}
         }
       }
     },
@@ -4441,20 +3413,14 @@
       "type": "structure",
       "members": {
         "Destination": {},
-        "DeliveryMedium": {
-          "shape": "Sq"
-        },
-        "AttributeName": {
-          "shape": "Sk"
-        }
+        "DeliveryMedium": {},
+        "AttributeName": {}
       }
     },
     "S84": {
       "type": "structure",
       "members": {
-        "UserPoolId": {
-          "shape": "S2"
-        },
+        "UserPoolId": {},
         "ClientId": {
           "shape": "S1i"
         },
@@ -4472,9 +3438,7 @@
     "S8e": {
       "type": "structure",
       "members": {
-        "SmsAuthenticationMessage": {
-          "shape": "S51"
-        },
+        "SmsAuthenticationMessage": {},
         "SmsConfiguration": {
           "shape": "S5c"
         }
@@ -4487,16 +3451,6 @@
           "type": "boolean"
         }
       }
-    },
-    "S8q": {
-      "type": "string",
-      "min": 1,
-      "pattern": "[\\S]+"
-    },
-    "S8z": {
-      "type": "integer",
-      "max": 60,
-      "min": 1
     },
     "S9f": {
       "type": "list",

--- a/apis/cognito-sync-2014-06-30.min.json
+++ b/apis/cognito-sync-2014-06-30.min.json
@@ -23,7 +23,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -32,9 +31,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "S2"
-          }
+          "IdentityPoolId": {}
         }
       }
     },
@@ -53,17 +50,14 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           }
@@ -93,17 +87,14 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           }
@@ -131,7 +122,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -160,12 +150,10 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           }
@@ -177,12 +165,8 @@
           "IdentityUsage": {
             "type": "structure",
             "members": {
-              "IdentityId": {
-                "shape": "S5"
-              },
-              "IdentityPoolId": {
-                "shape": "S2"
-              },
+              "IdentityId": {},
+              "IdentityPoolId": {},
               "LastModifiedDate": {
                 "type": "timestamp"
               },
@@ -209,7 +193,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -218,24 +201,14 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "S2"
-          },
+          "IdentityPoolId": {},
           "BulkPublishStartTime": {
             "type": "timestamp"
           },
           "BulkPublishCompleteTime": {
             "type": "timestamp"
           },
-          "BulkPublishStatus": {
-            "type": "string",
-            "enum": [
-              "NOT_STARTED",
-              "IN_PROGRESS",
-              "FAILED",
-              "SUCCEEDED"
-            ]
-          },
+          "BulkPublishStatus": {},
           "FailureMessage": {}
         }
       }
@@ -253,7 +226,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -281,7 +253,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           }
@@ -290,9 +261,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "S2"
-          },
+          "IdentityPoolId": {},
           "PushSync": {
             "shape": "Sv"
           },
@@ -316,12 +285,10 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
@@ -406,17 +373,14 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
@@ -483,33 +447,21 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
-          "Platform": {
-            "type": "string",
-            "enum": [
-              "APNS",
-              "APNS_SANDBOX",
-              "GCM",
-              "ADM"
-            ]
-          },
+          "Platform": {},
           "Token": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DeviceId": {
-            "shape": "S1m"
-          }
+          "DeviceId": {}
         }
       }
     },
@@ -526,7 +478,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
@@ -548,7 +499,6 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
@@ -563,9 +513,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "IdentityPoolId": {
-            "shape": "S2"
-          },
+          "IdentityPoolId": {},
           "PushSync": {
             "shape": "Sv"
           },
@@ -590,22 +538,18 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
           "DeviceId": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "DeviceId"
           }
@@ -632,22 +576,18 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
           "DeviceId": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "DeviceId"
           }
@@ -673,23 +613,18 @@
         ],
         "members": {
           "IdentityPoolId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "IdentityPoolId"
           },
           "IdentityId": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "IdentityId"
           },
           "DatasetName": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DatasetName"
           },
-          "DeviceId": {
-            "shape": "S1m"
-          },
+          "DeviceId": {},
           "RecordPatches": {
             "type": "list",
             "member": {
@@ -700,19 +635,9 @@
                 "SyncCount"
               ],
               "members": {
-                "Op": {
-                  "type": "string",
-                  "enum": [
-                    "replace",
-                    "remove"
-                  ]
-                },
-                "Key": {
-                  "shape": "S1e"
-                },
-                "Value": {
-                  "shape": "S1f"
-                },
+                "Op": {},
+                "Key": {},
+                "Value": {},
                 "SyncCount": {
                   "type": "long"
                 },
@@ -740,33 +665,11 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 1,
-      "max": 55,
-      "pattern": "[\\w-]+:[0-9a-f-]+"
-    },
-    "S5": {
-      "type": "string",
-      "min": 1,
-      "max": 55,
-      "pattern": "[\\w-]+:[0-9a-f-]+"
-    },
-    "S6": {
-      "type": "string",
-      "min": 1,
-      "max": 128,
-      "pattern": "[a-zA-Z0-9_.:-]+"
-    },
     "S8": {
       "type": "structure",
       "members": {
-        "IdentityId": {
-          "shape": "S5"
-        },
-        "DatasetName": {
-          "shape": "S6"
-        },
+        "IdentityId": {},
+        "DatasetName": {},
         "CreationDate": {
           "type": "timestamp"
         },
@@ -785,9 +688,7 @@
     "Sg": {
       "type": "structure",
       "members": {
-        "IdentityPoolId": {
-          "shape": "S2"
-        },
+        "IdentityPoolId": {},
         "SyncSessionsCount": {
           "type": "long"
         },
@@ -802,48 +703,24 @@
     "Sq": {
       "type": "map",
       "key": {},
-      "value": {},
-      "max": 1
+      "value": {}
     },
     "Sv": {
       "type": "structure",
       "members": {
         "ApplicationArns": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "pattern": "arn:aws:sns:[-0-9a-z]+:\\d+:app/[A-Z_]+/[a-zA-Z0-9_.-]+"
-          }
+          "member": {}
         },
-        "RoleArn": {
-          "shape": "Sy"
-        }
+        "RoleArn": {}
       }
-    },
-    "Sy": {
-      "type": "string",
-      "min": 20,
-      "max": 2048,
-      "pattern": "arn:aws:iam::\\d+:role/.*"
     },
     "Sz": {
       "type": "structure",
       "members": {
-        "StreamName": {
-          "type": "string",
-          "min": 1,
-          "max": 128
-        },
-        "RoleArn": {
-          "shape": "Sy"
-        },
-        "StreamingStatus": {
-          "type": "string",
-          "enum": [
-            "ENABLED",
-            "DISABLED"
-          ]
-        }
+        "StreamName": {},
+        "RoleArn": {},
+        "StreamingStatus": {}
       }
     },
     "S1c": {
@@ -851,12 +728,8 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S1e"
-          },
-          "Value": {
-            "shape": "S1f"
-          },
+          "Key": {},
+          "Value": {},
           "SyncCount": {
             "type": "long"
           },
@@ -869,20 +742,6 @@
           }
         }
       }
-    },
-    "S1e": {
-      "type": "string",
-      "min": 1,
-      "max": 1024
-    },
-    "S1f": {
-      "type": "string",
-      "max": 1048575
-    },
-    "S1m": {
-      "type": "string",
-      "min": 1,
-      "max": 256
     }
   },
   "examples": {}

--- a/apis/comprehend-2017-11-27.min.json
+++ b/apis/comprehend-2017-11-27.min.json
@@ -63,9 +63,7 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -106,9 +104,7 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -149,9 +145,7 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -169,9 +163,7 @@
                 "Index": {
                   "type": "integer"
                 },
-                "Sentiment": {
-                  "shape": "Sv"
-                },
+                "Sentiment": {},
                 "SentimentScore": {
                   "shape": "Sw"
                 }
@@ -195,9 +187,7 @@
           "TextList": {
             "shape": "S2"
           },
-          "LanguageCode": {
-            "shape": "Sy"
-          }
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -234,9 +224,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -255,9 +243,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -276,9 +262,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -297,9 +281,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -318,9 +300,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -339,9 +319,7 @@
           "Text"
         ],
         "members": {
-          "Text": {
-            "shape": "S3"
-          }
+          "Text": {}
         }
       },
       "output": {
@@ -361,12 +339,8 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {
-            "shape": "S3"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "Text": {},
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -386,12 +360,8 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {
-            "shape": "S3"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "Text": {},
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -411,20 +381,14 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {
-            "shape": "S3"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          }
+          "Text": {},
+          "LanguageCode": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Sentiment": {
-            "shape": "Sv"
-          },
+          "Sentiment": {},
           "SentimentScore": {
             "shape": "Sw"
           }
@@ -439,12 +403,8 @@
           "LanguageCode"
         ],
         "members": {
-          "Text": {
-            "shape": "S3"
-          },
-          "LanguageCode": {
-            "shape": "Sy"
-          }
+          "Text": {},
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -463,12 +423,8 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S1a"
-              },
-              "JobStatus": {
-                "shape": "S1b"
-              },
+              "JobName": {},
+              "JobStatus": {},
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -477,11 +433,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S27"
+            "type": "integer"
           }
         }
       },
@@ -494,9 +448,7 @@
               "shape": "S19"
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -507,12 +459,8 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S1a"
-              },
-              "JobStatus": {
-                "shape": "S1b"
-              },
+              "JobName": {},
+              "JobStatus": {},
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -521,11 +469,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S27"
+            "type": "integer"
           }
         }
       },
@@ -538,9 +484,7 @@
               "shape": "S1l"
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -551,12 +495,8 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S1a"
-              },
-              "JobStatus": {
-                "shape": "S1b"
-              },
+              "JobName": {},
+              "JobStatus": {},
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -565,11 +505,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S27"
+            "type": "integer"
           }
         }
       },
@@ -582,9 +520,7 @@
               "shape": "S1o"
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -595,12 +531,8 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S1a"
-              },
-              "JobStatus": {
-                "shape": "S1b"
-              },
+              "JobName": {},
+              "JobStatus": {},
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -609,11 +541,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S27"
+            "type": "integer"
           }
         }
       },
@@ -626,9 +556,7 @@
               "shape": "S1r"
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -639,12 +567,8 @@
           "Filter": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S1a"
-              },
-              "JobStatus": {
-                "shape": "S1b"
-              },
+              "JobName": {},
+              "JobStatus": {},
               "SubmitTimeBefore": {
                 "type": "timestamp"
               },
@@ -653,11 +577,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S27"
+            "type": "integer"
           }
         }
       },
@@ -670,9 +592,7 @@
               "shape": "S1u"
             }
           },
-          "NextToken": {
-            "shape": "S3"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -691,14 +611,9 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {
-            "shape": "S1i"
-          },
-          "JobName": {
-            "shape": "S1a"
-          },
+          "DataAccessRoleArn": {},
+          "JobName": {},
           "ClientRequestToken": {
-            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -706,12 +621,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -731,17 +642,10 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {
-            "shape": "S1i"
-          },
-          "JobName": {
-            "shape": "S1a"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          },
+          "DataAccessRoleArn": {},
+          "JobName": {},
+          "LanguageCode": {},
           "ClientRequestToken": {
-            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -749,12 +653,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -774,17 +674,10 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {
-            "shape": "S1i"
-          },
-          "JobName": {
-            "shape": "S1a"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          },
+          "DataAccessRoleArn": {},
+          "JobName": {},
+          "LanguageCode": {},
           "ClientRequestToken": {
-            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -792,12 +685,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -817,17 +706,10 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {
-            "shape": "S1i"
-          },
-          "JobName": {
-            "shape": "S1a"
-          },
-          "LanguageCode": {
-            "shape": "Se"
-          },
+          "DataAccessRoleArn": {},
+          "JobName": {},
+          "LanguageCode": {},
           "ClientRequestToken": {
-            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -835,12 +717,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -859,19 +737,12 @@
           "OutputDataConfig": {
             "shape": "S1h"
           },
-          "DataAccessRoleArn": {
-            "shape": "S1i"
-          },
-          "JobName": {
-            "shape": "S1a"
-          },
+          "DataAccessRoleArn": {},
+          "JobName": {},
           "NumberOfTopics": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           },
           "ClientRequestToken": {
-            "shape": "S2r",
             "idempotencyToken": true
           }
         }
@@ -879,12 +750,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -895,20 +762,14 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -919,20 +780,14 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -943,20 +798,14 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     },
@@ -967,20 +816,14 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S17"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S17"
-          },
-          "JobStatus": {
-            "shape": "S1b"
-          }
+          "JobId": {},
+          "JobStatus": {}
         }
       }
     }
@@ -988,22 +831,14 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
-    },
-    "S3": {
-      "type": "string",
-      "min": 1
+      "member": {}
     },
     "S8": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "LanguageCode": {
-            "shape": "S3"
-          },
+          "LanguageCode": {},
           "Score": {
             "type": "float"
           }
@@ -1018,21 +853,10 @@
           "Index": {
             "type": "integer"
           },
-          "ErrorCode": {
-            "shape": "S3"
-          },
-          "ErrorMessage": {
-            "shape": "S3"
-          }
+          "ErrorCode": {},
+          "ErrorMessage": {}
         }
       }
-    },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "en",
-        "es"
-      ]
     },
     "Si": {
       "type": "list",
@@ -1042,23 +866,8 @@
           "Score": {
             "type": "float"
           },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "PERSON",
-              "LOCATION",
-              "ORGANIZATION",
-              "COMMERCIAL_ITEM",
-              "EVENT",
-              "DATE",
-              "QUANTITY",
-              "TITLE",
-              "OTHER"
-            ]
-          },
-          "Text": {
-            "shape": "S3"
-          },
+          "Type": {},
+          "Text": {},
           "BeginOffset": {
             "type": "integer"
           },
@@ -1076,9 +885,7 @@
           "Score": {
             "type": "float"
           },
-          "Text": {
-            "shape": "S3"
-          },
+          "Text": {},
           "BeginOffset": {
             "type": "integer"
           },
@@ -1087,15 +894,6 @@
           }
         }
       }
-    },
-    "Sv": {
-      "type": "string",
-      "enum": [
-        "POSITIVE",
-        "NEGATIVE",
-        "NEUTRAL",
-        "MIXED"
-      ]
     },
     "Sw": {
       "type": "structure",
@@ -1114,12 +912,6 @@
         }
       }
     },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "en"
-      ]
-    },
     "S12": {
       "type": "list",
       "member": {
@@ -1128,9 +920,7 @@
           "TokenId": {
             "type": "integer"
           },
-          "Text": {
-            "shape": "S3"
-          },
+          "Text": {},
           "BeginOffset": {
             "type": "integer"
           },
@@ -1140,28 +930,7 @@
           "PartOfSpeech": {
             "type": "structure",
             "members": {
-              "Tag": {
-                "type": "string",
-                "enum": [
-                  "ADJ",
-                  "ADP",
-                  "ADV",
-                  "AUX",
-                  "CONJ",
-                  "DET",
-                  "INTJ",
-                  "NOUN",
-                  "NUM",
-                  "O",
-                  "PART",
-                  "PRON",
-                  "PROPN",
-                  "PUNCT",
-                  "SCONJ",
-                  "SYM",
-                  "VERB"
-                ]
-              },
+              "Tag": {},
               "Score": {
                 "type": "float"
               }
@@ -1170,23 +939,12 @@
         }
       }
     },
-    "S17": {
-      "type": "string",
-      "max": 32,
-      "min": 1
-    },
     "S19": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "S17"
-        },
-        "JobName": {
-          "shape": "S1a"
-        },
-        "JobStatus": {
-          "shape": "S1b"
-        },
+        "JobId": {},
+        "JobName": {},
+        "JobStatus": {},
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1200,27 +958,8 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "DataAccessRoleArn": {
-          "shape": "S1i"
-        }
+        "DataAccessRoleArn": {}
       }
-    },
-    "S1a": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
-    },
-    "S1b": {
-      "type": "string",
-      "enum": [
-        "SUBMITTED",
-        "IN_PROGRESS",
-        "COMPLETED",
-        "FAILED",
-        "STOP_REQUESTED",
-        "STOPPED"
-      ]
     },
     "S1e": {
       "type": "structure",
@@ -1228,22 +967,9 @@
         "S3Uri"
       ],
       "members": {
-        "S3Uri": {
-          "shape": "S1f"
-        },
-        "InputFormat": {
-          "type": "string",
-          "enum": [
-            "ONE_DOC_PER_FILE",
-            "ONE_DOC_PER_LINE"
-          ]
-        }
+        "S3Uri": {},
+        "InputFormat": {}
       }
-    },
-    "S1f": {
-      "type": "string",
-      "max": 1024,
-      "pattern": "s3://[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9](/.*)?"
     },
     "S1h": {
       "type": "structure",
@@ -1251,27 +977,15 @@
         "S3Uri"
       ],
       "members": {
-        "S3Uri": {
-          "shape": "S1f"
-        }
+        "S3Uri": {}
       }
-    },
-    "S1i": {
-      "type": "string",
-      "pattern": "arn:aws(-[^:]+)?:iam::[0-9]{12}:role/.+"
     },
     "S1l": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "S17"
-        },
-        "JobName": {
-          "shape": "S1a"
-        },
-        "JobStatus": {
-          "shape": "S1b"
-        },
+        "JobId": {},
+        "JobName": {},
+        "JobStatus": {},
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1285,26 +999,16 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {
-          "shape": "Se"
-        },
-        "DataAccessRoleArn": {
-          "shape": "S1i"
-        }
+        "LanguageCode": {},
+        "DataAccessRoleArn": {}
       }
     },
     "S1o": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "S17"
-        },
-        "JobName": {
-          "shape": "S1a"
-        },
-        "JobStatus": {
-          "shape": "S1b"
-        },
+        "JobId": {},
+        "JobName": {},
+        "JobStatus": {},
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1318,26 +1022,16 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {
-          "shape": "Se"
-        },
-        "DataAccessRoleArn": {
-          "shape": "S1i"
-        }
+        "LanguageCode": {},
+        "DataAccessRoleArn": {}
       }
     },
     "S1r": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "S17"
-        },
-        "JobName": {
-          "shape": "S1a"
-        },
-        "JobStatus": {
-          "shape": "S1b"
-        },
+        "JobId": {},
+        "JobName": {},
+        "JobStatus": {},
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1351,26 +1045,16 @@
         "OutputDataConfig": {
           "shape": "S1h"
         },
-        "LanguageCode": {
-          "shape": "Se"
-        },
-        "DataAccessRoleArn": {
-          "shape": "S1i"
-        }
+        "LanguageCode": {},
+        "DataAccessRoleArn": {}
       }
     },
     "S1u": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "S17"
-        },
-        "JobName": {
-          "shape": "S1a"
-        },
-        "JobStatus": {
-          "shape": "S1b"
-        },
+        "JobId": {},
+        "JobName": {},
+        "JobStatus": {},
         "Message": {},
         "SubmitTime": {
           "type": "timestamp"
@@ -1388,17 +1072,6 @@
           "type": "integer"
         }
       }
-    },
-    "S27": {
-      "type": "integer",
-      "max": 500,
-      "min": 1
-    },
-    "S2r": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9-]+$"
     }
   }
 }

--- a/apis/config-2014-11-12.min.json
+++ b/apis/config-2014-11-12.min.json
@@ -34,27 +34,17 @@
               "type": "structure",
               "members": {
                 "version": {},
-                "accountId": {
-                  "shape": "Sa"
-                },
+                "accountId": {},
                 "configurationItemCaptureTime": {
                   "type": "timestamp"
                 },
-                "configurationItemStatus": {
-                  "shape": "Sc"
-                },
+                "configurationItemStatus": {},
                 "configurationStateId": {},
                 "arn": {},
-                "resourceType": {
-                  "shape": "S4"
-                },
-                "resourceId": {
-                  "shape": "S5"
-                },
+                "resourceType": {},
+                "resourceId": {},
                 "resourceName": {},
-                "awsRegion": {
-                  "shape": "Sg"
-                },
+                "awsRegion": {},
                 "availabilityZone": {},
                 "resourceCreationTime": {
                   "type": "timestamp"
@@ -80,12 +70,8 @@
           "AuthorizedAwsRegion"
         ],
         "members": {
-          "AuthorizedAccountId": {
-            "shape": "Sa"
-          },
-          "AuthorizedAwsRegion": {
-            "shape": "Sg"
-          }
+          "AuthorizedAccountId": {},
+          "AuthorizedAwsRegion": {}
         }
       }
     },
@@ -96,9 +82,7 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {
-            "shape": "Sp"
-          }
+          "ConfigRuleName": {}
         }
       }
     },
@@ -109,9 +93,7 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          }
+          "ConfigurationAggregatorName": {}
         }
       }
     },
@@ -122,9 +104,7 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {
-            "shape": "St"
-          }
+          "ConfigurationRecorderName": {}
         }
       }
     },
@@ -135,9 +115,7 @@
           "DeliveryChannelName"
         ],
         "members": {
-          "DeliveryChannelName": {
-            "shape": "Sv"
-          }
+          "DeliveryChannelName": {}
         }
       }
     },
@@ -148,9 +126,7 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {
-            "shape": "Sp"
-          }
+          "ConfigRuleName": {}
         }
       },
       "output": {
@@ -166,12 +142,8 @@
           "RequesterAwsRegion"
         ],
         "members": {
-          "RequesterAccountId": {
-            "shape": "Sa"
-          },
-          "RequesterAwsRegion": {
-            "shape": "Sg"
-          }
+          "RequesterAccountId": {},
+          "RequesterAwsRegion": {}
         }
       }
     },
@@ -182,9 +154,7 @@
           "RetentionConfigurationName"
         ],
         "members": {
-          "RetentionConfigurationName": {
-            "shape": "S10"
-          }
+          "RetentionConfigurationName": {}
         }
       }
     },
@@ -195,9 +165,7 @@
           "deliveryChannelName"
         ],
         "members": {
-          "deliveryChannelName": {
-            "shape": "Sv"
-          }
+          "deliveryChannelName": {}
         }
       },
       "output": {
@@ -214,28 +182,18 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          },
+          "ConfigurationAggregatorName": {},
           "Filters": {
             "type": "structure",
             "members": {
-              "ConfigRuleName": {
-                "shape": "S16"
-              },
-              "ComplianceType": {
-                "shape": "S17"
-              },
-              "AccountId": {
-                "shape": "Sa"
-              },
-              "AwsRegion": {
-                "shape": "Sg"
-              }
+              "ConfigRuleName": {},
+              "ComplianceType": {},
+              "AccountId": {},
+              "AwsRegion": {}
             }
           },
           "Limit": {
-            "shape": "S18"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -248,18 +206,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {
-                  "shape": "S16"
-                },
+                "ConfigRuleName": {},
                 "Compliance": {
                   "shape": "S1d"
                 },
-                "AccountId": {
-                  "shape": "Sa"
-                },
-                "AwsRegion": {
-                  "shape": "Sg"
-                }
+                "AccountId": {},
+                "AwsRegion": {}
               }
             }
           },
@@ -272,7 +224,7 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -311,9 +263,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {
-                  "shape": "Sp"
-                },
+                "ConfigRuleName": {},
                 "Compliance": {
                   "shape": "S1d"
                 }
@@ -328,17 +278,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "ResourceType": {
-            "shape": "S1u"
-          },
-          "ResourceId": {
-            "shape": "S1v"
-          },
+          "ResourceType": {},
+          "ResourceId": {},
           "ComplianceTypes": {
             "shape": "S1p"
           },
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -351,12 +297,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "ResourceType": {
-                  "shape": "S1u"
-                },
-                "ResourceId": {
-                  "shape": "S1v"
-                },
+                "ResourceType": {},
+                "ResourceId": {},
                 "Compliance": {
                   "shape": "S1d"
                 }
@@ -376,9 +318,7 @@
           },
           "NextToken": {},
           "Limit": {
-            "type": "integer",
-            "max": 50,
-            "min": 0
+            "type": "integer"
           }
         }
       },
@@ -390,9 +330,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ConfigRuleName": {
-                  "shape": "Sp"
-                },
+                "ConfigRuleName": {},
                 "ConfigRuleArn": {},
                 "ConfigRuleId": {},
                 "LastSuccessfulInvocationTime": {
@@ -452,19 +390,14 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          },
+          "ConfigurationAggregatorName": {},
           "UpdateStatus": {
             "type": "list",
-            "member": {
-              "shape": "S2n"
-            },
-            "min": 1
+            "member": {}
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           }
         }
       },
@@ -477,19 +410,9 @@
               "type": "structure",
               "members": {
                 "SourceId": {},
-                "SourceType": {
-                  "type": "string",
-                  "enum": [
-                    "ACCOUNT",
-                    "ORGANIZATION"
-                  ]
-                },
-                "AwsRegion": {
-                  "shape": "Sg"
-                },
-                "LastUpdateStatus": {
-                  "shape": "S2n"
-                },
+                "SourceType": {},
+                "AwsRegion": {},
+                "LastUpdateStatus": {},
                 "LastUpdateTime": {
                   "type": "timestamp"
                 },
@@ -508,15 +431,11 @@
         "members": {
           "ConfigurationAggregatorNames": {
             "type": "list",
-            "member": {
-              "shape": "Sr"
-            },
-            "max": 10,
-            "min": 0
+            "member": {}
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           }
         }
       },
@@ -560,14 +479,7 @@
                 "recording": {
                   "type": "boolean"
                 },
-                "lastStatus": {
-                  "type": "string",
-                  "enum": [
-                    "Pending",
-                    "Success",
-                    "Failure"
-                  ]
-                },
+                "lastStatus": {},
                 "lastErrorCode": {},
                 "lastErrorMessage": {},
                 "lastStatusChangeTime": {
@@ -627,9 +539,7 @@
                 "configStreamDeliveryInfo": {
                   "type": "structure",
                   "members": {
-                    "lastStatus": {
-                      "shape": "S3n"
-                    },
+                    "lastStatus": {},
                     "lastErrorCode": {},
                     "lastErrorMessage": {},
                     "lastStatusChangeTime": {
@@ -669,9 +579,7 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer",
-            "max": 20,
-            "min": 0
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -684,12 +592,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "RequesterAccountId": {
-                  "shape": "Sa"
-                },
-                "RequesterAwsRegion": {
-                  "shape": "Sg"
-                }
+                "RequesterAccountId": {},
+                "RequesterAwsRegion": {}
               }
             }
           },
@@ -703,11 +607,7 @@
         "members": {
           "RetentionConfigurationNames": {
             "type": "list",
-            "member": {
-              "shape": "S10"
-            },
-            "max": 1,
-            "min": 0
+            "member": {}
           },
           "NextToken": {}
         }
@@ -735,23 +635,13 @@
           "AwsRegion"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          },
-          "ConfigRuleName": {
-            "shape": "S16"
-          },
-          "AccountId": {
-            "shape": "Sa"
-          },
-          "AwsRegion": {
-            "shape": "Sg"
-          },
-          "ComplianceType": {
-            "shape": "S17"
-          },
+          "ConfigurationAggregatorName": {},
+          "ConfigRuleName": {},
+          "AccountId": {},
+          "AwsRegion": {},
+          "ComplianceType": {},
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -767,24 +657,16 @@
                 "EvaluationResultIdentifier": {
                   "shape": "S49"
                 },
-                "ComplianceType": {
-                  "shape": "S17"
-                },
+                "ComplianceType": {},
                 "ResultRecordedTime": {
                   "type": "timestamp"
                 },
                 "ConfigRuleInvokedTime": {
                   "type": "timestamp"
                 },
-                "Annotation": {
-                  "shape": "S1u"
-                },
-                "AccountId": {
-                  "shape": "Sa"
-                },
-                "AwsRegion": {
-                  "shape": "Sg"
-                }
+                "Annotation": {},
+                "AccountId": {},
+                "AwsRegion": {}
               }
             }
           },
@@ -799,29 +681,17 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          },
+          "ConfigurationAggregatorName": {},
           "Filters": {
             "type": "structure",
             "members": {
-              "AccountId": {
-                "shape": "Sa"
-              },
-              "AwsRegion": {
-                "shape": "Sg"
-              }
+              "AccountId": {},
+              "AwsRegion": {}
             }
           },
-          "GroupByKey": {
-            "type": "string",
-            "enum": [
-              "ACCOUNT_ID",
-              "AWS_REGION"
-            ]
-          },
+          "GroupByKey": {},
           "Limit": {
-            "shape": "S18"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -829,17 +699,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "GroupByKey": {
-            "shape": "S1u"
-          },
+          "GroupByKey": {},
           "AggregateComplianceCounts": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "GroupName": {
-                  "shape": "S1u"
-                },
+                "GroupName": {},
                 "ComplianceSummary": {
                   "shape": "S4h"
                 }
@@ -857,14 +723,12 @@
           "ConfigRuleName"
         ],
         "members": {
-          "ConfigRuleName": {
-            "shape": "Sp"
-          },
+          "ConfigRuleName": {},
           "ComplianceTypes": {
             "shape": "S1p"
           },
           "Limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -887,12 +751,8 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceType": {
-            "shape": "S1u"
-          },
-          "ResourceId": {
-            "shape": "S1v"
-          },
+          "ResourceType": {},
+          "ResourceId": {},
           "ComplianceTypes": {
             "shape": "S1p"
           },
@@ -936,9 +796,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ResourceType": {
-                  "shape": "S1u"
-                },
+                "ResourceType": {},
                 "ComplianceSummary": {
                   "shape": "S4h"
                 }
@@ -956,7 +814,7 @@
             "shape": "S4q"
           },
           "limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "nextToken": {}
         }
@@ -972,9 +830,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "resourceType": {
-                  "shape": "S4"
-                },
+                "resourceType": {},
                 "count": {
                   "type": "long"
                 }
@@ -993,27 +849,17 @@
           "resourceId"
         ],
         "members": {
-          "resourceType": {
-            "shape": "S4"
-          },
-          "resourceId": {
-            "shape": "S5"
-          },
+          "resourceType": {},
+          "resourceId": {},
           "laterTime": {
             "type": "timestamp"
           },
           "earlierTime": {
             "type": "timestamp"
           },
-          "chronologicalOrder": {
-            "type": "string",
-            "enum": [
-              "Reverse",
-              "Forward"
-            ]
-          },
+          "chronologicalOrder": {},
           "limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "nextToken": {}
         }
@@ -1027,28 +873,18 @@
               "type": "structure",
               "members": {
                 "version": {},
-                "accountId": {
-                  "shape": "Sa"
-                },
+                "accountId": {},
                 "configurationItemCaptureTime": {
                   "type": "timestamp"
                 },
-                "configurationItemStatus": {
-                  "shape": "Sc"
-                },
+                "configurationItemStatus": {},
                 "configurationStateId": {},
                 "configurationItemMD5Hash": {},
                 "arn": {},
-                "resourceType": {
-                  "shape": "S4"
-                },
-                "resourceId": {
-                  "shape": "S5"
-                },
+                "resourceType": {},
+                "resourceId": {},
                 "resourceName": {},
-                "awsRegion": {
-                  "shape": "Sg"
-                },
+                "awsRegion": {},
                 "availabilityZone": {},
                 "resourceCreationTime": {
                   "type": "timestamp"
@@ -1067,12 +903,8 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "resourceType": {
-                        "shape": "S4"
-                      },
-                      "resourceId": {
-                        "shape": "S5"
-                      },
+                      "resourceType": {},
+                      "resourceId": {},
                       "resourceName": {},
                       "relationshipName": {}
                     }
@@ -1096,18 +928,14 @@
           "resourceType"
         ],
         "members": {
-          "resourceType": {
-            "shape": "S4"
-          },
+          "resourceType": {},
           "resourceIds": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            }
+            "member": {}
           },
           "resourceName": {},
           "limit": {
-            "shape": "S1i"
+            "type": "integer"
           },
           "includeDeletedResources": {
             "type": "boolean"
@@ -1123,12 +951,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "resourceType": {
-                  "shape": "S4"
-                },
-                "resourceId": {
-                  "shape": "S5"
-                },
+                "resourceType": {},
+                "resourceId": {},
                 "resourceName": {},
                 "resourceDeletionTime": {
                   "type": "timestamp"
@@ -1148,12 +972,8 @@
           "AuthorizedAwsRegion"
         ],
         "members": {
-          "AuthorizedAccountId": {
-            "shape": "Sa"
-          },
-          "AuthorizedAwsRegion": {
-            "shape": "Sg"
-          }
+          "AuthorizedAccountId": {},
+          "AuthorizedAwsRegion": {}
         }
       },
       "output": {
@@ -1185,9 +1005,7 @@
           "ConfigurationAggregatorName"
         ],
         "members": {
-          "ConfigurationAggregatorName": {
-            "shape": "Sr"
-          },
+          "ConfigurationAggregatorName": {},
           "AccountAggregationSources": {
             "shape": "S2y"
           },
@@ -1264,7 +1082,7 @@
         ],
         "members": {
           "RetentionPeriodInDays": {
-            "shape": "S44"
+            "type": "integer"
           }
         }
       },
@@ -1283,11 +1101,7 @@
         "members": {
           "ConfigRuleNames": {
             "type": "list",
-            "member": {
-              "shape": "Sp"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -1303,9 +1117,7 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {
-            "shape": "St"
-          }
+          "ConfigurationRecorderName": {}
         }
       }
     },
@@ -1316,9 +1128,7 @@
           "ConfigurationRecorderName"
         ],
         "members": {
-          "ConfigurationRecorderName": {
-            "shape": "St"
-          }
+          "ConfigurationRecorderName": {}
         }
       }
     }
@@ -1333,161 +1143,20 @@
           "resourceId"
         ],
         "members": {
-          "resourceType": {
-            "shape": "S4"
-          },
-          "resourceId": {
-            "shape": "S5"
-          }
+          "resourceType": {},
+          "resourceId": {}
         }
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "AWS::EC2::CustomerGateway",
-        "AWS::EC2::EIP",
-        "AWS::EC2::Host",
-        "AWS::EC2::Instance",
-        "AWS::EC2::InternetGateway",
-        "AWS::EC2::NetworkAcl",
-        "AWS::EC2::NetworkInterface",
-        "AWS::EC2::RouteTable",
-        "AWS::EC2::SecurityGroup",
-        "AWS::EC2::Subnet",
-        "AWS::CloudTrail::Trail",
-        "AWS::EC2::Volume",
-        "AWS::EC2::VPC",
-        "AWS::EC2::VPNConnection",
-        "AWS::EC2::VPNGateway",
-        "AWS::IAM::Group",
-        "AWS::IAM::Policy",
-        "AWS::IAM::Role",
-        "AWS::IAM::User",
-        "AWS::ACM::Certificate",
-        "AWS::RDS::DBInstance",
-        "AWS::RDS::DBSubnetGroup",
-        "AWS::RDS::DBSecurityGroup",
-        "AWS::RDS::DBSnapshot",
-        "AWS::RDS::EventSubscription",
-        "AWS::ElasticLoadBalancingV2::LoadBalancer",
-        "AWS::S3::Bucket",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::Redshift::Cluster",
-        "AWS::Redshift::ClusterSnapshot",
-        "AWS::Redshift::ClusterParameterGroup",
-        "AWS::Redshift::ClusterSecurityGroup",
-        "AWS::Redshift::ClusterSubnetGroup",
-        "AWS::Redshift::EventSubscription",
-        "AWS::CloudWatch::Alarm",
-        "AWS::CloudFormation::Stack",
-        "AWS::DynamoDB::Table",
-        "AWS::AutoScaling::AutoScalingGroup",
-        "AWS::AutoScaling::LaunchConfiguration",
-        "AWS::AutoScaling::ScalingPolicy",
-        "AWS::AutoScaling::ScheduledAction",
-        "AWS::CodeBuild::Project",
-        "AWS::WAF::RateBasedRule",
-        "AWS::WAF::Rule",
-        "AWS::WAF::WebACL",
-        "AWS::WAFRegional::RateBasedRule",
-        "AWS::WAFRegional::Rule",
-        "AWS::WAFRegional::WebACL",
-        "AWS::CloudFront::Distribution",
-        "AWS::CloudFront::StreamingDistribution",
-        "AWS::WAF::RuleGroup",
-        "AWS::WAFRegional::RuleGroup",
-        "AWS::Lambda::Function",
-        "AWS::ElasticBeanstalk::Application",
-        "AWS::ElasticBeanstalk::ApplicationVersion",
-        "AWS::ElasticBeanstalk::Environment",
-        "AWS::ElasticLoadBalancing::LoadBalancer",
-        "AWS::XRay::EncryptionConfig"
-      ]
-    },
-    "S5": {
-      "type": "string",
-      "max": 768,
-      "min": 1
-    },
-    "Sa": {
-      "type": "string",
-      "pattern": "\\d{12}"
-    },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "OK",
-        "ResourceDiscovered",
-        "ResourceNotRecorded",
-        "ResourceDeleted",
-        "ResourceDeletedNotRecorded"
-      ]
-    },
-    "Sg": {
-      "type": "string",
-      "max": 64,
-      "min": 1
+      }
     },
     "Sk": {
       "type": "map",
       "key": {},
       "value": {}
     },
-    "Sp": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "Sr": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\w\\-]+"
-    },
-    "St": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "Sv": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\w\\-]+"
-    },
-    "S16": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "S17": {
-      "type": "string",
-      "enum": [
-        "COMPLIANT",
-        "NON_COMPLIANT",
-        "NOT_APPLICABLE",
-        "INSUFFICIENT_DATA"
-      ]
-    },
-    "S18": {
-      "type": "integer",
-      "max": 1000,
-      "min": 0
-    },
     "S1d": {
       "type": "structure",
       "members": {
-        "ComplianceType": {
-          "shape": "S17"
-        },
+        "ComplianceType": {},
         "ComplianceContributorCount": {
           "shape": "S1e"
         }
@@ -1504,21 +1173,12 @@
         }
       }
     },
-    "S1i": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
-    },
     "S1l": {
       "type": "structure",
       "members": {
         "AggregationAuthorizationArn": {},
-        "AuthorizedAccountId": {
-          "shape": "Sa"
-        },
-        "AuthorizedAwsRegion": {
-          "shape": "Sg"
-        },
+        "AuthorizedAccountId": {},
+        "AuthorizedAwsRegion": {},
         "CreationTime": {
           "type": "timestamp"
         }
@@ -1526,29 +1186,11 @@
     },
     "S1o": {
       "type": "list",
-      "member": {
-        "shape": "Sp"
-      },
-      "max": 25,
-      "min": 0
+      "member": {}
     },
     "S1p": {
       "type": "list",
-      "member": {
-        "shape": "S17"
-      },
-      "max": 3,
-      "min": 0
-    },
-    "S1u": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S1v": {
-      "type": "string",
-      "max": 768,
-      "min": 1
+      "member": {}
     },
     "S27": {
       "type": "structure",
@@ -1556,38 +1198,20 @@
         "Source"
       ],
       "members": {
-        "ConfigRuleName": {
-          "shape": "Sp"
-        },
+        "ConfigRuleName": {},
         "ConfigRuleArn": {},
         "ConfigRuleId": {},
-        "Description": {
-          "type": "string",
-          "max": 256,
-          "min": 0
-        },
+        "Description": {},
         "Scope": {
           "type": "structure",
           "members": {
             "ComplianceResourceTypes": {
               "type": "list",
-              "member": {
-                "shape": "S1u"
-              },
-              "max": 100,
-              "min": 0
+              "member": {}
             },
-            "TagKey": {
-              "type": "string",
-              "max": 128,
-              "min": 1
-            },
-            "TagValue": {
-              "shape": "S1u"
-            },
-            "ComplianceResourceId": {
-              "shape": "S1v"
-            }
+            "TagKey": {},
+            "TagValue": {},
+            "ComplianceResourceId": {}
           }
         },
         "Source": {
@@ -1597,96 +1221,32 @@
             "SourceIdentifier"
           ],
           "members": {
-            "Owner": {
-              "type": "string",
-              "enum": [
-                "CUSTOM_LAMBDA",
-                "AWS"
-              ]
-            },
-            "SourceIdentifier": {
-              "shape": "S1u"
-            },
+            "Owner": {},
+            "SourceIdentifier": {},
             "SourceDetails": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "EventSource": {
-                    "type": "string",
-                    "enum": [
-                      "aws.config"
-                    ]
-                  },
-                  "MessageType": {
-                    "type": "string",
-                    "enum": [
-                      "ConfigurationItemChangeNotification",
-                      "ConfigurationSnapshotDeliveryCompleted",
-                      "ScheduledNotification",
-                      "OversizedConfigurationItemChangeNotification"
-                    ]
-                  },
-                  "MaximumExecutionFrequency": {
-                    "shape": "S2i"
-                  }
+                  "EventSource": {},
+                  "MessageType": {},
+                  "MaximumExecutionFrequency": {}
                 }
-              },
-              "max": 25,
-              "min": 0
+              }
             }
           }
         },
-        "InputParameters": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        },
-        "MaximumExecutionFrequency": {
-          "shape": "S2i"
-        },
-        "ConfigRuleState": {
-          "type": "string",
-          "enum": [
-            "ACTIVE",
-            "DELETING",
-            "DELETING_RESULTS",
-            "EVALUATING"
-          ]
-        },
-        "CreatedBy": {
-          "shape": "S1u"
-        }
+        "InputParameters": {},
+        "MaximumExecutionFrequency": {},
+        "ConfigRuleState": {},
+        "CreatedBy": {}
       }
-    },
-    "S2i": {
-      "type": "string",
-      "enum": [
-        "One_Hour",
-        "Three_Hours",
-        "Six_Hours",
-        "Twelve_Hours",
-        "TwentyFour_Hours"
-      ]
-    },
-    "S2n": {
-      "type": "string",
-      "enum": [
-        "FAILED",
-        "SUCCEEDED",
-        "OUTDATED"
-      ]
     },
     "S2w": {
       "type": "structure",
       "members": {
-        "ConfigurationAggregatorName": {
-          "shape": "Sr"
-        },
-        "ConfigurationAggregatorArn": {
-          "type": "string",
-          "pattern": "arn:aws[a-z\\-]*:config:[a-z\\-\\d]+:\\d+:config-aggregator/config-aggregator-[a-z\\d]+"
-        },
+        "ConfigurationAggregatorName": {},
+        "ConfigurationAggregatorArn": {},
         "AccountAggregationSources": {
           "shape": "S2y"
         },
@@ -1711,10 +1271,7 @@
         "members": {
           "AccountIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa"
-            },
-            "min": 1
+            "member": {}
           },
           "AllAwsRegions": {
             "type": "boolean"
@@ -1723,14 +1280,11 @@
             "shape": "S31"
           }
         }
-      },
-      "max": 1,
-      "min": 0
+      }
     },
     "S31": {
       "type": "list",
-      "member": {},
-      "min": 1
+      "member": {}
     },
     "S32": {
       "type": "structure",
@@ -1749,16 +1303,12 @@
     },
     "S34": {
       "type": "list",
-      "member": {
-        "shape": "St"
-      }
+      "member": {}
     },
     "S3c": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "St"
-        },
+        "name": {},
         "roleARN": {},
         "recordingGroup": {
           "type": "structure",
@@ -1771,9 +1321,7 @@
             },
             "resourceTypes": {
               "type": "list",
-              "member": {
-                "shape": "S4"
-              }
+              "member": {}
             }
           }
         }
@@ -1781,16 +1329,12 @@
     },
     "S3i": {
       "type": "list",
-      "member": {
-        "shape": "Sv"
-      }
+      "member": {}
     },
     "S3m": {
       "type": "structure",
       "members": {
-        "lastStatus": {
-          "shape": "S3n"
-        },
+        "lastStatus": {},
         "lastErrorCode": {},
         "lastErrorMessage": {},
         "lastAttemptTime": {
@@ -1804,29 +1348,17 @@
         }
       }
     },
-    "S3n": {
-      "type": "string",
-      "enum": [
-        "Success",
-        "Failure",
-        "Not_Applicable"
-      ]
-    },
     "S3s": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "Sv"
-        },
+        "name": {},
         "s3BucketName": {},
         "s3KeyPrefix": {},
         "snsTopicARN": {},
         "configSnapshotDeliveryProperties": {
           "type": "structure",
           "members": {
-            "deliveryFrequency": {
-              "shape": "S2i"
-            }
+            "deliveryFrequency": {}
           }
         }
       }
@@ -1838,18 +1370,11 @@
         "RetentionPeriodInDays"
       ],
       "members": {
-        "Name": {
-          "shape": "S10"
-        },
+        "Name": {},
         "RetentionPeriodInDays": {
-          "shape": "S44"
+          "type": "integer"
         }
       }
-    },
-    "S44": {
-      "type": "integer",
-      "max": 2557,
-      "min": 30
     },
     "S49": {
       "type": "structure",
@@ -1857,15 +1382,9 @@
         "EvaluationResultQualifier": {
           "type": "structure",
           "members": {
-            "ConfigRuleName": {
-              "shape": "Sp"
-            },
-            "ResourceType": {
-              "shape": "S1u"
-            },
-            "ResourceId": {
-              "shape": "S1v"
-            }
+            "ConfigRuleName": {},
+            "ResourceType": {},
+            "ResourceId": {}
           }
         },
         "OrderingTimestamp": {
@@ -1895,29 +1414,21 @@
           "EvaluationResultIdentifier": {
             "shape": "S49"
           },
-          "ComplianceType": {
-            "shape": "S17"
-          },
+          "ComplianceType": {},
           "ResultRecordedTime": {
             "type": "timestamp"
           },
           "ConfigRuleInvokedTime": {
             "type": "timestamp"
           },
-          "Annotation": {
-            "shape": "S1u"
-          },
+          "Annotation": {},
           "ResultToken": {}
         }
       }
     },
     "S4q": {
       "type": "list",
-      "member": {
-        "shape": "S1u"
-      },
-      "max": 20,
-      "min": 0
+      "member": {}
     },
     "S5t": {
       "type": "list",
@@ -1930,25 +1441,15 @@
           "OrderingTimestamp"
         ],
         "members": {
-          "ComplianceResourceType": {
-            "shape": "S1u"
-          },
-          "ComplianceResourceId": {
-            "shape": "S1v"
-          },
-          "ComplianceType": {
-            "shape": "S17"
-          },
-          "Annotation": {
-            "shape": "S1u"
-          },
+          "ComplianceResourceType": {},
+          "ComplianceResourceId": {},
+          "ComplianceType": {},
+          "Annotation": {},
           "OrderingTimestamp": {
             "type": "timestamp"
           }
         }
-      },
-      "max": 100,
-      "min": 0
+      }
     }
   }
 }

--- a/apis/connect-2017-08-08.min.json
+++ b/apis/connect-2017-08-08.min.json
@@ -28,13 +28,8 @@
           "InstanceId"
         ],
         "members": {
-          "Username": {
-            "shape": "S2"
-          },
-          "Password": {
-            "type": "string",
-            "pattern": "/^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[a-zA-Z\\d\\S]{8,64}$/"
-          },
+          "Username": {},
+          "Password": {},
           "IdentityInfo": {
             "shape": "S4"
           },
@@ -48,7 +43,6 @@
           "RoutingProfileId": {},
           "HierarchyGroupId": {},
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -75,7 +69,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -103,7 +96,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -117,9 +109,7 @@
             "members": {
               "Id": {},
               "Arn": {},
-              "Username": {
-                "shape": "S2"
-              },
+              "Username": {},
               "IdentityInfo": {
                 "shape": "S4"
               },
@@ -154,7 +144,6 @@
             "locationName": "HierarchyGroupId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -207,7 +196,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -252,7 +240,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -270,7 +257,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S1f"
+            "type": "integer"
           }
         }
       },
@@ -321,7 +308,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -365,7 +351,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -389,7 +374,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S1f"
+            "type": "integer"
           }
         }
       },
@@ -437,7 +422,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -446,9 +430,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
-            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -462,11 +446,7 @@
               "members": {
                 "Id": {},
                 "Arn": {},
-                "Name": {
-                  "type": "string",
-                  "max": 100,
-                  "min": 1
-                }
+                "Name": {}
               }
             }
           },
@@ -486,7 +466,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -495,9 +474,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
-            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -531,7 +510,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -540,9 +518,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
-            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -571,7 +549,6 @@
         ],
         "members": {
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           },
@@ -580,9 +557,9 @@
             "locationName": "nextToken"
           },
           "MaxResults": {
-            "shape": "S27",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -596,9 +573,7 @@
               "members": {
                 "Id": {},
                 "Arn": {},
-                "Username": {
-                  "shape": "S2"
-                }
+                "Username": {}
               }
             }
           },
@@ -620,17 +595,10 @@
         ],
         "members": {
           "DestinationPhoneNumber": {},
-          "ContactFlowId": {
-            "type": "string",
-            "max": 500
-          },
-          "InstanceId": {
-            "shape": "Si"
-          },
+          "ContactFlowId": {},
+          "InstanceId": {},
           "ClientToken": {
-            "idempotencyToken": true,
-            "type": "string",
-            "max": 500
+            "idempotencyToken": true
           },
           "SourcePhoneNumber": {},
           "QueueId": {},
@@ -642,9 +610,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContactId": {
-            "shape": "S2v"
-          }
+          "ContactId": {}
         }
       }
     },
@@ -659,12 +625,8 @@
           "InstanceId"
         ],
         "members": {
-          "ContactId": {
-            "shape": "S2v"
-          },
-          "InstanceId": {
-            "shape": "Si"
-          }
+          "ContactId": {},
+          "InstanceId": {}
         }
       },
       "output": {
@@ -684,12 +646,8 @@
           "Attributes"
         ],
         "members": {
-          "InitialContactId": {
-            "shape": "S2v"
-          },
-          "InstanceId": {
-            "shape": "Si"
-          },
+          "InitialContactId": {},
+          "InstanceId": {},
           "Attributes": {
             "shape": "S2r"
           }
@@ -717,7 +675,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -744,7 +701,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -771,7 +727,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -796,7 +751,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -823,7 +777,6 @@
             "locationName": "UserId"
           },
           "InstanceId": {
-            "shape": "Si",
             "location": "uri",
             "locationName": "InstanceId"
           }
@@ -832,25 +785,11 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 20,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\_\\-\\.]+"
-    },
     "S4": {
       "type": "structure",
       "members": {
-        "FirstName": {
-          "type": "string",
-          "max": 100,
-          "min": 1
-        },
-        "LastName": {
-          "type": "string",
-          "max": 100,
-          "min": 1
-        },
+        "FirstName": {},
+        "LastName": {},
         "Email": {}
       }
     },
@@ -860,33 +799,19 @@
         "PhoneType"
       ],
       "members": {
-        "PhoneType": {
-          "type": "string",
-          "enum": [
-            "SOFT_PHONE",
-            "DESK_PHONE"
-          ]
-        },
+        "PhoneType": {},
         "AutoAccept": {
           "type": "boolean"
         },
         "AfterContactWorkTimeLimit": {
-          "type": "integer",
-          "min": 0
+          "type": "integer"
         },
         "DeskPhoneNumber": {}
       }
     },
     "Se": {
       "type": "list",
-      "member": {},
-      "max": 10,
-      "min": 1
-    },
-    "Si": {
-      "type": "string",
-      "max": 100,
-      "min": 1
+      "member": {}
     },
     "Sw": {
       "type": "structure",
@@ -909,71 +834,24 @@
       "members": {
         "Queues": {
           "type": "list",
-          "member": {},
-          "max": 100,
-          "min": 1
+          "member": {}
         },
         "Channels": {
           "type": "list",
-          "member": {
-            "shape": "S17"
-          },
-          "max": 1
+          "member": {}
         }
       }
     },
-    "S17": {
-      "type": "string",
-      "enum": [
-        "VOICE"
-      ]
-    },
     "S18": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "QUEUE",
-          "CHANNEL"
-        ]
-      },
-      "max": 2
+      "member": {}
     },
     "S1b": {
       "type": "structure",
       "members": {
-        "Name": {
-          "type": "string",
-          "enum": [
-            "AGENTS_ONLINE",
-            "AGENTS_AVAILABLE",
-            "AGENTS_ON_CALL",
-            "AGENTS_NON_PRODUCTIVE",
-            "AGENTS_AFTER_CONTACT_WORK",
-            "AGENTS_ERROR",
-            "AGENTS_STAFFED",
-            "CONTACTS_IN_QUEUE",
-            "OLDEST_CONTACT_AGE",
-            "CONTACTS_SCHEDULED"
-          ]
-        },
-        "Unit": {
-          "shape": "S1d"
-        }
+        "Name": {},
+        "Unit": {}
       }
-    },
-    "S1d": {
-      "type": "string",
-      "enum": [
-        "SECONDS",
-        "COUNT",
-        "PERCENT"
-      ]
-    },
-    "S1f": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     },
     "S1j": {
       "type": "structure",
@@ -985,9 +863,7 @@
             "Arn": {}
           }
         },
-        "Channel": {
-          "shape": "S17"
-        }
+        "Channel": {}
       }
     },
     "S1s": {
@@ -997,85 +873,24 @@
     "S1v": {
       "type": "structure",
       "members": {
-        "Name": {
-          "type": "string",
-          "enum": [
-            "CONTACTS_QUEUED",
-            "CONTACTS_HANDLED",
-            "CONTACTS_ABANDONED",
-            "CONTACTS_CONSULTED",
-            "CONTACTS_AGENT_HUNG_UP_FIRST",
-            "CONTACTS_HANDLED_INCOMING",
-            "CONTACTS_HANDLED_OUTBOUND",
-            "CONTACTS_HOLD_ABANDONS",
-            "CONTACTS_TRANSFERRED_IN",
-            "CONTACTS_TRANSFERRED_OUT",
-            "CONTACTS_TRANSFERRED_IN_FROM_QUEUE",
-            "CONTACTS_TRANSFERRED_OUT_FROM_QUEUE",
-            "CONTACTS_MISSED",
-            "CALLBACK_CONTACTS_HANDLED",
-            "API_CONTACTS_HANDLED",
-            "OCCUPANCY",
-            "HANDLE_TIME",
-            "AFTER_CONTACT_WORK_TIME",
-            "QUEUED_TIME",
-            "ABANDON_TIME",
-            "QUEUE_ANSWER_TIME",
-            "HOLD_TIME",
-            "INTERACTION_TIME",
-            "INTERACTION_AND_HOLD_TIME",
-            "SERVICE_LEVEL"
-          ]
-        },
+        "Name": {},
         "Threshold": {
           "type": "structure",
           "members": {
-            "Comparison": {
-              "type": "string",
-              "enum": [
-                "LT"
-              ]
-            },
+            "Comparison": {},
             "ThresholdValue": {
               "type": "double"
             }
           }
         },
-        "Statistic": {
-          "type": "string",
-          "enum": [
-            "SUM",
-            "MAX",
-            "AVG"
-          ]
-        },
-        "Unit": {
-          "shape": "S1d"
-        }
+        "Statistic": {},
+        "Unit": {}
       }
-    },
-    "S27": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
     },
     "S2r": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 32767,
-        "min": 1
-      },
-      "value": {
-        "type": "string",
-        "max": 32767,
-        "min": 0
-      }
-    },
-    "S2v": {
-      "type": "string",
-      "max": 256,
-      "min": 1
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/cur-2017-01-06.min.json
+++ b/apis/cur-2017-01-06.min.json
@@ -17,9 +17,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "ReportName": {
-            "shape": "S2"
-          }
+          "ReportName": {}
         }
       },
       "output": {
@@ -34,9 +32,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer",
-            "max": 5,
-            "min": 5
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -73,11 +69,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 256,
-      "pattern": "[0-9A-Za-z!\\-_.*\\'()]+"
-    },
     "Sa": {
       "type": "structure",
       "required": [
@@ -91,69 +82,20 @@
         "S3Region"
       ],
       "members": {
-        "ReportName": {
-          "shape": "S2"
-        },
-        "TimeUnit": {
-          "type": "string",
-          "enum": [
-            "HOURLY",
-            "DAILY"
-          ]
-        },
-        "Format": {
-          "type": "string",
-          "enum": [
-            "textORcsv"
-          ]
-        },
-        "Compression": {
-          "type": "string",
-          "enum": [
-            "ZIP",
-            "GZIP"
-          ]
-        },
+        "ReportName": {},
+        "TimeUnit": {},
+        "Format": {},
+        "Compression": {},
         "AdditionalSchemaElements": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "RESOURCES"
-            ]
-          }
+          "member": {}
         },
-        "S3Bucket": {
-          "type": "string",
-          "max": 256
-        },
-        "S3Prefix": {
-          "type": "string",
-          "max": 256,
-          "pattern": "[0-9A-Za-z!\\-_.*\\'()/]*"
-        },
-        "S3Region": {
-          "type": "string",
-          "enum": [
-            "us-east-1",
-            "us-west-1",
-            "us-west-2",
-            "eu-central-1",
-            "eu-west-1",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ap-northeast-1"
-          ]
-        },
+        "S3Bucket": {},
+        "S3Prefix": {},
+        "S3Region": {},
         "AdditionalArtifacts": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "REDSHIFT",
-              "QUICKSIGHT"
-            ]
-          }
+          "member": {}
         }
       }
     }

--- a/apis/datapipeline-2012-10-29.min.json
+++ b/apis/datapipeline-2012-10-29.min.json
@@ -19,9 +19,7 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "parameterValues": {
             "shape": "S3"
           },
@@ -43,9 +41,7 @@
           "tags"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "tags": {
             "shape": "Sa"
           }
@@ -64,15 +60,9 @@
           "uniqueId"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "uniqueId": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "Sg"
-          },
+          "name": {},
+          "uniqueId": {},
+          "description": {},
           "tags": {
             "shape": "Sa"
           }
@@ -84,9 +74,7 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          }
+          "pipelineId": {}
         }
       }
     },
@@ -97,9 +85,7 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "cancelActive": {
             "type": "boolean"
           }
@@ -117,9 +103,7 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          }
+          "pipelineId": {}
         }
       }
     },
@@ -131,18 +115,14 @@
           "objectIds"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "objectIds": {
             "shape": "Sn"
           },
           "evaluateExpressions": {
             "type": "boolean"
           },
-          "marker": {
-            "shape": "Sg"
-          }
+          "marker": {}
         }
       },
       "output": {
@@ -154,9 +134,7 @@
           "pipelineObjects": {
             "shape": "Sq"
           },
-          "marker": {
-            "shape": "Sg"
-          },
+          "marker": {},
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -191,18 +169,12 @@
                 "fields"
               ],
               "members": {
-                "pipelineId": {
-                  "shape": "S2"
-                },
-                "name": {
-                  "shape": "S2"
-                },
+                "pipelineId": {},
+                "name": {},
                 "fields": {
                   "shape": "Ss"
                 },
-                "description": {
-                  "shape": "Sg"
-                },
+                "description": {},
                 "tags": {
                   "shape": "Sa"
                 }
@@ -221,15 +193,9 @@
           "expression"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
-          "objectId": {
-            "shape": "S2"
-          },
-          "expression": {
-            "shape": "Sz"
-          }
+          "pipelineId": {},
+          "objectId": {},
+          "expression": {}
         }
       },
       "output": {
@@ -238,9 +204,7 @@
           "evaluatedExpression"
         ],
         "members": {
-          "evaluatedExpression": {
-            "shape": "Sz"
-          }
+          "evaluatedExpression": {}
         }
       }
     },
@@ -251,12 +215,8 @@
           "pipelineId"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
-          "version": {
-            "shape": "Sg"
-          }
+          "pipelineId": {},
+          "version": {}
         }
       },
       "output": {
@@ -278,9 +238,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "marker": {
-            "shape": "Sg"
-          }
+          "marker": {}
         }
       },
       "output": {
@@ -294,18 +252,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {
-                  "shape": "S2"
-                },
-                "name": {
-                  "shape": "S2"
-                }
+                "id": {},
+                "name": {}
               }
             }
           },
-          "marker": {
-            "shape": "Sg"
-          },
+          "marker": {},
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -319,21 +271,13 @@
           "workerGroup"
         ],
         "members": {
-          "workerGroup": {
-            "shape": "Sg"
-          },
-          "hostname": {
-            "shape": "S2"
-          },
+          "workerGroup": {},
+          "hostname": {},
           "instanceIdentity": {
             "type": "structure",
             "members": {
-              "document": {
-                "shape": "Sg"
-              },
-              "signature": {
-                "shape": "Sg"
-              }
+              "document": {},
+              "signature": {}
             }
           }
         }
@@ -344,20 +288,12 @@
           "taskObject": {
             "type": "structure",
             "members": {
-              "taskId": {
-                "shape": "S1h"
-              },
-              "pipelineId": {
-                "shape": "S2"
-              },
-              "attemptId": {
-                "shape": "S2"
-              },
+              "taskId": {},
+              "pipelineId": {},
+              "attemptId": {},
               "objects": {
                 "type": "map",
-                "key": {
-                  "shape": "S2"
-                },
+                "key": {},
                 "value": {
                   "shape": "Sr"
                 }
@@ -375,9 +311,7 @@
           "pipelineObjects"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "pipelineObjects": {
             "shape": "Sq"
           },
@@ -415,9 +349,7 @@
           "sphere"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "query": {
             "type": "structure",
             "members": {
@@ -426,22 +358,11 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "fieldName": {
-                      "shape": "Sg"
-                    },
+                    "fieldName": {},
                     "operator": {
                       "type": "structure",
                       "members": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "EQ",
-                            "REF_EQ",
-                            "LE",
-                            "GE",
-                            "BETWEEN"
-                          ]
-                        },
+                        "type": {},
                         "values": {
                           "shape": "S1x"
                         }
@@ -452,12 +373,8 @@
               }
             }
           },
-          "sphere": {
-            "shape": "Sg"
-          },
-          "marker": {
-            "shape": "Sg"
-          },
+          "sphere": {},
+          "marker": {},
           "limit": {
             "type": "integer"
           }
@@ -469,9 +386,7 @@
           "ids": {
             "shape": "Sn"
           },
-          "marker": {
-            "shape": "Sg"
-          },
+          "marker": {},
           "hasMoreResults": {
             "type": "boolean"
           }
@@ -486,9 +401,7 @@
           "tagKeys"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "tagKeys": {
             "shape": "S1x"
           }
@@ -506,9 +419,7 @@
           "taskId"
         ],
         "members": {
-          "taskId": {
-            "shape": "S1h"
-          },
+          "taskId": {},
           "fields": {
             "shape": "Ss"
           }
@@ -533,15 +444,9 @@
           "taskrunnerId"
         ],
         "members": {
-          "taskrunnerId": {
-            "shape": "S2"
-          },
-          "workerGroup": {
-            "shape": "Sg"
-          },
-          "hostname": {
-            "shape": "S2"
-          }
+          "taskrunnerId": {},
+          "workerGroup": {},
+          "hostname": {}
         }
       },
       "output": {
@@ -565,15 +470,11 @@
           "status"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "objectIds": {
             "shape": "Sn"
           },
-          "status": {
-            "shape": "Sg"
-          }
+          "status": {}
         }
       }
     },
@@ -585,24 +486,11 @@
           "taskStatus"
         ],
         "members": {
-          "taskId": {
-            "shape": "S1h"
-          },
-          "taskStatus": {
-            "type": "string",
-            "enum": [
-              "FINISHED",
-              "FAILED",
-              "FALSE"
-            ]
-          },
-          "errorId": {
-            "shape": "Sg"
-          },
+          "taskId": {},
+          "taskStatus": {},
+          "errorId": {},
           "errorMessage": {},
-          "errorStackTrace": {
-            "shape": "Sg"
-          }
+          "errorStackTrace": {}
         }
       },
       "output": {
@@ -618,9 +506,7 @@
           "pipelineObjects"
         ],
         "members": {
-          "pipelineId": {
-            "shape": "S2"
-          },
+          "pipelineId": {},
           "pipelineObjects": {
             "shape": "Sq"
           },
@@ -652,12 +538,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 1,
-      "max": 1024,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S3": {
       "type": "list",
       "member": {
@@ -667,26 +547,10 @@
           "stringValue"
         ],
         "members": {
-          "id": {
-            "shape": "S5"
-          },
-          "stringValue": {
-            "shape": "S6"
-          }
+          "id": {},
+          "stringValue": {}
         }
       }
-    },
-    "S5": {
-      "type": "string",
-      "min": 1,
-      "max": 256,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S6": {
-      "type": "string",
-      "min": 0,
-      "max": 10240,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "Sa": {
       "type": "list",
@@ -697,32 +561,14 @@
           "value"
         ],
         "members": {
-          "key": {
-            "type": "string",
-            "min": 1,
-            "max": 128
-          },
-          "value": {
-            "type": "string",
-            "min": 0,
-            "max": 256
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "min": 0,
-      "max": 10
-    },
-    "Sg": {
-      "type": "string",
-      "min": 0,
-      "max": 1024,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
+      }
     },
     "Sn": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "Sq": {
       "type": "list",
@@ -738,12 +584,8 @@
         "fields"
       ],
       "members": {
-        "id": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S2"
-        },
+        "id": {},
+        "name": {},
         "fields": {
           "shape": "Ss"
         }
@@ -757,23 +599,11 @@
           "key"
         ],
         "members": {
-          "key": {
-            "shape": "S5"
-          },
-          "stringValue": {
-            "shape": "S6"
-          },
-          "refValue": {
-            "shape": "S5"
-          }
+          "key": {},
+          "stringValue": {},
+          "refValue": {}
         }
       }
-    },
-    "Sz": {
-      "type": "string",
-      "min": 0,
-      "max": 20971520,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S13": {
       "type": "list",
@@ -784,9 +614,7 @@
           "attributes"
         ],
         "members": {
-          "id": {
-            "shape": "S5"
-          },
+          "id": {},
           "attributes": {
             "type": "list",
             "member": {
@@ -796,38 +624,20 @@
                 "stringValue"
               ],
               "members": {
-                "key": {
-                  "type": "string",
-                  "min": 1,
-                  "max": 256,
-                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-                },
-                "stringValue": {
-                  "type": "string",
-                  "min": 0,
-                  "max": 10240,
-                  "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-                }
+                "key": {},
+                "stringValue": {}
               }
             }
           }
         }
       }
     },
-    "S1h": {
-      "type": "string",
-      "min": 1,
-      "max": 2048,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S1l": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "errors": {
             "shape": "S1n"
           }
@@ -836,21 +646,14 @@
     },
     "S1n": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "min": 0,
-        "max": 10000,
-        "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-      }
+      "member": {}
     },
     "S1p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "id": {
-            "shape": "S2"
-          },
+          "id": {},
           "warnings": {
             "shape": "S1n"
           }
@@ -859,9 +662,7 @@
     },
     "S1x": {
       "type": "list",
-      "member": {
-        "shape": "Sg"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/dax-2017-04-19.min.json
+++ b/apis/dax-2017-04-19.min.json
@@ -243,9 +243,7 @@
         "type": "structure",
         "members": {
           "SourceName": {},
-          "SourceType": {
-            "shape": "S1j"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -271,9 +269,7 @@
               "type": "structure",
               "members": {
                 "SourceName": {},
-                "SourceType": {
-                  "shape": "S1j"
-                },
+                "SourceType": {},
                 "Message": {},
                 "Date": {
                   "type": "timestamp"
@@ -649,15 +645,7 @@
         "SSEDescription": {
           "type": "structure",
           "members": {
-            "Status": {
-              "type": "string",
-              "enum": [
-                "ENABLING",
-                "ENABLED",
-                "DISABLING",
-                "DISABLED"
-              ]
-            }
+            "Status": {}
           }
         }
       }
@@ -710,13 +698,7 @@
         "type": "structure",
         "members": {
           "ParameterName": {},
-          "ParameterType": {
-            "type": "string",
-            "enum": [
-              "DEFAULT",
-              "NODE_TYPE_SPECIFIC"
-            ]
-          },
+          "ParameterType": {},
           "ParameterValue": {},
           "NodeTypeSpecificValues": {
             "type": "list",
@@ -732,31 +714,10 @@
           "Source": {},
           "DataType": {},
           "AllowedValues": {},
-          "IsModifiable": {
-            "type": "string",
-            "enum": [
-              "TRUE",
-              "FALSE",
-              "CONDITIONAL"
-            ]
-          },
-          "ChangeType": {
-            "type": "string",
-            "enum": [
-              "IMMEDIATE",
-              "REQUIRES_REBOOT"
-            ]
-          }
+          "IsModifiable": {},
+          "ChangeType": {}
         }
       }
-    },
-    "S1j": {
-      "type": "string",
-      "enum": [
-        "CLUSTER",
-        "PARAMETER_GROUP",
-        "SUBNET_GROUP"
-      ]
     }
   }
 }

--- a/apis/devicefarm-2015-06-23.min.json
+++ b/apis/devicefarm-2015-06-23.min.json
@@ -21,15 +21,9 @@
           "rules"
         ],
         "members": {
-          "projectArn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
+          "projectArn": {},
+          "name": {},
+          "description": {},
           "rules": {
             "shape": "S5"
           }
@@ -51,12 +45,8 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
+          "name": {},
+          "description": {},
           "packageCleanup": {
             "type": "boolean"
           },
@@ -85,18 +75,10 @@
           "name"
         ],
         "members": {
-          "projectArn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
-          "type": {
-            "shape": "Sj"
-          },
+          "projectArn": {},
+          "name": {},
+          "description": {},
+          "type": {},
           "uplinkBandwidthBits": {
             "type": "long"
           },
@@ -116,10 +98,10 @@
             "type": "long"
           },
           "uplinkLossPercent": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "downlinkLossPercent": {
-            "shape": "Sl"
+            "type": "integer"
           }
         }
       },
@@ -139,9 +121,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S3"
-          },
+          "name": {},
           "defaultJobTimeoutMinutes": {
             "type": "integer"
           }
@@ -164,49 +144,29 @@
           "deviceArn"
         ],
         "members": {
-          "projectArn": {
-            "shape": "S2"
-          },
-          "deviceArn": {
-            "shape": "S2"
-          },
-          "instanceArn": {
-            "shape": "S2"
-          },
-          "sshPublicKey": {
-            "type": "string",
-            "max": 8192,
-            "min": 0
-          },
+          "projectArn": {},
+          "deviceArn": {},
+          "instanceArn": {},
+          "sshPublicKey": {},
           "remoteDebugEnabled": {
             "type": "boolean"
           },
           "remoteRecordEnabled": {
             "type": "boolean"
           },
-          "remoteRecordAppArn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "clientId": {
-            "shape": "Sv"
-          },
+          "remoteRecordAppArn": {},
+          "name": {},
+          "clientId": {},
           "configuration": {
             "type": "structure",
             "members": {
-              "billingMethod": {
-                "shape": "Sx"
-              },
+              "billingMethod": {},
               "vpceConfigurationArns": {
                 "shape": "Sy"
               }
             }
           },
-          "interactionMode": {
-            "shape": "Sz"
-          },
+          "interactionMode": {},
           "skipAppResign": {
             "type": "boolean"
           }
@@ -230,18 +190,10 @@
           "type"
         ],
         "members": {
-          "projectArn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "type": {
-            "shape": "S1j"
-          },
-          "contentType": {
-            "shape": "S1k"
-          }
+          "projectArn": {},
+          "name": {},
+          "type": {},
+          "contentType": {}
         }
       },
       "output": {
@@ -262,18 +214,10 @@
           "serviceDnsName"
         ],
         "members": {
-          "vpceConfigurationName": {
-            "shape": "S1s"
-          },
-          "vpceServiceName": {
-            "shape": "S1t"
-          },
-          "serviceDnsName": {
-            "shape": "S1u"
-          },
-          "vpceConfigurationDescription": {
-            "shape": "S1v"
-          }
+          "vpceConfigurationName": {},
+          "vpceServiceName": {},
+          "serviceDnsName": {},
+          "vpceConfigurationDescription": {}
         }
       },
       "output": {
@@ -292,9 +236,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -309,9 +251,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -326,9 +266,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -343,9 +281,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -360,9 +296,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -377,9 +311,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -394,9 +326,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -411,9 +341,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -432,11 +360,7 @@
           "accountSettings": {
             "type": "structure",
             "members": {
-              "awsAccountNumber": {
-                "type": "string",
-                "max": 16,
-                "min": 2
-              },
+              "awsAccountNumber": {},
               "unmeteredDevices": {
                 "shape": "S2i"
               },
@@ -482,9 +406,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -503,9 +425,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -524,9 +444,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -545,15 +463,9 @@
           "devicePoolArn"
         ],
         "members": {
-          "devicePoolArn": {
-            "shape": "S2"
-          },
-          "appArn": {
-            "shape": "S2"
-          },
-          "testType": {
-            "shape": "S2s"
-          },
+          "devicePoolArn": {},
+          "appArn": {},
+          "testType": {},
           "test": {
             "shape": "S2t"
           },
@@ -581,9 +493,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -602,9 +512,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -623,9 +531,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -641,9 +547,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -655,9 +559,7 @@
           "nextPeriod": {
             "shape": "S3k"
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -668,9 +570,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -689,9 +589,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -710,9 +608,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -731,9 +627,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -752,9 +646,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -773,9 +665,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -794,9 +684,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -816,12 +704,8 @@
           "appArn"
         ],
         "members": {
-          "remoteAccessSessionArn": {
-            "shape": "S2"
-          },
-          "appArn": {
-            "shape": "S2"
-          }
+          "remoteAccessSessionArn": {},
+          "appArn": {}
         }
       },
       "output": {
@@ -841,20 +725,9 @@
           "type"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "SCREENSHOT",
-              "FILE",
-              "LOG"
-            ]
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "type": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -865,55 +738,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "arn": {
-                  "shape": "S2"
-                },
-                "name": {
-                  "shape": "S3"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "UNKNOWN",
-                    "SCREENSHOT",
-                    "DEVICE_LOG",
-                    "MESSAGE_LOG",
-                    "VIDEO_LOG",
-                    "RESULT_LOG",
-                    "SERVICE_LOG",
-                    "WEBKIT_LOG",
-                    "INSTRUMENTATION_OUTPUT",
-                    "EXERCISER_MONKEY_OUTPUT",
-                    "CALABASH_JSON_OUTPUT",
-                    "CALABASH_PRETTY_OUTPUT",
-                    "CALABASH_STANDARD_OUTPUT",
-                    "CALABASH_JAVA_XML_OUTPUT",
-                    "AUTOMATION_OUTPUT",
-                    "APPIUM_SERVER_OUTPUT",
-                    "APPIUM_JAVA_OUTPUT",
-                    "APPIUM_JAVA_XML_OUTPUT",
-                    "APPIUM_PYTHON_OUTPUT",
-                    "APPIUM_PYTHON_XML_OUTPUT",
-                    "EXPLORER_EVENT_LOG",
-                    "EXPLORER_SUMMARY_LOG",
-                    "APPLICATION_CRASH_REPORT",
-                    "XCTEST_LOG",
-                    "VIDEO",
-                    "CUSTOMER_ARTIFACT",
-                    "CUSTOMER_ARTIFACT_LOG",
-                    "TESTSPEC_OUTPUT"
-                  ]
-                },
+                "arn": {},
+                "name": {},
+                "type": {},
                 "extension": {},
-                "url": {
-                  "shape": "S1o"
-                }
+                "url": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -924,9 +757,7 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -935,9 +766,7 @@
           "deviceInstances": {
             "shape": "S1b"
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -948,15 +777,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "type": {
-            "shape": "Sc"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "type": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -968,9 +791,7 @@
               "shape": "Sb"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -978,12 +799,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -995,9 +812,7 @@
               "shape": "S14"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1008,9 +823,7 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -1022,9 +835,7 @@
               "shape": "Sh"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1035,12 +846,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1052,9 +859,7 @@
               "shape": "S3c"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1065,15 +870,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "type": {
-            "shape": "Sj"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "type": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1085,9 +884,7 @@
               "shape": "Sn"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1095,9 +892,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -1108,18 +903,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "id": {
-                  "shape": "S56"
-                },
-                "description": {
-                  "shape": "S4"
-                }
+                "id": {},
+                "description": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1127,9 +916,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -1141,9 +928,7 @@
               "shape": "S5a"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1151,9 +936,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -1165,9 +948,7 @@
               "shape": "S3o"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1175,12 +956,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1192,9 +969,7 @@
               "shape": "Sr"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1205,12 +980,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1222,9 +993,7 @@
               "shape": "S11"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1235,12 +1004,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1252,9 +1017,7 @@
               "shape": "S41"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1265,12 +1028,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1281,40 +1040,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "arn": {
-                  "shape": "S2"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "CPU",
-                    "MEMORY",
-                    "THREADS",
-                    "RX_RATE",
-                    "TX_RATE",
-                    "RX",
-                    "TX",
-                    "NATIVE_FRAMES",
-                    "NATIVE_FPS",
-                    "NATIVE_MIN_DRAWTIME",
-                    "NATIVE_AVG_DRAWTIME",
-                    "NATIVE_MAX_DRAWTIME",
-                    "OPENGL_FRAMES",
-                    "OPENGL_FPS",
-                    "OPENGL_MIN_DRAWTIME",
-                    "OPENGL_AVG_DRAWTIME",
-                    "OPENGL_MAX_DRAWTIME"
-                  ]
-                },
-                "url": {
-                  "shape": "S1o"
-                }
+                "arn": {},
+                "type": {},
+                "url": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1325,12 +1057,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1342,9 +1070,7 @@
               "shape": "S45"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1355,12 +1081,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1372,9 +1094,7 @@
               "shape": "S48"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1385,12 +1105,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1398,17 +1114,13 @@
         "members": {
           "uniqueProblems": {
             "type": "map",
-            "key": {
-              "shape": "S13"
-            },
+            "key": {},
             "value": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "message": {
-                    "shape": "S4"
-                  },
+                  "message": {},
                   "problems": {
                     "type": "list",
                     "member": {
@@ -1429,12 +1141,8 @@
                         "device": {
                           "shape": "S14"
                         },
-                        "result": {
-                          "shape": "S13"
-                        },
-                        "message": {
-                          "shape": "S4"
-                        }
+                        "result": {},
+                        "message": {}
                       }
                     }
                   }
@@ -1442,9 +1150,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1455,15 +1161,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "type": {
-            "shape": "S1j"
-          },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "arn": {},
+          "type": {},
+          "nextToken": {}
         }
       },
       "output": {
@@ -1475,9 +1175,7 @@
               "shape": "S1m"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1488,9 +1186,7 @@
           "maxResults": {
             "type": "integer"
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -1502,9 +1198,7 @@
               "shape": "S1x"
             }
           },
-          "nextToken": {
-            "shape": "S3i"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1512,15 +1206,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "offeringId": {
-            "shape": "S3l"
-          },
+          "offeringId": {},
           "quantity": {
             "type": "integer"
           },
-          "offeringPromotionId": {
-            "shape": "S56"
-          }
+          "offeringPromotionId": {}
         }
       },
       "output": {
@@ -1536,9 +1226,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "offeringId": {
-            "shape": "S3l"
-          },
+          "offeringId": {},
           "quantity": {
             "type": "integer"
           }
@@ -1562,18 +1250,10 @@
           "test"
         ],
         "members": {
-          "projectArn": {
-            "shape": "S2"
-          },
-          "appArn": {
-            "shape": "S2"
-          },
-          "devicePoolArn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
+          "projectArn": {},
+          "appArn": {},
+          "devicePoolArn": {},
+          "name": {},
           "test": {
             "shape": "S2t"
           },
@@ -1618,9 +1298,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -1639,9 +1317,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -1660,9 +1336,7 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          }
+          "arn": {}
         }
       },
       "output": {
@@ -1681,12 +1355,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "profileArn": {
-            "shape": "S2"
-          },
+          "arn": {},
+          "profileArn": {},
           "labels": {
             "shape": "S1d"
           }
@@ -1708,15 +1378,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
+          "arn": {},
+          "name": {},
+          "description": {},
           "rules": {
             "shape": "S5"
           }
@@ -1738,15 +1402,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
+          "arn": {},
+          "name": {},
+          "description": {},
           "packageCleanup": {
             "type": "boolean"
           },
@@ -1774,18 +1432,10 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "description": {
-            "shape": "S4"
-          },
-          "type": {
-            "shape": "Sj"
-          },
+          "arn": {},
+          "name": {},
+          "description": {},
+          "type": {},
           "uplinkBandwidthBits": {
             "type": "long"
           },
@@ -1805,10 +1455,10 @@
             "type": "long"
           },
           "uplinkLossPercent": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "downlinkLossPercent": {
-            "shape": "Sl"
+            "type": "integer"
           }
         }
       },
@@ -1828,12 +1478,8 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
+          "arn": {},
+          "name": {},
           "defaultJobTimeoutMinutes": {
             "type": "integer"
           }
@@ -1855,15 +1501,9 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S3"
-          },
-          "contentType": {
-            "shape": "S1k"
-          },
+          "arn": {},
+          "name": {},
+          "contentType": {},
           "editContent": {
             "type": "boolean"
           }
@@ -1885,21 +1525,11 @@
           "arn"
         ],
         "members": {
-          "arn": {
-            "shape": "S2"
-          },
-          "vpceConfigurationName": {
-            "shape": "S1s"
-          },
-          "vpceServiceName": {
-            "shape": "S1t"
-          },
-          "serviceDnsName": {
-            "shape": "S1u"
-          },
-          "vpceConfigurationDescription": {
-            "shape": "S1v"
-          }
+          "arn": {},
+          "vpceConfigurationName": {},
+          "vpceServiceName": {},
+          "serviceDnsName": {},
+          "vpceConfigurationDescription": {}
         }
       },
       "output": {
@@ -1913,84 +1543,28 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "min": 32
-    },
-    "S3": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "S4": {
-      "type": "string",
-      "max": 16384,
-      "min": 0
-    },
     "S5": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "attribute": {
-            "shape": "S7"
-          },
-          "operator": {
-            "type": "string",
-            "enum": [
-              "EQUALS",
-              "LESS_THAN",
-              "GREATER_THAN",
-              "IN",
-              "NOT_IN",
-              "CONTAINS"
-            ]
-          },
+          "attribute": {},
+          "operator": {},
           "value": {}
         }
       }
     },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "ARN",
-        "PLATFORM",
-        "FORM_FACTOR",
-        "MANUFACTURER",
-        "REMOTE_ACCESS_ENABLED",
-        "REMOTE_DEBUG_ENABLED",
-        "APPIUM_VERSION",
-        "INSTANCE_ARN",
-        "INSTANCE_LABELS",
-        "FLEET_TYPE"
-      ]
-    },
     "Sb": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "description": {
-          "shape": "S4"
-        },
-        "type": {
-          "shape": "Sc"
-        },
+        "arn": {},
+        "name": {},
+        "description": {},
+        "type": {},
         "rules": {
           "shape": "S5"
         }
       }
-    },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "CURATED",
-        "PRIVATE"
-      ]
     },
     "Sf": {
       "type": "list",
@@ -1999,9 +1573,7 @@
     "Sh": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
+        "arn": {},
         "packageCleanup": {
           "type": "boolean"
         },
@@ -2011,41 +1583,17 @@
         "rebootAfterUse": {
           "type": "boolean"
         },
-        "name": {
-          "shape": "S3"
-        },
-        "description": {
-          "shape": "S4"
-        }
+        "name": {},
+        "description": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "enum": [
-        "CURATED",
-        "PRIVATE"
-      ]
-    },
-    "Sl": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "description": {
-          "shape": "S4"
-        },
-        "type": {
-          "shape": "Sj"
-        },
+        "arn": {},
+        "name": {},
+        "description": {},
+        "type": {},
         "uplinkBandwidthBits": {
           "type": "long"
         },
@@ -2065,22 +1613,18 @@
           "type": "long"
         },
         "uplinkLossPercent": {
-          "shape": "Sl"
+          "type": "integer"
         },
         "downlinkLossPercent": {
-          "shape": "Sl"
+          "type": "integer"
         }
       }
     },
     "Sr": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
+        "arn": {},
+        "name": {},
         "defaultJobTimeoutMinutes": {
           "type": "integer"
         },
@@ -2089,55 +1633,21 @@
         }
       }
     },
-    "Sv": {
-      "type": "string",
-      "max": 64,
-      "min": 0
-    },
-    "Sx": {
-      "type": "string",
-      "enum": [
-        "METERED",
-        "UNMETERED"
-      ]
-    },
     "Sy": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "INTERACTIVE",
-        "NO_VIDEO",
-        "VIDEO_ONLY"
-      ],
-      "max": 64,
-      "min": 0
+      "member": {}
     },
     "S11": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
+        "arn": {},
+        "name": {},
         "created": {
           "type": "timestamp"
         },
-        "status": {
-          "shape": "S12"
-        },
-        "result": {
-          "shape": "S13"
-        },
-        "message": {
-          "shape": "S4"
-        },
+        "status": {},
+        "result": {},
+        "message": {},
         "started": {
           "type": "timestamp"
         },
@@ -2147,89 +1657,38 @@
         "device": {
           "shape": "S14"
         },
-        "instanceArn": {
-          "shape": "S2"
-        },
+        "instanceArn": {},
         "remoteDebugEnabled": {
           "type": "boolean"
         },
         "remoteRecordEnabled": {
           "type": "boolean"
         },
-        "remoteRecordAppArn": {
-          "shape": "S2"
-        },
-        "hostAddress": {
-          "type": "string",
-          "max": 1024
-        },
-        "clientId": {
-          "shape": "Sv"
-        },
-        "billingMethod": {
-          "shape": "Sx"
-        },
+        "remoteRecordAppArn": {},
+        "hostAddress": {},
+        "clientId": {},
+        "billingMethod": {},
         "deviceMinutes": {
           "shape": "S1g"
         },
         "endpoint": {},
         "deviceUdid": {},
-        "interactionMode": {
-          "shape": "Sz"
-        },
+        "interactionMode": {},
         "skipAppResign": {
           "type": "boolean"
         }
       }
     },
-    "S12": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "PENDING_CONCURRENCY",
-        "PENDING_DEVICE",
-        "PROCESSING",
-        "SCHEDULING",
-        "PREPARING",
-        "RUNNING",
-        "COMPLETED",
-        "STOPPING"
-      ]
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "PASSED",
-        "WARNED",
-        "FAILED",
-        "SKIPPED",
-        "ERRORED",
-        "STOPPED"
-      ]
-    },
     "S14": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
+        "arn": {},
+        "name": {},
         "manufacturer": {},
         "model": {},
         "modelId": {},
-        "formFactor": {
-          "type": "string",
-          "enum": [
-            "PHONE",
-            "TABLET"
-          ]
-        },
-        "platform": {
-          "shape": "S16"
-        },
+        "formFactor": {},
+        "platform": {},
         "os": {},
         "cpu": {
           "type": "structure",
@@ -2274,13 +1733,6 @@
         }
       }
     },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "ANDROID",
-        "IOS"
-      ]
-    },
     "S1b": {
       "type": "list",
       "member": {
@@ -2290,24 +1742,12 @@
     "S1c": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "deviceArn": {
-          "shape": "S2"
-        },
+        "arn": {},
+        "deviceArn": {},
         "labels": {
           "shape": "S1d"
         },
-        "status": {
-          "type": "string",
-          "enum": [
-            "IN_USE",
-            "PREPARING",
-            "AVAILABLE",
-            "NOT_AVAILABLE"
-          ]
-        },
+        "status": {},
         "udid": {},
         "instanceProfile": {
           "shape": "Sh"
@@ -2332,162 +1772,39 @@
         }
       }
     },
-    "S1j": {
-      "type": "string",
-      "enum": [
-        "ANDROID_APP",
-        "IOS_APP",
-        "WEB_APP",
-        "EXTERNAL_DATA",
-        "APPIUM_JAVA_JUNIT_TEST_PACKAGE",
-        "APPIUM_JAVA_TESTNG_TEST_PACKAGE",
-        "APPIUM_PYTHON_TEST_PACKAGE",
-        "APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE",
-        "APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE",
-        "APPIUM_WEB_PYTHON_TEST_PACKAGE",
-        "CALABASH_TEST_PACKAGE",
-        "INSTRUMENTATION_TEST_PACKAGE",
-        "UIAUTOMATION_TEST_PACKAGE",
-        "UIAUTOMATOR_TEST_PACKAGE",
-        "XCTEST_TEST_PACKAGE",
-        "XCTEST_UI_TEST_PACKAGE",
-        "APPIUM_JAVA_JUNIT_TEST_SPEC",
-        "APPIUM_JAVA_TESTNG_TEST_SPEC",
-        "APPIUM_PYTHON_TEST_SPEC",
-        "APPIUM_WEB_JAVA_JUNIT_TEST_SPEC",
-        "APPIUM_WEB_JAVA_TESTNG_TEST_SPEC",
-        "APPIUM_WEB_PYTHON_TEST_SPEC",
-        "INSTRUMENTATION_TEST_SPEC",
-        "XCTEST_UI_TEST_SPEC"
-      ]
-    },
-    "S1k": {
-      "type": "string",
-      "max": 64,
-      "min": 0
-    },
     "S1m": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
+        "arn": {},
+        "name": {},
         "created": {
           "type": "timestamp"
         },
-        "type": {
-          "shape": "S1j"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "INITIALIZED",
-            "PROCESSING",
-            "SUCCEEDED",
-            "FAILED"
-          ]
-        },
-        "url": {
-          "shape": "S1o"
-        },
-        "metadata": {
-          "type": "string",
-          "max": 8192,
-          "min": 0
-        },
-        "contentType": {
-          "shape": "S1k"
-        },
-        "message": {
-          "shape": "S4"
-        },
-        "category": {
-          "type": "string",
-          "enum": [
-            "CURATED",
-            "PRIVATE"
-          ]
-        }
+        "type": {},
+        "status": {},
+        "url": {},
+        "metadata": {},
+        "contentType": {},
+        "message": {},
+        "category": {}
       }
-    },
-    "S1o": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
-    },
-    "S1s": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
-    "S1t": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
-    },
-    "S1u": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
-    },
-    "S1v": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
     },
     "S1x": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "vpceConfigurationName": {
-          "shape": "S1s"
-        },
-        "vpceServiceName": {
-          "shape": "S1t"
-        },
-        "serviceDnsName": {
-          "shape": "S1u"
-        },
-        "vpceConfigurationDescription": {
-          "shape": "S1v"
-        }
+        "arn": {},
+        "vpceConfigurationName": {},
+        "vpceServiceName": {},
+        "serviceDnsName": {},
+        "vpceConfigurationDescription": {}
       }
     },
     "S2i": {
       "type": "map",
-      "key": {
-        "shape": "S16"
-      },
+      "key": {},
       "value": {
         "type": "integer"
       }
-    },
-    "S2s": {
-      "type": "string",
-      "enum": [
-        "BUILTIN_FUZZ",
-        "BUILTIN_EXPLORER",
-        "WEB_PERFORMANCE_PROFILE",
-        "APPIUM_JAVA_JUNIT",
-        "APPIUM_JAVA_TESTNG",
-        "APPIUM_PYTHON",
-        "APPIUM_WEB_JAVA_JUNIT",
-        "APPIUM_WEB_JAVA_TESTNG",
-        "APPIUM_WEB_PYTHON",
-        "CALABASH",
-        "INSTRUMENTATION",
-        "UIAUTOMATION",
-        "UIAUTOMATOR",
-        "XCTEST",
-        "XCTEST_UI",
-        "REMOTE_ACCESS_RECORD",
-        "REMOTE_ACCESS_REPLAY"
-      ]
     },
     "S2t": {
       "type": "structure",
@@ -2495,20 +1812,10 @@
         "type"
       ],
       "members": {
-        "type": {
-          "shape": "S2s"
-        },
-        "testPackageArn": {
-          "shape": "S2"
-        },
-        "testSpecArn": {
-          "shape": "S2"
-        },
-        "filter": {
-          "type": "string",
-          "max": 8192,
-          "min": 0
-        },
+        "type": {},
+        "testPackageArn": {},
+        "testSpecArn": {},
+        "filter": {},
         "parameters": {
           "type": "map",
           "key": {},
@@ -2519,12 +1826,8 @@
     "S2w": {
       "type": "structure",
       "members": {
-        "extraDataPackageArn": {
-          "shape": "S2"
-        },
-        "networkProfileArn": {
-          "shape": "S2"
-        },
+        "extraDataPackageArn": {},
+        "networkProfileArn": {},
         "locale": {},
         "location": {
           "shape": "S2x"
@@ -2541,9 +1844,7 @@
         "auxiliaryApps": {
           "shape": "Sy"
         },
-        "billingMethod": {
-          "shape": "Sx"
-        }
+        "billingMethod": {}
       }
     },
     "S2x": {
@@ -2611,12 +1912,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "message": {
-                  "shape": "S4"
-                },
-                "type": {
-                  "shape": "S7"
-                }
+                "message": {},
+                "type": {}
               }
             }
           }
@@ -2626,24 +1923,14 @@
     "S3c": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "type": {
-          "shape": "S2s"
-        },
+        "arn": {},
+        "name": {},
+        "type": {},
         "created": {
           "type": "timestamp"
         },
-        "status": {
-          "shape": "S12"
-        },
-        "result": {
-          "shape": "S13"
-        },
+        "status": {},
+        "result": {},
         "started": {
           "type": "timestamp"
         },
@@ -2653,15 +1940,11 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {
-          "shape": "S4"
-        },
+        "message": {},
         "device": {
           "shape": "S14"
         },
-        "instanceArn": {
-          "shape": "S2"
-        },
+        "instanceArn": {},
         "deviceMinutes": {
           "shape": "S1g"
         },
@@ -2697,35 +1980,17 @@
         }
       }
     },
-    "S3i": {
-      "type": "string",
-      "max": 1024,
-      "min": 4
-    },
     "S3k": {
       "type": "map",
-      "key": {
-        "shape": "S3l"
-      },
+      "key": {},
       "value": {
         "shape": "S3m"
       }
     },
-    "S3l": {
-      "type": "string",
-      "min": 32
-    },
     "S3m": {
       "type": "structure",
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "PURCHASE",
-            "RENEW",
-            "SYSTEM"
-          ]
-        },
+        "type": {},
         "offering": {
           "shape": "S3o"
         },
@@ -2740,21 +2005,10 @@
     "S3o": {
       "type": "structure",
       "members": {
-        "id": {
-          "shape": "S3l"
-        },
-        "description": {
-          "shape": "S4"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "RECURRING"
-          ]
-        },
-        "platform": {
-          "shape": "S16"
-        },
+        "id": {},
+        "description": {},
+        "type": {},
+        "platform": {},
         "recurringCharges": {
           "type": "list",
           "member": {
@@ -2763,12 +2017,7 @@
               "cost": {
                 "shape": "S3s"
               },
-              "frequency": {
-                "type": "string",
-                "enum": [
-                  "MONTHLY"
-                ]
-              }
+              "frequency": {}
             }
           }
         }
@@ -2780,38 +2029,21 @@
         "amount": {
           "type": "double"
         },
-        "currencyCode": {
-          "type": "string",
-          "enum": [
-            "USD"
-          ]
-        }
+        "currencyCode": {}
       }
     },
     "S41": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "type": {
-          "shape": "S2s"
-        },
-        "platform": {
-          "shape": "S16"
-        },
+        "arn": {},
+        "name": {},
+        "type": {},
+        "platform": {},
         "created": {
           "type": "timestamp"
         },
-        "status": {
-          "shape": "S12"
-        },
-        "result": {
-          "shape": "S13"
-        },
+        "status": {},
+        "result": {},
         "started": {
           "type": "timestamp"
         },
@@ -2821,18 +2053,14 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {
-          "shape": "S4"
-        },
+        "message": {},
         "totalJobs": {
           "type": "integer"
         },
         "completedJobs": {
           "type": "integer"
         },
-        "billingMethod": {
-          "shape": "Sx"
-        },
+        "billingMethod": {},
         "deviceMinutes": {
           "shape": "S1g"
         },
@@ -2840,28 +2068,18 @@
           "shape": "Sn"
         },
         "parsingResultUrl": {},
-        "resultCode": {
-          "type": "string",
-          "enum": [
-            "PARSING_FAILED",
-            "VPC_ENDPOINT_SETUP_FAILED"
-          ]
-        },
+        "resultCode": {},
         "seed": {
           "type": "integer"
         },
-        "appUpload": {
-          "shape": "S2"
-        },
+        "appUpload": {},
         "eventCount": {
           "type": "integer"
         },
         "jobTimeoutMinutes": {
           "type": "integer"
         },
-        "devicePoolArn": {
-          "shape": "S2"
-        },
+        "devicePoolArn": {},
         "locale": {},
         "radios": {
           "shape": "S32"
@@ -2876,32 +2094,20 @@
         "skipAppResign": {
           "type": "boolean"
         },
-        "testSpecArn": {
-          "shape": "S2"
-        }
+        "testSpecArn": {}
       }
     },
     "S45": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "type": {
-          "shape": "S2s"
-        },
+        "arn": {},
+        "name": {},
+        "type": {},
         "created": {
           "type": "timestamp"
         },
-        "status": {
-          "shape": "S12"
-        },
-        "result": {
-          "shape": "S13"
-        },
+        "status": {},
+        "result": {},
         "started": {
           "type": "timestamp"
         },
@@ -2911,9 +2117,7 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {
-          "shape": "S4"
-        },
+        "message": {},
         "deviceMinutes": {
           "shape": "S1g"
         }
@@ -2922,24 +2126,14 @@
     "S48": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        },
-        "type": {
-          "shape": "S2s"
-        },
+        "arn": {},
+        "name": {},
+        "type": {},
         "created": {
           "type": "timestamp"
         },
-        "status": {
-          "shape": "S12"
-        },
-        "result": {
-          "shape": "S13"
-        },
+        "status": {},
+        "result": {},
         "started": {
           "type": "timestamp"
         },
@@ -2949,17 +2143,11 @@
         "counters": {
           "shape": "S3d"
         },
-        "message": {
-          "shape": "S4"
-        },
+        "message": {},
         "deviceMinutes": {
           "shape": "S1g"
         }
       }
-    },
-    "S56": {
-      "type": "string",
-      "min": 4
     },
     "S5a": {
       "type": "structure",
@@ -2967,13 +2155,8 @@
         "offeringStatus": {
           "shape": "S3m"
         },
-        "transactionId": {
-          "type": "string",
-          "min": 32
-        },
-        "offeringPromotionId": {
-          "shape": "S56"
-        },
+        "transactionId": {},
+        "offeringPromotionId": {},
         "createdOn": {
           "type": "timestamp"
         },
@@ -2985,12 +2168,8 @@
     "S66": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S2"
-        },
-        "name": {
-          "shape": "S3"
-        }
+        "arn": {},
+        "name": {}
       }
     }
   }

--- a/apis/directconnect-2012-10-25.min.json
+++ b/apis/directconnect-2012-10-25.min.json
@@ -88,9 +88,7 @@
               },
               "authKey": {},
               "amazonAddress": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "customerAddress": {}
             }
           }
@@ -129,9 +127,7 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "routeFilterPrefixes": {
                 "shape": "Sy"
               }
@@ -204,9 +200,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "connectionState": {
-            "shape": "S9"
-          }
+          "connectionState": {}
         }
       }
     },
@@ -225,9 +219,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {
-            "shape": "Su"
-          }
+          "virtualInterfaceState": {}
         }
       }
     },
@@ -244,9 +236,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {
-            "shape": "Su"
-          }
+          "virtualInterfaceState": {}
         }
       }
     },
@@ -262,9 +252,7 @@
                 "type": "integer"
               },
               "authKey": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "amazonAddress": {},
               "customerAddress": {}
             }
@@ -411,9 +399,7 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "virtualGatewayId": {},
               "directConnectGatewayId": {}
             }
@@ -451,9 +437,7 @@
               "authKey": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "routeFilterPrefixes": {
                 "shape": "Sy"
               }
@@ -552,9 +536,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "interconnectState": {
-            "shape": "S1y"
-          }
+          "interconnectState": {}
         }
       }
     },
@@ -585,9 +567,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "virtualInterfaceState": {
-            "shape": "Su"
-          }
+          "virtualInterfaceState": {}
         }
       }
     },
@@ -600,9 +580,7 @@
         "members": {
           "connectionId": {},
           "providerName": {},
-          "loaContentType": {
-            "shape": "S2o"
-          }
+          "loaContentType": {}
         }
       },
       "output": {
@@ -690,15 +668,7 @@
                 "virtualInterfaceId": {},
                 "virtualInterfaceRegion": {},
                 "virtualInterfaceOwnerAccount": {},
-                "attachmentState": {
-                  "type": "string",
-                  "enum": [
-                    "attaching",
-                    "attached",
-                    "detaching",
-                    "detached"
-                  ]
-                },
+                "attachmentState": {},
                 "stateChangeError": {}
               }
             }
@@ -754,9 +724,7 @@
         "members": {
           "interconnectId": {},
           "providerName": {},
-          "loaContentType": {
-            "shape": "S2o"
-          }
+          "loaContentType": {}
         }
       },
       "output": {
@@ -816,9 +784,7 @@
         "members": {
           "connectionId": {},
           "providerName": {},
-          "loaContentType": {
-            "shape": "S2o"
-          }
+          "loaContentType": {}
         }
       },
       "output": {
@@ -957,9 +923,7 @@
           "resourceArn": {},
           "tagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S3v"
-            }
+            "member": {}
           }
         }
       },
@@ -994,9 +958,7 @@
         "ownerAccount": {},
         "connectionId": {},
         "connectionName": {},
-        "connectionState": {
-          "shape": "S9"
-        },
+        "connectionState": {},
         "region": {},
         "location": {},
         "bandwidth": {},
@@ -1014,29 +976,9 @@
         "awsDeviceV2": {}
       }
     },
-    "S9": {
-      "type": "string",
-      "enum": [
-        "ordering",
-        "requested",
-        "pending",
-        "available",
-        "down",
-        "deleting",
-        "deleted",
-        "rejected"
-      ]
-    },
     "Sf": {
       "type": "string",
       "deprecated": true
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "ipv4",
-        "ipv6"
-      ]
     },
     "Sq": {
       "type": "structure",
@@ -1059,12 +1001,8 @@
         "authKey": {},
         "amazonAddress": {},
         "customerAddress": {},
-        "addressFamily": {
-          "shape": "So"
-        },
-        "virtualInterfaceState": {
-          "shape": "Su"
-        },
+        "addressFamily": {},
+        "virtualInterfaceState": {},
         "customerRouterConfig": {},
         "virtualGatewayId": {},
         "directConnectGatewayId": {},
@@ -1080,28 +1018,11 @@
                 "type": "integer"
               },
               "authKey": {},
-              "addressFamily": {
-                "shape": "So"
-              },
+              "addressFamily": {},
               "amazonAddress": {},
               "customerAddress": {},
-              "bgpPeerState": {
-                "type": "string",
-                "enum": [
-                  "verifying",
-                  "pending",
-                  "available",
-                  "deleting",
-                  "deleted"
-                ]
-              },
-              "bgpStatus": {
-                "type": "string",
-                "enum": [
-                  "up",
-                  "down"
-                ]
-              },
+              "bgpPeerState": {},
+              "bgpStatus": {},
               "awsDeviceV2": {}
             }
           }
@@ -1109,19 +1030,6 @@
         "region": {},
         "awsDeviceV2": {}
       }
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "confirming",
-        "verifying",
-        "pending",
-        "available",
-        "down",
-        "deleting",
-        "deleted",
-        "rejected"
-      ]
     },
     "Sy": {
       "type": "list",
@@ -1141,15 +1049,7 @@
           "type": "long"
         },
         "ownerAccount": {},
-        "directConnectGatewayState": {
-          "type": "string",
-          "enum": [
-            "pending",
-            "available",
-            "deleting",
-            "deleted"
-          ]
-        },
+        "directConnectGatewayState": {},
         "stateChangeError": {}
       }
     },
@@ -1160,15 +1060,7 @@
         "virtualGatewayId": {},
         "virtualGatewayRegion": {},
         "virtualGatewayOwnerAccount": {},
-        "associationState": {
-          "type": "string",
-          "enum": [
-            "associating",
-            "associated",
-            "disassociating",
-            "disassociated"
-          ]
-        },
+        "associationState": {},
         "stateChangeError": {}
       }
     },
@@ -1177,9 +1069,7 @@
       "members": {
         "interconnectId": {},
         "interconnectName": {},
-        "interconnectState": {
-          "shape": "S1y"
-        },
+        "interconnectState": {},
         "region": {},
         "location": {},
         "bandwidth": {},
@@ -1193,17 +1083,6 @@
         "awsDeviceV2": {}
       }
     },
-    "S1y": {
-      "type": "string",
-      "enum": [
-        "requested",
-        "pending",
-        "available",
-        "down",
-        "deleting",
-        "deleted"
-      ]
-    },
     "S22": {
       "type": "structure",
       "members": {
@@ -1214,17 +1093,7 @@
         "lagId": {},
         "ownerAccount": {},
         "lagName": {},
-        "lagState": {
-          "type": "string",
-          "enum": [
-            "requested",
-            "pending",
-            "available",
-            "down",
-            "deleting",
-            "deleted"
-          ]
-        },
+        "lagState": {},
         "location": {},
         "region": {},
         "minimumLinks": {
@@ -1248,21 +1117,13 @@
         "shape": "S7"
       }
     },
-    "S2o": {
-      "type": "string",
-      "enum": [
-        "application/pdf"
-      ]
-    },
     "S2q": {
       "type": "structure",
       "members": {
         "loaContent": {
           "type": "blob"
         },
-        "loaContentType": {
-          "shape": "S2o"
-        }
+        "loaContentType": {}
       }
     },
     "S2t": {
@@ -1281,24 +1142,10 @@
           "key"
         ],
         "members": {
-          "key": {
-            "shape": "S3v"
-          },
-          "value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "min": 1
-    },
-    "S3v": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
     }
   }
 }

--- a/apis/discovery-2015-11-01.min.json
+++ b/apis/discovery-2015-11-01.min.json
@@ -146,17 +146,7 @@
                 },
                 "connectorId": {},
                 "version": {},
-                "health": {
-                  "type": "string",
-                  "enum": [
-                    "HEALTHY",
-                    "UNHEALTHY",
-                    "RUNNING",
-                    "UNKNOWN",
-                    "BLACKLISTED",
-                    "SHUTDOWN"
-                  ]
-                },
+                "health": {},
                 "lastHealthPingTime": {},
                 "collectionStatus": {},
                 "agentType": {},
@@ -203,9 +193,7 @@
             "member": {}
           },
           "maxResults": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           },
           "nextToken": {}
         }
@@ -219,23 +207,8 @@
               "type": "structure",
               "members": {
                 "exportId": {},
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "START_IN_PROGRESS",
-                    "START_FAILED",
-                    "ACTIVE",
-                    "ERROR",
-                    "STOP_IN_PROGRESS",
-                    "STOP_FAILED",
-                    "INACTIVE"
-                  ]
-                },
-                "statusDetail": {
-                  "type": "string",
-                  "max": 255,
-                  "min": 1
-                },
+                "status": {},
+                "statusDetail": {},
                 "s3Bucket": {},
                 "startTime": {
                   "type": "timestamp"
@@ -243,9 +216,7 @@
                 "stopTime": {
                   "type": "timestamp"
                 },
-                "dataSource": {
-                  "shape": "S1f"
-                },
+                "dataSource": {},
                 "schemaStorageConfig": {
                   "shape": "S1g"
                 }
@@ -340,9 +311,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "configurationType": {
-                  "shape": "S23"
-                },
+                "configurationType": {},
                 "configurationId": {},
                 "key": {},
                 "value": {},
@@ -484,9 +453,7 @@
           "configurationType"
         ],
         "members": {
-          "configurationType": {
-            "shape": "S23"
-          },
+          "configurationType": {},
           "filters": {
             "shape": "Sn"
           },
@@ -503,13 +470,7 @@
               ],
               "members": {
                 "fieldName": {},
-                "sortOrder": {
-                  "type": "string",
-                  "enum": [
-                    "ASC",
-                    "DESC"
-                  ]
-                }
+                "sortOrder": {}
               }
             }
           }
@@ -598,9 +559,7 @@
           "startTime": {
             "type": "timestamp"
           },
-          "dataSource": {
-            "shape": "S1f"
-          },
+          "dataSource": {},
           "schemaStorageConfig": {
             "shape": "S1g"
           }
@@ -634,13 +593,7 @@
         "members": {
           "exportDataFormat": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "CSV",
-                "GRAPHML"
-              ]
-            }
+            "member": {}
           },
           "filters": {
             "shape": "S1t"
@@ -766,19 +719,9 @@
       "type": "list",
       "member": {}
     },
-    "S1f": {
-      "type": "string",
-      "enum": [
-        "AGENT"
-      ]
-    },
     "S1g": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 252,
-        "min": 1
-      },
+      "key": {},
       "value": {}
     },
     "S1j": {
@@ -797,14 +740,7 @@
         ],
         "members": {
           "exportId": {},
-          "exportStatus": {
-            "type": "string",
-            "enum": [
-              "FAILED",
-              "SUCCEEDED",
-              "IN_PROGRESS"
-            ]
-          },
+          "exportStatus": {},
           "statusMessage": {},
           "configurationsDownloadUrl": {},
           "exportRequestTime": {
@@ -839,15 +775,6 @@
           "condition": {}
         }
       }
-    },
-    "S23": {
-      "type": "string",
-      "enum": [
-        "SERVER",
-        "PROCESS",
-        "CONNECTION",
-        "APPLICATION"
-      ]
     },
     "S2s": {
       "type": "list",

--- a/apis/dlm-2018-01-12.min.json
+++ b/apis/dlm-2018-01-12.min.json
@@ -27,12 +27,8 @@
         ],
         "members": {
           "ExecutionRoleArn": {},
-          "Description": {
-            "shape": "S3"
-          },
-          "State": {
-            "shape": "S4"
-          },
+          "Description": {},
+          "State": {},
           "PolicyDetails": {
             "shape": "S5"
           }
@@ -82,7 +78,6 @@
             "member": {}
           },
           "State": {
-            "shape": "Ss",
             "location": "querystring",
             "locationName": "state"
           },
@@ -95,17 +90,13 @@
             "location": "querystring",
             "locationName": "targetTags",
             "type": "list",
-            "member": {},
-            "max": 50,
-            "min": 1
+            "member": {}
           },
           "TagsToAdd": {
             "location": "querystring",
             "locationName": "tagsToAdd",
             "type": "list",
-            "member": {},
-            "max": 50,
-            "min": 0
+            "member": {}
           }
         }
       },
@@ -118,12 +109,8 @@
               "type": "structure",
               "members": {
                 "PolicyId": {},
-                "Description": {
-                  "shape": "S3"
-                },
-                "State": {
-                  "shape": "Ss"
-                }
+                "Description": {},
+                "State": {}
               }
             }
           }
@@ -154,12 +141,8 @@
             "type": "structure",
             "members": {
               "PolicyId": {},
-              "Description": {
-                "shape": "S3"
-              },
-              "State": {
-                "shape": "Ss"
-              },
+              "Description": {},
+              "State": {},
               "ExecutionRoleArn": {},
               "DateCreated": {
                 "type": "timestamp"
@@ -191,12 +174,8 @@
             "locationName": "policyId"
           },
           "ExecutionRoleArn": {},
-          "State": {
-            "shape": "S4"
-          },
-          "Description": {
-            "shape": "S3"
-          },
+          "State": {},
+          "Description": {},
           "PolicyDetails": {
             "shape": "S5"
           }
@@ -209,18 +188,6 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 500,
-      "min": 0
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
-    },
     "S5": {
       "type": "structure",
       "members": {
@@ -231,27 +198,19 @@
           "type": "list",
           "member": {
             "shape": "S9"
-          },
-          "max": 50,
-          "min": 1
+          }
         },
         "Schedules": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Name": {
-                "type": "string",
-                "max": 500,
-                "min": 0
-              },
+              "Name": {},
               "TagsToAdd": {
                 "type": "list",
                 "member": {
                   "shape": "S9"
-                },
-                "max": 50,
-                "min": 0
+                }
               },
               "CreateRule": {
                 "type": "structure",
@@ -261,22 +220,12 @@
                 ],
                 "members": {
                   "Interval": {
-                    "type": "integer",
-                    "min": 1
+                    "type": "integer"
                   },
-                  "IntervalUnit": {
-                    "type": "string",
-                    "enum": [
-                      "HOURS"
-                    ]
-                  },
+                  "IntervalUnit": {},
                   "Times": {
                     "type": "list",
-                    "member": {
-                      "type": "string",
-                      "pattern": "^([0-9]|0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$"
-                    },
-                    "max": 1
+                    "member": {}
                   }
                 }
               },
@@ -287,29 +236,18 @@
                 ],
                 "members": {
                   "Count": {
-                    "type": "integer",
-                    "max": 1000,
-                    "min": 1
+                    "type": "integer"
                   }
                 }
               }
             }
-          },
-          "max": 1,
-          "min": 1
+          }
         }
       }
     },
     "S6": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "VOLUME"
-        ]
-      },
-      "max": 1,
-      "min": 1
+      "member": {}
     },
     "S9": {
       "type": "structure",
@@ -321,14 +259,6 @@
         "Key": {},
         "Value": {}
       }
-    },
-    "Ss": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED",
-        "ERROR"
-      ]
     }
   }
 }

--- a/apis/dms-2016-01-01.min.json
+++ b/apis/dms-2016-01-01.min.json
@@ -41,9 +41,7 @@
         ],
         "members": {
           "EndpointIdentifier": {},
-          "EndpointType": {
-            "shape": "S7"
-          },
+          "EndpointType": {},
           "EngineName": {},
           "Username": {},
           "Password": {
@@ -60,9 +58,7 @@
             "shape": "S3"
           },
           "CertificateArn": {},
-          "SslMode": {
-            "shape": "Sa"
-          },
+          "SslMode": {},
           "ServiceAccessRoleArn": {},
           "ExternalTableDefinition": {},
           "DynamoDbSettings": {
@@ -210,9 +206,7 @@
           "SourceEndpointArn": {},
           "TargetEndpointArn": {},
           "ReplicationInstanceArn": {},
-          "MigrationType": {
-            "shape": "S1b"
-          },
+          "MigrationType": {},
           "TableMappings": {},
           "ReplicationTaskSettings": {},
           "CdcStartTime": {
@@ -448,9 +442,7 @@
                 "SupportsCDC": {
                   "type": "boolean"
                 },
-                "EndpointType": {
-                  "shape": "S7"
-                },
+                "EndpointType": {},
                 "EngineDisplayName": {}
               }
             }
@@ -544,9 +536,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S2n"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -578,9 +568,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S2n"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "Sm"
@@ -952,9 +940,7 @@
         "members": {
           "EndpointArn": {},
           "EndpointIdentifier": {},
-          "EndpointType": {
-            "shape": "S7"
-          },
+          "EndpointType": {},
           "EngineName": {},
           "Username": {},
           "Password": {
@@ -967,9 +953,7 @@
           "DatabaseName": {},
           "ExtraConnectionAttributes": {},
           "CertificateArn": {},
-          "SslMode": {
-            "shape": "Sa"
-          },
+          "SslMode": {},
           "ServiceAccessRoleArn": {},
           "ExternalTableDefinition": {},
           "DynamoDbSettings": {
@@ -1096,9 +1080,7 @@
         "members": {
           "ReplicationTaskArn": {},
           "ReplicationTaskIdentifier": {},
-          "MigrationType": {
-            "shape": "S1b"
-          },
+          "MigrationType": {},
           "TableMappings": {},
           "ReplicationTaskSettings": {},
           "CdcStartTime": {
@@ -1179,13 +1161,7 @@
               }
             }
           },
-          "ReloadOption": {
-            "type": "string",
-            "enum": [
-              "data-reload",
-              "validate-only"
-            ]
-          }
+          "ReloadOption": {}
         }
       },
       "output": {
@@ -1224,14 +1200,7 @@
         ],
         "members": {
           "ReplicationTaskArn": {},
-          "StartReplicationTaskType": {
-            "type": "string",
-            "enum": [
-              "start-replication",
-              "resume-processing",
-              "reload-target"
-            ]
-          },
+          "StartReplicationTaskType": {},
           "CdcStartTime": {
             "type": "timestamp"
           },
@@ -1319,25 +1288,9 @@
         }
       }
     },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "source",
-        "target"
-      ]
-    },
     "S8": {
       "type": "string",
       "sensitive": true
-    },
-    "Sa": {
-      "type": "string",
-      "enum": [
-        "none",
-        "require",
-        "verify-ca",
-        "verify-full"
-      ]
     },
     "Sb": {
       "type": "structure",
@@ -1357,13 +1310,7 @@
         "CsvDelimiter": {},
         "BucketFolder": {},
         "BucketName": {},
-        "CompressionType": {
-          "type": "string",
-          "enum": [
-            "none",
-            "gzip"
-          ]
-        }
+        "CompressionType": {}
       }
     },
     "Se": {
@@ -1385,28 +1332,9 @@
           "type": "integer"
         },
         "DatabaseName": {},
-        "AuthType": {
-          "type": "string",
-          "enum": [
-            "no",
-            "password"
-          ]
-        },
-        "AuthMechanism": {
-          "type": "string",
-          "enum": [
-            "default",
-            "mongodb_cr",
-            "scram_sha_1"
-          ]
-        },
-        "NestingLevel": {
-          "type": "string",
-          "enum": [
-            "none",
-            "one"
-          ]
-        },
+        "AuthType": {},
+        "AuthMechanism": {},
+        "NestingLevel": {},
         "ExtractDocId": {},
         "DocsToInvestigate": {},
         "AuthSource": {},
@@ -1417,9 +1345,7 @@
       "type": "structure",
       "members": {
         "EndpointIdentifier": {},
-        "EndpointType": {
-          "shape": "S7"
-        },
+        "EndpointType": {},
         "EngineName": {},
         "EngineDisplayName": {},
         "Username": {},
@@ -1433,9 +1359,7 @@
         "KmsKeyId": {},
         "EndpointArn": {},
         "CertificateArn": {},
-        "SslMode": {
-          "shape": "Sa"
-        },
+        "SslMode": {},
         "ServiceAccessRoleArn": {},
         "ExternalTableDefinition": {},
         "ExternalId": {},
@@ -1586,14 +1510,6 @@
       "type": "list",
       "member": {}
     },
-    "S1b": {
-      "type": "string",
-      "enum": [
-        "full-load",
-        "cdc",
-        "full-load-and-cdc"
-      ]
-    },
     "S1d": {
       "type": "structure",
       "members": {
@@ -1601,9 +1517,7 @@
         "SourceEndpointArn": {},
         "TargetEndpointArn": {},
         "ReplicationInstanceArn": {},
-        "MigrationType": {
-          "shape": "S1b"
-        },
+        "MigrationType": {},
         "TableMappings": {},
         "ReplicationTaskSettings": {},
         "Status": {},
@@ -1697,25 +1611,12 @@
         "ReplicationInstanceIdentifier": {}
       }
     },
-    "S2n": {
-      "type": "string",
-      "enum": [
-        "replication-instance"
-      ]
-    },
     "S2x": {
       "type": "structure",
       "members": {
         "EndpointArn": {},
         "ReplicationInstanceArn": {},
-        "Status": {
-          "type": "string",
-          "enum": [
-            "successful",
-            "failed",
-            "refreshing"
-          ]
-        },
+        "Status": {},
         "LastRefreshDate": {
           "type": "timestamp"
         },

--- a/apis/ds-2015-04-16.min.json
+++ b/apis/ds-2015-04-16.min.json
@@ -20,9 +20,7 @@
           "SharedDirectoryId"
         ],
         "members": {
-          "SharedDirectoryId": {
-            "shape": "S2"
-          }
+          "SharedDirectoryId": {}
         }
       },
       "output": {
@@ -42,20 +40,14 @@
           "IpRoutes"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "IpRoutes": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "CidrIp": {
-                  "shape": "Se"
-                },
-                "Description": {
-                  "shape": "Sf"
-                }
+                "CidrIp": {},
+                "Description": {}
               }
             }
           },
@@ -77,9 +69,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sj"
-          },
+          "ResourceId": {},
           "Tags": {
             "shape": "Sk"
           }
@@ -98,12 +88,8 @@
           "SchemaExtensionId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "SchemaExtensionId": {
-            "shape": "Sq"
-          }
+          "DirectoryId": {},
+          "SchemaExtensionId": {}
         }
       },
       "output": {
@@ -121,21 +107,13 @@
           "ConnectSettings"
         ],
         "members": {
-          "Name": {
-            "shape": "St"
-          },
-          "ShortName": {
-            "shape": "Su"
-          },
+          "Name": {},
+          "ShortName": {},
           "Password": {
             "shape": "Sv"
           },
-          "Description": {
-            "shape": "Sf"
-          },
-          "Size": {
-            "shape": "Sw"
-          },
+          "Description": {},
+          "Size": {},
           "ConnectSettings": {
             "type": "structure",
             "required": [
@@ -145,18 +123,14 @@
               "CustomerUserName"
             ],
             "members": {
-              "VpcId": {
-                "shape": "Sy"
-              },
+              "VpcId": {},
               "SubnetIds": {
                 "shape": "Sz"
               },
               "CustomerDnsIps": {
                 "shape": "S11"
               },
-              "CustomerUserName": {
-                "shape": "S13"
-              }
+              "CustomerUserName": {}
             }
           }
         }
@@ -164,9 +138,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       }
     },
@@ -178,23 +150,15 @@
           "Alias"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "Alias": {
-            "shape": "S16"
-          }
+          "DirectoryId": {},
+          "Alias": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "Alias": {
-            "shape": "S16"
-          }
+          "DirectoryId": {},
+          "Alias": {}
         }
       }
     },
@@ -207,24 +171,13 @@
           "Password"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "ComputerName": {
-            "shape": "S19"
-          },
+          "DirectoryId": {},
+          "ComputerName": {},
           "Password": {
             "type": "string",
-            "max": 64,
-            "min": 8,
-            "pattern": "[\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "OrganizationalUnitDistinguishedName": {
-            "type": "string",
-            "max": 2000,
-            "min": 1
-          },
+          "OrganizationalUnitDistinguishedName": {},
           "ComputerAttributes": {
             "shape": "S1c"
           }
@@ -236,15 +189,8 @@
           "Computer": {
             "type": "structure",
             "members": {
-              "ComputerId": {
-                "type": "string",
-                "max": 256,
-                "min": 1,
-                "pattern": "[&\\w+-.@]+"
-              },
-              "ComputerName": {
-                "shape": "S19"
-              },
+              "ComputerId": {},
+              "ComputerName": {},
               "ComputerAttributes": {
                 "shape": "S1c"
               }
@@ -262,12 +208,8 @@
           "DnsIpAddrs"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "RemoteDomainName": {
-            "shape": "S1k"
-          },
+          "DirectoryId": {},
+          "RemoteDomainName": {},
           "DnsIpAddrs": {
             "shape": "S11"
           }
@@ -287,21 +229,13 @@
           "Size"
         ],
         "members": {
-          "Name": {
-            "shape": "St"
-          },
-          "ShortName": {
-            "shape": "Su"
-          },
+          "Name": {},
+          "ShortName": {},
           "Password": {
             "shape": "S1n"
           },
-          "Description": {
-            "shape": "Sf"
-          },
-          "Size": {
-            "shape": "Sw"
-          },
+          "Description": {},
+          "Size": {},
           "VpcSettings": {
             "shape": "S1o"
           }
@@ -310,9 +244,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       }
     },
@@ -324,12 +256,8 @@
           "LogGroupName"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "LogGroupName": {
-            "shape": "S1r"
-          }
+          "DirectoryId": {},
+          "LogGroupName": {}
         }
       },
       "output": {
@@ -346,32 +274,22 @@
           "VpcSettings"
         ],
         "members": {
-          "Name": {
-            "shape": "St"
-          },
-          "ShortName": {
-            "shape": "Su"
-          },
+          "Name": {},
+          "ShortName": {},
           "Password": {
             "shape": "S1n"
           },
-          "Description": {
-            "shape": "Sf"
-          },
+          "Description": {},
           "VpcSettings": {
             "shape": "S1o"
           },
-          "Edition": {
-            "shape": "S1u"
-          }
+          "Edition": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       }
     },
@@ -382,20 +300,14 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S1x"
-          }
+          "DirectoryId": {},
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {
-            "shape": "S1z"
-          }
+          "SnapshotId": {}
         }
       }
     },
@@ -409,24 +321,14 @@
           "TrustDirection"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "RemoteDomainName": {
-            "shape": "S1k"
-          },
+          "DirectoryId": {},
+          "RemoteDomainName": {},
           "TrustPassword": {
             "type": "string",
-            "max": 128,
-            "min": 1,
             "sensitive": true
           },
-          "TrustDirection": {
-            "shape": "S22"
-          },
-          "TrustType": {
-            "shape": "S23"
-          },
+          "TrustDirection": {},
+          "TrustType": {},
           "ConditionalForwarderIpAddrs": {
             "shape": "S11"
           }
@@ -435,9 +337,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {
-            "shape": "S25"
-          }
+          "TrustId": {}
         }
       }
     },
@@ -449,12 +349,8 @@
           "RemoteDomainName"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "RemoteDomainName": {
-            "shape": "S1k"
-          }
+          "DirectoryId": {},
+          "RemoteDomainName": {}
         }
       },
       "output": {
@@ -469,17 +365,13 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       }
     },
@@ -490,9 +382,7 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       },
       "output": {
@@ -507,17 +397,13 @@
           "SnapshotId"
         ],
         "members": {
-          "SnapshotId": {
-            "shape": "S1z"
-          }
+          "SnapshotId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {
-            "shape": "S1z"
-          }
+          "SnapshotId": {}
         }
       }
     },
@@ -528,9 +414,7 @@
           "TrustId"
         ],
         "members": {
-          "TrustId": {
-            "shape": "S25"
-          },
+          "TrustId": {},
           "DeleteAssociatedConditionalForwarder": {
             "type": "boolean"
           }
@@ -539,9 +423,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {
-            "shape": "S25"
-          }
+          "TrustId": {}
         }
       }
     },
@@ -553,12 +435,8 @@
           "TopicName"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "TopicName": {
-            "shape": "S2i"
-          }
+          "DirectoryId": {},
+          "TopicName": {}
         }
       },
       "output": {
@@ -573,14 +451,10 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "RemoteDomainNames": {
             "type": "list",
-            "member": {
-              "shape": "S1k"
-            }
+            "member": {}
           }
         }
       },
@@ -592,18 +466,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "RemoteDomainName": {
-                  "shape": "S1k"
-                },
+                "RemoteDomainName": {},
                 "DnsIpAddrs": {
                   "shape": "S11"
                 },
-                "ReplicationScope": {
-                  "type": "string",
-                  "enum": [
-                    "Domain"
-                  ]
-                }
+                "ReplicationScope": {}
               }
             }
           }
@@ -619,7 +486,7 @@
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -631,57 +498,20 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "St"
-                },
-                "ShortName": {
-                  "shape": "Su"
-                },
-                "Size": {
-                  "shape": "Sw"
-                },
-                "Edition": {
-                  "shape": "S1u"
-                },
-                "Alias": {
-                  "shape": "S16"
-                },
-                "AccessUrl": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
-                "Description": {
-                  "shape": "Sf"
-                },
+                "DirectoryId": {},
+                "Name": {},
+                "ShortName": {},
+                "Size": {},
+                "Edition": {},
+                "Alias": {},
+                "AccessUrl": {},
+                "Description": {},
                 "DnsIpAddrs": {
                   "shape": "S11"
                 },
-                "Stage": {
-                  "type": "string",
-                  "enum": [
-                    "Requested",
-                    "Creating",
-                    "Created",
-                    "Active",
-                    "Inoperable",
-                    "Impaired",
-                    "Restoring",
-                    "RestoreFailed",
-                    "Deleting",
-                    "Deleted",
-                    "Failed"
-                  ]
-                },
-                "ShareStatus": {
-                  "shape": "S7"
-                },
-                "ShareMethod": {
-                  "shape": "S6"
-                },
+                "Stage": {},
+                "ShareStatus": {},
+                "ShareMethod": {},
                 "ShareNotes": {
                   "shape": "S8"
                 },
@@ -691,66 +521,44 @@
                 "StageLastUpdatedDateTime": {
                   "type": "timestamp"
                 },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "SimpleAD",
-                    "ADConnector",
-                    "MicrosoftAD",
-                    "SharedMicrosoftAD"
-                  ]
-                },
+                "Type": {},
                 "VpcSettings": {
                   "shape": "S31"
                 },
                 "ConnectSettings": {
                   "type": "structure",
                   "members": {
-                    "VpcId": {
-                      "shape": "Sy"
-                    },
+                    "VpcId": {},
                     "SubnetIds": {
                       "shape": "Sz"
                     },
-                    "CustomerUserName": {
-                      "shape": "S13"
-                    },
-                    "SecurityGroupId": {
-                      "shape": "S32"
-                    },
+                    "CustomerUserName": {},
+                    "SecurityGroupId": {},
                     "AvailabilityZones": {
                       "shape": "S33"
                     },
                     "ConnectIps": {
                       "type": "list",
-                      "member": {
-                        "shape": "S12"
-                      }
+                      "member": {}
                     }
                   }
                 },
                 "RadiusSettings": {
                   "shape": "S37"
                 },
-                "RadiusStatus": {
-                  "shape": "S3h"
-                },
+                "RadiusStatus": {},
                 "StageReason": {},
                 "SsoEnabled": {
                   "type": "boolean"
                 },
                 "DesiredNumberOfDomainControllers": {
-                  "shape": "S3k"
+                  "type": "integer"
                 },
                 "OwnerDirectoryDescription": {
                   "type": "structure",
                   "members": {
-                    "DirectoryId": {
-                      "shape": "S2"
-                    },
-                    "AccountId": {
-                      "shape": "S5"
-                    },
+                    "DirectoryId": {},
+                    "AccountId": {},
                     "DnsIpAddrs": {
                       "shape": "S11"
                     },
@@ -760,9 +568,7 @@
                     "RadiusSettings": {
                       "shape": "S37"
                     },
-                    "RadiusStatus": {
-                      "shape": "S3h"
-                    }
+                    "RadiusStatus": {}
                   }
                 }
               }
@@ -779,18 +585,14 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "DomainControllerIds": {
             "type": "list",
-            "member": {
-              "shape": "S3o"
-            }
+            "member": {}
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -802,34 +604,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "DomainControllerId": {
-                  "shape": "S3o"
-                },
-                "DnsIpAddr": {
-                  "shape": "S12"
-                },
-                "VpcId": {
-                  "shape": "Sy"
-                },
-                "SubnetId": {
-                  "shape": "S10"
-                },
+                "DirectoryId": {},
+                "DomainControllerId": {},
+                "DnsIpAddr": {},
+                "VpcId": {},
+                "SubnetId": {},
                 "AvailabilityZone": {},
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Creating",
-                    "Active",
-                    "Impaired",
-                    "Restoring",
-                    "Deleting",
-                    "Deleted",
-                    "Failed"
-                  ]
-                },
+                "Status": {},
                 "StatusReason": {},
                 "LaunchTime": {
                   "type": "timestamp"
@@ -848,14 +629,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "TopicNames": {
             "type": "list",
-            "member": {
-              "shape": "S2i"
-            }
+            "member": {}
           }
         }
       },
@@ -867,25 +644,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "TopicName": {
-                  "shape": "S2i"
-                },
+                "DirectoryId": {},
+                "TopicName": {},
                 "TopicArn": {},
                 "CreatedDateTime": {
                   "type": "timestamp"
                 },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Registered",
-                    "Topic not found",
-                    "Failed",
-                    "Deleted"
-                  ]
-                }
+                "Status": {}
               }
             }
           }
@@ -899,15 +664,13 @@
           "OwnerDirectoryId"
         ],
         "members": {
-          "OwnerDirectoryId": {
-            "shape": "S2"
-          },
+          "OwnerDirectoryId": {},
           "SharedDirectoryIds": {
             "shape": "S2r"
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -928,18 +691,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "SnapshotIds": {
             "type": "list",
-            "member": {
-              "shape": "S1z"
-            }
+            "member": {}
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -951,30 +710,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "SnapshotId": {
-                  "shape": "S1z"
-                },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "Auto",
-                    "Manual"
-                  ]
-                },
-                "Name": {
-                  "shape": "S1x"
-                },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Creating",
-                    "Completed",
-                    "Failed"
-                  ]
-                },
+                "DirectoryId": {},
+                "SnapshotId": {},
+                "Type": {},
+                "Name": {},
+                "Status": {},
                 "StartTime": {
                   "type": "timestamp"
                 }
@@ -989,18 +729,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "TrustIds": {
             "type": "list",
-            "member": {
-              "shape": "S25"
-            }
+            "member": {}
           },
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -1012,34 +748,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "TrustId": {
-                  "shape": "S25"
-                },
-                "RemoteDomainName": {
-                  "shape": "S1k"
-                },
-                "TrustType": {
-                  "shape": "S23"
-                },
-                "TrustDirection": {
-                  "shape": "S22"
-                },
-                "TrustState": {
-                  "type": "string",
-                  "enum": [
-                    "Creating",
-                    "Created",
-                    "Verifying",
-                    "VerifyFailed",
-                    "Verified",
-                    "Deleting",
-                    "Deleted",
-                    "Failed"
-                  ]
-                },
+                "DirectoryId": {},
+                "TrustId": {},
+                "RemoteDomainName": {},
+                "TrustType": {},
+                "TrustDirection": {},
+                "TrustState": {},
                 "CreatedDateTime": {
                   "type": "timestamp"
                 },
@@ -1064,9 +778,7 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       },
       "output": {
@@ -1081,12 +793,8 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "UserName": {
-            "shape": "S13"
-          },
+          "DirectoryId": {},
+          "UserName": {},
           "Password": {
             "shape": "Sv"
           }
@@ -1105,9 +813,7 @@
           "RadiusSettings"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "RadiusSettings": {
             "shape": "S37"
           }
@@ -1125,12 +831,8 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "UserName": {
-            "shape": "S13"
-          },
+          "DirectoryId": {},
+          "UserName": {},
           "Password": {
             "shape": "Sv"
           }
@@ -1153,28 +855,28 @@
             "type": "structure",
             "members": {
               "CloudOnlyDirectoriesLimit": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "CloudOnlyDirectoriesCurrentCount": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "CloudOnlyDirectoriesLimitReached": {
                 "type": "boolean"
               },
               "CloudOnlyMicrosoftADLimit": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "CloudOnlyMicrosoftADCurrentCount": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "CloudOnlyMicrosoftADLimitReached": {
                 "type": "boolean"
               },
               "ConnectedDirectoriesLimit": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "ConnectedDirectoriesCurrentCount": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "ConnectedDirectoriesLimitReached": {
                 "type": "boolean"
@@ -1191,9 +893,7 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          }
+          "DirectoryId": {}
         }
       },
       "output": {
@@ -1203,10 +903,10 @@
             "type": "structure",
             "members": {
               "ManualSnapshotsLimit": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "ManualSnapshotsCurrentCount": {
-                "shape": "S2t"
+                "type": "integer"
               },
               "ManualSnapshotsLimitReached": {
                 "type": "boolean"
@@ -1223,12 +923,10 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -1240,30 +938,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "CidrIp": {
-                  "shape": "Se"
-                },
-                "IpRouteStatusMsg": {
-                  "type": "string",
-                  "enum": [
-                    "Adding",
-                    "Added",
-                    "Removing",
-                    "Removed",
-                    "AddFailed",
-                    "RemoveFailed"
-                  ]
-                },
+                "DirectoryId": {},
+                "CidrIp": {},
+                "IpRouteStatusMsg": {},
                 "AddedDateTime": {
                   "type": "timestamp"
                 },
                 "IpRouteStatusReason": {},
-                "Description": {
-                  "shape": "Sf"
-                }
+                "Description": {}
               }
             }
           },
@@ -1275,12 +957,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -1292,12 +972,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "LogGroupName": {
-                  "shape": "S1r"
-                },
+                "DirectoryId": {},
+                "LogGroupName": {},
                 "SubscriptionCreatedDateTime": {
                   "type": "timestamp"
                 }
@@ -1315,12 +991,10 @@
           "DirectoryId"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -1332,29 +1006,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
-                "SchemaExtensionId": {
-                  "shape": "Sq"
-                },
-                "Description": {
-                  "shape": "Sf"
-                },
-                "SchemaExtensionStatus": {
-                  "type": "string",
-                  "enum": [
-                    "Initializing",
-                    "CreatingSnapshot",
-                    "UpdatingSchema",
-                    "Replicating",
-                    "CancelInProgress",
-                    "RollbackInProgress",
-                    "Cancelled",
-                    "Failed",
-                    "Completed"
-                  ]
-                },
+                "DirectoryId": {},
+                "SchemaExtensionId": {},
+                "Description": {},
+                "SchemaExtensionStatus": {},
                 "SchemaExtensionStatusReason": {},
                 "StartDateTime": {
                   "type": "timestamp"
@@ -1376,12 +1031,10 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sj"
-          },
+          "ResourceId": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S2t"
+            "type": "integer"
           }
         }
       },
@@ -1403,12 +1056,8 @@
           "TopicName"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "TopicName": {
-            "shape": "S2i"
-          }
+          "DirectoryId": {},
+          "TopicName": {}
         }
       },
       "output": {
@@ -1423,17 +1072,13 @@
           "SharedDirectoryId"
         ],
         "members": {
-          "SharedDirectoryId": {
-            "shape": "S2"
-          }
+          "SharedDirectoryId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {
-            "shape": "S2"
-          }
+          "SharedDirectoryId": {}
         }
       }
     },
@@ -1445,14 +1090,10 @@
           "CidrIps"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "CidrIps": {
             "type": "list",
-            "member": {
-              "shape": "Se"
-            }
+            "member": {}
           }
         }
       },
@@ -1469,14 +1110,10 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sj"
-          },
+          "ResourceId": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sm"
-            }
+            "member": {}
           }
         }
       },
@@ -1494,19 +1131,10 @@
           "NewPassword"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "UserName": {
-            "type": "string",
-            "max": 64,
-            "min": 1,
-            "pattern": "^(?!.*\\\\|.*\"|.*\\/|.*\\[|.*\\]|.*:|.*;|.*\\||.*=|.*,|.*\\+|.*\\*|.*\\?|.*<|.*>|.*@).*$"
-          },
+          "DirectoryId": {},
+          "UserName": {},
           "NewPassword": {
             "type": "string",
-            "max": 127,
-            "min": 1,
             "sensitive": true
           }
         }
@@ -1523,9 +1151,7 @@
           "SnapshotId"
         ],
         "members": {
-          "SnapshotId": {
-            "shape": "S1z"
-          }
+          "SnapshotId": {}
         }
       },
       "output": {
@@ -1542,9 +1168,7 @@
           "ShareMethod"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "ShareNotes": {
             "shape": "S8"
           },
@@ -1555,25 +1179,17 @@
               "Type"
             ],
             "members": {
-              "Id": {
-                "shape": "S65"
-              },
-              "Type": {
-                "shape": "S66"
-              }
+              "Id": {},
+              "Type": {}
             }
           },
-          "ShareMethod": {
-            "shape": "S6"
-          }
+          "ShareMethod": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {
-            "shape": "S2"
-          }
+          "SharedDirectoryId": {}
         }
       }
     },
@@ -1587,28 +1203,18 @@
           "Description"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "CreateSnapshotBeforeSchemaExtension": {
             "type": "boolean"
           },
-          "LdifContent": {
-            "type": "string",
-            "max": 500000,
-            "min": 1
-          },
-          "Description": {
-            "shape": "Sf"
-          }
+          "LdifContent": {},
+          "Description": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SchemaExtensionId": {
-            "shape": "Sq"
-          }
+          "SchemaExtensionId": {}
         }
       }
     },
@@ -1620,9 +1226,7 @@
           "UnshareTarget"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "UnshareTarget": {
             "type": "structure",
             "required": [
@@ -1630,12 +1234,8 @@
               "Type"
             ],
             "members": {
-              "Id": {
-                "shape": "S65"
-              },
-              "Type": {
-                "shape": "S66"
-              }
+              "Id": {},
+              "Type": {}
             }
           }
         }
@@ -1643,9 +1243,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "SharedDirectoryId": {
-            "shape": "S2"
-          }
+          "SharedDirectoryId": {}
         }
       }
     },
@@ -1658,12 +1256,8 @@
           "DnsIpAddrs"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "RemoteDomainName": {
-            "shape": "S1k"
-          },
+          "DirectoryId": {},
+          "RemoteDomainName": {},
           "DnsIpAddrs": {
             "shape": "S11"
           }
@@ -1682,11 +1276,9 @@
           "DesiredNumber"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "DesiredNumber": {
-            "shape": "S3k"
+            "type": "integer"
           }
         }
       },
@@ -1703,9 +1295,7 @@
           "RadiusSettings"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "RadiusSettings": {
             "shape": "S37"
           }
@@ -1723,47 +1313,27 @@
           "TrustId"
         ],
         "members": {
-          "TrustId": {
-            "shape": "S25"
-          }
+          "TrustId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TrustId": {
-            "shape": "S25"
-          }
+          "TrustId": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "^d-[0-9a-f]{10}$"
-    },
     "S4": {
       "type": "structure",
       "members": {
-        "OwnerAccountId": {
-          "shape": "S5"
-        },
-        "OwnerDirectoryId": {
-          "shape": "S2"
-        },
-        "ShareMethod": {
-          "shape": "S6"
-        },
-        "SharedAccountId": {
-          "shape": "S5"
-        },
-        "SharedDirectoryId": {
-          "shape": "S2"
-        },
-        "ShareStatus": {
-          "shape": "S7"
-        },
+        "OwnerAccountId": {},
+        "OwnerDirectoryId": {},
+        "ShareMethod": {},
+        "SharedAccountId": {},
+        "SharedDirectoryId": {},
+        "ShareStatus": {},
         "ShareNotes": {
           "shape": "S8"
         },
@@ -1775,49 +1345,9 @@
         }
       }
     },
-    "S5": {
-      "type": "string",
-      "pattern": "^(\\d{12})$"
-    },
-    "S6": {
-      "type": "string",
-      "enum": [
-        "ORGANIZATIONS",
-        "HANDSHAKE"
-      ]
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "Shared",
-        "PendingAcceptance",
-        "Rejected",
-        "Rejecting",
-        "RejectFailed",
-        "Sharing",
-        "ShareFailed",
-        "Deleted",
-        "Deleting"
-      ]
-    },
     "S8": {
       "type": "string",
-      "max": 1024,
       "sensitive": true
-    },
-    "Se": {
-      "type": "string",
-      "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([1-9]|[1-2][0-9]|3[0-2]))$"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 128,
-      "min": 0,
-      "pattern": "^([a-zA-Z0-9_])[\\\\a-zA-Z0-9_@#%*+=:?./!\\s-]*$"
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "^[d]-[0-9a-f]{10}$"
     },
     "Sk": {
       "type": "list",
@@ -1828,109 +1358,35 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "Sm"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
       }
     },
-    "Sm": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "Sq": {
-      "type": "string",
-      "pattern": "^e-[0-9a-f]{10}$"
-    },
-    "St": {
-      "type": "string",
-      "pattern": "^([a-zA-Z0-9]+[\\\\.-])+([a-zA-Z0-9])+$"
-    },
-    "Su": {
-      "type": "string",
-      "pattern": "^[^\\\\/:*?\\\"\\<\\>|.]+[^\\\\/:*?\\\"<>|]*$"
-    },
     "Sv": {
       "type": "string",
-      "max": 128,
-      "min": 1,
       "sensitive": true
-    },
-    "Sw": {
-      "type": "string",
-      "enum": [
-        "Small",
-        "Large"
-      ]
-    },
-    "Sy": {
-      "type": "string",
-      "pattern": "^(vpc-[0-9a-f]{8}|vpc-[0-9a-f]{17})$"
     },
     "Sz": {
       "type": "list",
-      "member": {
-        "shape": "S10"
-      }
-    },
-    "S10": {
-      "type": "string",
-      "pattern": "^(subnet-[0-9a-f]{8}|subnet-[0-9a-f]{17})$"
+      "member": {}
     },
     "S11": {
       "type": "list",
-      "member": {
-        "shape": "S12"
-      }
-    },
-    "S12": {
-      "type": "string",
-      "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-    },
-    "S13": {
-      "type": "string",
-      "min": 1,
-      "pattern": "[a-zA-Z0-9._-]+"
-    },
-    "S16": {
-      "type": "string",
-      "max": 62,
-      "min": 1,
-      "pattern": "^(?!d-)([\\da-zA-Z]+)([-]*[\\da-zA-Z])*"
-    },
-    "S19": {
-      "type": "string",
-      "max": 15,
-      "min": 1
+      "member": {}
     },
     "S1c": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Name": {
-            "type": "string",
-            "min": 1
-          },
+          "Name": {},
           "Value": {}
         }
       }
     },
-    "S1k": {
-      "type": "string",
-      "pattern": "^([a-zA-Z0-9]+[\\\\.-])+([a-zA-Z0-9])+[.]?$"
-    },
     "S1n": {
       "type": "string",
-      "pattern": "(?=^.{8,64}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9\\s])(?=.*[a-z])|(?=.*[^A-Za-z0-9\\s])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9\\s]))^.*",
       "sensitive": true
     },
     "S1o": {
@@ -1940,91 +1396,28 @@
         "SubnetIds"
       ],
       "members": {
-        "VpcId": {
-          "shape": "Sy"
-        },
+        "VpcId": {},
         "SubnetIds": {
           "shape": "Sz"
         }
       }
     },
-    "S1r": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[-._/#A-Za-z0-9]+"
-    },
-    "S1u": {
-      "type": "string",
-      "enum": [
-        "Enterprise",
-        "Standard"
-      ]
-    },
-    "S1x": {
-      "type": "string",
-      "max": 128,
-      "min": 0,
-      "pattern": "^([a-zA-Z0-9_])[\\\\a-zA-Z0-9_@#%*+=:?./!\\s-]*$"
-    },
-    "S1z": {
-      "type": "string",
-      "pattern": "^s-[0-9a-f]{10}$"
-    },
-    "S22": {
-      "type": "string",
-      "enum": [
-        "One-Way: Outgoing",
-        "One-Way: Incoming",
-        "Two-Way"
-      ]
-    },
-    "S23": {
-      "type": "string",
-      "enum": [
-        "Forest"
-      ]
-    },
-    "S25": {
-      "type": "string",
-      "pattern": "^t-[0-9a-f]{10}$"
-    },
-    "S2i": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
     "S2r": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
-    },
-    "S2t": {
-      "type": "integer",
-      "min": 0
+      "member": {}
     },
     "S31": {
       "type": "structure",
       "members": {
-        "VpcId": {
-          "shape": "Sy"
-        },
+        "VpcId": {},
         "SubnetIds": {
           "shape": "Sz"
         },
-        "SecurityGroupId": {
-          "shape": "S32"
-        },
+        "SecurityGroupId": {},
         "AvailabilityZones": {
           "shape": "S33"
         }
       }
-    },
-    "S32": {
-      "type": "string",
-      "pattern": "^(sg-[0-9a-f]{8}|sg-[0-9a-f]{17})$"
     },
     "S33": {
       "type": "list",
@@ -2035,78 +1428,27 @@
       "members": {
         "RadiusServers": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-          }
+          "member": {}
         },
         "RadiusPort": {
-          "type": "integer",
-          "max": 65535,
-          "min": 1025
+          "type": "integer"
         },
         "RadiusTimeout": {
-          "type": "integer",
-          "max": 20,
-          "min": 1
+          "type": "integer"
         },
         "RadiusRetries": {
-          "type": "integer",
-          "max": 10,
-          "min": 0
+          "type": "integer"
         },
         "SharedSecret": {
           "type": "string",
-          "max": 512,
-          "min": 8,
           "sensitive": true
         },
-        "AuthenticationProtocol": {
-          "type": "string",
-          "enum": [
-            "PAP",
-            "CHAP",
-            "MS-CHAPv1",
-            "MS-CHAPv2"
-          ]
-        },
-        "DisplayLabel": {
-          "type": "string",
-          "max": 64,
-          "min": 1
-        },
+        "AuthenticationProtocol": {},
+        "DisplayLabel": {},
         "UseSameUsername": {
           "type": "boolean"
         }
       }
-    },
-    "S3h": {
-      "type": "string",
-      "enum": [
-        "Creating",
-        "Completed",
-        "Failed"
-      ]
-    },
-    "S3k": {
-      "type": "integer",
-      "min": 2
-    },
-    "S3o": {
-      "type": "string",
-      "pattern": "^dc-[0-9a-f]{10}$"
-    },
-    "S65": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "S66": {
-      "type": "string",
-      "enum": [
-        "ACCOUNT"
-      ]
     }
   }
 }

--- a/apis/dynamodb-2011-12-05.min.json
+++ b/apis/dynamodb-2011-12-05.min.json
@@ -30,9 +30,7 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "members": {
@@ -68,9 +66,7 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "members": {
@@ -95,9 +91,7 @@
           "ProvisionedThroughput"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "KeySchema": {
             "shape": "Sy"
           },
@@ -123,18 +117,14 @@
           "Key"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {
-            "shape": "S1e"
-          }
+          "ReturnValues": {}
         }
       },
       "output": {
@@ -156,9 +146,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -177,9 +165,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -199,9 +185,7 @@
           "Key"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
@@ -229,13 +213,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartTableName": {
-            "shape": "S3"
-          },
+          "ExclusiveStartTableName": {},
           "Limit": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -244,13 +224,9 @@
         "members": {
           "TableNames": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           },
-          "LastEvaluatedTableName": {
-            "shape": "S3"
-          }
+          "LastEvaluatedTableName": {}
         }
       }
     },
@@ -262,18 +238,14 @@
           "Item"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Item": {
             "shape": "Ss"
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {
-            "shape": "S1e"
-          }
+          "ReturnValues": {}
         }
       },
       "output": {
@@ -296,14 +268,12 @@
           "HashKeyValue"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "AttributesToGet": {
             "shape": "Se"
           },
           "Limit": {
-            "shape": "S1t"
+            "type": "integer"
           },
           "ConsistentRead": {
             "type": "boolean"
@@ -350,14 +320,12 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "AttributesToGet": {
             "shape": "Se"
           },
           "Limit": {
-            "shape": "S1t"
+            "type": "integer"
           },
           "Count": {
             "type": "boolean"
@@ -404,40 +372,27 @@
           "AttributeUpdates"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
           "AttributeUpdates": {
             "type": "map",
-            "key": {
-              "shape": "Sf"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "members": {
                 "Value": {
                   "shape": "S7"
                 },
-                "Action": {
-                  "type": "string",
-                  "enum": [
-                    "ADD",
-                    "PUT",
-                    "DELETE"
-                  ]
-                }
+                "Action": {}
               }
             }
           },
           "Expected": {
             "shape": "S1b"
           },
-          "ReturnValues": {
-            "shape": "S1e"
-          }
+          "ReturnValues": {}
         }
       },
       "output": {
@@ -460,9 +415,7 @@
           "ProvisionedThroughput"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "ProvisionedThroughput": {
             "shape": "S12"
           }
@@ -481,9 +434,7 @@
   "shapes": {
     "S2": {
       "type": "map",
-      "key": {
-        "shape": "S3"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "required": [
@@ -494,9 +445,7 @@
             "type": "list",
             "member": {
               "shape": "S6"
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "AttributesToGet": {
             "shape": "Se"
@@ -505,15 +454,7 @@
             "type": "boolean"
           }
         }
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9_.-]+"
+      }
     },
     "S6": {
       "type": "structure",
@@ -555,14 +496,7 @@
     },
     "Se": {
       "type": "list",
-      "member": {
-        "shape": "Sf"
-      },
-      "min": 1
-    },
-    "Sf": {
-      "type": "string",
-      "max": 65535
+      "member": {}
     },
     "Sk": {
       "type": "list",
@@ -572,18 +506,14 @@
     },
     "Sl": {
       "type": "map",
-      "key": {
-        "shape": "Sf"
-      },
+      "key": {},
       "value": {
         "shape": "S7"
       }
     },
     "So": {
       "type": "map",
-      "key": {
-        "shape": "S3"
-      },
+      "key": {},
       "value": {
         "type": "list",
         "member": {
@@ -612,18 +542,12 @@
               }
             }
           }
-        },
-        "max": 25,
-        "min": 1
-      },
-      "max": 25,
-      "min": 1
+        }
+      }
     },
     "Ss": {
       "type": "map",
-      "key": {
-        "shape": "Sf"
-      },
+      "key": {},
       "value": {
         "shape": "S7"
       }
@@ -649,19 +573,8 @@
         "AttributeType"
       ],
       "members": {
-        "AttributeName": {
-          "type": "string",
-          "max": 255,
-          "min": 1
-        },
-        "AttributeType": {
-          "type": "string",
-          "enum": [
-            "S",
-            "N",
-            "B"
-          ]
-        }
+        "AttributeName": {},
+        "AttributeType": {}
       }
     },
     "S12": {
@@ -672,35 +585,21 @@
       ],
       "members": {
         "ReadCapacityUnits": {
-          "shape": "S13"
+          "type": "long"
         },
         "WriteCapacityUnits": {
-          "shape": "S13"
+          "type": "long"
         }
       }
-    },
-    "S13": {
-      "type": "long",
-      "min": 1
     },
     "S15": {
       "type": "structure",
       "members": {
-        "TableName": {
-          "shape": "S3"
-        },
+        "TableName": {},
         "KeySchema": {
           "shape": "Sy"
         },
-        "TableStatus": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "UPDATING",
-            "DELETING",
-            "ACTIVE"
-          ]
-        },
+        "TableStatus": {},
         "CreationDateTime": {
           "type": "timestamp"
         },
@@ -714,13 +613,13 @@
               "type": "timestamp"
             },
             "NumberOfDecreasesToday": {
-              "shape": "S13"
+              "type": "long"
             },
             "ReadCapacityUnits": {
-              "shape": "S13"
+              "type": "long"
             },
             "WriteCapacityUnits": {
-              "shape": "S13"
+              "type": "long"
             }
           }
         },
@@ -734,9 +633,7 @@
     },
     "S1b": {
       "type": "map",
-      "key": {
-        "shape": "Sf"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
@@ -748,20 +645,6 @@
           }
         }
       }
-    },
-    "S1e": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "ALL_OLD",
-        "UPDATED_OLD",
-        "ALL_NEW",
-        "UPDATED_NEW"
-      ]
-    },
-    "S1t": {
-      "type": "integer",
-      "min": 1
     },
     "S1u": {
       "type": "structure",
@@ -775,24 +658,7 @@
             "shape": "S7"
           }
         },
-        "ComparisonOperator": {
-          "type": "string",
-          "enum": [
-            "EQ",
-            "NE",
-            "IN",
-            "LE",
-            "LT",
-            "GE",
-            "GT",
-            "BETWEEN",
-            "NOT_NULL",
-            "NULL",
-            "CONTAINS",
-            "NOT_CONTAINS",
-            "BEGINS_WITH"
-          ]
-        }
+        "ComparisonOperator": {}
       }
     }
   }

--- a/apis/dynamodb-2012-08-10.min.json
+++ b/apis/dynamodb-2012-08-10.min.json
@@ -23,9 +23,7 @@
           "RequestItems": {
             "shape": "S2"
           },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          }
+          "ReturnConsumedCapacity": {}
         }
       },
       "output": {
@@ -33,9 +31,7 @@
         "members": {
           "Responses": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "shape": "Sr"
             }
@@ -60,12 +56,8 @@
           "RequestItems": {
             "shape": "S10"
           },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
-          "ReturnItemCollectionMetrics": {
-            "shape": "S16"
-          }
+          "ReturnConsumedCapacity": {},
+          "ReturnItemCollectionMetrics": {}
         }
       },
       "output": {
@@ -76,9 +68,7 @@
           },
           "ItemCollectionMetrics": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "type": "list",
               "member": {
@@ -101,12 +91,8 @@
           "BackupName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
-          "BackupName": {
-            "shape": "S1f"
-          }
+          "TableName": {},
+          "BackupName": {}
         }
       },
       "output": {
@@ -127,9 +113,7 @@
           "ReplicationGroup"
         ],
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          },
+          "GlobalTableName": {},
           "ReplicationGroup": {
             "shape": "S1p"
           }
@@ -158,9 +142,7 @@
           "AttributeDefinitions": {
             "shape": "S1z"
           },
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "KeySchema": {
             "shape": "S23"
           },
@@ -174,9 +156,7 @@
                 "Projection"
               ],
               "members": {
-                "IndexName": {
-                  "shape": "Sy"
-                },
+                "IndexName": {},
                 "KeySchema": {
                   "shape": "S23"
                 },
@@ -197,9 +177,7 @@
                 "ProvisionedThroughput"
               ],
               "members": {
-                "IndexName": {
-                  "shape": "Sy"
-                },
+                "IndexName": {},
                 "KeySchema": {
                   "shape": "S23"
                 },
@@ -240,9 +218,7 @@
           "BackupArn"
         ],
         "members": {
-          "BackupArn": {
-            "shape": "S1i"
-          }
+          "BackupArn": {}
         }
       },
       "output": {
@@ -263,27 +239,17 @@
           "Key"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ConditionalOperator": {
-            "shape": "S3r"
-          },
-          "ReturnValues": {
-            "shape": "S3s"
-          },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
-          "ReturnItemCollectionMetrics": {
-            "shape": "S16"
-          },
+          "ConditionalOperator": {},
+          "ReturnValues": {},
+          "ReturnConsumedCapacity": {},
+          "ReturnItemCollectionMetrics": {},
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -316,9 +282,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -338,9 +302,7 @@
           "BackupArn"
         ],
         "members": {
-          "BackupArn": {
-            "shape": "S1i"
-          }
+          "BackupArn": {}
         }
       },
       "output": {
@@ -360,9 +322,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -413,9 +373,7 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          }
+          "GlobalTableName": {}
         }
       },
       "output": {
@@ -435,17 +393,13 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          }
+          "GlobalTableName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          },
+          "GlobalTableName": {},
           "ReplicaSettings": {
             "shape": "S4f"
           }
@@ -462,16 +416,16 @@
         "type": "structure",
         "members": {
           "AccountMaxReadCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "AccountMaxWriteCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "TableMaxReadCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "TableMaxWriteCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           }
         }
       },
@@ -484,9 +438,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -506,9 +458,7 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          }
+          "TableName": {}
         }
       },
       "output": {
@@ -529,9 +479,7 @@
           "Key"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
@@ -541,9 +489,7 @@
           "ConsistentRead": {
             "type": "boolean"
           },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
+          "ReturnConsumedCapacity": {},
           "ProjectionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -567,13 +513,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Limit": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           },
           "TimeRangeLowerBound": {
             "type": "timestamp"
@@ -581,17 +523,8 @@
           "TimeRangeUpperBound": {
             "type": "timestamp"
           },
-          "ExclusiveStartBackupArn": {
-            "shape": "S1i"
-          },
-          "BackupType": {
-            "type": "string",
-            "enum": [
-              "USER",
-              "SYSTEM",
-              "ALL"
-            ]
-          }
+          "ExclusiveStartBackupArn": {},
+          "BackupType": {}
         }
       },
       "output": {
@@ -602,40 +535,26 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {
-                  "shape": "S3"
-                },
-                "TableId": {
-                  "shape": "S2t"
-                },
+                "TableName": {},
+                "TableId": {},
                 "TableArn": {},
-                "BackupArn": {
-                  "shape": "S1i"
-                },
-                "BackupName": {
-                  "shape": "S1f"
-                },
+                "BackupArn": {},
+                "BackupName": {},
                 "BackupCreationDateTime": {
                   "type": "timestamp"
                 },
                 "BackupExpiryDateTime": {
                   "type": "timestamp"
                 },
-                "BackupStatus": {
-                  "shape": "S1k"
-                },
-                "BackupType": {
-                  "shape": "S1l"
-                },
+                "BackupStatus": {},
+                "BackupType": {},
                 "BackupSizeBytes": {
-                  "shape": "S1j"
+                  "type": "long"
                 }
               }
             }
           },
-          "LastEvaluatedBackupArn": {
-            "shape": "S1i"
-          }
+          "LastEvaluatedBackupArn": {}
         }
       },
       "endpointdiscovery": {}
@@ -644,11 +563,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartGlobalTableName": {
-            "shape": "S3"
-          },
+          "ExclusiveStartGlobalTableName": {},
           "Limit": {
-            "shape": "S58"
+            "type": "integer"
           },
           "RegionName": {}
         }
@@ -661,18 +578,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "GlobalTableName": {
-                  "shape": "S3"
-                },
+                "GlobalTableName": {},
                 "ReplicationGroup": {
                   "shape": "S1p"
                 }
               }
             }
           },
-          "LastEvaluatedGlobalTableName": {
-            "shape": "S3"
-          }
+          "LastEvaluatedGlobalTableName": {}
         }
       },
       "endpointdiscovery": {}
@@ -681,13 +594,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ExclusiveStartTableName": {
-            "shape": "S3"
-          },
+          "ExclusiveStartTableName": {},
           "Limit": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -696,13 +605,9 @@
         "members": {
           "TableNames": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           },
-          "LastEvaluatedTableName": {
-            "shape": "S3"
-          }
+          "LastEvaluatedTableName": {}
         }
       },
       "endpointdiscovery": {}
@@ -714,9 +619,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S5h"
-          },
+          "ResourceArn": {},
           "NextToken": {}
         }
       },
@@ -739,27 +642,17 @@
           "Item"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Item": {
             "shape": "S14"
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ReturnValues": {
-            "shape": "S3s"
-          },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
-          "ReturnItemCollectionMetrics": {
-            "shape": "S16"
-          },
-          "ConditionalOperator": {
-            "shape": "S3r"
-          },
+          "ReturnValues": {},
+          "ReturnConsumedCapacity": {},
+          "ReturnItemCollectionMetrics": {},
+          "ConditionalOperator": {},
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
             "shape": "Sm"
@@ -792,29 +685,21 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
-          "IndexName": {
-            "shape": "Sy"
-          },
-          "Select": {
-            "shape": "S5r"
-          },
+          "TableName": {},
+          "IndexName": {},
+          "Select": {},
           "AttributesToGet": {
             "shape": "Sj"
           },
           "Limit": {
-            "shape": "S58"
+            "type": "integer"
           },
           "ConsistentRead": {
             "type": "boolean"
           },
           "KeyConditions": {
             "type": "map",
-            "key": {
-              "shape": "S7"
-            },
+            "key": {},
             "value": {
               "shape": "S5t"
             }
@@ -822,18 +707,14 @@
           "QueryFilter": {
             "shape": "S5u"
           },
-          "ConditionalOperator": {
-            "shape": "S3r"
-          },
+          "ConditionalOperator": {},
           "ScanIndexForward": {
             "type": "boolean"
           },
           "ExclusiveStartKey": {
             "shape": "S6"
           },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
+          "ReturnConsumedCapacity": {},
           "ProjectionExpression": {},
           "FilterExpression": {},
           "KeyConditionExpression": {},
@@ -875,12 +756,8 @@
           "BackupArn"
         ],
         "members": {
-          "TargetTableName": {
-            "shape": "S3"
-          },
-          "BackupArn": {
-            "shape": "S1i"
-          }
+          "TargetTableName": {},
+          "BackupArn": {}
         }
       },
       "output": {
@@ -901,12 +778,8 @@
           "TargetTableName"
         ],
         "members": {
-          "SourceTableName": {
-            "shape": "S3"
-          },
-          "TargetTableName": {
-            "shape": "S3"
-          },
+          "SourceTableName": {},
+          "TargetTableName": {},
           "UseLatestRestorableTime": {
             "type": "boolean"
           },
@@ -932,42 +805,28 @@
           "TableName"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
-          "IndexName": {
-            "shape": "Sy"
-          },
+          "TableName": {},
+          "IndexName": {},
           "AttributesToGet": {
             "shape": "Sj"
           },
           "Limit": {
-            "shape": "S58"
+            "type": "integer"
           },
-          "Select": {
-            "shape": "S5r"
-          },
+          "Select": {},
           "ScanFilter": {
             "shape": "S5u"
           },
-          "ConditionalOperator": {
-            "shape": "S3r"
-          },
+          "ConditionalOperator": {},
           "ExclusiveStartKey": {
             "shape": "S6"
           },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
+          "ReturnConsumedCapacity": {},
           "TotalSegments": {
-            "type": "integer",
-            "max": 1000000,
-            "min": 1
+            "type": "integer"
           },
           "Segment": {
-            "type": "integer",
-            "max": 999999,
-            "min": 0
+            "type": "integer"
           },
           "ProjectionExpression": {},
           "FilterExpression": {},
@@ -1012,9 +871,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S5h"
-          },
+          "ResourceArn": {},
           "Tags": {
             "shape": "S5k"
           }
@@ -1030,14 +887,10 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S5h"
-          },
+          "ResourceArn": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S5m"
-            }
+            "member": {}
           }
         }
       },
@@ -1051,9 +904,7 @@
           "PointInTimeRecoverySpecification"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "PointInTimeRecoverySpecification": {
             "type": "structure",
             "required": [
@@ -1085,9 +936,7 @@
           "ReplicaUpdates"
         ],
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          },
+          "GlobalTableName": {},
           "ReplicaUpdates": {
             "type": "list",
             "member": {
@@ -1133,11 +982,9 @@
           "GlobalTableName"
         ],
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          },
+          "GlobalTableName": {},
           "GlobalTableProvisionedWriteCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "GlobalTableProvisionedWriteCapacityAutoScalingSettingsUpdate": {
             "shape": "S6j"
@@ -1150,19 +997,15 @@
                 "IndexName"
               ],
               "members": {
-                "IndexName": {
-                  "shape": "Sy"
-                },
+                "IndexName": {},
                 "ProvisionedWriteCapacityUnits": {
-                  "shape": "S2f"
+                  "type": "long"
                 },
                 "ProvisionedWriteCapacityAutoScalingSettingsUpdate": {
                   "shape": "S6j"
                 }
               }
-            },
-            "max": 20,
-            "min": 1
+            }
           },
           "ReplicaSettingsUpdate": {
             "type": "list",
@@ -1174,7 +1017,7 @@
               "members": {
                 "RegionName": {},
                 "ReplicaProvisionedReadCapacityUnits": {
-                  "shape": "S2f"
+                  "type": "long"
                 },
                 "ReplicaProvisionedReadCapacityAutoScalingSettingsUpdate": {
                   "shape": "S6j"
@@ -1187,33 +1030,25 @@
                       "IndexName"
                     ],
                     "members": {
-                      "IndexName": {
-                        "shape": "Sy"
-                      },
+                      "IndexName": {},
                       "ProvisionedReadCapacityUnits": {
-                        "shape": "S2f"
+                        "type": "long"
                       },
                       "ProvisionedReadCapacityAutoScalingSettingsUpdate": {
                         "shape": "S6j"
                       }
                     }
-                  },
-                  "max": 20,
-                  "min": 1
+                  }
                 }
               }
-            },
-            "max": 50,
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GlobalTableName": {
-            "shape": "S3"
-          },
+          "GlobalTableName": {},
           "ReplicaSettings": {
             "shape": "S4f"
           }
@@ -1229,49 +1064,30 @@
           "Key"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "Key": {
             "shape": "S6"
           },
           "AttributeUpdates": {
             "type": "map",
-            "key": {
-              "shape": "S7"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "members": {
                 "Value": {
                   "shape": "S8"
                 },
-                "Action": {
-                  "type": "string",
-                  "enum": [
-                    "ADD",
-                    "PUT",
-                    "DELETE"
-                  ]
-                }
+                "Action": {}
               }
             }
           },
           "Expected": {
             "shape": "S3m"
           },
-          "ConditionalOperator": {
-            "shape": "S3r"
-          },
-          "ReturnValues": {
-            "shape": "S3s"
-          },
-          "ReturnConsumedCapacity": {
-            "shape": "So"
-          },
-          "ReturnItemCollectionMetrics": {
-            "shape": "S16"
-          },
+          "ConditionalOperator": {},
+          "ReturnValues": {},
+          "ReturnConsumedCapacity": {},
+          "ReturnItemCollectionMetrics": {},
           "UpdateExpression": {},
           "ConditionExpression": {},
           "ExpressionAttributeNames": {
@@ -1308,9 +1124,7 @@
           "AttributeDefinitions": {
             "shape": "S1z"
           },
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "ProvisionedThroughput": {
             "shape": "S2e"
           },
@@ -1326,9 +1140,7 @@
                     "ProvisionedThroughput"
                   ],
                   "members": {
-                    "IndexName": {
-                      "shape": "Sy"
-                    },
+                    "IndexName": {},
                     "ProvisionedThroughput": {
                       "shape": "S2e"
                     }
@@ -1343,9 +1155,7 @@
                     "ProvisionedThroughput"
                   ],
                   "members": {
-                    "IndexName": {
-                      "shape": "Sy"
-                    },
+                    "IndexName": {},
                     "KeySchema": {
                       "shape": "S23"
                     },
@@ -1363,9 +1173,7 @@
                     "IndexName"
                   ],
                   "members": {
-                    "IndexName": {
-                      "shape": "Sy"
-                    }
+                    "IndexName": {}
                   }
                 }
               }
@@ -1397,9 +1205,7 @@
           "TimeToLiveSpecification"
         ],
         "members": {
-          "TableName": {
-            "shape": "S3"
-          },
+          "TableName": {},
           "TimeToLiveSpecification": {
             "shape": "S78"
           }
@@ -1419,9 +1225,7 @@
   "shapes": {
     "S2": {
       "type": "map",
-      "key": {
-        "shape": "S3"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "required": [
@@ -1432,9 +1236,7 @@
             "type": "list",
             "member": {
               "shape": "S6"
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "AttributesToGet": {
             "shape": "Sj"
@@ -1447,28 +1249,14 @@
             "shape": "Sm"
           }
         }
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9_.-]+"
+      }
     },
     "S6": {
       "type": "map",
-      "key": {
-        "shape": "S7"
-      },
+      "key": {},
       "value": {
         "shape": "S8"
       }
-    },
-    "S7": {
-      "type": "string",
-      "max": 65535
     },
     "S8": {
       "type": "structure",
@@ -1494,9 +1282,7 @@
         },
         "M": {
           "type": "map",
-          "key": {
-            "shape": "S7"
-          },
+          "key": {},
           "value": {
             "shape": "S8"
           }
@@ -1517,25 +1303,12 @@
     },
     "Sj": {
       "type": "list",
-      "member": {
-        "shape": "S7"
-      },
-      "min": 1
+      "member": {}
     },
     "Sm": {
       "type": "map",
       "key": {},
-      "value": {
-        "shape": "S7"
-      }
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "INDEXES",
-        "TOTAL",
-        "NONE"
-      ]
+      "value": {}
     },
     "Sr": {
       "type": "list",
@@ -1545,9 +1318,7 @@
     },
     "Ss": {
       "type": "map",
-      "key": {
-        "shape": "S7"
-      },
+      "key": {},
       "value": {
         "shape": "S8"
       }
@@ -1561,9 +1332,7 @@
     "Su": {
       "type": "structure",
       "members": {
-        "TableName": {
-          "shape": "S3"
-        },
+        "TableName": {},
         "CapacityUnits": {
           "type": "double"
         },
@@ -1588,24 +1357,14 @@
     },
     "Sx": {
       "type": "map",
-      "key": {
-        "shape": "Sy"
-      },
+      "key": {},
       "value": {
         "shape": "Sw"
       }
     },
-    "Sy": {
-      "type": "string",
-      "max": 255,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
     "S10": {
       "type": "map",
-      "key": {
-        "shape": "S3"
-      },
+      "key": {},
       "value": {
         "type": "list",
         "member": {
@@ -1634,37 +1393,22 @@
               }
             }
           }
-        },
-        "max": 25,
-        "min": 1
-      },
-      "max": 25,
-      "min": 1
+        }
+      }
     },
     "S14": {
       "type": "map",
-      "key": {
-        "shape": "S7"
-      },
+      "key": {},
       "value": {
         "shape": "S8"
       }
-    },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "SIZE",
-        "NONE"
-      ]
     },
     "S1a": {
       "type": "structure",
       "members": {
         "ItemCollectionKey": {
           "type": "map",
-          "key": {
-            "shape": "S7"
-          },
+          "key": {},
           "value": {
             "shape": "S8"
           }
@@ -1677,12 +1421,6 @@
         }
       }
     },
-    "S1f": {
-      "type": "string",
-      "max": 255,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
     "S1h": {
       "type": "structure",
       "required": [
@@ -1693,21 +1431,13 @@
         "BackupCreationDateTime"
       ],
       "members": {
-        "BackupArn": {
-          "shape": "S1i"
-        },
-        "BackupName": {
-          "shape": "S1f"
-        },
+        "BackupArn": {},
+        "BackupName": {},
         "BackupSizeBytes": {
-          "shape": "S1j"
+          "type": "long"
         },
-        "BackupStatus": {
-          "shape": "S1k"
-        },
-        "BackupType": {
-          "shape": "S1l"
-        },
+        "BackupStatus": {},
+        "BackupType": {},
         "BackupCreationDateTime": {
           "type": "timestamp"
         },
@@ -1715,30 +1445,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S1i": {
-      "type": "string",
-      "max": 1024,
-      "min": 37
-    },
-    "S1j": {
-      "type": "long",
-      "min": 0
-    },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "DELETED",
-        "AVAILABLE"
-      ]
-    },
-    "S1l": {
-      "type": "string",
-      "enum": [
-        "USER",
-        "SYSTEM"
-      ]
     },
     "S1p": {
       "type": "list",
@@ -1765,18 +1471,8 @@
         "CreationDateTime": {
           "type": "timestamp"
         },
-        "GlobalTableStatus": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "ACTIVE",
-            "DELETING",
-            "UPDATING"
-          ]
-        },
-        "GlobalTableName": {
-          "shape": "S3"
-        }
+        "GlobalTableStatus": {},
+        "GlobalTableName": {}
       }
     },
     "S1z": {
@@ -1788,24 +1484,10 @@
           "AttributeType"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S21"
-          },
-          "AttributeType": {
-            "type": "string",
-            "enum": [
-              "S",
-              "N",
-              "B"
-            ]
-          }
+          "AttributeName": {},
+          "AttributeType": {}
         }
       }
-    },
-    "S21": {
-      "type": "string",
-      "max": 255,
-      "min": 1
     },
     "S23": {
       "type": "list",
@@ -1816,41 +1498,18 @@
           "KeyType"
         ],
         "members": {
-          "AttributeName": {
-            "shape": "S21"
-          },
-          "KeyType": {
-            "type": "string",
-            "enum": [
-              "HASH",
-              "RANGE"
-            ]
-          }
+          "AttributeName": {},
+          "KeyType": {}
         }
-      },
-      "max": 2,
-      "min": 1
+      }
     },
     "S28": {
       "type": "structure",
       "members": {
-        "ProjectionType": {
-          "type": "string",
-          "enum": [
-            "ALL",
-            "KEYS_ONLY",
-            "INCLUDE"
-          ]
-        },
+        "ProjectionType": {},
         "NonKeyAttributes": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "max": 255,
-            "min": 1
-          },
-          "max": 20,
-          "min": 1
+          "member": {}
         }
       }
     },
@@ -1862,16 +1521,12 @@
       ],
       "members": {
         "ReadCapacityUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "WriteCapacityUnits": {
-          "shape": "S2f"
+          "type": "long"
         }
       }
-    },
-    "S2f": {
-      "type": "long",
-      "min": 1
     },
     "S2g": {
       "type": "structure",
@@ -1879,15 +1534,7 @@
         "StreamEnabled": {
           "type": "boolean"
         },
-        "StreamViewType": {
-          "type": "string",
-          "enum": [
-            "NEW_IMAGE",
-            "OLD_IMAGE",
-            "NEW_AND_OLD_IMAGES",
-            "KEYS_ONLY"
-          ]
-        }
+        "StreamViewType": {}
       }
     },
     "S2j": {
@@ -1896,18 +1543,9 @@
         "Enabled": {
           "type": "boolean"
         },
-        "SSEType": {
-          "shape": "S2l"
-        },
+        "SSEType": {},
         "KMSMasterKeyId": {}
       }
-    },
-    "S2l": {
-      "type": "string",
-      "enum": [
-        "AES256",
-        "KMS"
-      ]
     },
     "S2o": {
       "type": "structure",
@@ -1915,21 +1553,11 @@
         "AttributeDefinitions": {
           "shape": "S1z"
         },
-        "TableName": {
-          "shape": "S3"
-        },
+        "TableName": {},
         "KeySchema": {
           "shape": "S23"
         },
-        "TableStatus": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "UPDATING",
-            "DELETING",
-            "ACTIVE"
-          ]
-        },
+        "TableStatus": {},
         "CreationDateTime": {
           "type": "timestamp"
         },
@@ -1943,17 +1571,13 @@
           "type": "long"
         },
         "TableArn": {},
-        "TableId": {
-          "shape": "S2t"
-        },
+        "TableId": {},
         "LocalSecondaryIndexes": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "IndexName": {
-                "shape": "Sy"
-              },
+              "IndexName": {},
               "KeySchema": {
                 "shape": "S23"
               },
@@ -1975,18 +1599,14 @@
           "member": {
             "type": "structure",
             "members": {
-              "IndexName": {
-                "shape": "Sy"
-              },
+              "IndexName": {},
               "KeySchema": {
                 "shape": "S23"
               },
               "Projection": {
                 "shape": "S28"
               },
-              "IndexStatus": {
-                "shape": "S2y"
-              },
+              "IndexStatus": {},
               "Backfilling": {
                 "type": "boolean"
               },
@@ -2007,11 +1627,7 @@
           "shape": "S2g"
         },
         "LatestStreamLabel": {},
-        "LatestStreamArn": {
-          "type": "string",
-          "max": 1024,
-          "min": 37
-        },
+        "LatestStreamArn": {},
         "RestoreSummary": {
           "type": "structure",
           "required": [
@@ -2019,9 +1635,7 @@
             "RestoreInProgress"
           ],
           "members": {
-            "SourceBackupArn": {
-              "shape": "S1i"
-            },
+            "SourceBackupArn": {},
             "SourceTableArn": {},
             "RestoreDateTime": {
               "type": "timestamp"
@@ -2046,45 +1660,21 @@
           "type": "timestamp"
         },
         "NumberOfDecreasesToday": {
-          "shape": "S2f"
+          "type": "long"
         },
         "ReadCapacityUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "WriteCapacityUnits": {
-          "shape": "S2f"
+          "type": "long"
         }
       }
-    },
-    "S2t": {
-      "type": "string",
-      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "S2y": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "UPDATING",
-        "DELETING",
-        "ACTIVE"
-      ]
     },
     "S34": {
       "type": "structure",
       "members": {
-        "Status": {
-          "type": "string",
-          "enum": [
-            "ENABLING",
-            "ENABLED",
-            "DISABLING",
-            "DISABLED",
-            "UPDATING"
-          ]
-        },
-        "SSEType": {
-          "shape": "S2l"
-        },
+        "Status": {},
+        "SSEType": {},
         "KMSMasterKeyArn": {}
       }
     },
@@ -2104,12 +1694,8 @@
             "ProvisionedThroughput"
           ],
           "members": {
-            "TableName": {
-              "shape": "S3"
-            },
-            "TableId": {
-              "shape": "S2t"
-            },
+            "TableName": {},
+            "TableId": {},
             "TableArn": {},
             "TableSizeBytes": {
               "type": "long"
@@ -2124,8 +1710,7 @@
               "shape": "S2e"
             },
             "ItemCount": {
-              "type": "long",
-              "min": 0
+              "type": "long"
             }
           }
         },
@@ -2137,9 +1722,7 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "IndexName": {
-                    "shape": "Sy"
-                  },
+                  "IndexName": {},
                   "KeySchema": {
                     "shape": "S23"
                   },
@@ -2154,9 +1737,7 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "IndexName": {
-                    "shape": "Sy"
-                  },
+                  "IndexName": {},
                   "KeySchema": {
                     "shape": "S23"
                   },
@@ -2185,30 +1766,13 @@
     "S3i": {
       "type": "structure",
       "members": {
-        "TimeToLiveStatus": {
-          "type": "string",
-          "enum": [
-            "ENABLING",
-            "DISABLING",
-            "ENABLED",
-            "DISABLED"
-          ]
-        },
-        "AttributeName": {
-          "shape": "S3k"
-        }
+        "TimeToLiveStatus": {},
+        "AttributeName": {}
       }
-    },
-    "S3k": {
-      "type": "string",
-      "max": 255,
-      "min": 1
     },
     "S3m": {
       "type": "map",
-      "key": {
-        "shape": "S7"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
@@ -2218,55 +1782,18 @@
           "Exists": {
             "type": "boolean"
           },
-          "ComparisonOperator": {
-            "shape": "S3p"
-          },
+          "ComparisonOperator": {},
           "AttributeValueList": {
             "shape": "S3q"
           }
         }
       }
     },
-    "S3p": {
-      "type": "string",
-      "enum": [
-        "EQ",
-        "NE",
-        "IN",
-        "LE",
-        "LT",
-        "GE",
-        "GT",
-        "BETWEEN",
-        "NOT_NULL",
-        "NULL",
-        "CONTAINS",
-        "NOT_CONTAINS",
-        "BEGINS_WITH"
-      ]
-    },
     "S3q": {
       "type": "list",
       "member": {
         "shape": "S8"
       }
-    },
-    "S3r": {
-      "type": "string",
-      "enum": [
-        "AND",
-        "OR"
-      ]
-    },
-    "S3s": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "ALL_OLD",
-        "UPDATED_OLD",
-        "ALL_NEW",
-        "UPDATED_NEW"
-      ]
     },
     "S3u": {
       "type": "map",
@@ -2281,23 +1808,11 @@
         "ContinuousBackupsStatus"
       ],
       "members": {
-        "ContinuousBackupsStatus": {
-          "type": "string",
-          "enum": [
-            "ENABLED",
-            "DISABLED"
-          ]
-        },
+        "ContinuousBackupsStatus": {},
         "PointInTimeRecoveryDescription": {
           "type": "structure",
           "members": {
-            "PointInTimeRecoveryStatus": {
-              "type": "string",
-              "enum": [
-                "ENABLED",
-                "DISABLED"
-              ]
-            },
+            "PointInTimeRecoveryStatus": {},
             "EarliestRestorableDateTime": {
               "type": "timestamp"
             },
@@ -2317,23 +1832,15 @@
         ],
         "members": {
           "RegionName": {},
-          "ReplicaStatus": {
-            "type": "string",
-            "enum": [
-              "CREATING",
-              "UPDATING",
-              "DELETING",
-              "ACTIVE"
-            ]
-          },
+          "ReplicaStatus": {},
           "ReplicaProvisionedReadCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "ReplicaProvisionedReadCapacityAutoScalingSettings": {
             "shape": "S4i"
           },
           "ReplicaProvisionedWriteCapacityUnits": {
-            "shape": "S2f"
+            "type": "long"
           },
           "ReplicaProvisionedWriteCapacityAutoScalingSettings": {
             "shape": "S4i"
@@ -2346,20 +1853,16 @@
                 "IndexName"
               ],
               "members": {
-                "IndexName": {
-                  "shape": "Sy"
-                },
-                "IndexStatus": {
-                  "shape": "S2y"
-                },
+                "IndexName": {},
+                "IndexStatus": {},
                 "ProvisionedReadCapacityUnits": {
-                  "shape": "S2f"
+                  "type": "long"
                 },
                 "ProvisionedReadCapacityAutoScalingSettings": {
                   "shape": "S4i"
                 },
                 "ProvisionedWriteCapacityUnits": {
-                  "shape": "S2f"
+                  "type": "long"
                 },
                 "ProvisionedWriteCapacityAutoScalingSettings": {
                   "shape": "S4i"
@@ -2374,10 +1877,10 @@
       "type": "structure",
       "members": {
         "MinimumUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "MaximumUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "AutoScalingDisabled": {
           "type": "boolean"
@@ -2388,9 +1891,7 @@
           "member": {
             "type": "structure",
             "members": {
-              "PolicyName": {
-                "shape": "S4l"
-              },
+              "PolicyName": {},
               "TargetTrackingScalingPolicyConfiguration": {
                 "type": "structure",
                 "required": [
@@ -2416,21 +1917,6 @@
         }
       }
     },
-    "S4l": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "\\p{Print}+"
-    },
-    "S58": {
-      "type": "integer",
-      "min": 1
-    },
-    "S5h": {
-      "type": "string",
-      "max": 1283,
-      "min": 1
-    },
     "S5k": {
       "type": "list",
       "member": {
@@ -2440,30 +1926,10 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S5m"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "S5m": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S5r": {
-      "type": "string",
-      "enum": [
-        "ALL_ATTRIBUTES",
-        "ALL_PROJECTED_ATTRIBUTES",
-        "SPECIFIC_ATTRIBUTES",
-        "COUNT"
-      ]
     },
     "S5t": {
       "type": "structure",
@@ -2474,16 +1940,12 @@
         "AttributeValueList": {
           "shape": "S3q"
         },
-        "ComparisonOperator": {
-          "shape": "S3p"
-        }
+        "ComparisonOperator": {}
       }
     },
     "S5u": {
       "type": "map",
-      "key": {
-        "shape": "S7"
-      },
+      "key": {},
       "value": {
         "shape": "S5t"
       }
@@ -2492,29 +1954,22 @@
       "type": "structure",
       "members": {
         "MinimumUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "MaximumUnits": {
-          "shape": "S2f"
+          "type": "long"
         },
         "AutoScalingDisabled": {
           "type": "boolean"
         },
-        "AutoScalingRoleArn": {
-          "type": "string",
-          "max": 1600,
-          "min": 1,
-          "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-        },
+        "AutoScalingRoleArn": {},
         "ScalingPolicyUpdate": {
           "type": "structure",
           "required": [
             "TargetTrackingScalingPolicyConfiguration"
           ],
           "members": {
-            "PolicyName": {
-              "shape": "S4l"
-            },
+            "PolicyName": {},
             "TargetTrackingScalingPolicyConfiguration": {
               "type": "structure",
               "required": [
@@ -2549,9 +2004,7 @@
         "Enabled": {
           "type": "boolean"
         },
-        "AttributeName": {
-          "shape": "S3k"
-        }
+        "AttributeName": {}
       }
     }
   }

--- a/apis/ec2-2016-11-15.min.json
+++ b/apis/ec2-2016-11-15.min.json
@@ -96,9 +96,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "Domain": {
-            "shape": "Su"
-          },
+          "Domain": {},
           "Address": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -116,7 +114,6 @@
             "locationName": "allocationId"
           },
           "Domain": {
-            "shape": "Su",
             "locationName": "domain"
           }
         }
@@ -132,7 +129,6 @@
         ],
         "members": {
           "AutoPlacement": {
-            "shape": "Sx",
             "locationName": "autoPlacement"
           },
           "AvailabilityZone": {
@@ -763,11 +759,9 @@
               ],
               "members": {
                 "CurrentSpotFleetRequestState": {
-                  "shape": "S3e",
                   "locationName": "currentSpotFleetRequestState"
                 },
                 "PreviousSpotFleetRequestState": {
-                  "shape": "S3e",
                   "locationName": "previousSpotFleetRequestState"
                 },
                 "SpotFleetRequestId": {
@@ -796,14 +790,7 @@
                   ],
                   "members": {
                     "Code": {
-                      "locationName": "code",
-                      "type": "string",
-                      "enum": [
-                        "fleetRequestIdDoesNotExist",
-                        "fleetRequestIdMalformed",
-                        "fleetRequestNotInCancellableState",
-                        "unexpectedError"
-                      ]
+                      "locationName": "code"
                     },
                     "Message": {
                       "locationName": "message"
@@ -850,15 +837,7 @@
                   "locationName": "spotInstanceRequestId"
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "active",
-                    "open",
-                    "closed",
-                    "cancelled",
-                    "completed"
-                  ]
+                  "locationName": "state"
                 }
               }
             }
@@ -1012,9 +991,7 @@
           "PublicIp": {
             "locationName": "IpAddress"
           },
-          "Type": {
-            "shape": "S3y"
-          },
+          "Type": {},
           "DryRun": {
             "locationName": "dryRun",
             "type": "boolean"
@@ -1155,12 +1132,8 @@
           "SpotOptions": {
             "type": "structure",
             "members": {
-              "AllocationStrategy": {
-                "shape": "S4u"
-              },
-              "InstanceInterruptionBehavior": {
-                "shape": "S4v"
-              },
+              "AllocationStrategy": {},
+              "InstanceInterruptionBehavior": {},
               "InstancePoolsToUseCount": {
                 "type": "integer"
               }
@@ -1169,14 +1142,10 @@
           "OnDemandOptions": {
             "type": "structure",
             "members": {
-              "AllocationStrategy": {
-                "shape": "S4x"
-              }
+              "AllocationStrategy": {}
             }
           },
-          "ExcessCapacityTerminationPolicy": {
-            "shape": "S4y"
-          },
+          "ExcessCapacityTerminationPolicy": {},
           "LaunchTemplateConfigs": {
             "type": "list",
             "member": {
@@ -1187,9 +1156,7 @@
                   "type": "structure",
                   "members": {
                     "LaunchTemplateId": {},
-                    "LaunchTemplateName": {
-                      "shape": "S52"
-                    },
+                    "LaunchTemplateName": {},
                     "Version": {}
                   }
                 },
@@ -1199,9 +1166,7 @@
                     "locationName": "item",
                     "type": "structure",
                     "members": {
-                      "InstanceType": {
-                        "shape": "S55"
-                      },
+                      "InstanceType": {},
                       "MaxPrice": {},
                       "SubnetId": {},
                       "AvailabilityZone": {},
@@ -1212,12 +1177,10 @@
                         "type": "double"
                       }
                     }
-                  },
-                  "max": 50
+                  }
                 }
               }
-            },
-            "max": 50
+            }
           },
           "TargetCapacitySpecification": {
             "shape": "S56"
@@ -1225,9 +1188,7 @@
           "TerminateInstancesWithExpiration": {
             "type": "boolean"
           },
-          "Type": {
-            "shape": "S58"
-          },
+          "Type": {},
           "ValidFrom": {
             "type": "timestamp"
           },
@@ -1271,20 +1232,9 @@
             "shape": "Sa",
             "locationName": "ResourceId"
           },
-          "ResourceType": {
-            "type": "string",
-            "enum": [
-              "VPC",
-              "Subnet",
-              "NetworkInterface"
-            ]
-          },
-          "TrafficType": {
-            "shape": "S5d"
-          },
-          "LogDestinationType": {
-            "shape": "S5e"
-          },
+          "ResourceType": {},
+          "TrafficType": {},
+          "LogDestinationType": {},
           "LogDestination": {}
         }
       },
@@ -1393,11 +1343,9 @@
             "type": "structure",
             "members": {
               "ContainerFormat": {
-                "shape": "S5r",
                 "locationName": "containerFormat"
               },
               "DiskImageFormat": {
-                "shape": "S5s",
                 "locationName": "diskImageFormat"
               },
               "S3Bucket": {
@@ -1412,7 +1360,6 @@
             "locationName": "instanceId"
           },
           "TargetEnvironment": {
-            "shape": "S5t",
             "locationName": "targetEnvironment"
           }
         }
@@ -1488,12 +1435,8 @@
             "type": "boolean"
           },
           "ClientToken": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          },
-          "VersionDescription": {
-            "shape": "S65"
-          },
+          "LaunchTemplateName": {},
+          "VersionDescription": {},
           "LaunchTemplateData": {
             "shape": "S66"
           }
@@ -1521,13 +1464,9 @@
           },
           "ClientToken": {},
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          },
+          "LaunchTemplateName": {},
           "SourceVersion": {},
-          "VersionDescription": {
-            "shape": "S65"
-          },
+          "VersionDescription": {},
           "LaunchTemplateData": {
             "shape": "S66"
           }
@@ -1635,7 +1574,6 @@
             "locationName": "protocol"
           },
           "RuleAction": {
-            "shape": "S81",
             "locationName": "ruleAction"
           },
           "RuleNumber": {
@@ -1708,9 +1646,7 @@
           "NetworkInterfaceId": {},
           "AwsAccountId": {},
           "AwsService": {},
-          "Permission": {
-            "shape": "S8h"
-          },
+          "Permission": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -1742,7 +1678,6 @@
             "locationName": "groupName"
           },
           "Strategy": {
-            "shape": "S8n",
             "locationName": "strategy"
           }
         }
@@ -1773,7 +1708,6 @@
               "type": "structure",
               "members": {
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Price": {
@@ -2029,9 +1963,7 @@
             "type": "integer"
           },
           "SnapshotId": {},
-          "VolumeType": {
-            "shape": "S5n"
-          },
+          "VolumeType": {},
           "DryRun": {
             "locationName": "dryRun",
             "type": "boolean"
@@ -2063,7 +1995,6 @@
             "type": "boolean"
           },
           "InstanceTenancy": {
-            "shape": "S4a",
             "locationName": "instanceTenancy"
           }
         }
@@ -2089,9 +2020,7 @@
           "DryRun": {
             "type": "boolean"
           },
-          "VpcEndpointType": {
-            "shape": "S9q"
-          },
+          "VpcEndpointType": {},
           "VpcId": {},
           "ServiceName": {},
           "PolicyDocument": {},
@@ -2292,9 +2221,7 @@
         ],
         "members": {
           "AvailabilityZone": {},
-          "Type": {
-            "shape": "S3y"
-          },
+          "Type": {},
           "AmazonSideAsn": {
             "type": "long"
           },
@@ -2398,11 +2325,9 @@
               "type": "structure",
               "members": {
                 "CurrentFleetState": {
-                  "shape": "Sb4",
                   "locationName": "currentFleetState"
                 },
                 "PreviousFleetState": {
-                  "shape": "Sb4",
                   "locationName": "previousFleetState"
                 },
                 "FleetId": {
@@ -2423,14 +2348,7 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code",
-                      "type": "string",
-                      "enum": [
-                        "fleetIdDoesNotExist",
-                        "fleetIdMalformed",
-                        "fleetNotInDeletableState",
-                        "unexpectedError"
-                      ]
+                      "locationName": "code"
                     },
                     "Message": {
                       "locationName": "message"
@@ -2535,9 +2453,7 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          }
+          "LaunchTemplateName": {}
         }
       },
       "output": {
@@ -2561,9 +2477,7 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          },
+          "LaunchTemplateName": {},
           "Versions": {
             "shape": "Sbi",
             "locationName": "LaunchTemplateVersion"
@@ -2615,16 +2529,7 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code",
-                      "type": "string",
-                      "enum": [
-                        "launchTemplateIdDoesNotExist",
-                        "launchTemplateIdMalformed",
-                        "launchTemplateNameDoesNotExist",
-                        "launchTemplateNameMalformed",
-                        "launchTemplateVersionDoesNotExist",
-                        "unexpectedError"
-                      ]
+                      "locationName": "code"
                     },
                     "Message": {
                       "locationName": "message"
@@ -3076,12 +2981,7 @@
             "locationName": "attributeName",
             "type": "list",
             "member": {
-              "locationName": "attributeName",
-              "type": "string",
-              "enum": [
-                "supported-platforms",
-                "default-vpc"
-              ]
+              "locationName": "attributeName"
             }
           },
           "DryRun": {
@@ -3173,7 +3073,6 @@
                   "locationName": "associationId"
                 },
                 "Domain": {
-                  "shape": "Su",
                   "locationName": "domain"
                 },
                 "NetworkInterfaceId": {
@@ -3250,14 +3149,7 @@
               "type": "structure",
               "members": {
                 "State": {
-                  "locationName": "zoneState",
-                  "type": "string",
-                  "enum": [
-                    "available",
-                    "information",
-                    "impaired",
-                    "unavailable"
-                  ]
+                  "locationName": "zoneState"
                 },
                 "Messages": {
                   "locationName": "messageSet",
@@ -3563,21 +3455,12 @@
                   "type": "structure",
                   "members": {
                     "Status": {
-                      "locationName": "status",
-                      "type": "string",
-                      "enum": [
-                        "OK",
-                        "IMPAIRED"
-                      ]
+                      "locationName": "status"
                     }
                   }
                 },
                 "ElasticGpuState": {
-                  "locationName": "elasticGpuState",
-                  "type": "string",
-                  "enum": [
-                    "ATTACHED"
-                  ]
+                  "locationName": "elasticGpuState"
                 },
                 "InstanceId": {
                   "locationName": "instanceId"
@@ -3633,9 +3516,7 @@
           "DryRun": {
             "type": "boolean"
           },
-          "EventType": {
-            "shape": "Sem"
-          },
+          "EventType": {},
           "MaxResults": {
             "type": "integer"
           },
@@ -3661,7 +3542,6 @@
                   "locationName": "eventInformation"
                 },
                 "EventType": {
-                  "shape": "Sem",
                   "locationName": "eventType"
                 },
                 "Timestamp": {
@@ -3760,14 +3640,7 @@
               "type": "structure",
               "members": {
                 "ActivityStatus": {
-                  "locationName": "activityStatus",
-                  "type": "string",
-                  "enum": [
-                    "error",
-                    "pending-fulfillment",
-                    "pending-termination",
-                    "fulfilled"
-                  ]
+                  "locationName": "activityStatus"
                 },
                 "CreateTime": {
                   "locationName": "createTime",
@@ -3777,14 +3650,12 @@
                   "locationName": "fleetId"
                 },
                 "FleetState": {
-                  "shape": "Sb4",
                   "locationName": "fleetState"
                 },
                 "ClientToken": {
                   "locationName": "clientToken"
                 },
                 "ExcessCapacityTerminationPolicy": {
-                  "shape": "S4y",
                   "locationName": "excessCapacityTerminationPolicy"
                 },
                 "FulfilledCapacity": {
@@ -3814,7 +3685,6 @@
                           "type": "structure",
                           "members": {
                             "InstanceType": {
-                              "shape": "S55",
                               "locationName": "instanceType"
                             },
                             "MaxPrice": {
@@ -3857,7 +3727,6 @@
                       "type": "integer"
                     },
                     "DefaultTargetCapacityType": {
-                      "shape": "S57",
                       "locationName": "defaultTargetCapacityType"
                     }
                   }
@@ -3867,7 +3736,6 @@
                   "type": "boolean"
                 },
                 "Type": {
-                  "shape": "S58",
                   "locationName": "type"
                 },
                 "ValidFrom": {
@@ -3887,11 +3755,9 @@
                   "type": "structure",
                   "members": {
                     "AllocationStrategy": {
-                      "shape": "S4u",
                       "locationName": "allocationStrategy"
                     },
                     "InstanceInterruptionBehavior": {
-                      "shape": "S4v",
                       "locationName": "instanceInterruptionBehavior"
                     },
                     "InstancePoolsToUseCount": {
@@ -3905,7 +3771,6 @@
                   "type": "structure",
                   "members": {
                     "AllocationStrategy": {
-                      "shape": "S4x",
                       "locationName": "allocationStrategy"
                     }
                   }
@@ -3976,11 +3841,9 @@
                   "locationName": "resourceId"
                 },
                 "TrafficType": {
-                  "shape": "S5d",
                   "locationName": "trafficType"
                 },
                 "LogDestinationType": {
-                  "shape": "S5e",
                   "locationName": "logDestinationType"
                 },
                 "LogDestination": {
@@ -4007,9 +3870,7 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {
-            "shape": "Sfe"
-          }
+          "Attribute": {}
         }
       },
       "output": {
@@ -4044,11 +3905,9 @@
             "shape": "Scs",
             "locationName": "Filter"
           },
-          "NextToken": {
-            "shape": "Sfq"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "Sfr"
+            "type": "integer"
           }
         }
       },
@@ -4092,14 +3951,7 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code",
-                      "type": "string",
-                      "enum": [
-                        "pending",
-                        "failed",
-                        "available",
-                        "unavailable"
-                      ]
+                      "locationName": "code"
                     },
                     "Message": {
                       "locationName": "message"
@@ -4136,7 +3988,6 @@
             }
           },
           "NextToken": {
-            "shape": "Sfq",
             "locationName": "nextToken"
           }
         }
@@ -4176,7 +4027,6 @@
               "type": "structure",
               "members": {
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Duration": {
@@ -4193,7 +4043,6 @@
                   "locationName": "offeringId"
                 },
                 "PaymentOption": {
-                  "shape": "Sg2",
                   "locationName": "paymentOption"
                 },
                 "UpfrontPrice": {
@@ -4239,7 +4088,6 @@
                   "type": "integer"
                 },
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Duration": {
@@ -4267,7 +4115,6 @@
                   "locationName": "offeringId"
                 },
                 "PaymentOption": {
-                  "shape": "Sg2",
                   "locationName": "paymentOption"
                 },
                 "Start": {
@@ -4275,14 +4122,7 @@
                   "type": "timestamp"
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "payment-pending",
-                    "payment-failed",
-                    "active",
-                    "retired"
-                  ]
+                  "locationName": "state"
                 },
                 "UpfrontPrice": {
                   "locationName": "upfrontPrice"
@@ -4328,7 +4168,6 @@
               "type": "structure",
               "members": {
                 "AutoPlacement": {
-                  "shape": "Sx",
                   "locationName": "autoPlacement"
                 },
                 "AvailabilityZone": {
@@ -4412,15 +4251,7 @@
                   }
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "available",
-                    "under-assessment",
-                    "permanent-failure",
-                    "released",
-                    "released-permanent-failure"
-                  ]
+                  "locationName": "state"
                 },
                 "AllocationTime": {
                   "locationName": "allocationTime",
@@ -4459,11 +4290,9 @@
             "locationName": "Filter"
           },
           "MaxResults": {
-            "shape": "Sfr"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sfq"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -4478,7 +4307,6 @@
             }
           },
           "NextToken": {
-            "shape": "Sfq",
             "locationName": "nextToken"
           }
         }
@@ -4534,18 +4362,7 @@
           "ImageId"
         ],
         "members": {
-          "Attribute": {
-            "type": "string",
-            "enum": [
-              "description",
-              "kernel",
-              "ramdisk",
-              "launchPermission",
-              "productCodes",
-              "blockDeviceMapping",
-              "sriovNetSupport"
-            ]
-          },
+          "Attribute": {},
           "ImageId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -4633,7 +4450,6 @@
               "type": "structure",
               "members": {
                 "Architecture": {
-                  "shape": "Sh6",
                   "locationName": "architecture"
                 },
                 "CreationDate": {
@@ -4646,13 +4462,7 @@
                   "locationName": "imageLocation"
                 },
                 "ImageType": {
-                  "locationName": "imageType",
-                  "type": "string",
-                  "enum": [
-                    "machine",
-                    "kernel",
-                    "ramdisk"
-                  ]
+                  "locationName": "imageType"
                 },
                 "Public": {
                   "locationName": "isPublic",
@@ -4665,7 +4475,6 @@
                   "locationName": "imageOwnerId"
                 },
                 "Platform": {
-                  "shape": "Sdq",
                   "locationName": "platform"
                 },
                 "ProductCodes": {
@@ -4676,17 +4485,7 @@
                   "locationName": "ramdiskId"
                 },
                 "State": {
-                  "locationName": "imageState",
-                  "type": "string",
-                  "enum": [
-                    "pending",
-                    "available",
-                    "invalid",
-                    "deregistered",
-                    "transient",
-                    "failed",
-                    "error"
-                  ]
+                  "locationName": "imageState"
                 },
                 "BlockDeviceMappings": {
                   "shape": "Sgx",
@@ -4700,7 +4499,6 @@
                   "type": "boolean"
                 },
                 "Hypervisor": {
-                  "shape": "Sh9",
                   "locationName": "hypervisor"
                 },
                 "ImageOwnerAlias": {
@@ -4713,7 +4511,6 @@
                   "locationName": "rootDeviceName"
                 },
                 "RootDeviceType": {
-                  "shape": "Sha",
                   "locationName": "rootDeviceType"
                 },
                 "SriovNetSupport": {
@@ -4728,7 +4525,6 @@
                   "locationName": "tagSet"
                 },
                 "VirtualizationType": {
-                  "shape": "Shc",
                   "locationName": "virtualizationType"
                 }
               }
@@ -4868,7 +4664,6 @@
         ],
         "members": {
           "Attribute": {
-            "shape": "Shr",
             "locationName": "attribute"
           },
           "DryRun": {
@@ -5038,15 +4833,7 @@
                     "type": "structure",
                     "members": {
                       "Code": {
-                        "locationName": "code",
-                        "type": "string",
-                        "enum": [
-                          "instance-reboot",
-                          "system-reboot",
-                          "system-maintenance",
-                          "instance-retirement",
-                          "instance-stop"
-                        ]
+                        "locationName": "code"
                       },
                       "Description": {
                         "locationName": "description"
@@ -5211,9 +4998,7 @@
             "type": "boolean"
           },
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          },
+          "LaunchTemplateName": {},
           "Versions": {
             "shape": "Sbi",
             "locationName": "LaunchTemplateVersion"
@@ -5262,7 +5047,6 @@
             "locationName": "LaunchTemplateName",
             "type": "list",
             "member": {
-              "shape": "S52",
               "locationName": "item"
             }
           },
@@ -5329,12 +5113,7 @@
               "type": "structure",
               "members": {
                 "MoveStatus": {
-                  "locationName": "moveStatus",
-                  "type": "string",
-                  "enum": [
-                    "movingToVpc",
-                    "restoringToClassic"
-                  ]
+                  "locationName": "moveStatus"
                 },
                 "PublicIp": {
                   "locationName": "publicIp"
@@ -5422,14 +5201,7 @@
         ],
         "members": {
           "Attribute": {
-            "locationName": "attribute",
-            "type": "string",
-            "enum": [
-              "description",
-              "groupSet",
-              "sourceDestCheck",
-              "attachment"
-            ]
+            "locationName": "attribute"
           },
           "DryRun": {
             "locationName": "dryRun",
@@ -5576,17 +5348,9 @@
                   "locationName": "groupName"
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "pending",
-                    "available",
-                    "deleting",
-                    "deleted"
-                  ]
+                  "locationName": "state"
                 },
                 "Strategy": {
-                  "shape": "S8n",
                   "locationName": "strategy"
                 }
               }
@@ -5742,9 +5506,7 @@
             "shape": "Scs",
             "locationName": "Filter"
           },
-          "OfferingClass": {
-            "shape": "Skl"
-          },
+          "OfferingClass": {},
           "ReservedInstancesIds": {
             "shape": "Skm",
             "locationName": "ReservedInstancesId"
@@ -5754,7 +5516,6 @@
             "type": "boolean"
           },
           "OfferingType": {
-            "shape": "Skn",
             "locationName": "offeringType"
           }
         }
@@ -5789,11 +5550,9 @@
                   "type": "integer"
                 },
                 "InstanceType": {
-                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
-                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "ReservedInstancesId": {
@@ -5804,33 +5563,22 @@
                   "type": "timestamp"
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "payment-pending",
-                    "active",
-                    "payment-failed",
-                    "retired"
-                  ]
+                  "locationName": "state"
                 },
                 "UsagePrice": {
                   "locationName": "usagePrice",
                   "type": "float"
                 },
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "InstanceTenancy": {
-                  "shape": "S4a",
                   "locationName": "instanceTenancy"
                 },
                 "OfferingClass": {
-                  "shape": "Skl",
                   "locationName": "offeringClass"
                 },
                 "OfferingType": {
-                  "shape": "Skn",
                   "locationName": "offeringType"
                 },
                 "RecurringCharges": {
@@ -5838,7 +5586,6 @@
                   "locationName": "recurringCharges"
                 },
                 "Scope": {
-                  "shape": "Skx",
                   "locationName": "scope"
                 },
                 "Tags": {
@@ -5982,9 +5729,7 @@
           "IncludeMarketplace": {
             "type": "boolean"
           },
-          "InstanceType": {
-            "shape": "S55"
-          },
+          "InstanceType": {},
           "MaxDuration": {
             "type": "long"
           },
@@ -5994,12 +5739,8 @@
           "MinDuration": {
             "type": "long"
           },
-          "OfferingClass": {
-            "shape": "Skl"
-          },
-          "ProductDescription": {
-            "shape": "Sks"
-          },
+          "OfferingClass": {},
+          "ProductDescription": {},
           "ReservedInstancesOfferingIds": {
             "locationName": "ReservedInstancesOfferingId",
             "type": "list",
@@ -6010,7 +5751,6 @@
             "type": "boolean"
           },
           "InstanceTenancy": {
-            "shape": "S4a",
             "locationName": "instanceTenancy"
           },
           "MaxResults": {
@@ -6021,7 +5761,6 @@
             "locationName": "nextToken"
           },
           "OfferingType": {
-            "shape": "Skn",
             "locationName": "offeringType"
           }
         }
@@ -6048,11 +5787,9 @@
                   "type": "float"
                 },
                 "InstanceType": {
-                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
-                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "ReservedInstancesOfferingId": {
@@ -6063,11 +5800,9 @@
                   "type": "float"
                 },
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "InstanceTenancy": {
-                  "shape": "S4a",
                   "locationName": "instanceTenancy"
                 },
                 "Marketplace": {
@@ -6075,11 +5810,9 @@
                   "type": "boolean"
                 },
                 "OfferingClass": {
-                  "shape": "Skl",
                   "locationName": "offeringClass"
                 },
                 "OfferingType": {
-                  "shape": "Skn",
                   "locationName": "offeringType"
                 },
                 "PricingDetails": {
@@ -6105,7 +5838,6 @@
                   "locationName": "recurringCharges"
                 },
                 "Scope": {
-                  "shape": "Skx",
                   "locationName": "scope"
                 }
               }
@@ -6463,9 +6195,7 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {
-            "shape": "Sma"
-          },
+          "Attribute": {},
           "SnapshotId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -6617,7 +6347,6 @@
             "type": "boolean"
           },
           "EventType": {
-            "shape": "Smo",
             "locationName": "eventType"
           },
           "MaxResults": {
@@ -6662,7 +6391,6 @@
                   "locationName": "eventInformation"
                 },
                 "EventType": {
-                  "shape": "Smo",
                   "locationName": "eventType"
                 },
                 "Timestamp": {
@@ -6733,14 +6461,7 @@
               ],
               "members": {
                 "ActivityStatus": {
-                  "locationName": "activityStatus",
-                  "type": "string",
-                  "enum": [
-                    "error",
-                    "pending_fulfillment",
-                    "pending_termination",
-                    "fulfilled"
-                  ]
+                  "locationName": "activityStatus"
                 },
                 "CreateTime": {
                   "locationName": "createTime",
@@ -6754,7 +6475,6 @@
                   "locationName": "spotFleetRequestId"
                 },
                 "SpotFleetRequestState": {
-                  "shape": "S3e",
                   "locationName": "spotFleetRequestState"
                 }
               }
@@ -6813,9 +6533,7 @@
           "InstanceTypes": {
             "locationName": "InstanceType",
             "type": "list",
-            "member": {
-              "shape": "S55"
-            }
+            "member": {}
           },
           "MaxResults": {
             "locationName": "maxResults",
@@ -6852,11 +6570,9 @@
                   "locationName": "availabilityZone"
                 },
                 "InstanceType": {
-                  "shape": "S55",
                   "locationName": "instanceType"
                 },
                 "ProductDescription": {
-                  "shape": "Sks",
                   "locationName": "productDescription"
                 },
                 "SpotPrice": {
@@ -6883,11 +6599,9 @@
             "type": "boolean"
           },
           "MaxResults": {
-            "shape": "Sfr"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sfq"
-          },
+          "NextToken": {},
           "VpcId": {}
         }
       },
@@ -7009,7 +6723,6 @@
                   "locationName": "resourceId"
                 },
                 "ResourceType": {
-                  "shape": "S10",
                   "locationName": "resourceType"
                 },
                 "Value": {
@@ -7029,13 +6742,7 @@
           "VolumeId"
         ],
         "members": {
-          "Attribute": {
-            "type": "string",
-            "enum": [
-              "autoEnableIO",
-              "productCodes"
-            ]
-          },
+          "Attribute": {},
           "VolumeId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -7162,12 +6869,7 @@
                         "type": "structure",
                         "members": {
                           "Name": {
-                            "locationName": "name",
-                            "type": "string",
-                            "enum": [
-                              "io-enabled",
-                              "io-performance"
-                            ]
+                            "locationName": "name"
                           },
                           "Status": {
                             "locationName": "status"
@@ -7176,13 +6878,7 @@
                       }
                     },
                     "Status": {
-                      "locationName": "status",
-                      "type": "string",
-                      "enum": [
-                        "ok",
-                        "impaired",
-                        "insufficient-data"
-                      ]
+                      "locationName": "status"
                     }
                   }
                 }
@@ -7280,13 +6976,7 @@
           "VpcId"
         ],
         "members": {
-          "Attribute": {
-            "type": "string",
-            "enum": [
-              "enableDnsSupport",
-              "enableDnsHostnames"
-            ]
-          },
+          "Attribute": {},
           "VpcId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -7361,11 +7051,10 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Sfr",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
-            "shape": "Sfq",
             "locationName": "nextToken"
           },
           "VpcIds": {
@@ -7377,7 +7066,6 @@
         "type": "structure",
         "members": {
           "NextToken": {
-            "shape": "Sfq",
             "locationName": "nextToken"
           },
           "Vpcs": {
@@ -7472,7 +7160,6 @@
                   "locationName": "vpcEndpointOwner"
                 },
                 "VpcEndpointState": {
-                  "shape": "S9t",
                   "locationName": "vpcEndpointState"
                 },
                 "CreationTimestamp": {
@@ -7558,16 +7245,7 @@
               "type": "structure",
               "members": {
                 "PrincipalType": {
-                  "locationName": "principalType",
-                  "type": "string",
-                  "enum": [
-                    "All",
-                    "Service",
-                    "OrganizationUnit",
-                    "Account",
-                    "User",
-                    "Role"
-                  ]
+                  "locationName": "principalType"
                 },
                 "Principal": {
                   "locationName": "principal"
@@ -8253,7 +7931,6 @@
         "type": "structure",
         "members": {
           "CurrencyCode": {
-            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Purchase": {
@@ -8532,7 +8209,6 @@
                 "locationName": "additionalInfo"
               },
               "Architecture": {
-                "shape": "Sh6",
                 "locationName": "architecture"
               },
               "GroupIds": {
@@ -8544,11 +8220,9 @@
                 "locationName": "GroupName"
               },
               "InstanceInitiatedShutdownBehavior": {
-                "shape": "S6k",
                 "locationName": "instanceInitiatedShutdownBehavior"
               },
               "InstanceType": {
-                "shape": "S55",
                 "locationName": "instanceType"
               },
               "Monitoring": {
@@ -8577,7 +8251,6 @@
             }
           },
           "Platform": {
-            "shape": "Sdq",
             "locationName": "platform"
           }
         }
@@ -8717,9 +8390,7 @@
           "DryRun": {
             "type": "boolean"
           },
-          "ExcessCapacityTerminationPolicy": {
-            "shape": "S4y"
-          },
+          "ExcessCapacityTerminationPolicy": {},
           "FleetId": {},
           "TargetCapacitySpecification": {
             "shape": "S56"
@@ -8747,12 +8418,8 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {
-            "shape": "Sfe"
-          },
-          "OperationType": {
-            "shape": "Ssf"
-          },
+          "Attribute": {},
+          "OperationType": {},
           "UserIds": {
             "shape": "Ssg",
             "locationName": "UserId"
@@ -8799,7 +8466,6 @@
         ],
         "members": {
           "AutoPlacement": {
-            "shape": "Sx",
             "locationName": "autoPlacement"
           },
           "HostIds": {
@@ -8882,9 +8548,7 @@
               }
             }
           },
-          "OperationType": {
-            "shape": "Ssf"
-          },
+          "OperationType": {},
           "ProductCodes": {
             "shape": "Ssi",
             "locationName": "ProductCode"
@@ -8916,7 +8580,6 @@
             "shape": "Shw"
           },
           "Attribute": {
-            "shape": "Shr",
             "locationName": "attribute"
           },
           "BlockDeviceMappings": {
@@ -9066,14 +8729,7 @@
                   "type": "structure",
                   "members": {
                     "Code": {
-                      "locationName": "code",
-                      "type": "string",
-                      "enum": [
-                        "InvalidInstanceID.Malformed",
-                        "InvalidInstanceID.NotFound",
-                        "IncorrectInstanceState",
-                        "InstanceCreditSpecification.NotSupported"
-                      ]
+                      "locationName": "code"
                     },
                     "Message": {
                       "locationName": "message"
@@ -9094,12 +8750,7 @@
         ],
         "members": {
           "Affinity": {
-            "locationName": "affinity",
-            "type": "string",
-            "enum": [
-              "default",
-              "host"
-            ]
+            "locationName": "affinity"
           },
           "GroupName": {},
           "HostId": {
@@ -9109,12 +8760,7 @@
             "locationName": "instanceId"
           },
           "Tenancy": {
-            "locationName": "tenancy",
-            "type": "string",
-            "enum": [
-              "dedicated",
-              "host"
-            ]
+            "locationName": "tenancy"
           }
         }
       },
@@ -9137,9 +8783,7 @@
           },
           "ClientToken": {},
           "LaunchTemplateId": {},
-          "LaunchTemplateName": {
-            "shape": "S52"
-          },
+          "LaunchTemplateName": {},
           "DefaultVersion": {
             "locationName": "SetDefaultVersion"
           }
@@ -9238,9 +8882,7 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {
-            "shape": "Sma"
-          },
+          "Attribute": {},
           "CreateVolumePermission": {
             "type": "structure",
             "members": {
@@ -9256,9 +8898,7 @@
             "shape": "Sm5",
             "locationName": "UserGroup"
           },
-          "OperationType": {
-            "shape": "Ssf"
-          },
+          "OperationType": {},
           "SnapshotId": {},
           "UserIds": {
             "shape": "Ssg",
@@ -9279,7 +8919,6 @@
         ],
         "members": {
           "ExcessCapacityTerminationPolicy": {
-            "shape": "Sn0",
             "locationName": "excessCapacityTerminationPolicy"
           },
           "SpotFleetRequestId": {
@@ -9334,9 +8973,7 @@
           "Size": {
             "type": "integer"
           },
-          "VolumeType": {
-            "shape": "S5n"
-          },
+          "VolumeType": {},
           "Iops": {
             "type": "integer"
           }
@@ -9575,12 +9212,7 @@
         ],
         "members": {
           "VpcId": {},
-          "InstanceTenancy": {
-            "type": "string",
-            "enum": [
-              "default"
-            ]
-          },
+          "InstanceTenancy": {},
           "DryRun": {
             "type": "boolean"
           }
@@ -9646,7 +9278,6 @@
             "locationName": "allocationId"
           },
           "Status": {
-            "shape": "Sue",
             "locationName": "status"
           }
         }
@@ -9661,9 +9292,7 @@
         ],
         "members": {
           "ClientToken": {},
-          "CurrencyCode": {
-            "shape": "S36"
-          },
+          "CurrencyCode": {},
           "HostIdSet": {
             "shape": "Srb"
           },
@@ -9678,7 +9307,6 @@
             "locationName": "clientToken"
           },
           "CurrencyCode": {
-            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Purchase": {
@@ -9719,7 +9347,6 @@
                 "type": "double"
               },
               "CurrencyCode": {
-                "shape": "S36",
                 "locationName": "currencyCode"
               }
             }
@@ -9764,8 +9391,7 @@
                 },
                 "PurchaseToken": {}
               }
-            },
-            "min": 1
+            }
           }
         }
       },
@@ -9810,7 +9436,6 @@
         "members": {
           "ImageLocation": {},
           "Architecture": {
-            "shape": "Sh6",
             "locationName": "architecture"
           },
           "BlockDeviceMappings": {
@@ -10051,7 +9676,6 @@
             "locationName": "protocol"
           },
           "RuleAction": {
-            "shape": "S81",
             "locationName": "ruleAction"
           },
           "RuleNumber": {
@@ -10159,19 +9783,7 @@
             "locationName": "reasonCode",
             "type": "list",
             "member": {
-              "locationName": "item",
-              "type": "string",
-              "enum": [
-                "instance-stuck-in-state",
-                "unresponsive",
-                "not-accepting-credentials",
-                "password-not-available",
-                "performance-network",
-                "performance-instance-store",
-                "performance-ebs-volume",
-                "performance-other",
-                "other"
-              ]
+              "locationName": "item"
             }
           },
           "StartTime": {
@@ -10179,12 +9791,7 @@
             "type": "timestamp"
           },
           "Status": {
-            "locationName": "status",
-            "type": "string",
-            "enum": [
-              "ok",
-              "impaired"
-            ]
+            "locationName": "status"
           }
         }
       }
@@ -10273,7 +9880,6 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
-                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -10309,7 +9915,6 @@
             "locationName": "spotPrice"
           },
           "Type": {
-            "shape": "S6t",
             "locationName": "type"
           },
           "ValidFrom": {
@@ -10320,9 +9925,7 @@
             "locationName": "validUntil",
             "type": "timestamp"
           },
-          "InstanceInterruptionBehavior": {
-            "shape": "S6u"
-          }
+          "InstanceInterruptionBehavior": {}
         }
       },
       "output": {
@@ -10346,12 +9949,7 @@
             "type": "boolean"
           },
           "FpgaImageId": {},
-          "Attribute": {
-            "type": "string",
-            "enum": [
-              "loadPermission"
-            ]
-          }
+          "Attribute": {}
         }
       },
       "output": {
@@ -10372,12 +9970,7 @@
           "ImageId"
         ],
         "members": {
-          "Attribute": {
-            "type": "string",
-            "enum": [
-              "launchPermission"
-            ]
-          },
+          "Attribute": {},
           "ImageId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -10395,7 +9988,6 @@
         ],
         "members": {
           "Attribute": {
-            "shape": "Shr",
             "locationName": "attribute"
           },
           "DryRun": {
@@ -10436,9 +10028,7 @@
           "SnapshotId"
         ],
         "members": {
-          "Attribute": {
-            "shape": "Sma"
-          },
+          "Attribute": {},
           "SnapshotId": {},
           "DryRun": {
             "locationName": "dryRun",
@@ -10470,7 +10060,6 @@
             "locationName": "publicIp"
           },
           "Status": {
-            "shape": "Sue",
             "locationName": "status"
           }
         }
@@ -10556,9 +10145,7 @@
             "locationName": "BlockDeviceMapping"
           },
           "ImageId": {},
-          "InstanceType": {
-            "shape": "S55"
-          },
+          "InstanceType": {},
           "Ipv6AddressCount": {
             "type": "integer"
           },
@@ -10614,7 +10201,6 @@
             "locationName": "iamInstanceProfile"
           },
           "InstanceInitiatedShutdownBehavior": {
-            "shape": "S6k",
             "locationName": "instanceInitiatedShutdownBehavior"
           },
           "NetworkInterfaces": {
@@ -10646,25 +10232,19 @@
           "InstanceMarketOptions": {
             "type": "structure",
             "members": {
-              "MarketType": {
-                "shape": "S6r"
-              },
+              "MarketType": {},
               "SpotOptions": {
                 "type": "structure",
                 "members": {
                   "MaxPrice": {},
-                  "SpotInstanceType": {
-                    "shape": "S6t"
-                  },
+                  "SpotInstanceType": {},
                   "BlockDurationMinutes": {
                     "type": "integer"
                   },
                   "ValidUntil": {
                     "type": "timestamp"
                   },
-                  "InstanceInterruptionBehavior": {
-                    "shape": "S6u"
-                  }
+                  "InstanceInterruptionBehavior": {}
                 }
               }
             }
@@ -11157,19 +10737,7 @@
           "type": "structure",
           "members": {
             "Code": {
-              "locationName": "code",
-              "type": "string",
-              "enum": [
-                "initiating-request",
-                "pending-acceptance",
-                "active",
-                "deleted",
-                "rejected",
-                "failed",
-                "expired",
-                "provisioning",
-                "deleting"
-              ]
+              "locationName": "code"
             },
             "Message": {
               "locationName": "message"
@@ -11261,20 +10829,6 @@
         }
       }
     },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "vpc",
-        "standard"
-      ]
-    },
-    "Sx": {
-      "type": "string",
-      "enum": [
-        "on",
-        "off"
-      ]
-    },
     "Sy": {
       "type": "list",
       "member": {
@@ -11282,7 +10836,6 @@
         "type": "structure",
         "members": {
           "ResourceType": {
-            "shape": "S10",
             "locationName": "resourceType"
           },
           "Tags": {
@@ -11291,29 +10844,6 @@
           }
         }
       }
-    },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "customer-gateway",
-        "dedicated-host",
-        "dhcp-options",
-        "image",
-        "instance",
-        "internet-gateway",
-        "network-acl",
-        "network-interface",
-        "reserved-instances",
-        "route-table",
-        "snapshot",
-        "spot-instances-request",
-        "subnet",
-        "security-group",
-        "volume",
-        "vpc",
-        "vpn-connection",
-        "vpn-gateway"
-      ]
     },
     "S12": {
       "type": "list",
@@ -11358,14 +10888,7 @@
           "locationName": "iamInstanceProfile"
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "associating",
-            "associated",
-            "disassociating",
-            "disassociated"
-          ]
+          "locationName": "state"
         },
         "Timestamp": {
           "locationName": "timestamp",
@@ -11398,16 +10921,7 @@
           "type": "structure",
           "members": {
             "State": {
-              "locationName": "state",
-              "type": "string",
-              "enum": [
-                "associating",
-                "associated",
-                "disassociating",
-                "disassociated",
-                "failing",
-                "failed"
-              ]
+              "locationName": "state"
             },
             "StatusMessage": {
               "locationName": "statusMessage"
@@ -11435,16 +10949,7 @@
       "type": "structure",
       "members": {
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "associating",
-            "associated",
-            "disassociating",
-            "disassociated",
-            "failing",
-            "failed"
-          ]
+          "locationName": "state"
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -11486,15 +10991,7 @@
           "locationName": "instanceId"
         },
         "State": {
-          "locationName": "status",
-          "type": "string",
-          "enum": [
-            "attaching",
-            "attached",
-            "detaching",
-            "detached",
-            "busy"
-          ]
+          "locationName": "status"
         },
         "VolumeId": {
           "locationName": "volumeId"
@@ -11509,22 +11006,12 @@
       "type": "structure",
       "members": {
         "State": {
-          "shape": "S26",
           "locationName": "state"
         },
         "VpcId": {
           "locationName": "vpcId"
         }
       }
-    },
-    "S26": {
-      "type": "string",
-      "enum": [
-        "attaching",
-        "attached",
-        "detaching",
-        "detached"
-      ]
     },
     "S28": {
       "type": "list",
@@ -11681,17 +11168,7 @@
           "type": "timestamp"
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "pending",
-            "waiting-for-shutdown",
-            "bundling",
-            "storing",
-            "cancelling",
-            "complete",
-            "failed"
-          ]
+          "locationName": "state"
         },
         "Storage": {
           "shape": "S2k",
@@ -11728,14 +11205,7 @@
                   "type": "integer"
                 },
                 "State": {
-                  "locationName": "state",
-                  "type": "string",
-                  "enum": [
-                    "available",
-                    "sold",
-                    "cancelled",
-                    "pending"
-                  ]
+                  "locationName": "state"
                 }
               }
             }
@@ -11752,7 +11222,6 @@
                   "type": "boolean"
                 },
                 "CurrencyCode": {
-                  "shape": "S36",
                   "locationName": "currencyCode"
                 },
                 "Price": {
@@ -11773,14 +11242,7 @@
             "locationName": "reservedInstancesListingId"
           },
           "Status": {
-            "locationName": "status",
-            "type": "string",
-            "enum": [
-              "active",
-              "pending",
-              "cancelled",
-              "closed"
-            ]
+            "locationName": "status"
           },
           "StatusMessage": {
             "locationName": "statusMessage"
@@ -11796,35 +11258,11 @@
         }
       }
     },
-    "S36": {
-      "type": "string",
-      "enum": [
-        "USD"
-      ]
-    },
-    "S3e": {
-      "type": "string",
-      "enum": [
-        "submitted",
-        "active",
-        "cancelled",
-        "failed",
-        "cancelled_running",
-        "cancelled_terminating",
-        "modifying"
-      ]
-    },
     "S3k": {
       "type": "list",
       "member": {
         "locationName": "SpotInstanceRequestId"
       }
-    },
-    "S3y": {
-      "type": "string",
-      "enum": [
-        "ipsec.1"
-      ]
     },
     "S40": {
       "type": "structure",
@@ -11872,12 +11310,7 @@
           "type": "boolean"
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "pending",
-            "available"
-          ]
+          "locationName": "state"
         },
         "SubnetId": {
           "locationName": "subnetId"
@@ -11913,18 +11346,12 @@
           "locationName": "dhcpOptionsId"
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "pending",
-            "available"
-          ]
+          "locationName": "state"
         },
         "VpcId": {
           "locationName": "vpcId"
         },
         "InstanceTenancy": {
-          "shape": "S4a",
           "locationName": "instanceTenancy"
         },
         "Ipv6CidrBlockAssociationSet": {
@@ -11952,14 +11379,6 @@
           "locationName": "tagSet"
         }
       }
-    },
-    "S4a": {
-      "type": "string",
-      "enum": [
-        "default",
-        "dedicated",
-        "host"
-      ]
     },
     "S4h": {
       "type": "structure",
@@ -12021,7 +11440,6 @@
         "type": "structure",
         "members": {
           "State": {
-            "shape": "S26",
             "locationName": "state"
           },
           "VpcId": {
@@ -12029,196 +11447,6 @@
           }
         }
       }
-    },
-    "S4u": {
-      "type": "string",
-      "enum": [
-        "lowest-price",
-        "diversified"
-      ]
-    },
-    "S4v": {
-      "type": "string",
-      "enum": [
-        "hibernate",
-        "stop",
-        "terminate"
-      ]
-    },
-    "S4x": {
-      "type": "string",
-      "enum": [
-        "lowest-price",
-        "prioritized"
-      ]
-    },
-    "S4y": {
-      "type": "string",
-      "enum": [
-        "no-termination",
-        "termination"
-      ]
-    },
-    "S52": {
-      "type": "string",
-      "max": 128,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9\\(\\)\\.-/_]+"
-    },
-    "S55": {
-      "type": "string",
-      "enum": [
-        "t1.micro",
-        "t2.nano",
-        "t2.micro",
-        "t2.small",
-        "t2.medium",
-        "t2.large",
-        "t2.xlarge",
-        "t2.2xlarge",
-        "t3.nano",
-        "t3.micro",
-        "t3.small",
-        "t3.medium",
-        "t3.large",
-        "t3.xlarge",
-        "t3.2xlarge",
-        "m1.small",
-        "m1.medium",
-        "m1.large",
-        "m1.xlarge",
-        "m3.medium",
-        "m3.large",
-        "m3.xlarge",
-        "m3.2xlarge",
-        "m4.large",
-        "m4.xlarge",
-        "m4.2xlarge",
-        "m4.4xlarge",
-        "m4.10xlarge",
-        "m4.16xlarge",
-        "m2.xlarge",
-        "m2.2xlarge",
-        "m2.4xlarge",
-        "cr1.8xlarge",
-        "r3.large",
-        "r3.xlarge",
-        "r3.2xlarge",
-        "r3.4xlarge",
-        "r3.8xlarge",
-        "r4.large",
-        "r4.xlarge",
-        "r4.2xlarge",
-        "r4.4xlarge",
-        "r4.8xlarge",
-        "r4.16xlarge",
-        "r5.large",
-        "r5.xlarge",
-        "r5.2xlarge",
-        "r5.4xlarge",
-        "r5.8xlarge",
-        "r5.12xlarge",
-        "r5.16xlarge",
-        "r5.24xlarge",
-        "r5.metal",
-        "r5d.large",
-        "r5d.xlarge",
-        "r5d.2xlarge",
-        "r5d.4xlarge",
-        "r5d.8xlarge",
-        "r5d.12xlarge",
-        "r5d.16xlarge",
-        "r5d.24xlarge",
-        "r5d.metal",
-        "x1.16xlarge",
-        "x1.32xlarge",
-        "x1e.xlarge",
-        "x1e.2xlarge",
-        "x1e.4xlarge",
-        "x1e.8xlarge",
-        "x1e.16xlarge",
-        "x1e.32xlarge",
-        "i2.xlarge",
-        "i2.2xlarge",
-        "i2.4xlarge",
-        "i2.8xlarge",
-        "i3.large",
-        "i3.xlarge",
-        "i3.2xlarge",
-        "i3.4xlarge",
-        "i3.8xlarge",
-        "i3.16xlarge",
-        "i3.metal",
-        "hi1.4xlarge",
-        "hs1.8xlarge",
-        "c1.medium",
-        "c1.xlarge",
-        "c3.large",
-        "c3.xlarge",
-        "c3.2xlarge",
-        "c3.4xlarge",
-        "c3.8xlarge",
-        "c4.large",
-        "c4.xlarge",
-        "c4.2xlarge",
-        "c4.4xlarge",
-        "c4.8xlarge",
-        "c5.large",
-        "c5.xlarge",
-        "c5.2xlarge",
-        "c5.4xlarge",
-        "c5.9xlarge",
-        "c5.18xlarge",
-        "c5d.large",
-        "c5d.xlarge",
-        "c5d.2xlarge",
-        "c5d.4xlarge",
-        "c5d.9xlarge",
-        "c5d.18xlarge",
-        "cc1.4xlarge",
-        "cc2.8xlarge",
-        "g2.2xlarge",
-        "g2.8xlarge",
-        "g3.4xlarge",
-        "g3.8xlarge",
-        "g3.16xlarge",
-        "cg1.4xlarge",
-        "p2.xlarge",
-        "p2.8xlarge",
-        "p2.16xlarge",
-        "p3.2xlarge",
-        "p3.8xlarge",
-        "p3.16xlarge",
-        "d2.xlarge",
-        "d2.2xlarge",
-        "d2.4xlarge",
-        "d2.8xlarge",
-        "f1.2xlarge",
-        "f1.4xlarge",
-        "f1.16xlarge",
-        "m5.large",
-        "m5.xlarge",
-        "m5.2xlarge",
-        "m5.4xlarge",
-        "m5.12xlarge",
-        "m5.24xlarge",
-        "m5d.large",
-        "m5d.xlarge",
-        "m5d.2xlarge",
-        "m5d.4xlarge",
-        "m5d.12xlarge",
-        "m5d.24xlarge",
-        "h1.2xlarge",
-        "h1.4xlarge",
-        "h1.8xlarge",
-        "h1.16xlarge",
-        "z1d.large",
-        "z1d.xlarge",
-        "z1d.2xlarge",
-        "z1d.3xlarge",
-        "z1d.6xlarge",
-        "z1d.12xlarge"
-      ]
     },
     "S56": {
       "type": "structure",
@@ -12235,39 +11463,8 @@
         "SpotTargetCapacity": {
           "type": "integer"
         },
-        "DefaultTargetCapacityType": {
-          "shape": "S57"
-        }
+        "DefaultTargetCapacityType": {}
       }
-    },
-    "S57": {
-      "type": "string",
-      "enum": [
-        "spot",
-        "on-demand"
-      ]
-    },
-    "S58": {
-      "type": "string",
-      "enum": [
-        "request",
-        "maintain"
-      ]
-    },
-    "S5d": {
-      "type": "string",
-      "enum": [
-        "ACCEPT",
-        "REJECT",
-        "ALL"
-      ]
-    },
-    "S5e": {
-      "type": "string",
-      "enum": [
-        "cloud-watch-logs",
-        "s3"
-      ]
     },
     "S5h": {
       "type": "structure",
@@ -12312,7 +11509,6 @@
               "type": "integer"
             },
             "VolumeType": {
-              "shape": "S5n",
               "locationName": "volumeType"
             },
             "Encrypted": {
@@ -12326,38 +11522,6 @@
           "locationName": "noDevice"
         }
       }
-    },
-    "S5n": {
-      "type": "string",
-      "enum": [
-        "standard",
-        "io1",
-        "gp2",
-        "sc1",
-        "st1"
-      ]
-    },
-    "S5r": {
-      "type": "string",
-      "enum": [
-        "ova"
-      ]
-    },
-    "S5s": {
-      "type": "string",
-      "enum": [
-        "VMDK",
-        "RAW",
-        "VHD"
-      ]
-    },
-    "S5t": {
-      "type": "string",
-      "enum": [
-        "citrix",
-        "vmware",
-        "microsoft"
-      ]
     },
     "S5v": {
       "type": "structure",
@@ -12373,11 +11537,9 @@
           "type": "structure",
           "members": {
             "ContainerFormat": {
-              "shape": "S5r",
               "locationName": "containerFormat"
             },
             "DiskImageFormat": {
-              "shape": "S5s",
               "locationName": "diskImageFormat"
             },
             "S3Bucket": {
@@ -12396,20 +11558,12 @@
               "locationName": "instanceId"
             },
             "TargetEnvironment": {
-              "shape": "S5t",
               "locationName": "targetEnvironment"
             }
           }
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "active",
-            "cancelling",
-            "cancelled",
-            "completed"
-          ]
+          "locationName": "state"
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -12431,10 +11585,6 @@
           "locationName": "tagSet"
         }
       }
-    },
-    "S65": {
-      "type": "string",
-      "max": 255
     },
     "S66": {
       "type": "structure",
@@ -12476,9 +11626,7 @@
                   "VolumeSize": {
                     "type": "integer"
                   },
-                  "VolumeType": {
-                    "shape": "S5n"
-                  }
+                  "VolumeType": {}
                 }
               },
               "NoDevice": {}
@@ -12532,9 +11680,7 @@
           }
         },
         "ImageId": {},
-        "InstanceType": {
-          "shape": "S55"
-        },
+        "InstanceType": {},
         "KeyName": {},
         "Monitoring": {
           "type": "structure",
@@ -12551,9 +11697,7 @@
             "Affinity": {},
             "GroupName": {},
             "HostId": {},
-            "Tenancy": {
-              "shape": "S4a"
-            },
+            "Tenancy": {},
             "SpreadDomain": {}
           }
         },
@@ -12561,9 +11705,7 @@
         "DisableApiTermination": {
           "type": "boolean"
         },
-        "InstanceInitiatedShutdownBehavior": {
-          "shape": "S6k"
-        },
+        "InstanceInitiatedShutdownBehavior": {},
         "UserData": {},
         "TagSpecifications": {
           "locationName": "TagSpecification",
@@ -12572,9 +11714,7 @@
             "locationName": "LaunchTemplateTagSpecificationRequest",
             "type": "structure",
             "members": {
-              "ResourceType": {
-                "shape": "S10"
-              },
+              "ResourceType": {},
               "Tags": {
                 "shape": "Sr",
                 "locationName": "Tag"
@@ -12601,25 +11741,19 @@
         "InstanceMarketOptions": {
           "type": "structure",
           "members": {
-            "MarketType": {
-              "shape": "S6r"
-            },
+            "MarketType": {},
             "SpotOptions": {
               "type": "structure",
               "members": {
                 "MaxPrice": {},
-                "SpotInstanceType": {
-                  "shape": "S6t"
-                },
+                "SpotInstanceType": {},
                 "BlockDurationMinutes": {
                   "type": "integer"
                 },
                 "ValidUntil": {
                   "type": "timestamp"
                 },
-                "InstanceInterruptionBehavior": {
-                  "shape": "S6u"
-                }
+                "InstanceInterruptionBehavior": {}
               }
             }
           }
@@ -12662,13 +11796,6 @@
         }
       }
     },
-    "S6k": {
-      "type": "string",
-      "enum": [
-        "stop",
-        "terminate"
-      ]
-    },
     "S6o": {
       "type": "structure",
       "required": [
@@ -12683,27 +11810,6 @@
       "member": {
         "locationName": "SecurityGroup"
       }
-    },
-    "S6r": {
-      "type": "string",
-      "enum": [
-        "spot"
-      ]
-    },
-    "S6t": {
-      "type": "string",
-      "enum": [
-        "one-time",
-        "persistent"
-      ]
-    },
-    "S6u": {
-      "type": "string",
-      "enum": [
-        "hibernate",
-        "stop",
-        "terminate"
-      ]
     },
     "S6v": {
       "type": "structure",
@@ -12721,7 +11827,6 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
-          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "CreateTime": {
@@ -12752,7 +11857,6 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
-          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "VersionNumber": {
@@ -12760,7 +11864,6 @@
           "type": "long"
         },
         "VersionDescription": {
-          "shape": "S65",
           "locationName": "versionDescription"
         },
         "CreateTime": {
@@ -12842,7 +11945,6 @@
                     "type": "integer"
                   },
                   "VolumeType": {
-                    "shape": "S5n",
                     "locationName": "volumeType"
                   }
                 }
@@ -12911,7 +12013,6 @@
           "locationName": "imageId"
         },
         "InstanceType": {
-          "shape": "S55",
           "locationName": "instanceType"
         },
         "KeyName": {
@@ -12944,7 +12045,6 @@
               "locationName": "hostId"
             },
             "Tenancy": {
-              "shape": "S4a",
               "locationName": "tenancy"
             },
             "SpreadDomain": {
@@ -12960,7 +12060,6 @@
           "type": "boolean"
         },
         "InstanceInitiatedShutdownBehavior": {
-          "shape": "S6k",
           "locationName": "instanceInitiatedShutdownBehavior"
         },
         "UserData": {
@@ -12974,7 +12073,6 @@
             "type": "structure",
             "members": {
               "ResourceType": {
-                "shape": "S10",
                 "locationName": "resourceType"
               },
               "Tags": {
@@ -13010,7 +12108,6 @@
           "type": "structure",
           "members": {
             "MarketType": {
-              "shape": "S6r",
               "locationName": "marketType"
             },
             "SpotOptions": {
@@ -13021,7 +12118,6 @@
                   "locationName": "maxPrice"
                 },
                 "SpotInstanceType": {
-                  "shape": "S6t",
                   "locationName": "spotInstanceType"
                 },
                 "BlockDurationMinutes": {
@@ -13033,7 +12129,6 @@
                   "type": "timestamp"
                 },
                 "InstanceInterruptionBehavior": {
-                  "shape": "S6u",
                   "locationName": "instanceInterruptionBehavior"
                 }
               }
@@ -13143,15 +12238,7 @@
           }
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "pending",
-            "failed",
-            "available",
-            "deleting",
-            "deleted"
-          ]
+          "locationName": "state"
         },
         "SubnetId": {
           "locationName": "subnetId"
@@ -13216,7 +12303,6 @@
                 "locationName": "protocol"
               },
               "RuleAction": {
-                "shape": "S81",
                 "locationName": "ruleAction"
               },
               "RuleNumber": {
@@ -13268,13 +12354,6 @@
         }
       }
     },
-    "S81": {
-      "type": "string",
-      "enum": [
-        "allow",
-        "deny"
-      ]
-    },
     "S85": {
       "type": "structure",
       "members": {
@@ -13297,12 +12376,7 @@
           "locationName": "groupSet"
         },
         "InterfaceType": {
-          "locationName": "interfaceType",
-          "type": "string",
-          "enum": [
-            "interface",
-            "natGateway"
-          ]
+          "locationName": "interfaceType"
         },
         "Ipv6Addresses": {
           "locationName": "ipv6AddressesSet",
@@ -13368,7 +12442,6 @@
           "type": "boolean"
         },
         "Status": {
-          "shape": "S8f",
           "locationName": "status"
         },
         "SubnetId": {
@@ -13428,7 +12501,6 @@
           "locationName": "instanceOwnerId"
         },
         "Status": {
-          "shape": "S26",
           "locationName": "status"
         }
       }
@@ -13448,23 +12520,6 @@
         }
       }
     },
-    "S8f": {
-      "type": "string",
-      "enum": [
-        "available",
-        "associated",
-        "attaching",
-        "in-use",
-        "detaching"
-      ]
-    },
-    "S8h": {
-      "type": "string",
-      "enum": [
-        "INSTANCE-ATTACH",
-        "EIP-ASSOCIATE"
-      ]
-    },
     "S8j": {
       "type": "structure",
       "members": {
@@ -13481,7 +12536,6 @@
           "locationName": "awsService"
         },
         "Permission": {
-          "shape": "S8h",
           "locationName": "permission"
         },
         "PermissionState": {
@@ -13489,14 +12543,7 @@
           "type": "structure",
           "members": {
             "State": {
-              "locationName": "state",
-              "type": "string",
-              "enum": [
-                "pending",
-                "granted",
-                "revoking",
-                "revoked"
-              ]
+              "locationName": "state"
             },
             "StatusMessage": {
               "locationName": "statusMessage"
@@ -13504,13 +12551,6 @@
           }
         }
       }
-    },
-    "S8n": {
-      "type": "string",
-      "enum": [
-        "cluster",
-        "spread"
-      ]
     },
     "S8w": {
       "type": "structure",
@@ -13589,21 +12629,10 @@
                 "locationName": "networkInterfaceId"
               },
               "Origin": {
-                "locationName": "origin",
-                "type": "string",
-                "enum": [
-                  "CreateRouteTable",
-                  "CreateRoute",
-                  "EnableVgwRoutePropagation"
-                ]
+                "locationName": "origin"
               },
               "State": {
-                "locationName": "state",
-                "type": "string",
-                "enum": [
-                  "active",
-                  "blackhole"
-                ]
+                "locationName": "state"
               },
               "VpcPeeringConnectionId": {
                 "locationName": "vpcPeeringConnectionId"
@@ -13650,13 +12679,7 @@
           "type": "timestamp"
         },
         "State": {
-          "locationName": "status",
-          "type": "string",
-          "enum": [
-            "pending",
-            "completed",
-            "error"
-          ]
+          "locationName": "status"
         },
         "StateMessage": {
           "locationName": "statusMessage"
@@ -13694,12 +12717,7 @@
           "locationName": "prefix"
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "Active",
-            "Inactive"
-          ]
+          "locationName": "state"
         }
       }
     },
@@ -13751,16 +12769,7 @@
           "locationName": "snapshotId"
         },
         "State": {
-          "locationName": "status",
-          "type": "string",
-          "enum": [
-            "creating",
-            "available",
-            "in-use",
-            "deleting",
-            "deleted",
-            "error"
-          ]
+          "locationName": "status"
         },
         "VolumeId": {
           "locationName": "volumeId"
@@ -13774,17 +12783,9 @@
           "locationName": "tagSet"
         },
         "VolumeType": {
-          "shape": "S5n",
           "locationName": "volumeType"
         }
       }
-    },
-    "S9q": {
-      "type": "string",
-      "enum": [
-        "Interface",
-        "Gateway"
-      ]
     },
     "S9s": {
       "type": "structure",
@@ -13793,7 +12794,6 @@
           "locationName": "vpcEndpointId"
         },
         "VpcEndpointType": {
-          "shape": "S9q",
           "locationName": "vpcEndpointType"
         },
         "VpcId": {
@@ -13803,7 +12803,6 @@
           "locationName": "serviceName"
         },
         "State": {
-          "shape": "S9t",
           "locationName": "state"
         },
         "PolicyDocument": {
@@ -13863,19 +12862,6 @@
         }
       }
     },
-    "S9t": {
-      "type": "string",
-      "enum": [
-        "PendingAcceptance",
-        "Pending",
-        "Available",
-        "Deleting",
-        "Deleted",
-        "Rejected",
-        "Failed",
-        "Expired"
-      ]
-    },
     "Sa0": {
       "type": "structure",
       "members": {
@@ -13889,11 +12875,7 @@
           "locationName": "vpcEndpointId"
         },
         "ConnectionNotificationType": {
-          "locationName": "connectionNotificationType",
-          "type": "string",
-          "enum": [
-            "Topic"
-          ]
+          "locationName": "connectionNotificationType"
         },
         "ConnectionNotificationArn": {
           "locationName": "connectionNotificationArn"
@@ -13903,12 +12885,7 @@
           "locationName": "connectionEvents"
         },
         "ConnectionNotificationState": {
-          "locationName": "connectionNotificationState",
-          "type": "string",
-          "enum": [
-            "Enabled",
-            "Disabled"
-          ]
+          "locationName": "connectionNotificationState"
         }
       }
     },
@@ -13926,15 +12903,7 @@
           "locationName": "serviceName"
         },
         "ServiceState": {
-          "locationName": "serviceState",
-          "type": "string",
-          "enum": [
-            "Pending",
-            "Available",
-            "Deleting",
-            "Deleted",
-            "Failed"
-          ]
+          "locationName": "serviceState"
         },
         "AvailabilityZones": {
           "shape": "Sa",
@@ -13964,12 +12933,7 @@
         "type": "structure",
         "members": {
           "ServiceType": {
-            "locationName": "serviceType",
-            "type": "string",
-            "enum": [
-              "Interface",
-              "Gateway"
-            ]
+            "locationName": "serviceType"
           }
         }
       }
@@ -13987,11 +12951,9 @@
           "locationName": "category"
         },
         "State": {
-          "shape": "Sai",
           "locationName": "state"
         },
         "Type": {
-          "shape": "S3y",
           "locationName": "type"
         },
         "VpnConnectionId": {
@@ -14021,14 +12983,9 @@
                 "locationName": "destinationCidrBlock"
               },
               "Source": {
-                "locationName": "source",
-                "type": "string",
-                "enum": [
-                  "Static"
-                ]
+                "locationName": "source"
               },
               "State": {
-                "shape": "Sai",
                 "locationName": "state"
               }
             }
@@ -14057,12 +13014,7 @@
                 "locationName": "outsideIpAddress"
               },
               "Status": {
-                "locationName": "status",
-                "type": "string",
-                "enum": [
-                  "UP",
-                  "DOWN"
-                ]
+                "locationName": "status"
               },
               "StatusMessage": {
                 "locationName": "statusMessage"
@@ -14072,15 +13024,6 @@
         }
       }
     },
-    "Sai": {
-      "type": "string",
-      "enum": [
-        "pending",
-        "available",
-        "deleting",
-        "deleted"
-      ]
-    },
     "Sat": {
       "type": "structure",
       "members": {
@@ -14088,11 +13031,9 @@
           "locationName": "availabilityZone"
         },
         "State": {
-          "shape": "Sai",
           "locationName": "state"
         },
         "Type": {
-          "shape": "S3y",
           "locationName": "type"
         },
         "VpcAttachments": {
@@ -14119,18 +13060,6 @@
     "Sb0": {
       "type": "list",
       "member": {}
-    },
-    "Sb4": {
-      "type": "string",
-      "enum": [
-        "submitted",
-        "active",
-        "deleted",
-        "failed",
-        "deleted-running",
-        "deleted-terminating",
-        "modifying"
-      ]
     },
     "Sbi": {
       "type": "list",
@@ -14198,7 +13127,6 @@
               "locationName": "instanceId"
             },
             "Platform": {
-              "shape": "Sdq",
               "locationName": "platform"
             },
             "Volumes": {
@@ -14269,14 +13197,7 @@
           }
         },
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "active",
-            "cancelling",
-            "cancelled",
-            "completed"
-          ]
+          "locationName": "state"
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -14287,12 +13208,6 @@
         }
       }
     },
-    "Sdq": {
-      "type": "string",
-      "enum": [
-        "Windows"
-      ]
-    },
     "Sdt": {
       "type": "structure",
       "members": {
@@ -14300,7 +13215,6 @@
           "locationName": "checksum"
         },
         "Format": {
-          "shape": "S5s",
           "locationName": "format"
         },
         "ImportManifestUrl": {
@@ -14323,14 +13237,6 @@
           "type": "long"
         }
       }
-    },
-    "Sem": {
-      "type": "string",
-      "enum": [
-        "instance-change",
-        "fleet-change",
-        "service-error"
-      ]
     },
     "Seq": {
       "type": "structure",
@@ -14362,12 +13268,7 @@
             "locationName": "spotInstanceRequestId"
           },
           "InstanceHealth": {
-            "locationName": "instanceHealth",
-            "type": "string",
-            "enum": [
-              "healthy",
-              "unhealthy"
-            ]
+            "locationName": "instanceHealth"
           }
         }
       }
@@ -14379,22 +13280,12 @@
           "locationName": "launchTemplateId"
         },
         "LaunchTemplateName": {
-          "shape": "S52",
           "locationName": "launchTemplateName"
         },
         "Version": {
           "locationName": "version"
         }
       }
-    },
-    "Sfe": {
-      "type": "string",
-      "enum": [
-        "description",
-        "name",
-        "loadPermission",
-        "productCodes"
-      ]
     },
     "Sfg": {
       "type": "structure",
@@ -14419,7 +13310,6 @@
                 "locationName": "userId"
               },
               "Group": {
-                "shape": "Sfj",
                 "locationName": "group"
               }
             }
@@ -14431,12 +13321,6 @@
         }
       }
     },
-    "Sfj": {
-      "type": "string",
-      "enum": [
-        "all"
-      ]
-    },
     "Sfk": {
       "type": "list",
       "member": {
@@ -14447,12 +13331,7 @@
             "locationName": "productCode"
           },
           "ProductCodeType": {
-            "locationName": "type",
-            "type": "string",
-            "enum": [
-              "devpay",
-              "marketplace"
-            ]
+            "locationName": "type"
           }
         }
       }
@@ -14462,24 +13341,6 @@
       "member": {
         "locationName": "Owner"
       }
-    },
-    "Sfq": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "Sfr": {
-      "type": "integer",
-      "max": 255,
-      "min": 5
-    },
-    "Sg2": {
-      "type": "string",
-      "enum": [
-        "AllUpfront",
-        "PartialUpfront",
-        "NoUpfront"
-      ]
     },
     "Sg8": {
       "type": "list",
@@ -14507,7 +13368,6 @@
         "type": "structure",
         "members": {
           "Group": {
-            "shape": "Sfj",
             "locationName": "group"
           },
           "UserId": {
@@ -14515,27 +13375,6 @@
           }
         }
       }
-    },
-    "Sh6": {
-      "type": "string",
-      "enum": [
-        "i386",
-        "x86_64"
-      ]
-    },
-    "Sh9": {
-      "type": "string",
-      "enum": [
-        "ovm",
-        "xen"
-      ]
-    },
-    "Sha": {
-      "type": "string",
-      "enum": [
-        "ebs",
-        "instance-store"
-      ]
     },
     "Shb": {
       "type": "structure",
@@ -14547,13 +13386,6 @@
           "locationName": "message"
         }
       }
-    },
-    "Shc": {
-      "type": "string",
-      "enum": [
-        "hvm",
-        "paravirtual"
-      ]
     },
     "She": {
       "type": "list",
@@ -14647,25 +13479,6 @@
         }
       }
     },
-    "Shr": {
-      "type": "string",
-      "enum": [
-        "instanceType",
-        "kernel",
-        "ramdisk",
-        "userData",
-        "disableApiTermination",
-        "instanceInitiatedShutdownBehavior",
-        "rootDeviceName",
-        "blockDeviceMapping",
-        "productCodes",
-        "sourceDestCheck",
-        "groupSet",
-        "ebsOptimized",
-        "sriovNetSupport",
-        "enaSupport"
-      ]
-    },
     "Sht": {
       "type": "list",
       "member": {
@@ -14688,7 +13501,6 @@
                 "type": "boolean"
               },
               "Status": {
-                "shape": "S26",
                 "locationName": "status"
               },
               "VolumeId": {
@@ -14716,16 +13528,7 @@
           "type": "integer"
         },
         "Name": {
-          "locationName": "name",
-          "type": "string",
-          "enum": [
-            "pending",
-            "running",
-            "shutting-down",
-            "terminated",
-            "stopping",
-            "stopped"
-          ]
+          "locationName": "name"
         }
       }
     },
@@ -14744,35 +13547,16 @@
                 "type": "timestamp"
               },
               "Name": {
-                "locationName": "name",
-                "type": "string",
-                "enum": [
-                  "reachability"
-                ]
+                "locationName": "name"
               },
               "Status": {
-                "locationName": "status",
-                "type": "string",
-                "enum": [
-                  "passed",
-                  "failed",
-                  "insufficient-data",
-                  "initializing"
-                ]
+                "locationName": "status"
               }
             }
           }
         },
         "Status": {
-          "locationName": "status",
-          "type": "string",
-          "enum": [
-            "ok",
-            "impaired",
-            "insufficient-data",
-            "not-applicable",
-            "initializing"
-          ]
+          "locationName": "status"
         }
       }
     },
@@ -14801,7 +13585,6 @@
                 "locationName": "instanceId"
               },
               "InstanceType": {
-                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -14823,7 +13606,6 @@
                 "locationName": "placement"
               },
               "Platform": {
-                "shape": "Sdq",
                 "locationName": "platform"
               },
               "PrivateDnsName": {
@@ -14859,7 +13641,6 @@
                 "locationName": "vpcId"
               },
               "Architecture": {
-                "shape": "Sh6",
                 "locationName": "architecture"
               },
               "BlockDeviceMappings": {
@@ -14878,7 +13659,6 @@
                 "type": "boolean"
               },
               "Hypervisor": {
-                "shape": "Sh9",
                 "locationName": "hypervisor"
               },
               "IamInstanceProfile": {
@@ -14886,12 +13666,7 @@
                 "locationName": "iamInstanceProfile"
               },
               "InstanceLifecycle": {
-                "locationName": "instanceLifecycle",
-                "type": "string",
-                "enum": [
-                  "spot",
-                  "scheduled"
-                ]
+                "locationName": "instanceLifecycle"
               },
               "ElasticGpuAssociations": {
                 "locationName": "elasticGpuAssociationSet",
@@ -14946,7 +13721,6 @@
                           "type": "integer"
                         },
                         "Status": {
-                          "shape": "S26",
                           "locationName": "status"
                         }
                       }
@@ -15006,7 +13780,6 @@
                       "type": "boolean"
                     },
                     "Status": {
-                      "shape": "S8f",
                       "locationName": "status"
                     },
                     "SubnetId": {
@@ -15022,7 +13795,6 @@
                 "locationName": "rootDeviceName"
               },
               "RootDeviceType": {
-                "shape": "Sha",
                 "locationName": "rootDeviceType"
               },
               "SecurityGroups": {
@@ -15048,7 +13820,6 @@
                 "locationName": "tagSet"
               },
               "VirtualizationType": {
-                "shape": "Shc",
                 "locationName": "virtualizationType"
               },
               "CpuOptions": {
@@ -15083,14 +13854,7 @@
       "type": "structure",
       "members": {
         "State": {
-          "locationName": "state",
-          "type": "string",
-          "enum": [
-            "disabled",
-            "disabling",
-            "enabled",
-            "pending"
-          ]
+          "locationName": "state"
         }
       }
     },
@@ -15110,7 +13874,6 @@
           "locationName": "hostId"
         },
         "Tenancy": {
-          "shape": "S4a",
           "locationName": "tenancy"
         },
         "SpreadDomain": {
@@ -15132,38 +13895,11 @@
         }
       }
     },
-    "Skl": {
-      "type": "string",
-      "enum": [
-        "standard",
-        "convertible"
-      ]
-    },
     "Skm": {
       "type": "list",
       "member": {
         "locationName": "ReservedInstancesId"
       }
-    },
-    "Skn": {
-      "type": "string",
-      "enum": [
-        "Heavy Utilization",
-        "Medium Utilization",
-        "Light Utilization",
-        "No Upfront",
-        "Partial Upfront",
-        "All Upfront"
-      ]
-    },
-    "Sks": {
-      "type": "string",
-      "enum": [
-        "Linux/UNIX",
-        "Linux/UNIX (Amazon VPC)",
-        "Windows",
-        "Windows (Amazon VPC)"
-      ]
     },
     "Sku": {
       "type": "list",
@@ -15176,21 +13912,10 @@
             "type": "double"
           },
           "Frequency": {
-            "locationName": "frequency",
-            "type": "string",
-            "enum": [
-              "Hourly"
-            ]
+            "locationName": "frequency"
           }
         }
       }
-    },
-    "Skx": {
-      "type": "string",
-      "enum": [
-        "Availability Zone",
-        "Region"
-      ]
     },
     "Sl7": {
       "type": "structure",
@@ -15203,14 +13928,12 @@
           "type": "integer"
         },
         "InstanceType": {
-          "shape": "S55",
           "locationName": "instanceType"
         },
         "Platform": {
           "locationName": "platform"
         },
         "Scope": {
-          "shape": "Skx",
           "locationName": "scope"
         }
       }
@@ -15307,13 +14030,6 @@
         "locationName": "GroupName"
       }
     },
-    "Sma": {
-      "type": "string",
-      "enum": [
-        "productCodes",
-        "createVolumePermission"
-      ]
-    },
     "Smc": {
       "type": "list",
       "member": {
@@ -15321,7 +14037,6 @@
         "type": "structure",
         "members": {
           "Group": {
-            "shape": "Sfj",
             "locationName": "group"
           },
           "UserId": {
@@ -15329,14 +14044,6 @@
           }
         }
       }
-    },
-    "Smo": {
-      "type": "string",
-      "enum": [
-        "instanceChange",
-        "fleetRequestChange",
-        "error"
-      ]
     },
     "Smx": {
       "type": "structure",
@@ -15346,26 +14053,15 @@
       ],
       "members": {
         "AllocationStrategy": {
-          "locationName": "allocationStrategy",
-          "type": "string",
-          "enum": [
-            "lowestPrice",
-            "diversified"
-          ]
+          "locationName": "allocationStrategy"
         },
         "OnDemandAllocationStrategy": {
-          "locationName": "onDemandAllocationStrategy",
-          "type": "string",
-          "enum": [
-            "lowestPrice",
-            "prioritized"
-          ]
+          "locationName": "onDemandAllocationStrategy"
         },
         "ClientToken": {
           "locationName": "clientToken"
         },
         "ExcessCapacityTerminationPolicy": {
-          "shape": "Sn0",
           "locationName": "excessCapacityTerminationPolicy"
         },
         "FulfilledCapacity": {
@@ -15409,7 +14105,6 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
-                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -15460,7 +14155,6 @@
                   "type": "structure",
                   "members": {
                     "ResourceType": {
-                      "shape": "S10",
                       "locationName": "resourceType"
                     },
                     "Tags": {
@@ -15492,7 +14186,6 @@
                   "type": "structure",
                   "members": {
                     "InstanceType": {
-                      "shape": "S55",
                       "locationName": "instanceType"
                     },
                     "SpotPrice": {
@@ -15534,7 +14227,6 @@
           "type": "boolean"
         },
         "Type": {
-          "shape": "S58",
           "locationName": "type"
         },
         "ValidFrom": {
@@ -15550,7 +14242,6 @@
           "type": "boolean"
         },
         "InstanceInterruptionBehavior": {
-          "shape": "S6u",
           "locationName": "instanceInterruptionBehavior"
         },
         "LoadBalancersConfig": {
@@ -15578,9 +14269,7 @@
                         "locationName": "name"
                       }
                     }
-                  },
-                  "max": 5,
-                  "min": 1
+                  }
                 }
               }
             },
@@ -15605,9 +14294,7 @@
                         "locationName": "arn"
                       }
                     }
-                  },
-                  "max": 5,
-                  "min": 1
+                  }
                 }
               }
             }
@@ -15618,13 +14305,6 @@
           "type": "integer"
         }
       }
-    },
-    "Sn0": {
-      "type": "string",
-      "enum": [
-        "noTermination",
-        "default"
-      ]
     },
     "Sn4": {
       "type": "list",
@@ -15691,7 +14371,6 @@
           "locationName": "groupName"
         },
         "Tenancy": {
-          "shape": "S4a",
           "locationName": "tenancy"
         }
       }
@@ -15756,7 +14435,6 @@
                 "locationName": "imageId"
               },
               "InstanceType": {
-                "shape": "S55",
                 "locationName": "instanceType"
               },
               "KernelId": {
@@ -15789,7 +14467,6 @@
             "locationName": "launchedAvailabilityZone"
           },
           "ProductDescription": {
-            "shape": "Sks",
             "locationName": "productDescription"
           },
           "SpotInstanceRequestId": {
@@ -15799,15 +14476,7 @@
             "locationName": "spotPrice"
           },
           "State": {
-            "locationName": "state",
-            "type": "string",
-            "enum": [
-              "open",
-              "active",
-              "closed",
-              "cancelled",
-              "failed"
-            ]
+            "locationName": "state"
           },
           "Status": {
             "locationName": "status",
@@ -15830,7 +14499,6 @@
             "locationName": "tagSet"
           },
           "Type": {
-            "shape": "S6t",
             "locationName": "type"
           },
           "ValidFrom": {
@@ -15842,7 +14510,6 @@
             "type": "timestamp"
           },
           "InstanceInterruptionBehavior": {
-            "shape": "S6u",
             "locationName": "instanceInterruptionBehavior"
           }
         }
@@ -15915,14 +14582,7 @@
           "locationName": "volumeId"
         },
         "ModificationState": {
-          "locationName": "modificationState",
-          "type": "string",
-          "enum": [
-            "modifying",
-            "optimizing",
-            "completed",
-            "failed"
-          ]
+          "locationName": "modificationState"
         },
         "StatusMessage": {
           "locationName": "statusMessage"
@@ -15936,7 +14596,6 @@
           "type": "integer"
         },
         "TargetVolumeType": {
-          "shape": "S5n",
           "locationName": "targetVolumeType"
         },
         "OriginalSize": {
@@ -15948,7 +14607,6 @@
           "type": "integer"
         },
         "OriginalVolumeType": {
-          "shape": "S5n",
           "locationName": "originalVolumeType"
         },
         "Progress": {
@@ -15984,7 +14642,6 @@
         "type": "structure",
         "members": {
           "CurrencyCode": {
-            "shape": "S36",
             "locationName": "currencyCode"
           },
           "Duration": {
@@ -16005,7 +14662,6 @@
             "locationName": "instanceFamily"
           },
           "PaymentOption": {
-            "shape": "Sg2",
             "locationName": "paymentOption"
           },
           "UpfrontPrice": {
@@ -16063,7 +14719,6 @@
           "type": "long"
         },
         "Format": {
-          "shape": "S5s",
           "locationName": "format"
         },
         "ImportManifestUrl": {
@@ -16082,13 +14737,6 @@
           "type": "long"
         }
       }
-    },
-    "Ssf": {
-      "type": "string",
-      "enum": [
-        "add",
-        "remove"
-      ]
     },
     "Ssg": {
       "type": "list",
@@ -16114,9 +14762,7 @@
         "locationName": "item",
         "type": "structure",
         "members": {
-          "Group": {
-            "shape": "Sfj"
-          },
+          "Group": {},
           "UserId": {}
         }
       }
@@ -16174,14 +14820,6 @@
           }
         }
       }
-    },
-    "Sue": {
-      "type": "string",
-      "enum": [
-        "MoveInProgress",
-        "InVpc",
-        "InClassic"
-      ]
     },
     "Sw8": {
       "type": "list",

--- a/apis/ecr-2015-09-21.min.json
+++ b/apis/ecr-2015-09-21.min.json
@@ -21,19 +21,11 @@
           "layerDigests"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "layerDigests": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -45,16 +37,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "layerDigest": {
-                  "shape": "S9"
-                },
-                "layerAvailability": {
-                  "type": "string",
-                  "enum": [
-                    "AVAILABLE",
-                    "UNAVAILABLE"
-                  ]
-                },
+                "layerDigest": {},
+                "layerAvailability": {},
                 "layerSize": {
                   "type": "long"
                 },
@@ -67,16 +51,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "layerDigest": {
-                  "shape": "S5"
-                },
-                "failureCode": {
-                  "type": "string",
-                  "enum": [
-                    "InvalidLayerDigest",
-                    "MissingLayerDigest"
-                  ]
-                },
+                "layerDigest": {},
+                "failureCode": {},
                 "failureReason": {}
               }
             }
@@ -92,12 +68,8 @@
           "imageIds"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "imageIds": {
             "shape": "Si"
           }
@@ -123,20 +95,14 @@
           "imageIds"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "imageIds": {
             "shape": "Si"
           },
           "acceptedMediaTypes": {
             "type": "list",
-            "member": {},
-            "max": 100,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -164,40 +130,22 @@
           "layerDigests"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "uploadId": {
-            "shape": "Sy"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "uploadId": {},
           "layerDigests": {
             "type": "list",
-            "member": {
-              "shape": "S9"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "uploadId": {
-            "shape": "Sy"
-          },
-          "layerDigest": {
-            "shape": "S9"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "uploadId": {},
+          "layerDigest": {}
         }
       }
     },
@@ -208,9 +156,7 @@
           "repositoryName"
         ],
         "members": {
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "repositoryName": {}
         }
       },
       "output": {
@@ -229,26 +175,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "registryId": {},
+          "repositoryName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {},
           "lastEvaluatedAt": {
             "type": "timestamp"
           }
@@ -262,12 +198,8 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "force": {
             "type": "boolean"
           }
@@ -289,26 +221,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "registryId": {},
+          "repositoryName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "policyText": {
-            "shape": "S1g"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "policyText": {}
         }
       }
     },
@@ -319,25 +241,19 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "imageIds": {
             "shape": "Si"
           },
           "nextToken": {},
           "maxResults": {
-            "shape": "S1j"
+            "type": "integer"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {
-                "shape": "S1l"
-              }
+              "tagStatus": {}
             }
           }
         }
@@ -350,12 +266,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "registryId": {
-                  "shape": "S2"
-                },
-                "repositoryName": {
-                  "shape": "S3"
-                },
+                "registryId": {},
+                "repositoryName": {},
                 "imageDigest": {},
                 "imageTags": {
                   "shape": "S1p"
@@ -377,20 +289,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
+          "registryId": {},
           "repositoryNames": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           },
           "nextToken": {},
           "maxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -413,11 +319,7 @@
         "members": {
           "registryIds": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            },
-            "max": 10,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -429,10 +331,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "authorizationToken": {
-                  "type": "string",
-                  "pattern": "^\\S+$"
-                },
+                "authorizationToken": {},
                 "expiresAt": {
                   "type": "timestamp"
                 },
@@ -451,24 +350,16 @@
           "layerDigest"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "layerDigest": {
-            "shape": "S9"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "layerDigest": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "downloadUrl": {},
-          "layerDigest": {
-            "shape": "S9"
-          }
+          "layerDigest": {}
         }
       }
     },
@@ -479,26 +370,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "registryId": {},
+          "repositoryName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {},
           "lastEvaluatedAt": {
             "type": "timestamp"
           }
@@ -512,25 +393,19 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "imageIds": {
             "shape": "Si"
           },
           "nextToken": {},
           "maxResults": {
-            "shape": "S1j"
+            "type": "integer"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {
-                "shape": "S1l"
-              }
+              "tagStatus": {}
             }
           }
         }
@@ -538,18 +413,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          },
-          "status": {
-            "shape": "S2b"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {},
+          "status": {},
           "nextToken": {},
           "previewResults": {
             "type": "list",
@@ -566,17 +433,11 @@
                 "action": {
                   "type": "structure",
                   "members": {
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "EXPIRE"
-                      ]
-                    }
+                    "type": {}
                   }
                 },
                 "appliedRulePriority": {
-                  "type": "integer",
-                  "min": 1
+                  "type": "integer"
                 }
               }
             }
@@ -585,8 +446,7 @@
             "type": "structure",
             "members": {
               "expiringImageTotalCount": {
-                "type": "integer",
-                "min": 0
+                "type": "integer"
               }
             }
           }
@@ -600,26 +460,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "registryId": {},
+          "repositoryName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "policyText": {
-            "shape": "S1g"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "policyText": {}
         }
       }
     },
@@ -630,22 +480,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          }
+          "registryId": {},
+          "repositoryName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "uploadId": {
-            "shape": "Sy"
-          },
+          "uploadId": {},
           "partSize": {
-            "shape": "S2n"
+            "type": "long"
           }
         }
       }
@@ -657,22 +501,16 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "nextToken": {},
           "maxResults": {
-            "shape": "S1j"
+            "type": "integer"
           },
           "filter": {
             "type": "structure",
             "members": {
-              "tagStatus": {
-                "shape": "S1l"
-              }
+              "tagStatus": {}
             }
           }
         }
@@ -695,12 +533,8 @@
           "imageManifest"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
+          "registryId": {},
+          "repositoryName": {},
           "imageManifest": {},
           "imageTag": {}
         }
@@ -722,29 +556,17 @@
           "lifecyclePolicyText"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {}
         }
       }
     },
@@ -756,15 +578,9 @@
           "policyText"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "policyText": {
-            "shape": "S1g"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "policyText": {},
           "force": {
             "type": "boolean"
           }
@@ -773,15 +589,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "policyText": {
-            "shape": "S1g"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "policyText": {}
         }
       }
     },
@@ -792,32 +602,18 @@
           "repositoryName"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "lifecyclePolicyText": {
-            "shape": "S19"
-          },
-          "status": {
-            "shape": "S2b"
-          }
+          "registryId": {},
+          "repositoryName": {},
+          "lifecyclePolicyText": {},
+          "status": {}
         }
       }
     },
@@ -832,20 +628,14 @@
           "layerPartBlob"
         ],
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "uploadId": {
-            "shape": "Sy"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "uploadId": {},
           "partFirstByte": {
-            "shape": "S2n"
+            "type": "long"
           },
           "partLastByte": {
-            "shape": "S2n"
+            "type": "long"
           },
           "layerPartBlob": {
             "type": "blob"
@@ -855,49 +645,22 @@
       "output": {
         "type": "structure",
         "members": {
-          "registryId": {
-            "shape": "S2"
-          },
-          "repositoryName": {
-            "shape": "S3"
-          },
-          "uploadId": {
-            "shape": "Sy"
-          },
+          "registryId": {},
+          "repositoryName": {},
+          "uploadId": {},
           "lastByteReceived": {
-            "shape": "S2n"
+            "type": "long"
           }
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "[0-9]{12}"
-    },
-    "S3": {
-      "type": "string",
-      "max": 256,
-      "min": 2,
-      "pattern": "(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*"
-    },
-    "S5": {
-      "type": "string",
-      "max": 1000,
-      "min": 0
-    },
-    "S9": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+"
-    },
     "Si": {
       "type": "list",
       "member": {
         "shape": "Sj"
-      },
-      "max": 100,
-      "min": 1
+      }
     },
     "Sj": {
       "type": "structure",
@@ -914,16 +677,7 @@
           "imageId": {
             "shape": "Sj"
           },
-          "failureCode": {
-            "type": "string",
-            "enum": [
-              "InvalidImageDigest",
-              "InvalidImageTag",
-              "ImageTagDoesNotMatchDigest",
-              "ImageNotFound",
-              "MissingDigestAndTag"
-            ]
-          },
+          "failureCode": {},
           "failureReason": {}
         }
       }
@@ -931,76 +685,29 @@
     "Sv": {
       "type": "structure",
       "members": {
-        "registryId": {
-          "shape": "S2"
-        },
-        "repositoryName": {
-          "shape": "S3"
-        },
+        "registryId": {},
+        "repositoryName": {},
         "imageId": {
           "shape": "Sj"
         },
         "imageManifest": {}
       }
     },
-    "Sy": {
-      "type": "string",
-      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-    },
     "S13": {
       "type": "structure",
       "members": {
         "repositoryArn": {},
-        "registryId": {
-          "shape": "S2"
-        },
-        "repositoryName": {
-          "shape": "S3"
-        },
+        "registryId": {},
+        "repositoryName": {},
         "repositoryUri": {},
         "createdAt": {
           "type": "timestamp"
         }
       }
     },
-    "S19": {
-      "type": "string",
-      "max": 10240,
-      "min": 100
-    },
-    "S1g": {
-      "type": "string",
-      "max": 10240,
-      "min": 0
-    },
-    "S1j": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "S1l": {
-      "type": "string",
-      "enum": [
-        "TAGGED",
-        "UNTAGGED"
-      ]
-    },
     "S1p": {
       "type": "list",
       "member": {}
-    },
-    "S2b": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "COMPLETE",
-        "EXPIRED",
-        "FAILED"
-      ]
-    },
-    "S2n": {
-      "type": "long",
-      "min": 0
     }
   }
 }

--- a/apis/ecs-2014-11-13.min.json
+++ b/apis/ecs-2014-11-13.min.json
@@ -50,9 +50,7 @@
             "type": "integer"
           },
           "clientToken": {},
-          "launchType": {
-            "shape": "Se"
-          },
+          "launchType": {},
           "platformVersion": {},
           "role": {},
           "deploymentConfiguration": {
@@ -70,9 +68,7 @@
           "healthCheckGracePeriodSeconds": {
             "type": "integer"
           },
-          "schedulingStrategy": {
-            "shape": "Sq"
-          }
+          "schedulingStrategy": {}
         }
       },
       "output": {
@@ -199,12 +195,7 @@
           },
           "include": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "STATISTICS"
-              ]
-            }
+            "member": {}
           }
         }
       },
@@ -344,9 +335,7 @@
         ],
         "members": {
           "cluster": {},
-          "targetType": {
-            "shape": "S11"
-          },
+          "targetType": {},
           "attributeName": {},
           "attributeValue": {},
           "nextToken": {},
@@ -395,9 +384,7 @@
           "maxResults": {
             "type": "integer"
           },
-          "status": {
-            "shape": "S3y"
-          }
+          "status": {}
         }
       },
       "output": {
@@ -419,12 +406,8 @@
           "maxResults": {
             "type": "integer"
           },
-          "launchType": {
-            "shape": "Se"
-          },
-          "schedulingStrategy": {
-            "shape": "Sq"
-          }
+          "launchType": {},
+          "schedulingStrategy": {}
         }
       },
       "output": {
@@ -442,14 +425,7 @@
         "type": "structure",
         "members": {
           "familyPrefix": {},
-          "status": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "INACTIVE",
-              "ALL"
-            ]
-          },
+          "status": {},
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -471,16 +447,8 @@
         "type": "structure",
         "members": {
           "familyPrefix": {},
-          "status": {
-            "shape": "S2q"
-          },
-          "sort": {
-            "type": "string",
-            "enum": [
-              "ASC",
-              "DESC"
-            ]
-          },
+          "status": {},
+          "sort": {},
           "nextToken": {},
           "maxResults": {
             "type": "integer"
@@ -510,17 +478,8 @@
           },
           "startedBy": {},
           "serviceName": {},
-          "desiredStatus": {
-            "type": "string",
-            "enum": [
-              "RUNNING",
-              "PENDING",
-              "STOPPED"
-            ]
-          },
-          "launchType": {
-            "shape": "Se"
-          }
+          "desiredStatus": {},
+          "launchType": {}
         }
       },
       "output": {
@@ -594,9 +553,7 @@
           "family": {},
           "taskRoleArn": {},
           "executionRoleArn": {},
-          "networkMode": {
-            "shape": "S2j"
-          },
+          "networkMode": {},
           "containerDefinitions": {
             "shape": "S1o"
           },
@@ -645,9 +602,7 @@
           "placementStrategy": {
             "shape": "Sj"
           },
-          "launchType": {
-            "shape": "Se"
-          },
+          "launchType": {},
           "platformVersion": {},
           "networkConfiguration": {
             "shape": "Sm"
@@ -835,9 +790,7 @@
           "containerInstances": {
             "shape": "So"
           },
-          "status": {
-            "shape": "S3y"
-          }
+          "status": {}
         }
       },
       "output": {
@@ -954,13 +907,6 @@
         }
       }
     },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "EC2",
-        "FARGATE"
-      ]
-    },
     "Sf": {
       "type": "structure",
       "members": {
@@ -977,13 +923,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "distinctInstance",
-              "memberOf"
-            ]
-          },
+          "type": {},
           "expression": {}
         }
       }
@@ -993,14 +933,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "random",
-              "spread",
-              "binpack"
-            ]
-          },
+          "type": {},
           "field": {}
         }
       }
@@ -1020,13 +953,7 @@
             "securityGroups": {
               "shape": "So"
             },
-            "assignPublicIp": {
-              "type": "string",
-              "enum": [
-                "ENABLED",
-                "DISABLED"
-              ]
-            }
+            "assignPublicIp": {}
           }
         }
       }
@@ -1034,13 +961,6 @@
     "So": {
       "type": "list",
       "member": {}
-    },
-    "Sq": {
-      "type": "string",
-      "enum": [
-        "REPLICA",
-        "DAEMON"
-      ]
     },
     "Ss": {
       "type": "structure",
@@ -1064,9 +984,7 @@
         "pendingCount": {
           "type": "integer"
         },
-        "launchType": {
-          "shape": "Se"
-        },
+        "launchType": {},
         "platformVersion": {},
         "taskDefinition": {},
         "deploymentConfiguration": {
@@ -1095,9 +1013,7 @@
               "updatedAt": {
                 "type": "timestamp"
               },
-              "launchType": {
-                "shape": "Se"
-              },
+              "launchType": {},
               "platformVersion": {},
               "networkConfiguration": {
                 "shape": "Sm"
@@ -1134,9 +1050,7 @@
         "healthCheckGracePeriodSeconds": {
           "type": "integer"
         },
-        "schedulingStrategy": {
-          "shape": "Sq"
-        }
+        "schedulingStrategy": {}
       }
     },
     "Sz": {
@@ -1153,17 +1067,9 @@
       "members": {
         "name": {},
         "value": {},
-        "targetType": {
-          "shape": "S11"
-        },
+        "targetType": {},
         "targetId": {}
       }
-    },
-    "S11": {
-      "type": "string",
-      "enum": [
-        "container-instance"
-      ]
     },
     "S1a": {
       "type": "structure",
@@ -1192,17 +1098,7 @@
         "pendingTasksCount": {
           "type": "integer"
         },
-        "agentUpdateStatus": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "STAGING",
-            "STAGED",
-            "UPDATING",
-            "UPDATED",
-            "FAILED"
-          ]
-        },
+        "agentUpdateStatus": {},
         "attributes": {
           "shape": "Sz"
         },
@@ -1271,18 +1167,14 @@
         "family": {},
         "taskRoleArn": {},
         "executionRoleArn": {},
-        "networkMode": {
-          "shape": "S2j"
-        },
+        "networkMode": {},
         "revision": {
           "type": "integer"
         },
         "volumes": {
           "shape": "S2k"
         },
-        "status": {
-          "shape": "S2q"
-        },
+        "status": {},
         "requiresAttributes": {
           "type": "list",
           "member": {
@@ -1341,9 +1233,7 @@
                 "hostPort": {
                   "type": "integer"
                 },
-                "protocol": {
-                  "shape": "S1t"
-                }
+                "protocol": {}
               }
             }
           },
@@ -1410,14 +1300,7 @@
                     "containerPath": {},
                     "permissions": {
                       "type": "list",
-                      "member": {
-                        "type": "string",
-                        "enum": [
-                          "read",
-                          "write",
-                          "mknod"
-                        ]
-                      }
+                      "member": {}
                     }
                   }
                 }
@@ -1505,26 +1388,7 @@
                 "hardLimit"
               ],
               "members": {
-                "name": {
-                  "type": "string",
-                  "enum": [
-                    "core",
-                    "cpu",
-                    "data",
-                    "fsize",
-                    "locks",
-                    "memlock",
-                    "msgqueue",
-                    "nice",
-                    "nofile",
-                    "nproc",
-                    "rss",
-                    "rtprio",
-                    "rttime",
-                    "sigpending",
-                    "stack"
-                  ]
-                },
+                "name": {},
                 "softLimit": {
                   "type": "integer"
                 },
@@ -1540,18 +1404,7 @@
               "logDriver"
             ],
             "members": {
-              "logDriver": {
-                "type": "string",
-                "enum": [
-                  "json-file",
-                  "syslog",
-                  "journald",
-                  "gelf",
-                  "fluentd",
-                  "awslogs",
-                  "splunk"
-                ]
-              },
+              "logDriver": {},
               "options": {
                 "type": "map",
                 "key": {},
@@ -1595,27 +1448,11 @@
         }
       }
     },
-    "S1t": {
-      "type": "string",
-      "enum": [
-        "tcp",
-        "udp"
-      ]
-    },
     "S1u": {
       "type": "list",
       "member": {
         "shape": "S7"
       }
-    },
-    "S2j": {
-      "type": "string",
-      "enum": [
-        "bridge",
-        "host",
-        "awsvpc",
-        "none"
-      ]
     },
     "S2k": {
       "type": "list",
@@ -1632,13 +1469,7 @@
           "dockerVolumeConfiguration": {
             "type": "structure",
             "members": {
-              "scope": {
-                "type": "string",
-                "enum": [
-                  "task",
-                  "shared"
-                ]
-              },
+              "scope": {},
               "autoprovision": {
                 "type": "boolean"
               },
@@ -1659,37 +1490,19 @@
       "key": {},
       "value": {}
     },
-    "S2q": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "INACTIVE"
-      ]
-    },
     "S2s": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "memberOf"
-            ]
-          },
+          "type": {},
           "expression": {}
         }
       }
     },
     "S2v": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "EC2",
-          "FARGATE"
-        ]
-      }
+      "member": {}
     },
     "S32": {
       "type": "list",
@@ -1754,9 +1567,7 @@
                   }
                 }
               },
-              "healthStatus": {
-                "shape": "S3p"
-              }
+              "healthStatus": {}
             }
           }
         },
@@ -1765,13 +1576,7 @@
           "type": "long"
         },
         "stoppedReason": {},
-        "connectivity": {
-          "type": "string",
-          "enum": [
-            "CONNECTED",
-            "DISCONNECTED"
-          ]
-        },
+        "connectivity": {},
         "connectivityAt": {
           "type": "timestamp"
         },
@@ -1797,16 +1602,12 @@
           "type": "timestamp"
         },
         "group": {},
-        "launchType": {
-          "shape": "Se"
-        },
+        "launchType": {},
         "platformVersion": {},
         "attachments": {
           "shape": "S1i"
         },
-        "healthStatus": {
-          "shape": "S3p"
-        }
+        "healthStatus": {}
       }
     },
     "S3g": {
@@ -1852,26 +1653,9 @@
           "hostPort": {
             "type": "integer"
           },
-          "protocol": {
-            "shape": "S1t"
-          }
+          "protocol": {}
         }
       }
-    },
-    "S3p": {
-      "type": "string",
-      "enum": [
-        "HEALTHY",
-        "UNHEALTHY",
-        "UNKNOWN"
-      ]
-    },
-    "S3y": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "DRAINING"
-      ]
     }
   }
 }

--- a/apis/eks-2017-11-01.min.json
+++ b/apis/eks-2017-11-01.min.json
@@ -25,12 +25,7 @@
           "resourcesVpcConfig"
         ],
         "members": {
-          "name": {
-            "type": "string",
-            "max": 255,
-            "min": 1,
-            "pattern": "[A-Za-z0-9\\-_]*"
-          },
+          "name": {},
           "version": {},
           "roleArn": {},
           "resourcesVpcConfig": {
@@ -124,9 +119,7 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -173,15 +166,7 @@
             "vpcId": {}
           }
         },
-        "status": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "ACTIVE",
-            "DELETING",
-            "FAILED"
-          ]
-        },
+        "status": {},
         "certificateAuthority": {
           "type": "structure",
           "members": {

--- a/apis/elasticache-2015-02-02.min.json
+++ b/apis/elasticache-2015-02-02.min.json
@@ -86,9 +86,7 @@
         "members": {
           "CacheClusterId": {},
           "ReplicationGroupId": {},
-          "AZMode": {
-            "shape": "So"
-          },
+          "AZMode": {},
           "PreferredAvailabilityZone": {},
           "PreferredAvailabilityZones": {
             "shape": "Sp"
@@ -664,9 +662,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S37"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -694,9 +690,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S37"
-                },
+                "SourceType": {},
                 "Message": {},
                 "Date": {
                   "type": "timestamp"
@@ -923,9 +917,7 @@
           "CacheNodeIdsToRemove": {
             "shape": "Sz"
           },
-          "AZMode": {
-            "shape": "So"
-          },
+          "AZMode": {},
           "NewAvailabilityZones": {
             "shape": "Sp"
           },
@@ -1079,9 +1071,7 @@
               "locationName": "ReshardingConfiguration",
               "type": "structure",
               "members": {
-                "NodeGroupId": {
-                  "shape": "Sl"
-                },
+                "NodeGroupId": {},
                 "PreferredAvailabilityZones": {
                   "shape": "Sm"
                 }
@@ -1091,14 +1081,12 @@
           "NodeGroupsToRemove": {
             "type": "list",
             "member": {
-              "shape": "Sl",
               "locationName": "NodeGroupToRemove"
             }
           },
           "NodeGroupsToRetain": {
             "type": "list",
             "member": {
-              "shape": "Sl",
               "locationName": "NodeGroupToRetain"
             }
           }
@@ -1236,9 +1224,7 @@
         ],
         "members": {
           "ReplicationGroupId": {},
-          "NodeGroupId": {
-            "shape": "Sl"
-          }
+          "NodeGroupId": {}
         }
       },
       "output": {
@@ -1330,9 +1316,7 @@
         "NumNodeGroups": {
           "type": "integer"
         },
-        "AutomaticFailover": {
-          "shape": "Sh"
-        },
+        "AutomaticFailover": {},
         "NodeSnapshots": {
           "type": "list",
           "member": {
@@ -1359,21 +1343,10 @@
       },
       "wrapper": true
     },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "enabled",
-        "disabled",
-        "enabling",
-        "disabling"
-      ]
-    },
     "Sk": {
       "type": "structure",
       "members": {
-        "NodeGroupId": {
-          "shape": "Sl"
-        },
+        "NodeGroupId": {},
         "Slots": {},
         "ReplicaCount": {
           "type": "integer"
@@ -1384,24 +1357,11 @@
         }
       }
     },
-    "Sl": {
-      "type": "string",
-      "max": 4,
-      "min": 1,
-      "pattern": "\\d+"
-    },
     "Sm": {
       "type": "list",
       "member": {
         "locationName": "AvailabilityZone"
       }
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "single-az",
-        "cross-az"
-      ]
     },
     "Sp": {
       "type": "list",
@@ -1605,13 +1565,7 @@
           "type": "structure",
           "members": {
             "PrimaryClusterId": {},
-            "AutomaticFailoverStatus": {
-              "type": "string",
-              "enum": [
-                "enabled",
-                "disabled"
-              ]
-            },
+            "AutomaticFailoverStatus": {},
             "Resharding": {
               "type": "structure",
               "members": {
@@ -1665,9 +1619,7 @@
           }
         },
         "SnapshottingClusterId": {},
-        "AutomaticFailover": {
-          "shape": "Sh"
-        },
+        "AutomaticFailover": {},
         "ConfigurationEndpoint": {
           "shape": "Sw"
         },
@@ -1701,9 +1653,7 @@
           "NewReplicaCount"
         ],
         "members": {
-          "NodeGroupId": {
-            "shape": "Sl"
-          },
+          "NodeGroupId": {},
           "NewReplicaCount": {
             "type": "integer"
           },
@@ -1729,18 +1679,9 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ChangeType": {
-            "shape": "S2s"
-          }
+          "ChangeType": {}
         }
       }
-    },
-    "S2s": {
-      "type": "string",
-      "enum": [
-        "immediate",
-        "requires-reboot"
-      ]
     },
     "S2t": {
       "type": "list",
@@ -1768,21 +1709,9 @@
               }
             }
           },
-          "ChangeType": {
-            "shape": "S2s"
-          }
+          "ChangeType": {}
         }
       }
-    },
-    "S37": {
-      "type": "string",
-      "enum": [
-        "cache-cluster",
-        "cache-parameter-group",
-        "cache-security-group",
-        "cache-subnet-group",
-        "replication-group"
-      ]
     },
     "S3h": {
       "type": "structure",

--- a/apis/elasticbeanstalk-2010-12-01.min.json
+++ b/apis/elasticbeanstalk-2010-12-01.min.json
@@ -17,9 +17,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "EnvironmentName": {}
         }
       }
     },
@@ -41,9 +39,7 @@
         "members": {
           "ActionId": {},
           "ActionDescription": {},
-          "ActionType": {
-            "shape": "S7"
-          },
+          "ActionType": {},
           "Status": {}
         }
       }
@@ -55,9 +51,7 @@
           "CNAMEPrefix"
         ],
         "members": {
-          "CNAMEPrefix": {
-            "shape": "S9"
-          }
+          "CNAMEPrefix": {}
         }
       },
       "output": {
@@ -67,9 +61,7 @@
           "Available": {
             "type": "boolean"
           },
-          "FullyQualifiedCNAME": {
-            "shape": "Sc"
-          }
+          "FullyQualifiedCNAME": {}
         }
       }
     },
@@ -77,17 +69,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "GroupName": {
-            "shape": "Sf"
-          },
+          "ApplicationName": {},
+          "GroupName": {},
           "VersionLabels": {
             "type": "list",
-            "member": {
-              "shape": "Sh"
-            }
+            "member": {}
           }
         }
       },
@@ -103,12 +89,8 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "Description": {
-            "shape": "So"
-          },
+          "ApplicationName": {},
+          "Description": {},
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -127,15 +109,9 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
-          "Description": {
-            "shape": "So"
-          },
+          "ApplicationName": {},
+          "VersionLabel": {},
+          "Description": {},
           "SourceBuildInformation": {
             "shape": "S1j"
           },
@@ -150,20 +126,9 @@
             ],
             "members": {
               "ArtifactName": {},
-              "CodeBuildServiceRole": {
-                "shape": "S1r"
-              },
-              "ComputeType": {
-                "type": "string",
-                "enum": [
-                  "BUILD_GENERAL1_SMALL",
-                  "BUILD_GENERAL1_MEDIUM",
-                  "BUILD_GENERAL1_LARGE"
-                ]
-              },
-              "Image": {
-                "shape": "S1r"
-              },
+              "CodeBuildServiceRole": {},
+              "ComputeType": {},
+              "Image": {},
               "TimeoutInMinutes": {
                 "type": "integer"
               }
@@ -190,29 +155,19 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
+          "ApplicationName": {},
+          "TemplateName": {},
           "SolutionStackName": {},
           "PlatformArn": {},
           "SourceConfiguration": {
             "type": "structure",
             "members": {
-              "ApplicationName": {
-                "shape": "Se"
-              },
-              "TemplateName": {
-                "shape": "Sn"
-              }
+              "ApplicationName": {},
+              "TemplateName": {}
             }
           },
           "EnvironmentId": {},
-          "Description": {
-            "shape": "So"
-          },
+          "Description": {},
           "OptionSettings": {
             "shape": "S21"
           }
@@ -230,21 +185,11 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "EnvironmentName": {
-            "shape": "S3"
-          },
-          "GroupName": {
-            "shape": "Sf"
-          },
-          "Description": {
-            "shape": "So"
-          },
-          "CNAMEPrefix": {
-            "shape": "S9"
-          },
+          "ApplicationName": {},
+          "EnvironmentName": {},
+          "GroupName": {},
+          "Description": {},
+          "CNAMEPrefix": {},
           "Tier": {
             "shape": "S11"
           },
@@ -254,12 +199,8 @@
               "shape": "S2b"
             }
           },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
+          "VersionLabel": {},
+          "TemplateName": {},
           "SolutionStackName": {},
           "PlatformArn": {},
           "OptionSettings": {
@@ -289,9 +230,7 @@
           "PlatformDefinitionBundle": {
             "shape": "S1n"
           },
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "OptionSettings": {
             "shape": "S21"
           }
@@ -318,9 +257,7 @@
         "resultWrapper": "CreateStorageLocationResult",
         "type": "structure",
         "members": {
-          "S3Bucket": {
-            "shape": "S1o"
-          }
+          "S3Bucket": {}
         }
       }
     },
@@ -331,9 +268,7 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
+          "ApplicationName": {},
           "TerminateEnvByForce": {
             "type": "boolean"
           }
@@ -348,12 +283,8 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
+          "ApplicationName": {},
+          "VersionLabel": {},
           "DeleteSourceBundle": {
             "type": "boolean"
           }
@@ -368,12 +299,8 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          }
+          "ApplicationName": {},
+          "TemplateName": {}
         }
       }
     },
@@ -385,12 +312,8 @@
           "EnvironmentName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "ApplicationName": {},
+          "EnvironmentName": {}
         }
       }
     },
@@ -443,14 +366,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
+          "ApplicationName": {},
           "VersionLabels": {
             "shape": "S1g"
           },
           "MaxRecords": {
-            "shape": "S39"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -475,9 +396,7 @@
         "members": {
           "ApplicationNames": {
             "type": "list",
-            "member": {
-              "shape": "Se"
-            }
+            "member": {}
           }
         }
       },
@@ -498,15 +417,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "ApplicationName": {},
+          "TemplateName": {},
+          "EnvironmentName": {},
           "SolutionStackName": {},
           "PlatformArn": {},
           "Options": {
@@ -532,13 +445,7 @@
                 "UserDefined": {
                   "type": "boolean"
                 },
-                "ValueType": {
-                  "type": "string",
-                  "enum": [
-                    "Scalar",
-                    "List"
-                  ]
-                },
+                "ValueType": {},
                 "ValueOptions": {
                   "type": "list",
                   "member": {}
@@ -572,15 +479,9 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "ApplicationName": {},
+          "TemplateName": {},
+          "EnvironmentName": {}
         }
       },
       "output": {
@@ -600,25 +501,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "EnvironmentId": {},
           "AttributeNames": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "Status",
-                "Color",
-                "Causes",
-                "ApplicationMetrics",
-                "InstancesHealth",
-                "All",
-                "HealthStatus",
-                "RefreshedAt"
-              ]
-            }
+            "member": {}
           }
         }
       },
@@ -626,13 +513,9 @@
         "resultWrapper": "DescribeEnvironmentHealthResult",
         "type": "structure",
         "members": {
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "HealthStatus": {},
-          "Status": {
-            "shape": "Su"
-          },
+          "Status": {},
           "Color": {},
           "Causes": {
             "shape": "S43"
@@ -680,9 +563,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "NextToken": {},
           "MaxItems": {
             "type": "integer"
@@ -699,30 +580,10 @@
               "type": "structure",
               "members": {
                 "ActionId": {},
-                "ActionType": {
-                  "shape": "S7"
-                },
+                "ActionType": {},
                 "ActionDescription": {},
-                "FailureType": {
-                  "type": "string",
-                  "enum": [
-                    "UpdateCancelled",
-                    "CancellationFailed",
-                    "RollbackFailed",
-                    "RollbackSuccessful",
-                    "InternalFailure",
-                    "InvalidEnvironmentState",
-                    "PermissionsError"
-                  ]
-                },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Completed",
-                    "Failed",
-                    "Unknown"
-                  ]
-                },
+                "FailureType": {},
+                "Status": {},
                 "FailureDescription": {},
                 "ExecutedTime": {
                   "type": "timestamp"
@@ -731,9 +592,7 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "NextToken": {}
         }
@@ -745,9 +604,7 @@
         "members": {
           "EnvironmentName": {},
           "EnvironmentId": {},
-          "Status": {
-            "shape": "S4l"
-          }
+          "Status": {}
         }
       },
       "output": {
@@ -761,19 +618,13 @@
               "members": {
                 "ActionId": {},
                 "ActionDescription": {},
-                "ActionType": {
-                  "shape": "S7"
-                },
-                "Status": {
-                  "shape": "S4l"
-                },
+                "ActionType": {},
+                "Status": {},
                 "WindowStartTime": {
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 100,
-            "min": 1
+            }
           }
         }
       }
@@ -783,9 +634,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "EnvironmentName": {}
         }
       },
       "output": {
@@ -795,9 +644,7 @@
           "EnvironmentResources": {
             "type": "structure",
             "members": {
-              "EnvironmentName": {
-                "shape": "S3"
-              },
+              "EnvironmentName": {},
               "AutoScalingGroups": {
                 "type": "list",
                 "member": {
@@ -862,21 +709,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
+          "ApplicationName": {},
+          "VersionLabel": {},
           "EnvironmentIds": {
             "type": "list",
             "member": {}
           },
           "EnvironmentNames": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           },
           "IncludeDeleted": {
             "type": "boolean"
@@ -885,7 +726,7 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "shape": "S39"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -899,24 +740,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
+          "ApplicationName": {},
+          "VersionLabel": {},
+          "TemplateName": {},
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "PlatformArn": {},
           "RequestId": {},
-          "Severity": {
-            "shape": "S5c"
-          },
+          "Severity": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -924,7 +755,7 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "shape": "S39"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -942,23 +773,13 @@
                   "type": "timestamp"
                 },
                 "Message": {},
-                "ApplicationName": {
-                  "shape": "Se"
-                },
-                "VersionLabel": {
-                  "shape": "Sh"
-                },
-                "TemplateName": {
-                  "shape": "Sn"
-                },
-                "EnvironmentName": {
-                  "shape": "S3"
-                },
+                "ApplicationName": {},
+                "VersionLabel": {},
+                "TemplateName": {},
+                "EnvironmentName": {},
                 "PlatformArn": {},
                 "RequestId": {},
-                "Severity": {
-                  "shape": "S5c"
-                }
+                "Severity": {}
               }
             }
           },
@@ -970,32 +791,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "EnvironmentId": {},
           "AttributeNames": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "HealthStatus",
-                "Color",
-                "Causes",
-                "ApplicationMetrics",
-                "RefreshedAt",
-                "LaunchedAt",
-                "System",
-                "Deployment",
-                "AvailabilityZone",
-                "InstanceType",
-                "All"
-              ]
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S5n"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1007,11 +809,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "InstanceId": {
-                  "type": "string",
-                  "max": 255,
-                  "min": 1
-                },
+                "InstanceId": {},
                 "HealthStatus": {},
                 "Color": {},
                 "Causes": {
@@ -1084,9 +882,7 @@
           "RefreshedAt": {
             "type": "timestamp"
           },
-          "NextToken": {
-            "shape": "S5n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1109,9 +905,7 @@
               "PlatformName": {},
               "PlatformVersion": {},
               "SolutionStackName": {},
-              "PlatformStatus": {
-                "shape": "S2m"
-              },
+              "PlatformStatus": {},
               "DateCreated": {
                 "type": "timestamp"
               },
@@ -1119,9 +913,7 @@
                 "type": "timestamp"
               },
               "PlatformCategory": {},
-              "Description": {
-                "shape": "So"
-              },
+              "Description": {},
               "Maintainer": {},
               "OperatingSystemName": {},
               "OperatingSystemVersion": {},
@@ -1183,11 +975,7 @@
                 "SolutionStackName": {},
                 "PermittedFileTypes": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 100,
-                    "min": 1
-                  }
+                  "member": {}
                 }
               }
             }
@@ -1214,8 +1002,7 @@
             }
           },
           "MaxRecords": {
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1260,9 +1047,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "EnvironmentName": {}
         }
       }
     },
@@ -1274,12 +1059,8 @@
         ],
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
-          "InfoType": {
-            "shape": "S6y"
-          }
+          "EnvironmentName": {},
+          "InfoType": {}
         }
       }
     },
@@ -1288,9 +1069,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          }
+          "EnvironmentName": {}
         }
       }
     },
@@ -1302,12 +1081,8 @@
         ],
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
-          "InfoType": {
-            "shape": "S6y"
-          }
+          "EnvironmentName": {},
+          "InfoType": {}
         }
       },
       "output": {
@@ -1319,9 +1094,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "InfoType": {
-                  "shape": "S6y"
-                },
+                "InfoType": {},
                 "Ec2InstanceId": {},
                 "SampleTimestamp": {
                   "type": "timestamp"
@@ -1338,13 +1111,9 @@
         "type": "structure",
         "members": {
           "SourceEnvironmentId": {},
-          "SourceEnvironmentName": {
-            "shape": "S3"
-          },
+          "SourceEnvironmentName": {},
           "DestinationEnvironmentId": {},
-          "DestinationEnvironmentName": {
-            "shape": "S3"
-          }
+          "DestinationEnvironmentName": {}
         }
       }
     },
@@ -1353,9 +1122,7 @@
         "type": "structure",
         "members": {
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "EnvironmentName": {},
           "TerminateResources": {
             "type": "boolean"
           },
@@ -1376,12 +1143,8 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "Description": {
-            "shape": "So"
-          }
+          "ApplicationName": {},
+          "Description": {}
         }
       },
       "output": {
@@ -1397,9 +1160,7 @@
           "ResourceLifecycleConfig"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
+          "ApplicationName": {},
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -1409,9 +1170,7 @@
         "resultWrapper": "UpdateApplicationResourceLifecycleResult",
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
+          "ApplicationName": {},
           "ResourceLifecycleConfig": {
             "shape": "S17"
           }
@@ -1426,15 +1185,9 @@
           "VersionLabel"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
-          "Description": {
-            "shape": "So"
-          }
+          "ApplicationName": {},
+          "VersionLabel": {},
+          "Description": {}
         }
       },
       "output": {
@@ -1450,15 +1203,9 @@
           "TemplateName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
-          "Description": {
-            "shape": "So"
-          },
+          "ApplicationName": {},
+          "TemplateName": {},
+          "Description": {},
           "OptionSettings": {
             "shape": "S21"
           },
@@ -1476,28 +1223,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
+          "ApplicationName": {},
           "EnvironmentId": {},
-          "EnvironmentName": {
-            "shape": "S3"
-          },
-          "GroupName": {
-            "shape": "Sf"
-          },
-          "Description": {
-            "shape": "So"
-          },
+          "EnvironmentName": {},
+          "GroupName": {},
+          "Description": {},
           "Tier": {
             "shape": "S11"
           },
-          "VersionLabel": {
-            "shape": "Sh"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
+          "VersionLabel": {},
+          "TemplateName": {},
           "SolutionStackName": {},
           "PlatformArn": {},
           "OptionSettings": {
@@ -1526,9 +1261,7 @@
           },
           "TagsToRemove": {
             "type": "list",
-            "member": {
-              "shape": "S2c"
-            }
+            "member": {}
           }
         }
       }
@@ -1541,15 +1274,9 @@
           "OptionSettings"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "Se"
-          },
-          "TemplateName": {
-            "shape": "Sn"
-          },
-          "EnvironmentName": {
-            "shape": "S3"
-          },
+          "ApplicationName": {},
+          "TemplateName": {},
+          "EnvironmentName": {},
           "OptionSettings": {
             "shape": "S21"
           }
@@ -1565,13 +1292,7 @@
               "type": "structure",
               "members": {
                 "Message": {},
-                "Severity": {
-                  "type": "string",
-                  "enum": [
-                    "error",
-                    "warning"
-                  ]
-                },
+                "Severity": {},
                 "Namespace": {},
                 "OptionName": {}
               }
@@ -1582,44 +1303,6 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 40,
-      "min": 4
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "InstanceRefresh",
-        "PlatformUpdate",
-        "Unknown"
-      ]
-    },
-    "S9": {
-      "type": "string",
-      "max": 63,
-      "min": 4
-    },
-    "Sc": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "Se": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "Sf": {
-      "type": "string",
-      "max": 19,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
     "Si": {
       "type": "structure",
       "members": {
@@ -1635,64 +1318,28 @@
     "Sk": {
       "type": "structure",
       "members": {
-        "EnvironmentName": {
-          "shape": "S3"
-        },
+        "EnvironmentName": {},
         "EnvironmentId": {},
-        "ApplicationName": {
-          "shape": "Se"
-        },
-        "VersionLabel": {
-          "shape": "Sh"
-        },
+        "ApplicationName": {},
+        "VersionLabel": {},
         "SolutionStackName": {},
         "PlatformArn": {},
-        "TemplateName": {
-          "shape": "Sn"
-        },
-        "Description": {
-          "shape": "So"
-        },
+        "TemplateName": {},
+        "Description": {},
         "EndpointURL": {},
-        "CNAME": {
-          "shape": "Sc"
-        },
+        "CNAME": {},
         "DateCreated": {
           "type": "timestamp"
         },
         "DateUpdated": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "Launching",
-            "Updating",
-            "Ready",
-            "Terminating",
-            "Terminated"
-          ]
-        },
+        "Status": {},
         "AbortableOperationInProgress": {
           "type": "boolean"
         },
-        "Health": {
-          "shape": "Su"
-        },
-        "HealthStatus": {
-          "type": "string",
-          "enum": [
-            "NoData",
-            "Unknown",
-            "Pending",
-            "Ok",
-            "Info",
-            "Warning",
-            "Degraded",
-            "Severe",
-            "Suspended"
-          ]
-        },
+        "Health": {},
+        "HealthStatus": {},
         "Resources": {
           "type": "structure",
           "members": {
@@ -1732,24 +1379,6 @@
         },
         "EnvironmentArn": {}
       }
-    },
-    "Sn": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "So": {
-      "type": "string",
-      "max": 200
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "Green",
-        "Yellow",
-        "Red",
-        "Grey"
-      ]
     },
     "S11": {
       "type": "structure",
@@ -1816,12 +1445,8 @@
       "type": "structure",
       "members": {
         "ApplicationArn": {},
-        "ApplicationName": {
-          "shape": "Se"
-        },
-        "Description": {
-          "shape": "So"
-        },
+        "ApplicationName": {},
+        "Description": {},
         "DateCreated": {
           "type": "timestamp"
         },
@@ -1833,9 +1458,7 @@
         },
         "ConfigurationTemplates": {
           "type": "list",
-          "member": {
-            "shape": "Sn"
-          }
+          "member": {}
         },
         "ResourceLifecycleConfig": {
           "shape": "S17"
@@ -1844,9 +1467,7 @@
     },
     "S1g": {
       "type": "list",
-      "member": {
-        "shape": "Sh"
-      }
+      "member": {}
     },
     "S1j": {
       "type": "structure",
@@ -1856,47 +1477,17 @@
         "SourceLocation"
       ],
       "members": {
-        "SourceType": {
-          "type": "string",
-          "enum": [
-            "Git",
-            "Zip"
-          ]
-        },
-        "SourceRepository": {
-          "type": "string",
-          "enum": [
-            "CodeCommit",
-            "S3"
-          ]
-        },
-        "SourceLocation": {
-          "type": "string",
-          "max": 255,
-          "min": 3,
-          "pattern": ".+/.+"
-        }
+        "SourceType": {},
+        "SourceRepository": {},
+        "SourceLocation": {}
       }
     },
     "S1n": {
       "type": "structure",
       "members": {
-        "S3Bucket": {
-          "shape": "S1o"
-        },
-        "S3Key": {
-          "type": "string",
-          "max": 1024
-        }
+        "S3Bucket": {},
+        "S3Key": {}
       }
-    },
-    "S1o": {
-      "type": "string",
-      "max": 255
-    },
-    "S1r": {
-      "type": "string",
-      "pattern": ".*\\S.*"
     },
     "S1v": {
       "type": "structure",
@@ -1910,15 +1501,9 @@
       "type": "structure",
       "members": {
         "ApplicationVersionArn": {},
-        "ApplicationName": {
-          "shape": "Se"
-        },
-        "Description": {
-          "shape": "So"
-        },
-        "VersionLabel": {
-          "shape": "Sh"
-        },
+        "ApplicationName": {},
+        "Description": {},
+        "VersionLabel": {},
         "SourceBuildInformation": {
           "shape": "S1j"
         },
@@ -1932,16 +1517,7 @@
         "DateUpdated": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "Processed",
-            "Unprocessed",
-            "Failed",
-            "Processing",
-            "Building"
-          ]
-        }
+        "Status": {}
       }
     },
     "S21": {
@@ -1949,45 +1525,23 @@
       "member": {
         "type": "structure",
         "members": {
-          "ResourceName": {
-            "shape": "S23"
-          },
+          "ResourceName": {},
           "Namespace": {},
           "OptionName": {},
           "Value": {}
         }
       }
     },
-    "S23": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
     "S27": {
       "type": "structure",
       "members": {
         "SolutionStackName": {},
         "PlatformArn": {},
-        "ApplicationName": {
-          "shape": "Se"
-        },
-        "TemplateName": {
-          "shape": "Sn"
-        },
-        "Description": {
-          "shape": "So"
-        },
-        "EnvironmentName": {
-          "shape": "S3"
-        },
-        "DeploymentStatus": {
-          "type": "string",
-          "enum": [
-            "deployed",
-            "pending",
-            "failed"
-          ]
-        },
+        "ApplicationName": {},
+        "TemplateName": {},
+        "Description": {},
+        "EnvironmentName": {},
+        "DeploymentStatus": {},
         "DateCreated": {
           "type": "timestamp"
         },
@@ -2002,29 +1556,16 @@
     "S2b": {
       "type": "structure",
       "members": {
-        "Key": {
-          "shape": "S2c"
-        },
-        "Value": {
-          "type": "string",
-          "max": 256,
-          "min": 1
-        }
+        "Key": {},
+        "Value": {}
       }
-    },
-    "S2c": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S2e": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceName": {
-            "shape": "S23"
-          },
+          "ResourceName": {},
           "Namespace": {},
           "OptionName": {}
         }
@@ -2035,9 +1576,7 @@
       "members": {
         "PlatformArn": {},
         "PlatformOwner": {},
-        "PlatformStatus": {
-          "shape": "S2m"
-        },
+        "PlatformStatus": {},
         "PlatformCategory": {},
         "OperatingSystemName": {},
         "OperatingSystemVersion": {},
@@ -2048,16 +1587,6 @@
           "shape": "S2s"
         }
       }
-    },
-    "S2m": {
-      "type": "string",
-      "enum": [
-        "Creating",
-        "Failed",
-        "Ready",
-        "Deleting",
-        "Deleted"
-      ]
     },
     "S2q": {
       "type": "list",
@@ -2075,18 +1604,9 @@
         }
       }
     },
-    "S39": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
     "S43": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      }
+      "member": {}
     },
     "S45": {
       "type": "structure",
@@ -2145,43 +1665,11 @@
         }
       }
     },
-    "S4l": {
-      "type": "string",
-      "enum": [
-        "Scheduled",
-        "Pending",
-        "Running",
-        "Unknown"
-      ]
-    },
-    "S5c": {
-      "type": "string",
-      "enum": [
-        "TRACE",
-        "DEBUG",
-        "INFO",
-        "WARN",
-        "ERROR",
-        "FATAL"
-      ]
-    },
-    "S5n": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
     "S6v": {
       "type": "list",
       "member": {
         "shape": "S2b"
       }
-    },
-    "S6y": {
-      "type": "string",
-      "enum": [
-        "tail",
-        "bundle"
-      ]
     }
   }
 }

--- a/apis/elasticfilesystem-2015-02-01.min.json
+++ b/apis/elasticfilesystem-2015-02-01.min.json
@@ -22,23 +22,15 @@
           "CreationToken"
         ],
         "members": {
-          "CreationToken": {
-            "shape": "S2"
-          },
-          "PerformanceMode": {
-            "shape": "S3"
-          },
+          "CreationToken": {},
+          "PerformanceMode": {},
           "Encrypted": {
             "type": "boolean"
           },
-          "KmsKeyId": {
-            "shape": "S5"
-          },
-          "ThroughputMode": {
-            "shape": "S6"
-          },
+          "KmsKeyId": {},
+          "ThroughputMode": {},
           "ProvisionedThroughputInMibps": {
-            "shape": "S7"
+            "type": "double"
           }
         }
       },
@@ -148,9 +140,7 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Ss"
-            }
+            "member": {}
           }
         }
       }
@@ -165,16 +155,15 @@
         "type": "structure",
         "members": {
           "MaxItems": {
-            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           },
           "Marker": {
             "location": "querystring",
             "locationName": "Marker"
           },
           "CreationToken": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "CreationToken"
           },
@@ -238,9 +227,9 @@
         "type": "structure",
         "members": {
           "MaxItems": {
-            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           },
           "Marker": {
             "location": "querystring",
@@ -283,9 +272,9 @@
         ],
         "members": {
           "MaxItems": {
-            "shape": "Sy",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           },
           "Marker": {
             "location": "querystring",
@@ -349,11 +338,9 @@
             "location": "uri",
             "locationName": "FileSystemId"
           },
-          "ThroughputMode": {
-            "shape": "S6"
-          },
+          "ThroughputMode": {},
           "ProvisionedThroughputInMibps": {
-            "shape": "S7"
+            "type": "double"
           }
         }
       },
@@ -363,34 +350,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "enum": [
-        "generalPurpose",
-        "maxIO"
-      ]
-    },
-    "S5": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "enum": [
-        "bursting",
-        "provisioned"
-      ]
-    },
-    "S7": {
-      "type": "double",
-      "min": 0
-    },
     "S8": {
       "type": "structure",
       "required": [
@@ -405,22 +364,15 @@
       ],
       "members": {
         "OwnerId": {},
-        "CreationToken": {
-          "shape": "S2"
-        },
+        "CreationToken": {},
         "FileSystemId": {},
         "CreationTime": {
           "type": "timestamp"
         },
-        "LifeCycleState": {
-          "shape": "Sc"
-        },
-        "Name": {
-          "shape": "Sd"
-        },
+        "LifeCycleState": {},
+        "Name": {},
         "NumberOfMountTargets": {
-          "type": "integer",
-          "min": 0
+          "type": "integer"
         },
         "SizeInBytes": {
           "type": "structure",
@@ -429,49 +381,27 @@
           ],
           "members": {
             "Value": {
-              "type": "long",
-              "min": 0
+              "type": "long"
             },
             "Timestamp": {
               "type": "timestamp"
             }
           }
         },
-        "PerformanceMode": {
-          "shape": "S3"
-        },
+        "PerformanceMode": {},
         "Encrypted": {
           "type": "boolean"
         },
-        "KmsKeyId": {
-          "shape": "S5"
-        },
-        "ThroughputMode": {
-          "shape": "S6"
-        },
+        "KmsKeyId": {},
+        "ThroughputMode": {},
         "ProvisionedThroughputInMibps": {
-          "shape": "S7"
+          "type": "double"
         }
       }
     },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "creating",
-        "available",
-        "updating",
-        "deleting",
-        "deleted"
-      ]
-    },
-    "Sd": {
-      "type": "string",
-      "max": 256
-    },
     "Sk": {
       "type": "list",
-      "member": {},
-      "max": 5
+      "member": {}
     },
     "Sm": {
       "type": "structure",
@@ -486,9 +416,7 @@
         "MountTargetId": {},
         "FileSystemId": {},
         "SubnetId": {},
-        "LifeCycleState": {
-          "shape": "Sc"
-        },
+        "LifeCycleState": {},
         "IpAddress": {},
         "NetworkInterfaceId": {}
       }
@@ -502,23 +430,10 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "Ss"
-          },
-          "Value": {
-            "shape": "Sd"
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "Ss": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Sy": {
-      "type": "integer",
-      "min": 1
     }
   }
 }

--- a/apis/elasticloadbalancing-2012-06-01.min.json
+++ b/apis/elasticloadbalancing-2012-06-01.min.json
@@ -318,7 +318,7 @@
         "members": {
           "Marker": {},
           "PageSize": {
-            "shape": "S1v"
+            "type": "integer"
           }
         }
       },
@@ -478,7 +478,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S1v"
+            "type": "integer"
           }
         }
       },
@@ -545,7 +545,7 @@
                     "type": "structure",
                     "members": {
                       "InstancePort": {
-                        "shape": "S11"
+                        "type": "integer"
                       },
                       "PolicyNames": {
                         "shape": "S2s"
@@ -596,9 +596,7 @@
         "members": {
           "LoadBalancerNames": {
             "type": "list",
-            "member": {},
-            "max": 20,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -758,12 +756,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S6"
-                }
+                "Key": {}
               }
-            },
-            "min": 1
+            }
           }
         }
       },
@@ -857,24 +852,10 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "shape": "S6"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      }
     },
     "Sa": {
       "type": "list",
@@ -896,24 +877,16 @@
       "members": {
         "Target": {},
         "Interval": {
-          "type": "integer",
-          "max": 300,
-          "min": 5
+          "type": "integer"
         },
         "Timeout": {
-          "type": "integer",
-          "max": 60,
-          "min": 2
+          "type": "integer"
         },
         "UnhealthyThreshold": {
-          "type": "integer",
-          "max": 10,
-          "min": 2
+          "type": "integer"
         },
         "HealthyThreshold": {
-          "type": "integer",
-          "max": 10,
-          "min": 2
+          "type": "integer"
         }
       }
     },
@@ -937,15 +910,10 @@
         },
         "InstanceProtocol": {},
         "InstancePort": {
-          "shape": "S11"
+          "type": "integer"
         },
         "SSLCertificateId": {}
       }
-    },
-    "S11": {
-      "type": "integer",
-      "max": 65535,
-      "min": 1
     },
     "S13": {
       "type": "list",
@@ -959,11 +927,6 @@
           "InstanceId": {}
         }
       }
-    },
-    "S1v": {
-      "type": "integer",
-      "max": 400,
-      "min": 1
     },
     "S2a": {
       "type": "structure",
@@ -1016,9 +979,7 @@
           ],
           "members": {
             "IdleTimeout": {
-              "type": "integer",
-              "max": 3600,
-              "min": 1
+              "type": "integer"
             }
           }
         },
@@ -1027,19 +988,10 @@
           "member": {
             "type": "structure",
             "members": {
-              "Key": {
-                "type": "string",
-                "max": 256,
-                "pattern": "^[a-zA-Z0-9.]+$"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "pattern": "^[a-zA-Z0-9.]+$"
-              }
+              "Key": {},
+              "Value": {}
             }
-          },
-          "max": 10
+          }
         }
       }
     },

--- a/apis/elasticloadbalancingv2-2015-12-01.min.json
+++ b/apis/elasticloadbalancingv2-2015-12-01.min.json
@@ -69,11 +69,9 @@
         ],
         "members": {
           "LoadBalancerArn": {},
-          "Protocol": {
-            "shape": "Si"
-          },
+          "Protocol": {},
           "Port": {
-            "shape": "Sj"
+            "type": "integer"
           },
           "SslPolicy": {},
           "Certificates": {
@@ -111,18 +109,12 @@
           "SecurityGroups": {
             "shape": "S20"
           },
-          "Scheme": {
-            "shape": "S22"
-          },
+          "Scheme": {},
           "Tags": {
             "shape": "Sb"
           },
-          "Type": {
-            "shape": "S23"
-          },
-          "IpAddressType": {
-            "shape": "S24"
-          }
+          "Type": {},
+          "IpAddressType": {}
         }
       },
       "output": {
@@ -150,7 +142,7 @@
             "shape": "S2m"
           },
           "Priority": {
-            "shape": "S2r"
+            "type": "integer"
           },
           "Actions": {
             "shape": "Sl"
@@ -178,38 +170,30 @@
         ],
         "members": {
           "Name": {},
-          "Protocol": {
-            "shape": "Si"
-          },
+          "Protocol": {},
           "Port": {
-            "shape": "Sj"
+            "type": "integer"
           },
           "VpcId": {},
-          "HealthCheckProtocol": {
-            "shape": "Si"
-          },
+          "HealthCheckProtocol": {},
           "HealthCheckPort": {},
-          "HealthCheckPath": {
-            "shape": "S31"
-          },
+          "HealthCheckPath": {},
           "HealthCheckIntervalSeconds": {
-            "shape": "S32"
+            "type": "integer"
           },
           "HealthCheckTimeoutSeconds": {
-            "shape": "S33"
+            "type": "integer"
           },
           "HealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
           "UnhealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
           "Matcher": {
             "shape": "S35"
           },
-          "TargetType": {
-            "shape": "S37"
-          }
+          "TargetType": {}
         }
       },
       "output": {
@@ -312,7 +296,7 @@
         "members": {
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -344,7 +328,7 @@
           "ListenerArn": {},
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -370,7 +354,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -418,7 +402,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -444,7 +428,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -469,7 +453,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -572,7 +556,7 @@
           },
           "Marker": {},
           "PageSize": {
-            "shape": "S3r"
+            "type": "integer"
           }
         }
       },
@@ -616,33 +600,8 @@
                 "TargetHealth": {
                   "type": "structure",
                   "members": {
-                    "State": {
-                      "type": "string",
-                      "enum": [
-                        "initial",
-                        "healthy",
-                        "unhealthy",
-                        "unused",
-                        "draining",
-                        "unavailable"
-                      ]
-                    },
-                    "Reason": {
-                      "type": "string",
-                      "enum": [
-                        "Elb.RegistrationInProgress",
-                        "Elb.InitialHealthChecking",
-                        "Target.ResponseCodeMismatch",
-                        "Target.Timeout",
-                        "Target.FailedHealthChecks",
-                        "Target.NotRegistered",
-                        "Target.NotInUse",
-                        "Target.DeregistrationInProgress",
-                        "Target.InvalidState",
-                        "Target.IpUnusable",
-                        "Elb.InternalError"
-                      ]
-                    },
+                    "State": {},
+                    "Reason": {},
                     "Description": {}
                   }
                 }
@@ -661,11 +620,9 @@
         "members": {
           "ListenerArn": {},
           "Port": {
-            "shape": "Sj"
+            "type": "integer"
           },
-          "Protocol": {
-            "shape": "Si"
-          },
+          "Protocol": {},
           "SslPolicy": {},
           "Certificates": {
             "shape": "S3"
@@ -743,24 +700,20 @@
         ],
         "members": {
           "TargetGroupArn": {},
-          "HealthCheckProtocol": {
-            "shape": "Si"
-          },
+          "HealthCheckProtocol": {},
           "HealthCheckPort": {},
-          "HealthCheckPath": {
-            "shape": "S31"
-          },
+          "HealthCheckPath": {},
           "HealthCheckIntervalSeconds": {
-            "shape": "S32"
+            "type": "integer"
           },
           "HealthCheckTimeoutSeconds": {
-            "shape": "S33"
+            "type": "integer"
           },
           "HealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
           "UnhealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
           "Matcher": {
             "shape": "S35"
@@ -854,9 +807,7 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sd"
-            }
+            "member": {}
           }
         }
       },
@@ -875,18 +826,14 @@
         ],
         "members": {
           "LoadBalancerArn": {},
-          "IpAddressType": {
-            "shape": "S24"
-          }
+          "IpAddressType": {}
         }
       },
       "output": {
         "resultWrapper": "SetIpAddressTypeResult",
         "type": "structure",
         "members": {
-          "IpAddressType": {
-            "shape": "S24"
-          }
+          "IpAddressType": {}
         }
       }
     },
@@ -904,7 +851,7 @@
               "members": {
                 "RuleArn": {},
                 "Priority": {
-                  "shape": "S2r"
+                  "type": "integer"
                 }
               }
             }
@@ -997,37 +944,10 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "shape": "Sd"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "Si": {
-      "type": "string",
-      "enum": [
-        "HTTP",
-        "HTTPS",
-        "TCP"
-      ]
-    },
-    "Sj": {
-      "type": "integer",
-      "max": 65535,
-      "min": 1
+      }
     },
     "Sl": {
       "type": "list",
@@ -1037,16 +957,7 @@
           "Type"
         ],
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "forward",
-              "authenticate-oidc",
-              "authenticate-cognito",
-              "redirect",
-              "fixed-response"
-            ]
-          },
+          "Type": {},
           "TargetGroupArn": {},
           "AuthenticateOidcConfig": {
             "type": "structure",
@@ -1075,14 +986,7 @@
                 "key": {},
                 "value": {}
               },
-              "OnUnauthenticatedRequest": {
-                "type": "string",
-                "enum": [
-                  "deny",
-                  "allow",
-                  "authenticate"
-                ]
-              }
+              "OnUnauthenticatedRequest": {}
             }
           },
           "AuthenticateCognitoConfig": {
@@ -1106,20 +1010,11 @@
                 "key": {},
                 "value": {}
               },
-              "OnUnauthenticatedRequest": {
-                "type": "string",
-                "enum": [
-                  "deny",
-                  "allow",
-                  "authenticate"
-                ]
-              }
+              "OnUnauthenticatedRequest": {}
             }
           },
           "Order": {
-            "type": "integer",
-            "max": 50000,
-            "min": 1
+            "type": "integer"
           },
           "RedirectConfig": {
             "type": "structure",
@@ -1127,33 +1022,12 @@
               "StatusCode"
             ],
             "members": {
-              "Protocol": {
-                "type": "string",
-                "pattern": "^(HTTPS?|#\\{protocol\\})$"
-              },
+              "Protocol": {},
               "Port": {},
-              "Host": {
-                "type": "string",
-                "max": 128,
-                "min": 1
-              },
-              "Path": {
-                "type": "string",
-                "max": 128,
-                "min": 1
-              },
-              "Query": {
-                "type": "string",
-                "max": 128,
-                "min": 0
-              },
-              "StatusCode": {
-                "type": "string",
-                "enum": [
-                  "HTTP_301",
-                  "HTTP_302"
-                ]
-              }
+              "Host": {},
+              "Path": {},
+              "Query": {},
+              "StatusCode": {}
             }
           },
           "FixedResponseConfig": {
@@ -1162,20 +1036,9 @@
               "StatusCode"
             ],
             "members": {
-              "MessageBody": {
-                "type": "string",
-                "max": 1024,
-                "min": 0
-              },
-              "StatusCode": {
-                "type": "string",
-                "pattern": "^(2|4|5)\\d\\d$"
-              },
-              "ContentType": {
-                "type": "string",
-                "max": 32,
-                "min": 0
-              }
+              "MessageBody": {},
+              "StatusCode": {},
+              "ContentType": {}
             }
           }
         }
@@ -1189,11 +1052,9 @@
           "ListenerArn": {},
           "LoadBalancerArn": {},
           "Port": {
-            "shape": "Sj"
+            "type": "integer"
           },
-          "Protocol": {
-            "shape": "Si"
-          },
+          "Protocol": {},
           "Certificates": {
             "shape": "S3"
           },
@@ -1222,27 +1083,6 @@
       "type": "list",
       "member": {}
     },
-    "S22": {
-      "type": "string",
-      "enum": [
-        "internet-facing",
-        "internal"
-      ]
-    },
-    "S23": {
-      "type": "string",
-      "enum": [
-        "application",
-        "network"
-      ]
-    },
-    "S24": {
-      "type": "string",
-      "enum": [
-        "ipv4",
-        "dualstack"
-      ]
-    },
     "S26": {
       "type": "list",
       "member": {
@@ -1255,37 +1095,23 @@
             "type": "timestamp"
           },
           "LoadBalancerName": {},
-          "Scheme": {
-            "shape": "S22"
-          },
+          "Scheme": {},
           "VpcId": {},
           "State": {
             "type": "structure",
             "members": {
-              "Code": {
-                "type": "string",
-                "enum": [
-                  "active",
-                  "provisioning",
-                  "active_impaired",
-                  "failed"
-                ]
-              },
+              "Code": {},
               "Reason": {}
             }
           },
-          "Type": {
-            "shape": "S23"
-          },
+          "Type": {},
           "AvailabilityZones": {
             "shape": "S2f"
           },
           "SecurityGroups": {
             "shape": "S20"
           },
-          "IpAddressType": {
-            "shape": "S24"
-          }
+          "IpAddressType": {}
         }
       }
     },
@@ -1314,21 +1140,13 @@
       "member": {
         "type": "structure",
         "members": {
-          "Field": {
-            "type": "string",
-            "max": 64
-          },
+          "Field": {},
           "Values": {
             "type": "list",
             "member": {}
           }
         }
       }
-    },
-    "S2r": {
-      "type": "integer",
-      "max": 50000,
-      "min": 1
     },
     "S2t": {
       "type": "list",
@@ -1349,26 +1167,6 @@
         }
       }
     },
-    "S31": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S32": {
-      "type": "integer",
-      "max": 300,
-      "min": 5
-    },
-    "S33": {
-      "type": "integer",
-      "max": 60,
-      "min": 2
-    },
-    "S34": {
-      "type": "integer",
-      "max": 10,
-      "min": 2
-    },
     "S35": {
       "type": "structure",
       "required": [
@@ -1378,13 +1176,6 @@
         "HttpCode": {}
       }
     },
-    "S37": {
-      "type": "string",
-      "enum": [
-        "instance",
-        "ip"
-      ]
-    },
     "S39": {
       "type": "list",
       "member": {
@@ -1392,41 +1183,33 @@
         "members": {
           "TargetGroupArn": {},
           "TargetGroupName": {},
-          "Protocol": {
-            "shape": "Si"
-          },
+          "Protocol": {},
           "Port": {
-            "shape": "Sj"
+            "type": "integer"
           },
           "VpcId": {},
-          "HealthCheckProtocol": {
-            "shape": "Si"
-          },
+          "HealthCheckProtocol": {},
           "HealthCheckPort": {},
           "HealthCheckIntervalSeconds": {
-            "shape": "S32"
+            "type": "integer"
           },
           "HealthCheckTimeoutSeconds": {
-            "shape": "S33"
+            "type": "integer"
           },
           "HealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
           "UnhealthyThresholdCount": {
-            "shape": "S34"
+            "type": "integer"
           },
-          "HealthCheckPath": {
-            "shape": "S31"
-          },
+          "HealthCheckPath": {},
           "Matcher": {
             "shape": "S35"
           },
           "LoadBalancerArns": {
             "shape": "S3b"
           },
-          "TargetType": {
-            "shape": "S37"
-          }
+          "TargetType": {}
         }
       }
     },
@@ -1448,44 +1231,27 @@
       "members": {
         "Id": {},
         "Port": {
-          "shape": "Sj"
+          "type": "integer"
         },
         "AvailabilityZone": {}
       }
-    },
-    "S3r": {
-      "type": "integer",
-      "max": 400,
-      "min": 1
     },
     "S44": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 256,
-            "pattern": "^[a-zA-Z0-9._]+$"
-          },
-          "Value": {
-            "type": "string",
-            "max": 1024
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 20
+      }
     },
     "S4v": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 256,
-            "pattern": "^[a-zA-Z0-9._]+$"
-          },
+          "Key": {},
           "Value": {}
         }
       }

--- a/apis/elasticmapreduce-2009-03-31.min.json
+++ b/apis/elasticmapreduce-2009-03-31.min.json
@@ -22,9 +22,7 @@
           "InstanceFleet"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          },
+          "ClusterId": {},
           "InstanceFleet": {
             "shape": "S3"
           }
@@ -33,9 +31,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          },
+          "ClusterId": {},
           "InstanceFleetId": {}
         }
       }
@@ -51,22 +47,16 @@
           "InstanceGroups": {
             "shape": "Sq"
           },
-          "JobFlowId": {
-            "shape": "S2"
-          }
+          "JobFlowId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobFlowId": {
-            "shape": "S2"
-          },
+          "JobFlowId": {},
           "InstanceGroupIds": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           }
         }
       }
@@ -79,9 +69,7 @@
           "Steps"
         ],
         "members": {
-          "JobFlowId": {
-            "shape": "S2"
-          },
+          "JobFlowId": {},
           "Steps": {
             "shape": "S1b"
           }
@@ -119,9 +107,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          },
+          "ClusterId": {},
           "StepIds": {
             "shape": "S1k"
           }
@@ -136,13 +122,7 @@
               "type": "structure",
               "members": {
                 "StepId": {},
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "SUBMITTED",
-                    "FAILED"
-                  ]
-                },
+                "Status": {},
                 "Reason": {}
               }
             }
@@ -158,9 +138,7 @@
           "SecurityConfiguration"
         ],
         "members": {
-          "Name": {
-            "shape": "S1h"
-          },
+          "Name": {},
           "SecurityConfiguration": {}
         }
       },
@@ -171,9 +149,7 @@
           "CreationDateTime"
         ],
         "members": {
-          "Name": {
-            "shape": "S1h"
-          },
+          "Name": {},
           "CreationDateTime": {
             "type": "timestamp"
           }
@@ -187,9 +163,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S1h"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -242,13 +216,7 @@
                   }
                 }
               },
-              "InstanceCollectionType": {
-                "type": "string",
-                "enum": [
-                  "INSTANCE_FLEET",
-                  "INSTANCE_GROUP"
-                ]
-              },
+              "InstanceCollectionType": {},
               "LogUri": {},
               "RequestedAmiVersion": {},
               "RunningAmiVersion": {},
@@ -276,24 +244,14 @@
               "Configurations": {
                 "shape": "Sh"
               },
-              "SecurityConfiguration": {
-                "shape": "S1h"
-              },
-              "AutoScalingRole": {
-                "shape": "S1h"
-              },
-              "ScaleDownBehavior": {
-                "shape": "S2h"
-              },
-              "CustomAmiId": {
-                "shape": "S2"
-              },
+              "SecurityConfiguration": {},
+              "AutoScalingRole": {},
+              "ScaleDownBehavior": {},
+              "CustomAmiId": {},
               "EbsRootVolumeSize": {
                 "type": "integer"
               },
-              "RepoUpgradeOnBoot": {
-                "shape": "S2i"
-              },
+              "RepoUpgradeOnBoot": {},
               "KerberosAttributes": {
                 "shape": "S2j"
               }
@@ -317,9 +275,7 @@
           },
           "JobFlowStates": {
             "type": "list",
-            "member": {
-              "shape": "S2m"
-            }
+            "member": {}
           }
         }
       },
@@ -337,18 +293,10 @@
                 "Instances"
               ],
               "members": {
-                "JobFlowId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S2"
-                },
-                "LogUri": {
-                  "shape": "S1h"
-                },
-                "AmiVersion": {
-                  "shape": "S2"
-                },
+                "JobFlowId": {},
+                "Name": {},
+                "LogUri": {},
+                "AmiVersion": {},
                 "ExecutionStatusDetail": {
                   "type": "structure",
                   "required": [
@@ -356,9 +304,7 @@
                     "CreationDateTime"
                   ],
                   "members": {
-                    "State": {
-                      "shape": "S2m"
-                    },
+                    "State": {},
                     "CreationDateTime": {
                       "type": "timestamp"
                     },
@@ -371,9 +317,7 @@
                     "EndDateTime": {
                       "type": "timestamp"
                     },
-                    "LastStateChangeReason": {
-                      "shape": "S1h"
-                    }
+                    "LastStateChangeReason": {}
                   }
                 },
                 "Instances": {
@@ -384,18 +328,10 @@
                     "InstanceCount"
                   ],
                   "members": {
-                    "MasterInstanceType": {
-                      "shape": "S8"
-                    },
-                    "MasterPublicDnsName": {
-                      "shape": "S1h"
-                    },
-                    "MasterInstanceId": {
-                      "shape": "S1h"
-                    },
-                    "SlaveInstanceType": {
-                      "shape": "S8"
-                    },
+                    "MasterInstanceType": {},
+                    "MasterPublicDnsName": {},
+                    "MasterInstanceId": {},
+                    "SlaveInstanceType": {},
                     "InstanceCount": {
                       "type": "integer"
                     },
@@ -413,36 +349,20 @@
                           "CreationDateTime"
                         ],
                         "members": {
-                          "InstanceGroupId": {
-                            "shape": "S2"
-                          },
-                          "Name": {
-                            "shape": "S2"
-                          },
-                          "Market": {
-                            "shape": "Ss"
-                          },
-                          "InstanceRole": {
-                            "shape": "St"
-                          },
-                          "BidPrice": {
-                            "shape": "S2"
-                          },
-                          "InstanceType": {
-                            "shape": "S8"
-                          },
+                          "InstanceGroupId": {},
+                          "Name": {},
+                          "Market": {},
+                          "InstanceRole": {},
+                          "BidPrice": {},
+                          "InstanceType": {},
                           "InstanceRequestCount": {
                             "type": "integer"
                           },
                           "InstanceRunningCount": {
                             "type": "integer"
                           },
-                          "State": {
-                            "shape": "S2u"
-                          },
-                          "LastStateChangeReason": {
-                            "shape": "S1h"
-                          },
+                          "State": {},
+                          "LastStateChangeReason": {},
                           "CreationDateTime": {
                             "type": "timestamp"
                           },
@@ -461,12 +381,8 @@
                     "NormalizedInstanceHours": {
                       "type": "integer"
                     },
-                    "Ec2KeyName": {
-                      "shape": "S2"
-                    },
-                    "Ec2SubnetId": {
-                      "shape": "S2"
-                    },
+                    "Ec2KeyName": {},
+                    "Ec2SubnetId": {},
                     "Placement": {
                       "shape": "S2v"
                     },
@@ -476,9 +392,7 @@
                     "TerminationProtected": {
                       "type": "boolean"
                     },
-                    "HadoopVersion": {
-                      "shape": "S2"
-                    }
+                    "HadoopVersion": {}
                   }
                 },
                 "Steps": {
@@ -500,18 +414,7 @@
                           "CreationDateTime"
                         ],
                         "members": {
-                          "State": {
-                            "type": "string",
-                            "enum": [
-                              "PENDING",
-                              "RUNNING",
-                              "CONTINUE",
-                              "COMPLETED",
-                              "CANCELLED",
-                              "FAILED",
-                              "INTERRUPTED"
-                            ]
-                          },
+                          "State": {},
                           "CreationDateTime": {
                             "type": "timestamp"
                           },
@@ -521,9 +424,7 @@
                           "EndDateTime": {
                             "type": "timestamp"
                           },
-                          "LastStateChangeReason": {
-                            "shape": "S1h"
-                          }
+                          "LastStateChangeReason": {}
                         }
                       }
                     }
@@ -546,18 +447,10 @@
                 "VisibleToAllUsers": {
                   "type": "boolean"
                 },
-                "JobFlowRole": {
-                  "shape": "S1h"
-                },
-                "ServiceRole": {
-                  "shape": "S1h"
-                },
-                "AutoScalingRole": {
-                  "shape": "S1h"
-                },
-                "ScaleDownBehavior": {
-                  "shape": "S2h"
-                }
+                "JobFlowRole": {},
+                "ServiceRole": {},
+                "AutoScalingRole": {},
+                "ScaleDownBehavior": {}
               }
             }
           }
@@ -572,17 +465,13 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S1h"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S1h"
-          },
+          "Name": {},
           "SecurityConfiguration": {},
           "CreationDateTime": {
             "type": "timestamp"
@@ -613,9 +502,7 @@
               "Config": {
                 "shape": "S3a"
               },
-              "ActionOnFailure": {
-                "shape": "S1d"
-              },
+              "ActionOnFailure": {},
               "Status": {
                 "shape": "S3b"
               }
@@ -667,9 +554,7 @@
           },
           "ClusterStates": {
             "type": "list",
-            "member": {
-              "shape": "S26"
-            }
+            "member": {}
           },
           "Marker": {}
         }
@@ -717,36 +602,15 @@
               "type": "structure",
               "members": {
                 "Id": {},
-                "Name": {
-                  "shape": "S2"
-                },
+                "Name": {},
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {
-                      "type": "string",
-                      "enum": [
-                        "PROVISIONING",
-                        "BOOTSTRAPPING",
-                        "RUNNING",
-                        "RESIZING",
-                        "SUSPENDED",
-                        "TERMINATING",
-                        "TERMINATED"
-                      ]
-                    },
+                    "State": {},
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {
-                          "type": "string",
-                          "enum": [
-                            "INTERNAL_ERROR",
-                            "VALIDATION_ERROR",
-                            "INSTANCE_FAILURE",
-                            "CLUSTER_TERMINATED"
-                          ]
-                        },
+                        "Code": {},
                         "Message": {}
                       }
                     },
@@ -766,37 +630,31 @@
                     }
                   }
                 },
-                "InstanceFleetType": {
-                  "shape": "S4"
-                },
+                "InstanceFleetType": {},
                 "TargetOnDemandCapacity": {
-                  "shape": "S5"
+                  "type": "integer"
                 },
                 "TargetSpotCapacity": {
-                  "shape": "S5"
+                  "type": "integer"
                 },
                 "ProvisionedOnDemandCapacity": {
-                  "shape": "S5"
+                  "type": "integer"
                 },
                 "ProvisionedSpotCapacity": {
-                  "shape": "S5"
+                  "type": "integer"
                 },
                 "InstanceTypeSpecifications": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "InstanceType": {
-                        "shape": "S8"
-                      },
+                      "InstanceType": {},
                       "WeightedCapacity": {
-                        "shape": "S5"
+                        "type": "integer"
                       },
-                      "BidPrice": {
-                        "shape": "S2"
-                      },
+                      "BidPrice": {},
                       "BidPriceAsPercentageOfOnDemandPrice": {
-                        "shape": "S9"
+                        "type": "double"
                       },
                       "Configurations": {
                         "shape": "Sh"
@@ -841,16 +699,10 @@
               "members": {
                 "Id": {},
                 "Name": {},
-                "Market": {
-                  "shape": "Ss"
-                },
-                "InstanceGroupType": {
-                  "shape": "S49"
-                },
+                "Market": {},
+                "InstanceGroupType": {},
                 "BidPrice": {},
-                "InstanceType": {
-                  "shape": "S8"
-                },
+                "InstanceType": {},
                 "RequestedInstanceCount": {
                   "type": "integer"
                 },
@@ -860,21 +712,11 @@
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {
-                      "shape": "S2u"
-                    },
+                    "State": {},
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {
-                          "type": "string",
-                          "enum": [
-                            "INTERNAL_ERROR",
-                            "VALIDATION_ERROR",
-                            "INSTANCE_FAILURE",
-                            "CLUSTER_TERMINATED"
-                          ]
-                        },
+                        "Code": {},
                         "Message": {}
                       }
                     },
@@ -927,19 +769,13 @@
           "InstanceGroupId": {},
           "InstanceGroupTypes": {
             "type": "list",
-            "member": {
-              "shape": "S49"
-            }
+            "member": {}
           },
           "InstanceFleetId": {},
-          "InstanceFleetType": {
-            "shape": "S4"
-          },
+          "InstanceFleetType": {},
           "InstanceStates": {
             "type": "list",
-            "member": {
-              "shape": "S4q"
-            }
+            "member": {}
           },
           "Marker": {}
         }
@@ -961,22 +797,11 @@
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "State": {
-                      "shape": "S4q"
-                    },
+                    "State": {},
                     "StateChangeReason": {
                       "type": "structure",
                       "members": {
-                        "Code": {
-                          "type": "string",
-                          "enum": [
-                            "INTERNAL_ERROR",
-                            "VALIDATION_ERROR",
-                            "INSTANCE_FAILURE",
-                            "BOOTSTRAP_FAILURE",
-                            "CLUSTER_TERMINATED"
-                          ]
-                        },
+                        "Code": {},
                         "Message": {}
                       }
                     },
@@ -998,12 +823,8 @@
                 },
                 "InstanceGroupId": {},
                 "InstanceFleetId": {},
-                "Market": {
-                  "shape": "Ss"
-                },
-                "InstanceType": {
-                  "shape": "S8"
-                },
+                "Market": {},
+                "InstanceType": {},
                 "EbsVolumes": {
                   "type": "list",
                   "member": {
@@ -1036,9 +857,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S1h"
-                },
+                "Name": {},
                 "CreationDateTime": {
                   "type": "timestamp"
                 }
@@ -1059,9 +878,7 @@
           "ClusterId": {},
           "StepStates": {
             "type": "list",
-            "member": {
-              "shape": "S3c"
-            }
+            "member": {}
           },
           "StepIds": {
             "shape": "S1i"
@@ -1082,9 +899,7 @@
                 "Config": {
                   "shape": "S3a"
                 },
-                "ActionOnFailure": {
-                  "shape": "S1d"
-                },
+                "ActionOnFailure": {},
                 "Status": {
                   "shape": "S3b"
                 }
@@ -1112,10 +927,10 @@
             "members": {
               "InstanceFleetId": {},
               "TargetOnDemandCapacity": {
-                "shape": "S5"
+                "type": "integer"
               },
               "TargetSpotCapacity": {
-                "shape": "S5"
+                "type": "integer"
               }
             }
           }
@@ -1135,9 +950,7 @@
                 "InstanceGroupId"
               ],
               "members": {
-                "InstanceGroupId": {
-                  "shape": "S2"
-                },
+                "InstanceGroupId": {},
                 "InstanceCount": {
                   "type": "integer"
                 },
@@ -1225,30 +1038,16 @@
           "Instances"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "LogUri": {
-            "shape": "S1h"
-          },
-          "AdditionalInfo": {
-            "shape": "S1h"
-          },
-          "AmiVersion": {
-            "shape": "S2"
-          },
-          "ReleaseLabel": {
-            "shape": "S2"
-          },
+          "Name": {},
+          "LogUri": {},
+          "AdditionalInfo": {},
+          "AmiVersion": {},
+          "ReleaseLabel": {},
           "Instances": {
             "type": "structure",
             "members": {
-              "MasterInstanceType": {
-                "shape": "S8"
-              },
-              "SlaveInstanceType": {
-                "shape": "S8"
-              },
+              "MasterInstanceType": {},
+              "SlaveInstanceType": {},
               "InstanceCount": {
                 "type": "integer"
               },
@@ -1261,9 +1060,7 @@
                   "shape": "S3"
                 }
               },
-              "Ec2KeyName": {
-                "shape": "S2"
-              },
+              "Ec2KeyName": {},
               "Placement": {
                 "shape": "S2v"
               },
@@ -1273,24 +1070,14 @@
               "TerminationProtected": {
                 "type": "boolean"
               },
-              "HadoopVersion": {
-                "shape": "S2"
-              },
-              "Ec2SubnetId": {
-                "shape": "S2"
-              },
+              "HadoopVersion": {},
+              "Ec2SubnetId": {},
               "Ec2SubnetIds": {
                 "shape": "S2b"
               },
-              "EmrManagedMasterSecurityGroup": {
-                "shape": "S2"
-              },
-              "EmrManagedSlaveSecurityGroup": {
-                "shape": "S2"
-              },
-              "ServiceAccessSecurityGroup": {
-                "shape": "S2"
-              },
+              "EmrManagedMasterSecurityGroup": {},
+              "EmrManagedSlaveSecurityGroup": {},
+              "ServiceAccessSecurityGroup": {},
               "AdditionalMasterSecurityGroups": {
                 "shape": "S5o"
               },
@@ -1316,9 +1103,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S2"
-                },
+                "Name": {},
                 "Args": {
                   "shape": "S1i"
                 }
@@ -1334,33 +1119,19 @@
           "VisibleToAllUsers": {
             "type": "boolean"
           },
-          "JobFlowRole": {
-            "shape": "S1h"
-          },
-          "ServiceRole": {
-            "shape": "S1h"
-          },
+          "JobFlowRole": {},
+          "ServiceRole": {},
           "Tags": {
             "shape": "S1n"
           },
-          "SecurityConfiguration": {
-            "shape": "S1h"
-          },
-          "AutoScalingRole": {
-            "shape": "S1h"
-          },
-          "ScaleDownBehavior": {
-            "shape": "S2h"
-          },
-          "CustomAmiId": {
-            "shape": "S2"
-          },
+          "SecurityConfiguration": {},
+          "AutoScalingRole": {},
+          "ScaleDownBehavior": {},
+          "CustomAmiId": {},
           "EbsRootVolumeSize": {
             "type": "integer"
           },
-          "RepoUpgradeOnBoot": {
-            "shape": "S2i"
-          },
+          "RepoUpgradeOnBoot": {},
           "KerberosAttributes": {
             "shape": "S2j"
           }
@@ -1369,9 +1140,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobFlowId": {
-            "shape": "S2"
-          }
+          "JobFlowId": {}
         }
       }
     },
@@ -1424,29 +1193,19 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 256,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S3": {
       "type": "structure",
       "required": [
         "InstanceFleetType"
       ],
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
-        "InstanceFleetType": {
-          "shape": "S4"
-        },
+        "Name": {},
+        "InstanceFleetType": {},
         "TargetOnDemandCapacity": {
-          "shape": "S5"
+          "type": "integer"
         },
         "TargetSpotCapacity": {
-          "shape": "S5"
+          "type": "integer"
         },
         "InstanceTypeConfigs": {
           "type": "list",
@@ -1456,17 +1215,13 @@
               "InstanceType"
             ],
             "members": {
-              "InstanceType": {
-                "shape": "S8"
-              },
+              "InstanceType": {},
               "WeightedCapacity": {
-                "shape": "S5"
+                "type": "integer"
               },
-              "BidPrice": {
-                "shape": "S2"
-              },
+              "BidPrice": {},
               "BidPriceAsPercentageOfOnDemandPrice": {
-                "shape": "S9"
+                "type": "double"
               },
               "EbsConfiguration": {
                 "shape": "Sa"
@@ -1481,28 +1236,6 @@
           "shape": "Sk"
         }
       }
-    },
-    "S4": {
-      "type": "string",
-      "enum": [
-        "MASTER",
-        "CORE",
-        "TASK"
-      ]
-    },
-    "S5": {
-      "type": "integer",
-      "min": 0
-    },
-    "S8": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S9": {
-      "type": "double",
-      "min": 0
     },
     "Sa": {
       "type": "structure",
@@ -1579,17 +1312,11 @@
           ],
           "members": {
             "TimeoutDurationMinutes": {
-              "shape": "S5"
+              "type": "integer"
             },
-            "TimeoutAction": {
-              "type": "string",
-              "enum": [
-                "SWITCH_TO_ON_DEMAND",
-                "TERMINATE_CLUSTER"
-              ]
-            },
+            "TimeoutAction": {},
             "BlockDurationMinutes": {
-              "shape": "S5"
+              "type": "integer"
             }
           }
         }
@@ -1605,21 +1332,11 @@
           "InstanceCount"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "Market": {
-            "shape": "Ss"
-          },
-          "InstanceRole": {
-            "shape": "St"
-          },
-          "BidPrice": {
-            "shape": "S2"
-          },
-          "InstanceType": {
-            "shape": "S8"
-          },
+          "Name": {},
+          "Market": {},
+          "InstanceRole": {},
+          "BidPrice": {},
+          "InstanceType": {},
           "InstanceCount": {
             "type": "integer"
           },
@@ -1634,21 +1351,6 @@
           }
         }
       }
-    },
-    "Ss": {
-      "type": "string",
-      "enum": [
-        "ON_DEMAND",
-        "SPOT"
-      ]
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "MASTER",
-        "CORE",
-        "TASK"
-      ]
     },
     "Su": {
       "type": "structure",
@@ -1698,23 +1400,14 @@
               "SimpleScalingPolicyConfiguration"
             ],
             "members": {
-              "Market": {
-                "shape": "Ss"
-              },
+              "Market": {},
               "SimpleScalingPolicyConfiguration": {
                 "type": "structure",
                 "required": [
                   "ScalingAdjustment"
                 ],
                 "members": {
-                  "AdjustmentType": {
-                    "type": "string",
-                    "enum": [
-                      "CHANGE_IN_CAPACITY",
-                      "PERCENT_CHANGE_IN_CAPACITY",
-                      "EXACT_CAPACITY"
-                    ]
-                  },
+                  "AdjustmentType": {},
                   "ScalingAdjustment": {
                     "type": "integer"
                   },
@@ -1740,15 +1433,7 @@
                   "Threshold"
                 ],
                 "members": {
-                  "ComparisonOperator": {
-                    "type": "string",
-                    "enum": [
-                      "GREATER_THAN_OR_EQUAL",
-                      "GREATER_THAN",
-                      "LESS_THAN",
-                      "LESS_THAN_OR_EQUAL"
-                    ]
-                  },
+                  "ComparisonOperator": {},
                   "EvaluationPeriods": {
                     "type": "integer"
                   },
@@ -1757,51 +1442,11 @@
                   "Period": {
                     "type": "integer"
                   },
-                  "Statistic": {
-                    "type": "string",
-                    "enum": [
-                      "SAMPLE_COUNT",
-                      "AVERAGE",
-                      "SUM",
-                      "MINIMUM",
-                      "MAXIMUM"
-                    ]
-                  },
+                  "Statistic": {},
                   "Threshold": {
-                    "shape": "S9"
+                    "type": "double"
                   },
-                  "Unit": {
-                    "type": "string",
-                    "enum": [
-                      "NONE",
-                      "SECONDS",
-                      "MICRO_SECONDS",
-                      "MILLI_SECONDS",
-                      "BYTES",
-                      "KILO_BYTES",
-                      "MEGA_BYTES",
-                      "GIGA_BYTES",
-                      "TERA_BYTES",
-                      "BITS",
-                      "KILO_BITS",
-                      "MEGA_BITS",
-                      "GIGA_BITS",
-                      "TERA_BITS",
-                      "PERCENT",
-                      "COUNT",
-                      "BYTES_PER_SECOND",
-                      "KILO_BYTES_PER_SECOND",
-                      "MEGA_BYTES_PER_SECOND",
-                      "GIGA_BYTES_PER_SECOND",
-                      "TERA_BYTES_PER_SECOND",
-                      "BITS_PER_SECOND",
-                      "KILO_BITS_PER_SECOND",
-                      "MEGA_BITS_PER_SECOND",
-                      "GIGA_BITS_PER_SECOND",
-                      "TERA_BITS_PER_SECOND",
-                      "COUNT_PER_SECOND"
-                    ]
-                  },
+                  "Unit": {},
                   "Dimensions": {
                     "type": "list",
                     "member": {
@@ -1832,12 +1477,8 @@
         "HadoopJarStep"
       ],
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
-        "ActionOnFailure": {
-          "shape": "S1d"
-        },
+        "Name": {},
+        "ActionOnFailure": {},
         "HadoopJarStep": {
           "type": "structure",
           "required": [
@@ -1849,21 +1490,13 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "Key": {
-                    "shape": "S1h"
-                  },
-                  "Value": {
-                    "shape": "S1h"
-                  }
+                  "Key": {},
+                  "Value": {}
                 }
               }
             },
-            "Jar": {
-              "shape": "S1h"
-            },
-            "MainClass": {
-              "shape": "S1h"
-            },
+            "Jar": {},
+            "MainClass": {},
             "Args": {
               "shape": "S1i"
             }
@@ -1871,32 +1504,13 @@
         }
       }
     },
-    "S1d": {
-      "type": "string",
-      "enum": [
-        "TERMINATE_JOB_FLOW",
-        "TERMINATE_CLUSTER",
-        "CANCEL_AND_WAIT",
-        "CONTINUE"
-      ]
-    },
-    "S1h": {
-      "type": "string",
-      "max": 10280,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S1i": {
       "type": "list",
-      "member": {
-        "shape": "S1h"
-      }
+      "member": {}
     },
     "S1k": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "S1n": {
       "type": "list",
@@ -1911,25 +1525,11 @@
     "S25": {
       "type": "structure",
       "members": {
-        "State": {
-          "shape": "S26"
-        },
+        "State": {},
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {
-              "type": "string",
-              "enum": [
-                "INTERNAL_ERROR",
-                "VALIDATION_ERROR",
-                "INSTANCE_FAILURE",
-                "INSTANCE_FLEET_TIMEOUT",
-                "BOOTSTRAP_FAILURE",
-                "USER_REQUEST",
-                "STEP_FAILURE",
-                "ALL_STEPS_COMPLETED"
-              ]
-            },
+            "Code": {},
             "Message": {}
           }
         },
@@ -1949,23 +1549,9 @@
         }
       }
     },
-    "S26": {
-      "type": "string",
-      "enum": [
-        "STARTING",
-        "BOOTSTRAPPING",
-        "RUNNING",
-        "WAITING",
-        "TERMINATING",
-        "TERMINATED",
-        "TERMINATED_WITH_ERRORS"
-      ]
-    },
     "S2b": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "S2c": {
       "type": "list",
@@ -1987,20 +1573,6 @@
         }
       }
     },
-    "S2h": {
-      "type": "string",
-      "enum": [
-        "TERMINATE_AT_INSTANCE_HOUR",
-        "TERMINATE_AT_TASK_COMPLETION"
-      ]
-    },
-    "S2i": {
-      "type": "string",
-      "enum": [
-        "SECURITY",
-        "NONE"
-      ]
-    },
     "S2j": {
       "type": "structure",
       "required": [
@@ -2008,57 +1580,17 @@
         "KdcAdminPassword"
       ],
       "members": {
-        "Realm": {
-          "shape": "S2"
-        },
-        "KdcAdminPassword": {
-          "shape": "S2"
-        },
-        "CrossRealmTrustPrincipalPassword": {
-          "shape": "S2"
-        },
-        "ADDomainJoinUser": {
-          "shape": "S2"
-        },
-        "ADDomainJoinPassword": {
-          "shape": "S2"
-        }
+        "Realm": {},
+        "KdcAdminPassword": {},
+        "CrossRealmTrustPrincipalPassword": {},
+        "ADDomainJoinUser": {},
+        "ADDomainJoinPassword": {}
       }
-    },
-    "S2m": {
-      "type": "string",
-      "enum": [
-        "STARTING",
-        "BOOTSTRAPPING",
-        "RUNNING",
-        "WAITING",
-        "SHUTTING_DOWN",
-        "TERMINATED",
-        "COMPLETED",
-        "FAILED"
-      ]
-    },
-    "S2u": {
-      "type": "string",
-      "enum": [
-        "PROVISIONING",
-        "BOOTSTRAPPING",
-        "RUNNING",
-        "RESIZING",
-        "SUSPENDED",
-        "TERMINATING",
-        "TERMINATED",
-        "ARRESTED",
-        "SHUTTING_DOWN",
-        "ENDED"
-      ]
     },
     "S2v": {
       "type": "structure",
       "members": {
-        "AvailabilityZone": {
-          "shape": "S1h"
-        },
+        "AvailabilityZone": {},
         "AvailabilityZones": {
           "shape": "S2b"
         }
@@ -2071,18 +1603,14 @@
         "ScriptBootstrapAction"
       ],
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
+        "Name": {},
         "ScriptBootstrapAction": {
           "type": "structure",
           "required": [
             "Path"
           ],
           "members": {
-            "Path": {
-              "shape": "S1h"
-            },
+            "Path": {},
             "Args": {
               "shape": "S1i"
             }
@@ -2092,9 +1620,7 @@
     },
     "S34": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "S3a": {
       "type": "structure",
@@ -2112,18 +1638,11 @@
     "S3b": {
       "type": "structure",
       "members": {
-        "State": {
-          "shape": "S3c"
-        },
+        "State": {},
         "StateChangeReason": {
           "type": "structure",
           "members": {
-            "Code": {
-              "type": "string",
-              "enum": [
-                "NONE"
-              ]
-            },
+            "Code": {},
             "Message": {}
           }
         },
@@ -2151,18 +1670,6 @@
         }
       }
     },
-    "S3c": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "CANCEL_PENDING",
-        "RUNNING",
-        "COMPLETED",
-        "CANCELLED",
-        "FAILED",
-        "INTERRUPTED"
-      ]
-    },
     "S42": {
       "type": "list",
       "member": {
@@ -2174,14 +1681,6 @@
           "Device": {}
         }
       }
-    },
-    "S49": {
-      "type": "string",
-      "enum": [
-        "MASTER",
-        "CORE",
-        "TASK"
-      ]
     },
     "S4e": {
       "type": "structure",
@@ -2215,28 +1714,11 @@
         "Status": {
           "type": "structure",
           "members": {
-            "State": {
-              "type": "string",
-              "enum": [
-                "PENDING",
-                "ATTACHING",
-                "ATTACHED",
-                "DETACHING",
-                "DETACHED",
-                "FAILED"
-              ]
-            },
+            "State": {},
             "StateChangeReason": {
               "type": "structure",
               "members": {
-                "Code": {
-                  "type": "string",
-                  "enum": [
-                    "USER_REQUEST",
-                    "PROVISION_FAILURE",
-                    "CLEANUP_FAILURE"
-                  ]
-                },
+                "Code": {},
                 "Message": {}
               }
             }
@@ -2250,21 +1732,9 @@
         }
       }
     },
-    "S4q": {
-      "type": "string",
-      "enum": [
-        "AWAITING_FULFILLMENT",
-        "PROVISIONING",
-        "BOOTSTRAPPING",
-        "RUNNING",
-        "TERMINATED"
-      ]
-    },
     "S5o": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/elastictranscoder-2012-09-25.min.json
+++ b/apis/elastictranscoder-2012-09-25.min.json
@@ -23,7 +23,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -45,9 +44,7 @@
           "PipelineId"
         ],
         "members": {
-          "PipelineId": {
-            "shape": "S2"
-          },
+          "PipelineId": {},
           "Input": {
             "shape": "S5"
           },
@@ -61,23 +58,16 @@
             "type": "list",
             "member": {
               "shape": "Su"
-            },
-            "max": 30
+            }
           },
-          "OutputKeyPrefix": {
-            "shape": "Sm"
-          },
+          "OutputKeyPrefix": {},
           "Playlists": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S1j"
-                },
-                "Format": {
-                  "shape": "S1k"
-                },
+                "Name": {},
+                "Format": {},
                 "OutputKeys": {
                   "shape": "S1l"
                 },
@@ -88,8 +78,7 @@
                   "shape": "S1q"
                 }
               }
-            },
-            "max": 30
+            }
           },
           "UserMetadata": {
             "shape": "S1v"
@@ -118,21 +107,11 @@
           "Role"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "InputBucket": {
-            "shape": "S27"
-          },
-          "OutputBucket": {
-            "shape": "S27"
-          },
-          "Role": {
-            "shape": "S28"
-          },
-          "AwsKmsKeyArn": {
-            "shape": "S29"
-          },
+          "Name": {},
+          "InputBucket": {},
+          "OutputBucket": {},
+          "Role": {},
+          "AwsKmsKeyArn": {},
           "Notifications": {
             "shape": "S2a"
           },
@@ -168,15 +147,9 @@
           "Container"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "Description": {
-            "shape": "S21"
-          },
-          "Container": {
-            "shape": "S2q"
-          },
+          "Name": {},
+          "Description": {},
+          "Container": {},
           "Video": {
             "shape": "S2r"
           },
@@ -211,7 +184,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -235,7 +207,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -258,17 +229,14 @@
         ],
         "members": {
           "PipelineId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "PipelineId"
           },
           "Ascending": {
-            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -280,9 +248,7 @@
           "Jobs": {
             "shape": "S3v"
           },
-          "NextPageToken": {
-            "shape": "S2"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -298,17 +264,14 @@
         ],
         "members": {
           "Status": {
-            "shape": "S20",
             "location": "uri",
             "locationName": "Status"
           },
           "Ascending": {
-            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -320,9 +283,7 @@
           "Jobs": {
             "shape": "S3v"
           },
-          "NextPageToken": {
-            "shape": "S2"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -335,12 +296,10 @@
         "type": "structure",
         "members": {
           "Ascending": {
-            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -355,9 +314,7 @@
               "shape": "S2l"
             }
           },
-          "NextPageToken": {
-            "shape": "S2"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -370,12 +327,10 @@
         "type": "structure",
         "members": {
           "Ascending": {
-            "shape": "S3t",
             "location": "querystring",
             "locationName": "Ascending"
           },
           "PageToken": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "PageToken"
           }
@@ -390,9 +345,7 @@
               "shape": "S3m"
             }
           },
-          "NextPageToken": {
-            "shape": "S2"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -408,7 +361,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -435,7 +387,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -465,7 +416,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -494,21 +444,12 @@
           "Topics"
         ],
         "members": {
-          "Role": {
-            "shape": "S28"
-          },
-          "InputBucket": {
-            "shape": "S27"
-          },
-          "OutputBucket": {
-            "shape": "S27"
-          },
+          "Role": {},
+          "InputBucket": {},
+          "OutputBucket": {},
           "Topics": {
             "type": "list",
-            "member": {
-              "shape": "S2b"
-            },
-            "max": 30
+            "member": {}
           }
         },
         "deprecated": true
@@ -516,10 +457,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Success": {
-            "type": "string",
-            "pattern": "(^true$)|(^false$)"
-          },
+          "Success": {},
           "Messages": {
             "type": "list",
             "member": {}
@@ -542,22 +480,13 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Name": {
-            "shape": "So"
-          },
-          "InputBucket": {
-            "shape": "S27"
-          },
-          "Role": {
-            "shape": "S28"
-          },
-          "AwsKmsKeyArn": {
-            "shape": "S29"
-          },
+          "Name": {},
+          "InputBucket": {},
+          "Role": {},
+          "AwsKmsKeyArn": {},
           "Notifications": {
             "shape": "S2a"
           },
@@ -593,7 +522,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -623,13 +551,10 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Status": {
-            "shape": "S2m"
-          }
+          "Status": {}
         }
       },
       "output": {
@@ -643,33 +568,15 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "^\\d{13}-\\w{6}$"
-    },
     "S5": {
       "type": "structure",
       "members": {
-        "Key": {
-          "shape": "S6"
-        },
-        "FrameRate": {
-          "shape": "S7"
-        },
-        "Resolution": {
-          "shape": "S8"
-        },
-        "AspectRatio": {
-          "shape": "S9"
-        },
-        "Interlaced": {
-          "type": "string",
-          "pattern": "(^auto$)|(^true$)|(^false$)"
-        },
-        "Container": {
-          "type": "string",
-          "pattern": "(^auto$)|(^3gp$)|(^asf$)|(^avi$)|(^divx$)|(^flv$)|(^mkv$)|(^mov$)|(^mp4$)|(^mpeg$)|(^mpeg-ps$)|(^mpeg-ts$)|(^mxf$)|(^ogg$)|(^ts$)|(^vob$)|(^wav$)|(^webm$)|(^mp3$)|(^m4a$)|(^aac$)"
-        },
+        "Key": {},
+        "FrameRate": {},
+        "Resolution": {},
+        "AspectRatio": {},
+        "Interlaced": {},
+        "Container": {},
         "Encryption": {
           "shape": "Sc"
         },
@@ -679,9 +586,7 @@
         "InputCaptions": {
           "type": "structure",
           "members": {
-            "MergePolicy": {
-              "shape": "Sj"
-            },
+            "MergePolicy": {},
             "CaptionSources": {
               "shape": "Sk"
             }
@@ -696,9 +601,7 @@
             "Height": {
               "type": "integer"
             },
-            "FrameRate": {
-              "shape": "Sr"
-            },
+            "FrameRate": {},
             "FileSize": {
               "type": "long"
             },
@@ -709,136 +612,54 @@
         }
       }
     },
-    "S6": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "pattern": "(^auto$)|(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
-    },
-    "S8": {
-      "type": "string",
-      "pattern": "(^auto$)|(^\\d{1,5}x\\d{1,5}$)"
-    },
-    "S9": {
-      "type": "string",
-      "pattern": "(^auto$)|(^1:1$)|(^4:3$)|(^3:2$)|(^16:9$)"
-    },
     "Sc": {
       "type": "structure",
       "members": {
-        "Mode": {
-          "type": "string",
-          "pattern": "(^s3$)|(^s3-aws-kms$)|(^aes-cbc-pkcs7$)|(^aes-ctr$)|(^aes-gcm$)"
-        },
-        "Key": {
-          "shape": "Se"
-        },
-        "KeyMd5": {
-          "shape": "Se"
-        },
-        "InitializationVector": {
-          "shape": "Sf"
-        }
+        "Mode": {},
+        "Key": {},
+        "KeyMd5": {},
+        "InitializationVector": {}
       }
-    },
-    "Se": {
-      "type": "string",
-      "pattern": "^$|(^(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}==|[A-Za-z0-9\\+/]{3}=)?$)"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 255,
-      "min": 0
     },
     "Sg": {
       "type": "structure",
       "members": {
-        "StartTime": {
-          "shape": "Sh"
-        },
-        "Duration": {
-          "shape": "Sh"
-        }
+        "StartTime": {},
+        "Duration": {}
       }
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "(^\\d{1,5}(\\.\\d{0,3})?$)|(^([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\\.\\d{0,3})?$)"
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "(^MergeOverride$)|(^MergeRetain$)|(^Override$)"
     },
     "Sk": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S6"
-          },
-          "Language": {
-            "shape": "Sm"
-          },
-          "TimeOffset": {
-            "type": "string",
-            "pattern": "(^[+-]?\\d{1,5}(\\.\\d{0,3})?$)|(^[+-]?([0-1]?[0-9]:|2[0-3]:)?([0-5]?[0-9]:)?[0-5]?[0-9](\\.\\d{0,3})?$)"
-          },
-          "Label": {
-            "shape": "So"
-          },
+          "Key": {},
+          "Language": {},
+          "TimeOffset": {},
+          "Label": {},
           "Encryption": {
             "shape": "Sc"
           }
         }
-      },
-      "max": 20
-    },
-    "Sm": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "So": {
-      "type": "string",
-      "max": 40,
-      "min": 1
-    },
-    "Sr": {
-      "type": "string",
-      "pattern": "^\\d{1,5}(\\.\\d{0,5})?$"
+      }
     },
     "St": {
       "type": "list",
       "member": {
         "shape": "S5"
-      },
-      "max": 200
+      }
     },
     "Su": {
       "type": "structure",
       "members": {
-        "Key": {
-          "shape": "Sm"
-        },
-        "ThumbnailPattern": {
-          "shape": "Sv"
-        },
+        "Key": {},
+        "ThumbnailPattern": {},
         "ThumbnailEncryption": {
           "shape": "Sc"
         },
-        "Rotate": {
-          "shape": "Sw"
-        },
-        "PresetId": {
-          "shape": "S2"
-        },
-        "SegmentDuration": {
-          "shape": "Sr"
-        },
+        "Rotate": {},
+        "PresetId": {},
+        "SegmentDuration": {},
         "Watermarks": {
           "shape": "Sx"
         },
@@ -857,72 +678,34 @@
         }
       }
     },
-    "Sv": {
-      "type": "string",
-      "pattern": "(^$)|(^.*\\{count\\}.*$)"
-    },
-    "Sw": {
-      "type": "string",
-      "pattern": "(^auto$)|(^0$)|(^90$)|(^180$)|(^270$)"
-    },
     "Sx": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "PresetWatermarkId": {
-            "shape": "Sz"
-          },
-          "InputKey": {
-            "shape": "S10"
-          },
+          "PresetWatermarkId": {},
+          "InputKey": {},
           "Encryption": {
             "shape": "Sc"
           }
         }
       }
     },
-    "Sz": {
-      "type": "string",
-      "max": 40,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "(^.{1,1020}.jpg$)|(^.{1,1019}.jpeg$)|(^.{1,1020}.png$)"
-    },
     "S11": {
       "type": "structure",
       "members": {
-        "MergePolicy": {
-          "type": "string",
-          "pattern": "(^Replace$)|(^Prepend$)|(^Append$)|(^Fallback$)"
-        },
+        "MergePolicy": {},
         "Artwork": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "InputKey": {
-                "shape": "S10"
-              },
-              "MaxWidth": {
-                "shape": "S15"
-              },
-              "MaxHeight": {
-                "shape": "S15"
-              },
-              "SizingPolicy": {
-                "shape": "S16"
-              },
-              "PaddingPolicy": {
-                "shape": "S17"
-              },
-              "AlbumArtFormat": {
-                "shape": "S18"
-              },
+              "InputKey": {},
+              "MaxWidth": {},
+              "MaxHeight": {},
+              "SizingPolicy": {},
+              "PaddingPolicy": {},
+              "AlbumArtFormat": {},
               "Encryption": {
                 "shape": "Sc"
               }
@@ -930,22 +713,6 @@
           }
         }
       }
-    },
-    "S15": {
-      "type": "string",
-      "pattern": "(^auto$)|(^\\d{2,4}$)"
-    },
-    "S16": {
-      "type": "string",
-      "pattern": "(^Fit$)|(^Fill$)|(^Stretch$)|(^Keep$)|(^ShrinkToFit$)|(^ShrinkToFill$)"
-    },
-    "S17": {
-      "type": "string",
-      "pattern": "(^Pad$)|(^NoPad$)"
-    },
-    "S18": {
-      "type": "string",
-      "pattern": "(^jpg$)|(^png$)"
     },
     "S19": {
       "type": "list",
@@ -964,7 +731,6 @@
       "type": "structure",
       "members": {
         "MergePolicy": {
-          "shape": "Sj",
           "deprecated": true
         },
         "CaptionSources": {
@@ -976,96 +742,41 @@
           "member": {
             "type": "structure",
             "members": {
-              "Format": {
-                "type": "string",
-                "pattern": "(^mov-text$)|(^srt$)|(^scc$)|(^webvtt$)|(^dfxp$)|(^cea-708$)"
-              },
-              "Pattern": {
-                "type": "string",
-                "pattern": "(^$)|(^.*\\{language\\}.*$)"
-              },
+              "Format": {},
+              "Pattern": {},
               "Encryption": {
                 "shape": "Sc"
               }
             }
-          },
-          "max": 4
+          }
         }
       }
     },
-    "S1j": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S1k": {
-      "type": "string",
-      "pattern": "(^HLSv3$)|(^HLSv4$)|(^Smooth$)|(^MPEG-DASH$)"
-    },
     "S1l": {
       "type": "list",
-      "member": {
-        "shape": "Sm"
-      },
-      "max": 30
+      "member": {}
     },
     "S1m": {
       "type": "structure",
       "members": {
-        "Method": {
-          "type": "string",
-          "pattern": "(^aes-128$)"
-        },
-        "Key": {
-          "shape": "Se"
-        },
-        "KeyMd5": {
-          "shape": "Se"
-        },
-        "InitializationVector": {
-          "shape": "Sf"
-        },
-        "LicenseAcquisitionUrl": {
-          "type": "string",
-          "max": 512,
-          "min": 0
-        },
-        "KeyStoragePolicy": {
-          "type": "string",
-          "pattern": "(^NoStore$)|(^WithVariantPlaylists$)"
-        }
+        "Method": {},
+        "Key": {},
+        "KeyMd5": {},
+        "InitializationVector": {},
+        "LicenseAcquisitionUrl": {},
+        "KeyStoragePolicy": {}
       }
     },
     "S1q": {
       "type": "structure",
       "members": {
-        "Format": {
-          "type": "string",
-          "pattern": "(^microsoft$)|(^discretix-3.0$)"
-        },
-        "Key": {
-          "shape": "S1s"
-        },
-        "KeyMd5": {
-          "shape": "S1s"
-        },
-        "KeyId": {
-          "type": "string",
-          "pattern": "(^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$)|(^[0-9A-Fa-f]{32}$)"
-        },
-        "InitializationVector": {
-          "shape": "Sf"
-        },
-        "LicenseAcquisitionUrl": {
-          "type": "string",
-          "max": 512,
-          "min": 1
-        }
+        "Format": {},
+        "Key": {},
+        "KeyMd5": {},
+        "KeyId": {},
+        "InitializationVector": {},
+        "LicenseAcquisitionUrl": {}
       }
-    },
-    "S1s": {
-      "type": "string",
-      "pattern": "(^(?:[A-Za-z0-9\\+/]{4})*(?:[A-Za-z0-9\\+/]{2}==|[A-Za-z0-9\\+/]{3}=)?$)"
     },
     "S1v": {
       "type": "map",
@@ -1075,13 +786,9 @@
     "S1y": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
+        "Id": {},
         "Arn": {},
-        "PipelineId": {
-          "shape": "S2"
-        },
+        "PipelineId": {},
         "Input": {
           "shape": "S5"
         },
@@ -1097,20 +804,14 @@
             "shape": "S1z"
           }
         },
-        "OutputKeyPrefix": {
-          "shape": "Sm"
-        },
+        "OutputKeyPrefix": {},
         "Playlists": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "S1j"
-              },
-              "Format": {
-                "shape": "S1k"
-              },
+              "Name": {},
+              "Format": {},
               "OutputKeys": {
                 "shape": "S1l"
               },
@@ -1120,18 +821,12 @@
               "PlayReadyDrm": {
                 "shape": "S1q"
               },
-              "Status": {
-                "shape": "S20"
-              },
-              "StatusDetail": {
-                "shape": "S21"
-              }
+              "Status": {},
+              "StatusDetail": {}
             }
           }
         },
-        "Status": {
-          "shape": "S20"
-        },
+        "Status": {},
         "UserMetadata": {
           "shape": "S1v"
         },
@@ -1155,30 +850,16 @@
       "type": "structure",
       "members": {
         "Id": {},
-        "Key": {
-          "shape": "Sm"
-        },
-        "ThumbnailPattern": {
-          "shape": "Sv"
-        },
+        "Key": {},
+        "ThumbnailPattern": {},
         "ThumbnailEncryption": {
           "shape": "Sc"
         },
-        "Rotate": {
-          "shape": "Sw"
-        },
-        "PresetId": {
-          "shape": "S2"
-        },
-        "SegmentDuration": {
-          "shape": "Sr"
-        },
-        "Status": {
-          "shape": "S20"
-        },
-        "StatusDetail": {
-          "shape": "S21"
-        },
+        "Rotate": {},
+        "PresetId": {},
+        "SegmentDuration": {},
+        "Status": {},
+        "StatusDetail": {},
         "Duration": {
           "type": "long"
         },
@@ -1188,9 +869,7 @@
         "Height": {
           "type": "integer"
         },
-        "FrameRate": {
-          "shape": "Sr"
-        },
+        "FrameRate": {},
         "FileSize": {
           "type": "long"
         },
@@ -1216,112 +895,47 @@
         "AppliedColorSpaceConversion": {}
       }
     },
-    "S20": {
-      "type": "string",
-      "pattern": "(^Submitted$)|(^Progressing$)|(^Complete$)|(^Canceled$)|(^Error$)"
-    },
-    "S21": {
-      "type": "string",
-      "max": 255,
-      "min": 0
-    },
-    "S27": {
-      "type": "string",
-      "pattern": "^(\\w|\\.|-){1,255}$"
-    },
-    "S28": {
-      "type": "string",
-      "pattern": "^arn:aws:iam::\\w{12}:role/.+$"
-    },
-    "S29": {
-      "type": "string",
-      "max": 255,
-      "min": 0
-    },
     "S2a": {
       "type": "structure",
       "members": {
-        "Progressing": {
-          "shape": "S2b"
-        },
-        "Completed": {
-          "shape": "S2b"
-        },
-        "Warning": {
-          "shape": "S2b"
-        },
-        "Error": {
-          "shape": "S2b"
-        }
+        "Progressing": {},
+        "Completed": {},
+        "Warning": {},
+        "Error": {}
       }
-    },
-    "S2b": {
-      "type": "string",
-      "pattern": "(^$)|(^arn:aws:sns:.*:\\w{12}:.+$)"
     },
     "S2c": {
       "type": "structure",
       "members": {
-        "Bucket": {
-          "shape": "S27"
-        },
-        "StorageClass": {
-          "type": "string",
-          "pattern": "(^ReducedRedundancy$)|(^Standard$)"
-        },
+        "Bucket": {},
+        "StorageClass": {},
         "Permissions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "GranteeType": {
-                "type": "string",
-                "pattern": "(^Canonical$)|(^Email$)|(^Group$)"
-              },
-              "Grantee": {
-                "type": "string",
-                "max": 255,
-                "min": 1
-              },
+              "GranteeType": {},
+              "Grantee": {},
               "Access": {
                 "type": "list",
-                "member": {
-                  "type": "string",
-                  "pattern": "(^FullControl$)|(^Read$)|(^ReadAcp$)|(^WriteAcp$)"
-                },
-                "max": 30
+                "member": {}
               }
             }
-          },
-          "max": 30
+          }
         }
       }
     },
     "S2l": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
+        "Id": {},
         "Arn": {},
-        "Name": {
-          "shape": "So"
-        },
-        "Status": {
-          "shape": "S2m"
-        },
-        "InputBucket": {
-          "shape": "S27"
-        },
-        "OutputBucket": {
-          "shape": "S27"
-        },
-        "Role": {
-          "shape": "S28"
-        },
-        "AwsKmsKeyArn": {
-          "shape": "S29"
-        },
+        "Name": {},
+        "Status": {},
+        "InputBucket": {},
+        "OutputBucket": {},
+        "Role": {},
+        "AwsKmsKeyArn": {},
         "Notifications": {
           "shape": "S2a"
         },
@@ -1333,10 +947,6 @@
         }
       }
     },
-    "S2m": {
-      "type": "string",
-      "pattern": "(^Active$)|(^Paused$)"
-    },
     "S2n": {
       "type": "list",
       "member": {
@@ -1347,163 +957,62 @@
         }
       }
     },
-    "S2q": {
-      "type": "string",
-      "pattern": "(^mp4$)|(^ts$)|(^webm$)|(^mp3$)|(^flac$)|(^oga$)|(^ogg$)|(^fmp4$)|(^mpg$)|(^flv$)|(^gif$)|(^mxf$)|(^wav$)|(^mp2$)"
-    },
     "S2r": {
       "type": "structure",
       "members": {
-        "Codec": {
-          "type": "string",
-          "pattern": "(^H\\.264$)|(^vp8$)|(^vp9$)|(^mpeg2$)|(^gif$)"
-        },
+        "Codec": {},
         "CodecOptions": {
           "type": "map",
-          "key": {
-            "shape": "S2u"
-          },
-          "value": {
-            "shape": "S2u"
-          },
-          "max": 30
+          "key": {},
+          "value": {}
         },
-        "KeyframesMaxDist": {
-          "type": "string",
-          "pattern": "^\\d{1,6}$"
-        },
-        "FixedGOP": {
-          "type": "string",
-          "pattern": "(^true$)|(^false$)"
-        },
-        "BitRate": {
-          "type": "string",
-          "pattern": "(^\\d{2,5}$)|(^auto$)"
-        },
-        "FrameRate": {
-          "shape": "S7"
-        },
-        "MaxFrameRate": {
-          "type": "string",
-          "pattern": "(^10$)|(^15$)|(^23.97$)|(^24$)|(^25$)|(^29.97$)|(^30$)|(^50$)|(^60$)"
-        },
-        "Resolution": {
-          "shape": "S8"
-        },
-        "AspectRatio": {
-          "shape": "S9"
-        },
-        "MaxWidth": {
-          "shape": "S15"
-        },
-        "MaxHeight": {
-          "shape": "S15"
-        },
-        "DisplayAspectRatio": {
-          "shape": "S9"
-        },
-        "SizingPolicy": {
-          "shape": "S16"
-        },
-        "PaddingPolicy": {
-          "shape": "S17"
-        },
+        "KeyframesMaxDist": {},
+        "FixedGOP": {},
+        "BitRate": {},
+        "FrameRate": {},
+        "MaxFrameRate": {},
+        "Resolution": {},
+        "AspectRatio": {},
+        "MaxWidth": {},
+        "MaxHeight": {},
+        "DisplayAspectRatio": {},
+        "SizingPolicy": {},
+        "PaddingPolicy": {},
         "Watermarks": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "Id": {
-                "shape": "Sz"
-              },
-              "MaxWidth": {
-                "shape": "S31"
-              },
-              "MaxHeight": {
-                "shape": "S31"
-              },
-              "SizingPolicy": {
-                "type": "string",
-                "pattern": "(^Fit$)|(^Stretch$)|(^ShrinkToFit$)"
-              },
-              "HorizontalAlign": {
-                "type": "string",
-                "pattern": "(^Left$)|(^Right$)|(^Center$)"
-              },
-              "HorizontalOffset": {
-                "shape": "S31"
-              },
-              "VerticalAlign": {
-                "type": "string",
-                "pattern": "(^Top$)|(^Bottom$)|(^Center$)"
-              },
-              "VerticalOffset": {
-                "shape": "S31"
-              },
-              "Opacity": {
-                "type": "string",
-                "pattern": "^\\d{1,3}(\\.\\d{0,20})?$"
-              },
-              "Target": {
-                "type": "string",
-                "pattern": "(^Content$)|(^Frame$)"
-              }
+              "Id": {},
+              "MaxWidth": {},
+              "MaxHeight": {},
+              "SizingPolicy": {},
+              "HorizontalAlign": {},
+              "HorizontalOffset": {},
+              "VerticalAlign": {},
+              "VerticalOffset": {},
+              "Opacity": {},
+              "Target": {}
             }
           }
         }
       }
     },
-    "S2u": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S31": {
-      "type": "string",
-      "pattern": "(^\\d{1,3}(\\.\\d{0,5})?%$)|(^\\d{1,4}?px$)"
-    },
     "S37": {
       "type": "structure",
       "members": {
-        "Codec": {
-          "type": "string",
-          "pattern": "(^AAC$)|(^vorbis$)|(^mp3$)|(^mp2$)|(^pcm$)|(^flac$)"
-        },
-        "SampleRate": {
-          "type": "string",
-          "pattern": "(^auto$)|(^22050$)|(^32000$)|(^44100$)|(^48000$)|(^96000$)|(^192000$)"
-        },
-        "BitRate": {
-          "type": "string",
-          "pattern": "^\\d{1,3}$"
-        },
-        "Channels": {
-          "type": "string",
-          "pattern": "(^auto$)|(^0$)|(^1$)|(^2$)"
-        },
-        "AudioPackingMode": {
-          "type": "string",
-          "pattern": "(^SingleTrack$)|(^OneChannelPerTrack$)|(^OneChannelPerTrackWithMosTo8Tracks$)"
-        },
+        "Codec": {},
+        "SampleRate": {},
+        "BitRate": {},
+        "Channels": {},
+        "AudioPackingMode": {},
         "CodecOptions": {
           "type": "structure",
           "members": {
-            "Profile": {
-              "type": "string",
-              "pattern": "(^auto$)|(^AAC-LC$)|(^HE-AAC$)|(^HE-AACv2$)"
-            },
-            "BitDepth": {
-              "type": "string",
-              "pattern": "(^8$)|(^16$)|(^24$)|(^32$)"
-            },
-            "BitOrder": {
-              "type": "string",
-              "pattern": "(^LittleEndian$)"
-            },
-            "Signed": {
-              "type": "string",
-              "pattern": "(^Unsigned$)|(^Signed$)"
-            }
+            "Profile": {},
+            "BitDepth": {},
+            "BitOrder": {},
+            "Signed": {}
           }
         }
       }
@@ -1511,50 +1020,24 @@
     "S3i": {
       "type": "structure",
       "members": {
-        "Format": {
-          "shape": "S18"
-        },
-        "Interval": {
-          "type": "string",
-          "pattern": "^\\d{1,5}$"
-        },
-        "Resolution": {
-          "type": "string",
-          "pattern": "^\\d{1,5}x\\d{1,5}$"
-        },
-        "AspectRatio": {
-          "shape": "S9"
-        },
-        "MaxWidth": {
-          "shape": "S15"
-        },
-        "MaxHeight": {
-          "shape": "S15"
-        },
-        "SizingPolicy": {
-          "shape": "S16"
-        },
-        "PaddingPolicy": {
-          "shape": "S17"
-        }
+        "Format": {},
+        "Interval": {},
+        "Resolution": {},
+        "AspectRatio": {},
+        "MaxWidth": {},
+        "MaxHeight": {},
+        "SizingPolicy": {},
+        "PaddingPolicy": {}
       }
     },
     "S3m": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
+        "Id": {},
         "Arn": {},
-        "Name": {
-          "shape": "So"
-        },
-        "Description": {
-          "shape": "S21"
-        },
-        "Container": {
-          "shape": "S2q"
-        },
+        "Name": {},
+        "Description": {},
+        "Container": {},
         "Audio": {
           "shape": "S37"
         },
@@ -1564,15 +1047,8 @@
         "Thumbnails": {
           "shape": "S3i"
         },
-        "Type": {
-          "type": "string",
-          "pattern": "(^System$)|(^Custom$)"
-        }
+        "Type": {}
       }
-    },
-    "S3t": {
-      "type": "string",
-      "pattern": "(^true$)|(^false$)"
     },
     "S3v": {
       "type": "list",

--- a/apis/email-2010-12-01.min.json
+++ b/apis/email-2010-12-01.min.json
@@ -269,9 +269,7 @@
         ],
         "members": {
           "Identity": {},
-          "PolicyName": {
-            "shape": "S2g"
-          }
+          "PolicyName": {}
         }
       },
       "output": {
@@ -385,14 +383,7 @@
           "ConfigurationSetName": {},
           "ConfigurationSetAttributeNames": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "eventDestinations",
-                "trackingOptions",
-                "reputationOptions"
-              ]
-            }
+            "member": {}
           }
         }
       },
@@ -540,9 +531,7 @@
                 "DkimEnabled": {
                   "type": "boolean"
                 },
-                "DkimVerificationStatus": {
-                  "shape": "S3f"
-                },
+                "DkimVerificationStatus": {},
                 "DkimTokens": {
                   "shape": "S3g"
                 }
@@ -583,18 +572,8 @@
               ],
               "members": {
                 "MailFromDomain": {},
-                "MailFromDomainStatus": {
-                  "type": "string",
-                  "enum": [
-                    "Pending",
-                    "Success",
-                    "Failed",
-                    "TemporaryFailure"
-                  ]
-                },
-                "BehaviorOnMXFailure": {
-                  "shape": "S3o"
-                }
+                "MailFromDomainStatus": {},
+                "BehaviorOnMXFailure": {}
               }
             }
           }
@@ -676,12 +655,8 @@
         "members": {
           "Policies": {
             "type": "map",
-            "key": {
-              "shape": "S2g"
-            },
-            "value": {
-              "shape": "S3y"
-            }
+            "key": {},
+            "value": {}
           }
         }
       }
@@ -714,9 +689,7 @@
                 "VerificationStatus"
               ],
               "members": {
-                "VerificationStatus": {
-                  "shape": "S3f"
-                },
+                "VerificationStatus": {},
                 "VerificationToken": {}
               }
             }
@@ -822,9 +795,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -853,13 +824,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "IdentityType": {
-            "type": "string",
-            "enum": [
-              "EmailAddress",
-              "Domain"
-            ]
-          },
+          "IdentityType": {},
           "NextToken": {},
           "MaxItems": {
             "type": "integer"
@@ -993,12 +958,8 @@
         ],
         "members": {
           "Identity": {},
-          "PolicyName": {
-            "shape": "S2g"
-          },
-          "Policy": {
-            "shape": "S3y"
-          }
+          "PolicyName": {},
+          "Policy": {}
         }
       },
       "output": {
@@ -1065,17 +1026,7 @@
               "members": {
                 "Recipient": {},
                 "RecipientArn": {},
-                "BounceType": {
-                  "type": "string",
-                  "enum": [
-                    "DoesNotExist",
-                    "MessageTooLarge",
-                    "ExceededQuota",
-                    "ContentRejected",
-                    "Undefined",
-                    "TemporaryFailure"
-                  ]
-                },
+                "BounceType": {},
                 "RecipientDsnFields": {
                   "type": "structure",
                   "required": [
@@ -1084,16 +1035,7 @@
                   ],
                   "members": {
                     "FinalRecipient": {},
-                    "Action": {
-                      "type": "string",
-                      "enum": [
-                        "failed",
-                        "delayed",
-                        "delivered",
-                        "relayed",
-                        "expanded"
-                      ]
-                    },
+                    "Action": {},
                     "RemoteMta": {},
                     "Status": {},
                     "DiagnosticCode": {},
@@ -1141,9 +1083,7 @@
           },
           "Template": {},
           "TemplateArn": {},
-          "DefaultTemplateData": {
-            "shape": "S5y"
-          },
+          "DefaultTemplateData": {},
           "Destinations": {
             "type": "list",
             "member": {
@@ -1158,9 +1098,7 @@
                 "ReplacementTags": {
                   "shape": "S5u"
                 },
-                "ReplacementTemplateData": {
-                  "shape": "S5y"
-                }
+                "ReplacementTemplateData": {}
               }
             }
           }
@@ -1178,25 +1116,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Success",
-                    "MessageRejected",
-                    "MailFromDomainNotVerified",
-                    "ConfigurationSetDoesNotExist",
-                    "TemplateDoesNotExist",
-                    "AccountSuspended",
-                    "AccountThrottled",
-                    "AccountDailyQuotaExceeded",
-                    "InvalidSendingPoolName",
-                    "AccountSendingPaused",
-                    "ConfigurationSetSendingPaused",
-                    "InvalidParameterValue",
-                    "TransientFailure",
-                    "Failed"
-                  ]
-                },
+                "Status": {},
                 "Error": {},
                 "MessageId": {}
               }
@@ -1353,9 +1273,7 @@
           "ConfigurationSetName": {},
           "Template": {},
           "TemplateArn": {},
-          "TemplateData": {
-            "shape": "S5y"
-          }
+          "TemplateData": {}
         }
       },
       "output": {
@@ -1432,9 +1350,7 @@
         ],
         "members": {
           "Identity": {},
-          "NotificationType": {
-            "shape": "S6t"
-          },
+          "NotificationType": {},
           "Enabled": {
             "type": "boolean"
           }
@@ -1455,9 +1371,7 @@
         "members": {
           "Identity": {},
           "MailFromDomain": {},
-          "BehaviorOnMXFailure": {
-            "shape": "S3o"
-          }
+          "BehaviorOnMXFailure": {}
         }
       },
       "output": {
@@ -1475,9 +1389,7 @@
         ],
         "members": {
           "Identity": {},
-          "NotificationType": {
-            "shape": "S6t"
-          },
+          "NotificationType": {},
           "SnsTopic": {}
         }
       },
@@ -1515,9 +1427,7 @@
         ],
         "members": {
           "TemplateName": {},
-          "TemplateData": {
-            "shape": "S5y"
-          }
+          "TemplateData": {}
         }
       },
       "output": {
@@ -1757,19 +1667,7 @@
         },
         "MatchingEventTypes": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "send",
-              "reject",
-              "bounce",
-              "complaint",
-              "delivery",
-              "open",
-              "click",
-              "renderingFailure"
-            ]
-          }
+          "member": {}
         },
         "KinesisFirehoseDestination": {
           "type": "structure",
@@ -1799,14 +1697,7 @@
                 ],
                 "members": {
                   "DimensionName": {},
-                  "DimensionValueSource": {
-                    "type": "string",
-                    "enum": [
-                      "messageTag",
-                      "emailHeader",
-                      "linkTag"
-                    ]
-                  },
+                  "DimensionValueSource": {},
                   "DefaultDimensionValue": {}
                 }
               }
@@ -1845,13 +1736,7 @@
             "Cidr"
           ],
           "members": {
-            "Policy": {
-              "type": "string",
-              "enum": [
-                "Block",
-                "Allow"
-              ]
-            },
+            "Policy": {},
             "Cidr": {}
           }
         }
@@ -1867,13 +1752,7 @@
         "Enabled": {
           "type": "boolean"
         },
-        "TlsPolicy": {
-          "type": "string",
-          "enum": [
-            "Require",
-            "Optional"
-          ]
-        },
+        "TlsPolicy": {},
         "Recipients": {
           "type": "list",
           "member": {}
@@ -1928,13 +1807,7 @@
                 "members": {
                   "TopicArn": {},
                   "FunctionArn": {},
-                  "InvocationType": {
-                    "type": "string",
-                    "enum": [
-                      "Event",
-                      "RequestResponse"
-                    ]
-                  }
+                  "InvocationType": {}
                 }
               },
               "StopAction": {
@@ -1943,12 +1816,7 @@
                   "Scope"
                 ],
                 "members": {
-                  "Scope": {
-                    "type": "string",
-                    "enum": [
-                      "RuleSet"
-                    ]
-                  },
+                  "Scope": {},
                   "TopicArn": {}
                 }
               },
@@ -1970,13 +1838,7 @@
                 ],
                 "members": {
                   "TopicArn": {},
-                  "Encoding": {
-                    "type": "string",
-                    "enum": [
-                      "UTF-8",
-                      "Base64"
-                    ]
-                  }
+                  "Encoding": {}
                 }
               }
             }
@@ -1999,11 +1861,6 @@
         "HtmlPart": {}
       }
     },
-    "S2g": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
     "S2t": {
       "type": "structure",
       "members": {
@@ -2023,36 +1880,13 @@
       "type": "list",
       "member": {}
     },
-    "S3f": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "Success",
-        "Failed",
-        "TemporaryFailure",
-        "NotStarted"
-      ]
-    },
     "S3g": {
       "type": "list",
       "member": {}
     },
-    "S3o": {
-      "type": "string",
-      "enum": [
-        "UseDefaultValue",
-        "RejectMessage"
-      ]
-    },
     "S3v": {
       "type": "list",
-      "member": {
-        "shape": "S2g"
-      }
-    },
-    "S3y": {
-      "type": "string",
-      "min": 1
+      "member": {}
     },
     "S53": {
       "type": "list",
@@ -2086,10 +1920,6 @@
         }
       }
     },
-    "S5y": {
-      "type": "string",
-      "max": 262144
-    },
     "S61": {
       "type": "structure",
       "members": {
@@ -2113,14 +1943,6 @@
         "Data": {},
         "Charset": {}
       }
-    },
-    "S6t": {
-      "type": "string",
-      "enum": [
-        "Bounce",
-        "Complaint",
-        "Delivery"
-      ]
     }
   }
 }

--- a/apis/entitlement.marketplace-2017-01-11.min.json
+++ b/apis/entitlement.marketplace-2017-01-11.min.json
@@ -20,27 +20,16 @@
           "ProductCode"
         ],
         "members": {
-          "ProductCode": {
-            "shape": "S2"
-          },
+          "ProductCode": {},
           "Filter": {
             "type": "map",
-            "key": {
-              "type": "string",
-              "enum": [
-                "CUSTOMER_IDENTIFIER",
-                "DIMENSION"
-              ]
-            },
+            "key": {},
             "value": {
               "type": "list",
-              "member": {},
-              "min": 1
+              "member": {}
             }
           },
-          "NextToken": {
-            "shape": "S7"
-          },
+          "NextToken": {},
           "MaxResults": {
             "type": "integer"
           }
@@ -54,15 +43,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "ProductCode": {
-                  "shape": "S2"
-                },
-                "Dimension": {
-                  "shape": "S7"
-                },
-                "CustomerIdentifier": {
-                  "shape": "S7"
-                },
+                "ProductCode": {},
+                "Dimension": {},
+                "CustomerIdentifier": {},
                 "Value": {
                   "type": "structure",
                   "members": {
@@ -82,25 +65,12 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "min": 0
+            }
           },
-          "NextToken": {
-            "shape": "S7"
-          }
+          "NextToken": {}
         }
       }
     }
   },
-  "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "pattern": "\\S+"
-    }
-  }
+  "shapes": {}
 }

--- a/apis/es-2015-01-01.min.json
+++ b/apis/es-2015-01-01.min.json
@@ -38,9 +38,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S8"
-          },
+          "DomainName": {},
           "ElasticsearchVersion": {},
           "ElasticsearchClusterConfig": {
             "shape": "Sa"
@@ -93,7 +91,6 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -126,7 +123,6 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -156,7 +152,6 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -186,9 +181,7 @@
         "members": {
           "DomainNames": {
             "type": "list",
-            "member": {
-              "shape": "S8"
-            }
+            "member": {}
           }
         }
       },
@@ -220,12 +213,10 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           },
           "InstanceType": {
-            "shape": "Sb",
             "location": "uri",
             "locationName": "InstanceType"
           },
@@ -309,14 +300,13 @@
         "type": "structure",
         "members": {
           "ReservedElasticsearchInstanceOfferingId": {
-            "shape": "S2e",
             "location": "querystring",
             "locationName": "offeringId"
           },
           "MaxResults": {
-            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -333,12 +323,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "ReservedElasticsearchInstanceOfferingId": {
-                  "shape": "S2e"
-                },
-                "ElasticsearchInstanceType": {
-                  "shape": "Sb"
-                },
+                "ReservedElasticsearchInstanceOfferingId": {},
+                "ElasticsearchInstanceType": {},
                 "Duration": {
                   "type": "integer"
                 },
@@ -349,9 +335,7 @@
                   "type": "double"
                 },
                 "CurrencyCode": {},
-                "PaymentOption": {
-                  "shape": "S2m"
-                },
+                "PaymentOption": {},
                 "RecurringCharges": {
                   "shape": "S2n"
                 }
@@ -370,14 +354,13 @@
         "type": "structure",
         "members": {
           "ReservedElasticsearchInstanceId": {
-            "shape": "S2e",
             "location": "querystring",
             "locationName": "reservationId"
           },
           "MaxResults": {
-            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -394,16 +377,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "ReservationName": {
-                  "shape": "S2t"
-                },
-                "ReservedElasticsearchInstanceId": {
-                  "shape": "S2e"
-                },
+                "ReservationName": {},
+                "ReservedElasticsearchInstanceId": {},
                 "ReservedElasticsearchInstanceOfferingId": {},
-                "ElasticsearchInstanceType": {
-                  "shape": "Sb"
-                },
+                "ElasticsearchInstanceType": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -421,9 +398,7 @@
                   "type": "integer"
                 },
                 "State": {},
-                "PaymentOption": {
-                  "shape": "S2m"
-                },
+                "PaymentOption": {},
                 "RecurringCharges": {
                   "shape": "S2n"
                 }
@@ -442,7 +417,6 @@
         "type": "structure",
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           }
@@ -478,14 +452,13 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           },
           "MaxResults": {
-            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -505,20 +478,14 @@
                 "StartTimestamp": {
                   "type": "timestamp"
                 },
-                "UpgradeStatus": {
-                  "shape": "S35"
-                },
+                "UpgradeStatus": {},
                 "StepsList": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "UpgradeStep": {
-                        "shape": "S38"
-                      },
-                      "UpgradeStepStatus": {
-                        "shape": "S35"
-                      },
+                      "UpgradeStep": {},
+                      "UpgradeStepStatus": {},
                       "Issues": {
                         "type": "list",
                         "member": {}
@@ -548,7 +515,6 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           }
@@ -557,12 +523,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "UpgradeStep": {
-            "shape": "S38"
-          },
-          "StepStatus": {
-            "shape": "S35"
-          },
+          "UpgradeStep": {},
+          "StepStatus": {},
           "UpgradeName": {}
         }
       }
@@ -580,9 +542,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {
-                  "shape": "S8"
-                }
+                "DomainName": {}
               }
             }
           }
@@ -605,14 +565,13 @@
             "locationName": "ElasticsearchVersion"
           },
           "DomainName": {
-            "shape": "S8",
             "location": "querystring",
             "locationName": "domainName"
           },
           "MaxResults": {
-            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -625,9 +584,7 @@
         "members": {
           "ElasticsearchInstanceTypes": {
             "type": "list",
-            "member": {
-              "shape": "Sb"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -642,9 +599,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S2f",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -699,27 +656,18 @@
           "ReservationName"
         ],
         "members": {
-          "ReservedElasticsearchInstanceOfferingId": {
-            "shape": "S2e"
-          },
-          "ReservationName": {
-            "shape": "S2t"
-          },
+          "ReservedElasticsearchInstanceOfferingId": {},
+          "ReservationName": {},
           "InstanceCount": {
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ReservedElasticsearchInstanceId": {
-            "shape": "S2e"
-          },
-          "ReservationName": {
-            "shape": "S2t"
-          }
+          "ReservedElasticsearchInstanceId": {},
+          "ReservationName": {}
         }
       }
     },
@@ -752,7 +700,6 @@
         ],
         "members": {
           "DomainName": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "DomainName"
           },
@@ -803,9 +750,7 @@
           "TargetVersion"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S8"
-          },
+          "DomainName": {},
           "TargetVersion": {},
           "PerformCheckOnly": {
             "type": "boolean"
@@ -815,9 +760,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DomainName": {
-            "shape": "S8"
-          },
+          "DomainName": {},
           "TargetVersion": {},
           "PerformCheckOnly": {
             "type": "boolean"
@@ -836,31 +779,15 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 28,
-      "min": 3,
-      "pattern": "[a-z][a-z0-9\\-]+"
     },
     "Sa": {
       "type": "structure",
       "members": {
-        "InstanceType": {
-          "shape": "Sb"
-        },
+        "InstanceType": {},
         "InstanceCount": {
           "type": "integer"
         },
@@ -870,58 +797,11 @@
         "ZoneAwarenessEnabled": {
           "type": "boolean"
         },
-        "DedicatedMasterType": {
-          "shape": "Sb"
-        },
+        "DedicatedMasterType": {},
         "DedicatedMasterCount": {
           "type": "integer"
         }
       }
-    },
-    "Sb": {
-      "type": "string",
-      "enum": [
-        "m3.medium.elasticsearch",
-        "m3.large.elasticsearch",
-        "m3.xlarge.elasticsearch",
-        "m3.2xlarge.elasticsearch",
-        "m4.large.elasticsearch",
-        "m4.xlarge.elasticsearch",
-        "m4.2xlarge.elasticsearch",
-        "m4.4xlarge.elasticsearch",
-        "m4.10xlarge.elasticsearch",
-        "t2.micro.elasticsearch",
-        "t2.small.elasticsearch",
-        "t2.medium.elasticsearch",
-        "r3.large.elasticsearch",
-        "r3.xlarge.elasticsearch",
-        "r3.2xlarge.elasticsearch",
-        "r3.4xlarge.elasticsearch",
-        "r3.8xlarge.elasticsearch",
-        "i2.xlarge.elasticsearch",
-        "i2.2xlarge.elasticsearch",
-        "d2.xlarge.elasticsearch",
-        "d2.2xlarge.elasticsearch",
-        "d2.4xlarge.elasticsearch",
-        "d2.8xlarge.elasticsearch",
-        "c4.large.elasticsearch",
-        "c4.xlarge.elasticsearch",
-        "c4.2xlarge.elasticsearch",
-        "c4.4xlarge.elasticsearch",
-        "c4.8xlarge.elasticsearch",
-        "r4.large.elasticsearch",
-        "r4.xlarge.elasticsearch",
-        "r4.2xlarge.elasticsearch",
-        "r4.4xlarge.elasticsearch",
-        "r4.8xlarge.elasticsearch",
-        "r4.16xlarge.elasticsearch",
-        "i3.large.elasticsearch",
-        "i3.xlarge.elasticsearch",
-        "i3.2xlarge.elasticsearch",
-        "i3.4xlarge.elasticsearch",
-        "i3.8xlarge.elasticsearch",
-        "i3.16xlarge.elasticsearch"
-      ]
     },
     "Se": {
       "type": "structure",
@@ -929,14 +809,7 @@
         "EBSEnabled": {
           "type": "boolean"
         },
-        "VolumeType": {
-          "type": "string",
-          "enum": [
-            "standard",
-            "gp2",
-            "io1"
-          ]
-        },
+        "VolumeType": {},
         "VolumeSize": {
           "type": "integer"
         },
@@ -974,23 +847,9 @@
         "Enabled": {
           "type": "boolean"
         },
-        "UserPoolId": {
-          "type": "string",
-          "max": 55,
-          "min": 1,
-          "pattern": "[\\w-]+_[0-9a-zA-Z]+"
-        },
-        "IdentityPoolId": {
-          "type": "string",
-          "max": 55,
-          "min": 1,
-          "pattern": "[\\w-]+:[0-9a-f-]+"
-        },
-        "RoleArn": {
-          "type": "string",
-          "max": 2048,
-          "min": 20
-        }
+        "UserPoolId": {},
+        "IdentityPoolId": {},
+        "RoleArn": {}
       }
     },
     "Sp": {
@@ -999,11 +858,7 @@
         "Enabled": {
           "type": "boolean"
         },
-        "KmsKeyId": {
-          "type": "string",
-          "max": 500,
-          "min": 1
-        }
+        "KmsKeyId": {}
       }
     },
     "Sr": {
@@ -1021,14 +876,7 @@
     },
     "St": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "INDEX_SLOW_LOGS",
-          "SEARCH_SLOW_LOGS",
-          "ES_APPLICATION_LOGS"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
@@ -1048,14 +896,8 @@
         "ElasticsearchClusterConfig"
       ],
       "members": {
-        "DomainId": {
-          "type": "string",
-          "max": 64,
-          "min": 1
-        },
-        "DomainName": {
-          "shape": "S8"
-        },
+        "DomainId": {},
+        "DomainName": {},
         "ARN": {},
         "Created": {
           "type": "boolean"
@@ -1298,17 +1140,9 @@
           "type": "timestamp"
         },
         "UpdateVersion": {
-          "type": "integer",
-          "min": 0
+          "type": "integer"
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "RequiresIndexDocuments",
-            "Processing",
-            "Active"
-          ]
-        },
+        "State": {},
         "PendingDeletion": {
           "type": "boolean"
         }
@@ -1317,22 +1151,6 @@
     "S25": {
       "type": "list",
       "member": {}
-    },
-    "S2e": {
-      "type": "string",
-      "pattern": "\\p{XDigit}{8}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{4}-\\p{XDigit}{12}"
-    },
-    "S2f": {
-      "type": "integer",
-      "max": 100
-    },
-    "S2m": {
-      "type": "string",
-      "enum": [
-        "ALL_UPFRONT",
-        "PARTIAL_UPFRONT",
-        "NO_UPFRONT"
-      ]
     },
     "S2n": {
       "type": "list",
@@ -1346,31 +1164,9 @@
         }
       }
     },
-    "S2t": {
-      "type": "string",
-      "max": 64,
-      "min": 5
-    },
     "S2y": {
       "type": "list",
       "member": {}
-    },
-    "S35": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "SUCCEEDED",
-        "SUCCEEDED_WITH_ISSUES",
-        "FAILED"
-      ]
-    },
-    "S38": {
-      "type": "string",
-      "enum": [
-        "PRE_UPGRADE_CHECK",
-        "SNAPSHOT",
-        "UPGRADE"
-      ]
     }
   }
 }

--- a/apis/events-2015-10-07.min.json
+++ b/apis/events-2015-10-07.min.json
@@ -19,9 +19,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       }
     },
@@ -46,33 +44,19 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "Arn": {
-            "shape": "S8"
-          },
+          "Name": {},
+          "Arn": {},
           "EventPattern": {},
-          "ScheduleExpression": {
-            "shape": "Sa"
-          },
-          "State": {
-            "shape": "Sb"
-          },
-          "Description": {
-            "shape": "Sc"
-          },
-          "RoleArn": {
-            "shape": "Sd"
-          }
+          "ScheduleExpression": {},
+          "State": {},
+          "Description": {},
+          "RoleArn": {}
         }
       }
     },
@@ -83,9 +67,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       }
     },
@@ -96,9 +78,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       }
     },
@@ -109,14 +89,10 @@
           "TargetArn"
         ],
         "members": {
-          "TargetArn": {
-            "shape": "Sh"
-          },
-          "NextToken": {
-            "shape": "Si"
-          },
+          "TargetArn": {},
+          "NextToken": {},
           "Limit": {
-            "shape": "Sj"
+            "type": "integer"
           }
         }
       },
@@ -125,13 +101,9 @@
         "members": {
           "RuleNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "Si"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -139,14 +111,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "NamePrefix": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "Si"
-          },
+          "NamePrefix": {},
+          "NextToken": {},
           "Limit": {
-            "shape": "Sj"
+            "type": "integer"
           }
         }
       },
@@ -158,31 +126,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S2"
-                },
-                "Arn": {
-                  "shape": "S8"
-                },
+                "Name": {},
+                "Arn": {},
                 "EventPattern": {},
-                "State": {
-                  "shape": "Sb"
-                },
-                "Description": {
-                  "shape": "Sc"
-                },
-                "ScheduleExpression": {
-                  "shape": "Sa"
-                },
-                "RoleArn": {
-                  "shape": "Sd"
-                }
+                "State": {},
+                "Description": {},
+                "ScheduleExpression": {},
+                "RoleArn": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Si"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -193,14 +147,10 @@
           "Rule"
         ],
         "members": {
-          "Rule": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "Si"
-          },
+          "Rule": {},
+          "NextToken": {},
           "Limit": {
-            "shape": "Sj"
+            "type": "integer"
           }
         }
       },
@@ -210,9 +160,7 @@
           "Targets": {
             "shape": "Ss"
           },
-          "NextToken": {
-            "shape": "Si"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -239,9 +187,7 @@
                 "DetailType": {},
                 "Detail": {}
               }
-            },
-            "max": 10,
-            "min": 1
+            }
           }
         }
       },
@@ -274,21 +220,9 @@
           "StatementId"
         ],
         "members": {
-          "Action": {
-            "type": "string",
-            "max": 64,
-            "min": 1,
-            "pattern": "events:[a-zA-Z]+"
-          },
-          "Principal": {
-            "type": "string",
-            "max": 12,
-            "min": 1,
-            "pattern": "(\\d{12}|\\*)"
-          },
-          "StatementId": {
-            "shape": "S22"
-          }
+          "Action": {},
+          "Principal": {},
+          "StatementId": {}
         }
       }
     },
@@ -299,30 +233,18 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ScheduleExpression": {
-            "shape": "Sa"
-          },
+          "Name": {},
+          "ScheduleExpression": {},
           "EventPattern": {},
-          "State": {
-            "shape": "Sb"
-          },
-          "Description": {
-            "shape": "Sc"
-          },
-          "RoleArn": {
-            "shape": "Sd"
-          }
+          "State": {},
+          "Description": {},
+          "RoleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "RuleArn": {
-            "shape": "S8"
-          }
+          "RuleArn": {}
         }
       }
     },
@@ -334,9 +256,7 @@
           "Targets"
         ],
         "members": {
-          "Rule": {
-            "shape": "S2"
-          },
+          "Rule": {},
           "Targets": {
             "shape": "Ss"
           }
@@ -353,9 +273,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {
-                  "shape": "Su"
-                },
+                "TargetId": {},
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
@@ -371,9 +289,7 @@
           "StatementId"
         ],
         "members": {
-          "StatementId": {
-            "shape": "S22"
-          }
+          "StatementId": {}
         }
       }
     },
@@ -385,16 +301,10 @@
           "Ids"
         ],
         "members": {
-          "Rule": {
-            "shape": "S2"
-          },
+          "Rule": {},
           "Ids": {
             "type": "list",
-            "member": {
-              "shape": "Su"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -409,9 +319,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {
-                  "shape": "Su"
-                },
+                "TargetId": {},
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
@@ -443,52 +351,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\.\\-_A-Za-z0-9]+"
-    },
-    "S8": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "Sa": {
-      "type": "string",
-      "max": 256
-    },
-    "Sb": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
-    },
-    "Sc": {
-      "type": "string",
-      "max": 512
-    },
-    "Sd": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "Si": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "Sj": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
     "Ss": {
       "type": "list",
       "member": {
@@ -498,22 +360,11 @@
           "Arn"
         ],
         "members": {
-          "Id": {
-            "shape": "Su"
-          },
-          "Arn": {
-            "shape": "Sh"
-          },
-          "RoleArn": {
-            "shape": "Sd"
-          },
-          "Input": {
-            "type": "string",
-            "max": 8192
-          },
-          "InputPath": {
-            "shape": "Sw"
-          },
+          "Id": {},
+          "Arn": {},
+          "RoleArn": {},
+          "Input": {},
+          "InputPath": {},
           "InputTransformer": {
             "type": "structure",
             "required": [
@@ -522,22 +373,10 @@
             "members": {
               "InputPathsMap": {
                 "type": "map",
-                "key": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1,
-                  "pattern": "[A-Za-z0-9\\_\\-]+"
-                },
-                "value": {
-                  "shape": "Sw"
-                },
-                "max": 10
+                "key": {},
+                "value": {}
               },
-              "InputTemplate": {
-                "type": "string",
-                "max": 8192,
-                "min": 1
-              }
+              "InputTemplate": {}
             }
           },
           "KinesisParameters": {
@@ -546,10 +385,7 @@
               "PartitionKeyPath"
             ],
             "members": {
-              "PartitionKeyPath": {
-                "type": "string",
-                "max": 256
-              }
+              "PartitionKeyPath": {}
             }
           },
           "RunCommandParameters": {
@@ -567,26 +403,13 @@
                     "Values"
                   ],
                   "members": {
-                    "Key": {
-                      "type": "string",
-                      "max": 128,
-                      "min": 1,
-                      "pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$"
-                    },
+                    "Key": {},
                     "Values": {
                       "type": "list",
-                      "member": {
-                        "type": "string",
-                        "max": 256,
-                        "min": 1
-                      },
-                      "max": 50,
-                      "min": 1
+                      "member": {}
                     }
                   }
-                },
-                "max": 5,
-                "min": 1
+                }
               }
             }
           },
@@ -596,22 +419,11 @@
               "TaskDefinitionArn"
             ],
             "members": {
-              "TaskDefinitionArn": {
-                "type": "string",
-                "max": 1600,
-                "min": 1
-              },
+              "TaskDefinitionArn": {},
               "TaskCount": {
-                "type": "integer",
-                "min": 1
+                "type": "integer"
               },
-              "LaunchType": {
-                "type": "string",
-                "enum": [
-                  "EC2",
-                  "FARGATE"
-                ]
-              },
+              "LaunchType": {},
               "NetworkConfiguration": {
                 "type": "structure",
                 "members": {
@@ -627,13 +439,7 @@
                       "SecurityGroups": {
                         "shape": "S1f"
                       },
-                      "AssignPublicIp": {
-                        "type": "string",
-                        "enum": [
-                          "ENABLED",
-                          "DISABLED"
-                        ]
-                      }
+                      "AssignPublicIp": {}
                     }
                   }
                 }
@@ -676,29 +482,11 @@
             }
           }
         }
-      },
-      "max": 100,
-      "min": 1
-    },
-    "Su": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\.\\-_A-Za-z0-9]+"
-    },
-    "Sw": {
-      "type": "string",
-      "max": 256
+      }
     },
     "S1f": {
       "type": "list",
       "member": {}
-    },
-    "S22": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9-_]+"
     }
   }
 }

--- a/apis/firehose-2015-08-04.min.json
+++ b/apis/firehose-2015-08-04.min.json
@@ -20,12 +20,8 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
-          "DeliveryStreamType": {
-            "shape": "S3"
-          },
+          "DeliveryStreamName": {},
+          "DeliveryStreamType": {},
           "KinesisStreamSourceConfiguration": {
             "type": "structure",
             "required": [
@@ -33,12 +29,8 @@
               "RoleARN"
             ],
             "members": {
-              "KinesisStreamARN": {
-                "shape": "S5"
-              },
-              "RoleARN": {
-                "shape": "S6"
-              }
+              "KinesisStreamARN": {},
+              "RoleARN": {}
             }
           },
           "S3DestinationConfiguration": {
@@ -52,19 +44,13 @@
               "BucketARN"
             ],
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "BucketARN": {
-                "shape": "S8"
-              },
+              "RoleARN": {},
+              "BucketARN": {},
               "Prefix": {},
               "BufferingHints": {
                 "shape": "Sa"
               },
-              "CompressionFormat": {
-                "shape": "Sd"
-              },
+              "CompressionFormat": {},
               "EncryptionConfiguration": {
                 "shape": "Se"
               },
@@ -74,9 +60,7 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {
-                "shape": "Sv"
-              },
+              "S3BackupMode": {},
               "S3BackupConfiguration": {
                 "shape": "S7"
               },
@@ -96,12 +80,8 @@
               "S3Configuration"
             ],
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "ClusterJDBCURL": {
-                "shape": "S1m"
-              },
+              "RoleARN": {},
+              "ClusterJDBCURL": {},
               "CopyCommand": {
                 "shape": "S1n"
               },
@@ -120,9 +100,7 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {
-                "shape": "S1v"
-              },
+              "S3BackupMode": {},
               "S3BackupConfiguration": {
                 "shape": "S7"
               },
@@ -141,30 +119,18 @@
               "S3Configuration"
             ],
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "DomainARN": {
-                "shape": "S1x"
-              },
-              "IndexName": {
-                "shape": "S1y"
-              },
-              "TypeName": {
-                "shape": "S1z"
-              },
-              "IndexRotationPeriod": {
-                "shape": "S20"
-              },
+              "RoleARN": {},
+              "DomainARN": {},
+              "IndexName": {},
+              "TypeName": {},
+              "IndexRotationPeriod": {},
               "BufferingHints": {
                 "shape": "S21"
               },
               "RetryOptions": {
                 "shape": "S24"
               },
-              "S3BackupMode": {
-                "shape": "S26"
-              },
+              "S3BackupMode": {},
               "S3Configuration": {
                 "shape": "S7"
               },
@@ -186,19 +152,15 @@
             ],
             "members": {
               "HECEndpoint": {},
-              "HECEndpointType": {
-                "shape": "S29"
-              },
+              "HECEndpointType": {},
               "HECToken": {},
               "HECAcknowledgmentTimeoutInSeconds": {
-                "shape": "S2b"
+                "type": "integer"
               },
               "RetryOptions": {
                 "shape": "S2c"
               },
-              "S3BackupMode": {
-                "shape": "S2e"
-              },
+              "S3BackupMode": {},
               "S3Configuration": {
                 "shape": "S7"
               },
@@ -215,9 +177,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DeliveryStreamARN": {
-            "shape": "S2g"
-          }
+          "DeliveryStreamARN": {}
         }
       }
     },
@@ -228,9 +188,7 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          }
+          "DeliveryStreamName": {}
         }
       },
       "output": {
@@ -245,17 +203,11 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
+          "DeliveryStreamName": {},
           "Limit": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
-          "ExclusiveStartDestinationId": {
-            "shape": "S2l"
-          }
+          "ExclusiveStartDestinationId": {}
         }
       },
       "output": {
@@ -276,26 +228,11 @@
               "HasMoreDestinations"
             ],
             "members": {
-              "DeliveryStreamName": {
-                "shape": "S2"
-              },
-              "DeliveryStreamARN": {
-                "shape": "S2g"
-              },
-              "DeliveryStreamStatus": {
-                "type": "string",
-                "enum": [
-                  "CREATING",
-                  "DELETING",
-                  "ACTIVE"
-                ]
-              },
-              "DeliveryStreamType": {
-                "shape": "S3"
-              },
-              "VersionId": {
-                "shape": "S2p"
-              },
+              "DeliveryStreamName": {},
+              "DeliveryStreamARN": {},
+              "DeliveryStreamStatus": {},
+              "DeliveryStreamType": {},
+              "VersionId": {},
               "CreateTimestamp": {
                 "type": "timestamp"
               },
@@ -308,12 +245,8 @@
                   "KinesisStreamSourceDescription": {
                     "type": "structure",
                     "members": {
-                      "KinesisStreamARN": {
-                        "shape": "S5"
-                      },
-                      "RoleARN": {
-                        "shape": "S6"
-                      },
+                      "KinesisStreamARN": {},
+                      "RoleARN": {},
                       "DeliveryStartTimestamp": {
                         "type": "timestamp"
                       }
@@ -329,9 +262,7 @@
                     "DestinationId"
                   ],
                   "members": {
-                    "DestinationId": {
-                      "shape": "S2l"
-                    },
+                    "DestinationId": {},
                     "S3DestinationDescription": {
                       "shape": "S2w"
                     },
@@ -345,19 +276,13 @@
                         "EncryptionConfiguration"
                       ],
                       "members": {
-                        "RoleARN": {
-                          "shape": "S6"
-                        },
-                        "BucketARN": {
-                          "shape": "S8"
-                        },
+                        "RoleARN": {},
+                        "BucketARN": {},
                         "Prefix": {},
                         "BufferingHints": {
                           "shape": "Sa"
                         },
-                        "CompressionFormat": {
-                          "shape": "Sd"
-                        },
+                        "CompressionFormat": {},
                         "EncryptionConfiguration": {
                           "shape": "Se"
                         },
@@ -367,9 +292,7 @@
                         "ProcessingConfiguration": {
                           "shape": "Sn"
                         },
-                        "S3BackupMode": {
-                          "shape": "Sv"
-                        },
+                        "S3BackupMode": {},
                         "S3BackupDescription": {
                           "shape": "S2w"
                         },
@@ -388,12 +311,8 @@
                         "S3DestinationDescription"
                       ],
                       "members": {
-                        "RoleARN": {
-                          "shape": "S6"
-                        },
-                        "ClusterJDBCURL": {
-                          "shape": "S1m"
-                        },
+                        "RoleARN": {},
+                        "ClusterJDBCURL": {},
                         "CopyCommand": {
                           "shape": "S1n"
                         },
@@ -409,9 +328,7 @@
                         "ProcessingConfiguration": {
                           "shape": "Sn"
                         },
-                        "S3BackupMode": {
-                          "shape": "S1v"
-                        },
+                        "S3BackupMode": {},
                         "S3BackupDescription": {
                           "shape": "S2w"
                         },
@@ -423,30 +340,18 @@
                     "ElasticsearchDestinationDescription": {
                       "type": "structure",
                       "members": {
-                        "RoleARN": {
-                          "shape": "S6"
-                        },
-                        "DomainARN": {
-                          "shape": "S1x"
-                        },
-                        "IndexName": {
-                          "shape": "S1y"
-                        },
-                        "TypeName": {
-                          "shape": "S1z"
-                        },
-                        "IndexRotationPeriod": {
-                          "shape": "S20"
-                        },
+                        "RoleARN": {},
+                        "DomainARN": {},
+                        "IndexName": {},
+                        "TypeName": {},
+                        "IndexRotationPeriod": {},
                         "BufferingHints": {
                           "shape": "S21"
                         },
                         "RetryOptions": {
                           "shape": "S24"
                         },
-                        "S3BackupMode": {
-                          "shape": "S26"
-                        },
+                        "S3BackupMode": {},
                         "S3DestinationDescription": {
                           "shape": "S2w"
                         },
@@ -462,19 +367,15 @@
                       "type": "structure",
                       "members": {
                         "HECEndpoint": {},
-                        "HECEndpointType": {
-                          "shape": "S29"
-                        },
+                        "HECEndpointType": {},
                         "HECToken": {},
                         "HECAcknowledgmentTimeoutInSeconds": {
-                          "shape": "S2b"
+                          "type": "integer"
                         },
                         "RetryOptions": {
                           "shape": "S2c"
                         },
-                        "S3BackupMode": {
-                          "shape": "S2e"
-                        },
+                        "S3BackupMode": {},
                         "S3DestinationDescription": {
                           "shape": "S2w"
                         },
@@ -502,16 +403,10 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
-          "DeliveryStreamType": {
-            "shape": "S3"
-          },
-          "ExclusiveStartDeliveryStreamName": {
-            "shape": "S2"
-          }
+          "DeliveryStreamType": {},
+          "ExclusiveStartDeliveryStreamName": {}
         }
       },
       "output": {
@@ -523,9 +418,7 @@
         "members": {
           "DeliveryStreamNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           },
           "HasMoreDeliveryStreams": {
             "type": "boolean"
@@ -540,16 +433,10 @@
           "DeliveryStreamName"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
-          "ExclusiveStartTagKey": {
-            "shape": "S36"
-          },
+          "DeliveryStreamName": {},
+          "ExclusiveStartTagKey": {},
           "Limit": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -564,9 +451,7 @@
             "type": "list",
             "member": {
               "shape": "S3a"
-            },
-            "max": 50,
-            "min": 0
+            }
           },
           "HasMoreTags": {
             "type": "boolean"
@@ -582,9 +467,7 @@
           "Record"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
+          "DeliveryStreamName": {},
           "Record": {
             "shape": "S3d"
           }
@@ -596,9 +479,7 @@
           "RecordId"
         ],
         "members": {
-          "RecordId": {
-            "shape": "S3g"
-          }
+          "RecordId": {}
         }
       }
     },
@@ -610,16 +491,12 @@
           "Records"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
+          "DeliveryStreamName": {},
           "Records": {
             "type": "list",
             "member": {
               "shape": "S3d"
-            },
-            "max": 500,
-            "min": 1
+            }
           }
         }
       },
@@ -631,22 +508,18 @@
         ],
         "members": {
           "FailedPutCount": {
-            "shape": "S1c"
+            "type": "integer"
           },
           "RequestResponses": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "RecordId": {
-                  "shape": "S3g"
-                },
+                "RecordId": {},
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
-            },
-            "max": 500,
-            "min": 1
+            }
           }
         }
       }
@@ -659,16 +532,12 @@
           "Tags"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
+          "DeliveryStreamName": {},
           "Tags": {
             "type": "list",
             "member": {
               "shape": "S3a"
-            },
-            "max": 50,
-            "min": 1
+            }
           }
         }
       },
@@ -685,16 +554,10 @@
           "TagKeys"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
+          "DeliveryStreamName": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S36"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -712,15 +575,9 @@
           "DestinationId"
         ],
         "members": {
-          "DeliveryStreamName": {
-            "shape": "S2"
-          },
-          "CurrentDeliveryStreamVersionId": {
-            "shape": "S2p"
-          },
-          "DestinationId": {
-            "shape": "S2l"
-          },
+          "DeliveryStreamName": {},
+          "CurrentDeliveryStreamVersionId": {},
+          "DestinationId": {},
           "S3DestinationUpdate": {
             "shape": "S3v",
             "deprecated": true
@@ -728,19 +585,13 @@
           "ExtendedS3DestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "BucketARN": {
-                "shape": "S8"
-              },
+              "RoleARN": {},
+              "BucketARN": {},
               "Prefix": {},
               "BufferingHints": {
                 "shape": "Sa"
               },
-              "CompressionFormat": {
-                "shape": "Sd"
-              },
+              "CompressionFormat": {},
               "EncryptionConfiguration": {
                 "shape": "Se"
               },
@@ -750,9 +601,7 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {
-                "shape": "Sv"
-              },
+              "S3BackupMode": {},
               "S3BackupUpdate": {
                 "shape": "S3v"
               },
@@ -764,12 +613,8 @@
           "RedshiftDestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "ClusterJDBCURL": {
-                "shape": "S1m"
-              },
+              "RoleARN": {},
+              "ClusterJDBCURL": {},
               "CopyCommand": {
                 "shape": "S1n"
               },
@@ -788,9 +633,7 @@
               "ProcessingConfiguration": {
                 "shape": "Sn"
               },
-              "S3BackupMode": {
-                "shape": "S1v"
-              },
+              "S3BackupMode": {},
               "S3BackupUpdate": {
                 "shape": "S3v"
               },
@@ -802,21 +645,11 @@
           "ElasticsearchDestinationUpdate": {
             "type": "structure",
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "DomainARN": {
-                "shape": "S1x"
-              },
-              "IndexName": {
-                "shape": "S1y"
-              },
-              "TypeName": {
-                "shape": "S1z"
-              },
-              "IndexRotationPeriod": {
-                "shape": "S20"
-              },
+              "RoleARN": {},
+              "DomainARN": {},
+              "IndexName": {},
+              "TypeName": {},
+              "IndexRotationPeriod": {},
               "BufferingHints": {
                 "shape": "S21"
               },
@@ -838,19 +671,15 @@
             "type": "structure",
             "members": {
               "HECEndpoint": {},
-              "HECEndpointType": {
-                "shape": "S29"
-              },
+              "HECEndpointType": {},
               "HECToken": {},
               "HECAcknowledgmentTimeoutInSeconds": {
-                "shape": "S2b"
+                "type": "integer"
               },
               "RetryOptions": {
                 "shape": "S2c"
               },
-              "S3BackupMode": {
-                "shape": "S2e"
-              },
+              "S3BackupMode": {},
               "S3Update": {
                 "shape": "S3v"
               },
@@ -871,31 +700,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S3": {
-      "type": "string",
-      "enum": [
-        "DirectPut",
-        "KinesisStreamAsSource"
-      ]
-    },
-    "S5": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
-    "S6": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
     "S7": {
       "type": "structure",
       "required": [
@@ -903,19 +707,13 @@
         "BucketARN"
       ],
       "members": {
-        "RoleARN": {
-          "shape": "S6"
-        },
-        "BucketARN": {
-          "shape": "S8"
-        },
+        "RoleARN": {},
+        "BucketARN": {},
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {
-          "shape": "Sd"
-        },
+        "CompressionFormat": {},
         "EncryptionConfiguration": {
           "shape": "Se"
         },
@@ -924,57 +722,28 @@
         }
       }
     },
-    "S8": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
     "Sa": {
       "type": "structure",
       "members": {
         "SizeInMBs": {
-          "type": "integer",
-          "max": 128,
-          "min": 1
+          "type": "integer"
         },
         "IntervalInSeconds": {
-          "type": "integer",
-          "max": 900,
-          "min": 60
+          "type": "integer"
         }
       }
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "UNCOMPRESSED",
-        "GZIP",
-        "ZIP",
-        "Snappy"
-      ]
     },
     "Se": {
       "type": "structure",
       "members": {
-        "NoEncryptionConfig": {
-          "type": "string",
-          "enum": [
-            "NoEncryption"
-          ]
-        },
+        "NoEncryptionConfig": {},
         "KMSEncryptionConfig": {
           "type": "structure",
           "required": [
             "AWSKMSKeyARN"
           ],
           "members": {
-            "AWSKMSKeyARN": {
-              "type": "string",
-              "max": 512,
-              "min": 1,
-              "pattern": "arn:.*"
-            }
+            "AWSKMSKeyARN": {}
           }
         }
       }
@@ -1003,12 +772,7 @@
               "Type"
             ],
             "members": {
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "Lambda"
-                ]
-              },
+              "Type": {},
               "Parameters": {
                 "type": "list",
                 "member": {
@@ -1018,21 +782,8 @@
                     "ParameterValue"
                   ],
                   "members": {
-                    "ParameterName": {
-                      "type": "string",
-                      "enum": [
-                        "LambdaArn",
-                        "NumberOfRetries",
-                        "RoleArn",
-                        "BufferSizeInMBs",
-                        "BufferIntervalInSeconds"
-                      ]
-                    },
-                    "ParameterValue": {
-                      "type": "string",
-                      "max": 512,
-                      "min": 1
-                    }
+                    "ParameterName": {},
+                    "ParameterValue": {}
                   }
                 }
               }
@@ -1041,37 +792,18 @@
         }
       }
     },
-    "Sv": {
-      "type": "string",
-      "enum": [
-        "Disabled",
-        "Enabled"
-      ]
-    },
     "Sw": {
       "type": "structure",
       "members": {
         "SchemaConfiguration": {
           "type": "structure",
           "members": {
-            "RoleARN": {
-              "shape": "Sy"
-            },
-            "CatalogId": {
-              "shape": "Sy"
-            },
-            "DatabaseName": {
-              "shape": "Sy"
-            },
-            "TableName": {
-              "shape": "Sy"
-            },
-            "Region": {
-              "shape": "Sy"
-            },
-            "VersionId": {
-              "shape": "Sy"
-            }
+            "RoleARN": {},
+            "CatalogId": {},
+            "DatabaseName": {},
+            "TableName": {},
+            "Region": {},
+            "VersionId": {}
           }
         },
         "InputFormatConfiguration": {
@@ -1091,12 +823,8 @@
                     },
                     "ColumnToJsonKeyMappings": {
                       "type": "map",
-                      "key": {
-                        "shape": "Sy"
-                      },
-                      "value": {
-                        "shape": "S13"
-                      }
+                      "key": {},
+                      "value": {}
                     }
                   }
                 },
@@ -1105,9 +833,7 @@
                   "members": {
                     "TimestampFormats": {
                       "type": "list",
-                      "member": {
-                        "shape": "S13"
-                      }
+                      "member": {}
                     }
                   }
                 }
@@ -1125,82 +851,51 @@
                   "type": "structure",
                   "members": {
                     "BlockSizeBytes": {
-                      "shape": "S19"
+                      "type": "integer"
                     },
                     "PageSizeBytes": {
-                      "type": "integer",
-                      "min": 65536
+                      "type": "integer"
                     },
-                    "Compression": {
-                      "type": "string",
-                      "enum": [
-                        "UNCOMPRESSED",
-                        "GZIP",
-                        "SNAPPY"
-                      ]
-                    },
+                    "Compression": {},
                     "EnableDictionaryCompression": {
                       "type": "boolean"
                     },
                     "MaxPaddingBytes": {
-                      "shape": "S1c"
+                      "type": "integer"
                     },
-                    "WriterVersion": {
-                      "type": "string",
-                      "enum": [
-                        "V1",
-                        "V2"
-                      ]
-                    }
+                    "WriterVersion": {}
                   }
                 },
                 "OrcSerDe": {
                   "type": "structure",
                   "members": {
                     "StripeSizeBytes": {
-                      "type": "integer",
-                      "min": 8388608
+                      "type": "integer"
                     },
                     "BlockSizeBytes": {
-                      "shape": "S19"
+                      "type": "integer"
                     },
                     "RowIndexStride": {
-                      "type": "integer",
-                      "min": 1000
+                      "type": "integer"
                     },
                     "EnablePadding": {
                       "type": "boolean"
                     },
                     "PaddingTolerance": {
-                      "shape": "S1h"
+                      "type": "double"
                     },
-                    "Compression": {
-                      "type": "string",
-                      "enum": [
-                        "NONE",
-                        "ZLIB",
-                        "SNAPPY"
-                      ]
-                    },
+                    "Compression": {},
                     "BloomFilterColumns": {
                       "type": "list",
-                      "member": {
-                        "shape": "Sy"
-                      }
+                      "member": {}
                     },
                     "BloomFilterFalsePositiveProbability": {
-                      "shape": "S1h"
+                      "type": "double"
                     },
                     "DictionaryKeyThreshold": {
-                      "shape": "S1h"
+                      "type": "double"
                     },
-                    "FormatVersion": {
-                      "type": "string",
-                      "enum": [
-                        "V0_11",
-                        "V0_12"
-                      ]
-                    }
+                    "FormatVersion": {}
                   }
                 }
               }
@@ -1212,111 +907,41 @@
         }
       }
     },
-    "Sy": {
-      "type": "string",
-      "pattern": "^\\S+$"
-    },
-    "S13": {
-      "type": "string",
-      "pattern": "^(?!\\s*$).+"
-    },
-    "S19": {
-      "type": "integer",
-      "min": 67108864
-    },
-    "S1c": {
-      "type": "integer",
-      "min": 0
-    },
-    "S1h": {
-      "type": "double",
-      "max": 1,
-      "min": 0
-    },
-    "S1m": {
-      "type": "string",
-      "min": 1,
-      "pattern": "jdbc:(redshift|postgresql)://((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+redshift\\.amazonaws\\.com:\\d{1,5}/[a-zA-Z0-9_$]+"
-    },
     "S1n": {
       "type": "structure",
       "required": [
         "DataTableName"
       ],
       "members": {
-        "DataTableName": {
-          "type": "string",
-          "min": 1
-        },
+        "DataTableName": {},
         "DataTableColumns": {},
         "CopyOptions": {}
       }
     },
     "S1r": {
       "type": "string",
-      "min": 1,
       "sensitive": true
     },
     "S1s": {
       "type": "string",
-      "min": 6,
       "sensitive": true
     },
     "S1t": {
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer",
-          "max": 7200,
-          "min": 0
+          "type": "integer"
         }
       }
-    },
-    "S1v": {
-      "type": "string",
-      "enum": [
-        "Disabled",
-        "Enabled"
-      ]
-    },
-    "S1x": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
-    "S1y": {
-      "type": "string",
-      "max": 80,
-      "min": 1
-    },
-    "S1z": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S20": {
-      "type": "string",
-      "enum": [
-        "NoRotation",
-        "OneHour",
-        "OneDay",
-        "OneWeek",
-        "OneMonth"
-      ]
     },
     "S21": {
       "type": "structure",
       "members": {
         "IntervalInSeconds": {
-          "type": "integer",
-          "max": 900,
-          "min": 60
+          "type": "integer"
         },
         "SizeInMBs": {
-          "type": "integer",
-          "max": 100,
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -1324,64 +949,17 @@
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer",
-          "max": 7200,
-          "min": 0
+          "type": "integer"
         }
       }
-    },
-    "S26": {
-      "type": "string",
-      "enum": [
-        "FailedDocumentsOnly",
-        "AllDocuments"
-      ]
-    },
-    "S29": {
-      "type": "string",
-      "enum": [
-        "Raw",
-        "Event"
-      ]
-    },
-    "S2b": {
-      "type": "integer",
-      "max": 600,
-      "min": 180
     },
     "S2c": {
       "type": "structure",
       "members": {
         "DurationInSeconds": {
-          "type": "integer",
-          "max": 7200,
-          "min": 0
+          "type": "integer"
         }
       }
-    },
-    "S2e": {
-      "type": "string",
-      "enum": [
-        "FailedEventsOnly",
-        "AllEvents"
-      ]
-    },
-    "S2g": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
-    "S2l": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S2p": {
-      "type": "string",
-      "max": 50,
-      "min": 1,
-      "pattern": "[0-9]+"
     },
     "S2w": {
       "type": "structure",
@@ -1393,19 +971,13 @@
         "EncryptionConfiguration"
       ],
       "members": {
-        "RoleARN": {
-          "shape": "S6"
-        },
-        "BucketARN": {
-          "shape": "S8"
-        },
+        "RoleARN": {},
+        "BucketARN": {},
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {
-          "shape": "Sd"
-        },
+        "CompressionFormat": {},
         "EncryptionConfiguration": {
           "shape": "Se"
         },
@@ -1414,25 +986,14 @@
         }
       }
     },
-    "S36": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
     "S3a": {
       "type": "structure",
       "required": [
         "Key"
       ],
       "members": {
-        "Key": {
-          "shape": "S36"
-        },
-        "Value": {
-          "type": "string",
-          "max": 256,
-          "min": 0
-        }
+        "Key": {},
+        "Value": {}
       }
     },
     "S3d": {
@@ -1442,32 +1003,20 @@
       ],
       "members": {
         "Data": {
-          "type": "blob",
-          "max": 1024000,
-          "min": 0
+          "type": "blob"
         }
       }
-    },
-    "S3g": {
-      "type": "string",
-      "min": 1
     },
     "S3v": {
       "type": "structure",
       "members": {
-        "RoleARN": {
-          "shape": "S6"
-        },
-        "BucketARN": {
-          "shape": "S8"
-        },
+        "RoleARN": {},
+        "BucketARN": {},
         "Prefix": {},
         "BufferingHints": {
           "shape": "Sa"
         },
-        "CompressionFormat": {
-          "shape": "Sd"
-        },
+        "CompressionFormat": {},
         "EncryptionConfiguration": {
           "shape": "Se"
         },

--- a/apis/fms-2018-01-01.min.json
+++ b/apis/fms-2018-01-01.min.json
@@ -20,9 +20,7 @@
           "AdminAccount"
         ],
         "members": {
-          "AdminAccount": {
-            "shape": "S2"
-          }
+          "AdminAccount": {}
         }
       }
     },
@@ -39,9 +37,7 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "S5"
-          }
+          "PolicyId": {}
         }
       }
     },
@@ -59,19 +55,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "AdminAccount": {
-            "shape": "S2"
-          },
-          "RoleStatus": {
-            "type": "string",
-            "enum": [
-              "READY",
-              "CREATING",
-              "PENDING_DELETION",
-              "DELETING",
-              "DELETED"
-            ]
-          }
+          "AdminAccount": {},
+          "RoleStatus": {}
         }
       }
     },
@@ -83,12 +68,8 @@
           "MemberAccount"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "S5"
-          },
-          "MemberAccount": {
-            "shape": "S2"
-          }
+          "PolicyId": {},
+          "MemberAccount": {}
         }
       },
       "output": {
@@ -97,36 +78,17 @@
           "PolicyComplianceDetail": {
             "type": "structure",
             "members": {
-              "PolicyOwner": {
-                "shape": "S2"
-              },
-              "PolicyId": {
-                "shape": "S5"
-              },
-              "MemberAccount": {
-                "shape": "S2"
-              },
+              "PolicyOwner": {},
+              "PolicyId": {},
+              "MemberAccount": {},
               "Violators": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "ResourceId": {
-                      "type": "string",
-                      "max": 1024,
-                      "min": 1
-                    },
-                    "ViolationReason": {
-                      "type": "string",
-                      "enum": [
-                        "WEB_ACL_MISSING_RULE_GROUP",
-                        "RESOURCE_MISSING_WEB_ACL",
-                        "RESOURCE_INCORRECT_WEB_ACL"
-                      ]
-                    },
-                    "ResourceType": {
-                      "shape": "Sh"
-                    }
+                    "ResourceId": {},
+                    "ViolationReason": {},
+                    "ResourceType": {}
                   }
                 }
               },
@@ -152,12 +114,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "SnsTopicArn": {
-            "shape": "Sp"
-          },
-          "SnsRoleName": {
-            "shape": "Sp"
-          }
+          "SnsTopicArn": {},
+          "SnsRoleName": {}
         }
       }
     },
@@ -168,9 +126,7 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "S5"
-          }
+          "PolicyId": {}
         }
       },
       "output": {
@@ -179,9 +135,7 @@
           "Policy": {
             "shape": "Ss"
           },
-          "PolicyArn": {
-            "shape": "Sp"
-          }
+          "PolicyArn": {}
         }
       }
     },
@@ -192,14 +146,10 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "S5"
-          },
-          "NextToken": {
-            "shape": "S17"
-          },
+          "PolicyId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S18"
+            "type": "integer"
           }
         }
       },
@@ -211,33 +161,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyOwner": {
-                  "shape": "S2"
-                },
-                "PolicyId": {
-                  "shape": "S5"
-                },
-                "PolicyName": {
-                  "shape": "St"
-                },
-                "MemberAccount": {
-                  "shape": "S2"
-                },
+                "PolicyOwner": {},
+                "PolicyId": {},
+                "PolicyName": {},
+                "MemberAccount": {},
                 "EvaluationResults": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "ComplianceStatus": {
-                        "type": "string",
-                        "enum": [
-                          "COMPLIANT",
-                          "NON_COMPLIANT"
-                        ]
-                      },
+                      "ComplianceStatus": {},
                       "ViolatorCount": {
-                        "type": "long",
-                        "min": 0
+                        "type": "long"
                       },
                       "EvaluationLimitExceeded": {
                         "type": "boolean"
@@ -254,9 +189,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S17"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -264,11 +197,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S17"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S18"
+            "type": "integer"
           }
         }
       },
@@ -277,13 +208,9 @@
         "members": {
           "MemberAccounts": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S17"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -291,11 +218,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S17"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S18"
+            "type": "integer"
           }
         }
       },
@@ -307,30 +232,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyArn": {
-                  "shape": "Sp"
-                },
-                "PolicyId": {
-                  "shape": "S5"
-                },
-                "PolicyName": {
-                  "shape": "St"
-                },
-                "ResourceType": {
-                  "shape": "Sh"
-                },
-                "SecurityServiceType": {
-                  "shape": "Sw"
-                },
+                "PolicyArn": {},
+                "PolicyId": {},
+                "PolicyName": {},
+                "ResourceType": {},
+                "SecurityServiceType": {},
                 "RemediationEnabled": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S17"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -342,12 +255,8 @@
           "SnsRoleName"
         ],
         "members": {
-          "SnsTopicArn": {
-            "shape": "Sp"
-          },
-          "SnsRoleName": {
-            "shape": "Sp"
-          }
+          "SnsTopicArn": {},
+          "SnsRoleName": {}
         }
       }
     },
@@ -369,48 +278,16 @@
           "Policy": {
             "shape": "Ss"
           },
-          "PolicyArn": {
-            "shape": "Sp"
-          }
+          "PolicyArn": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "max": 36,
-      "min": 36
-    },
-    "Sh": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
     "Sk": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "AWSCONFIG",
-          "AWSWAF"
-        ]
-      },
-      "value": {
-        "type": "string",
-        "max": 1024,
-        "min": 1
-      }
-    },
-    "Sp": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
+      "key": {},
+      "value": {}
     },
     "Ss": {
       "type": "structure",
@@ -422,36 +299,20 @@
         "RemediationEnabled"
       ],
       "members": {
-        "PolicyId": {
-          "shape": "S5"
-        },
-        "PolicyName": {
-          "shape": "St"
-        },
-        "PolicyUpdateToken": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        },
+        "PolicyId": {},
+        "PolicyName": {},
+        "PolicyUpdateToken": {},
         "SecurityServicePolicyData": {
           "type": "structure",
           "required": [
             "Type"
           ],
           "members": {
-            "Type": {
-              "shape": "Sw"
-            },
-            "ManagedServiceData": {
-              "type": "string",
-              "max": 1024,
-              "min": 1
-            }
+            "Type": {},
+            "ManagedServiceData": {}
           }
         },
-        "ResourceType": {
-          "shape": "Sh"
-        },
+        "ResourceType": {},
         "ResourceTags": {
           "type": "list",
           "member": {
@@ -460,21 +321,10 @@
               "Key"
             ],
             "members": {
-              "Key": {
-                "type": "string",
-                "max": 128,
-                "min": 1,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
-          },
-          "max": 8,
-          "min": 0
+          }
         },
         "ExcludeResourceTags": {
           "type": "boolean"
@@ -490,42 +340,13 @@
         }
       }
     },
-    "St": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Sw": {
-      "type": "string",
-      "enum": [
-        "WAF"
-      ]
-    },
     "S12": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "ACCOUNT"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "list",
-        "member": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        }
+        "member": {}
       }
-    },
-    "S17": {
-      "type": "string",
-      "min": 1
-    },
-    "S18": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     }
   }
 }

--- a/apis/gamelift-2015-10-01.min.json
+++ b/apis/gamelift-2015-10-01.min.json
@@ -21,19 +21,11 @@
           "AcceptanceType"
         ],
         "members": {
-          "TicketId": {
-            "shape": "S2"
-          },
+          "TicketId": {},
           "PlayerIds": {
             "shape": "S3"
           },
-          "AcceptanceType": {
-            "type": "string",
-            "enum": [
-              "ACCEPT",
-              "REJECT"
-            ]
-          }
+          "AcceptanceType": {}
         }
       },
       "output": {
@@ -49,12 +41,8 @@
           "RoutingStrategy"
         ],
         "members": {
-          "Name": {
-            "shape": "S8"
-          },
-          "Description": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Description": {},
           "RoutingStrategy": {
             "shape": "S9"
           }
@@ -73,18 +61,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S4"
-          },
-          "Version": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Version": {},
           "StorageLocation": {
             "shape": "Sj"
           },
-          "OperatingSystem": {
-            "shape": "Sl"
-          }
+          "OperatingSystem": {}
         }
       },
       "output": {
@@ -111,33 +93,19 @@
           "EC2InstanceType"
         ],
         "members": {
-          "Name": {
-            "shape": "S4"
-          },
-          "Description": {
-            "shape": "S4"
-          },
-          "BuildId": {
-            "shape": "So"
-          },
-          "ServerLaunchPath": {
-            "shape": "S4"
-          },
-          "ServerLaunchParameters": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Description": {},
+          "BuildId": {},
+          "ServerLaunchPath": {},
+          "ServerLaunchParameters": {},
           "LogPaths": {
             "shape": "S3"
           },
-          "EC2InstanceType": {
-            "shape": "St"
-          },
+          "EC2InstanceType": {},
           "EC2InboundPermissions": {
             "shape": "Su"
           },
-          "NewGameSessionProtectionPolicy": {
-            "shape": "Sz"
-          },
+          "NewGameSessionProtectionPolicy": {},
           "RuntimeConfiguration": {
             "shape": "S10"
           },
@@ -147,15 +115,9 @@
           "MetricGroups": {
             "shape": "S18"
           },
-          "PeerVpcAwsAccountId": {
-            "shape": "S4"
-          },
-          "PeerVpcId": {
-            "shape": "S4"
-          },
-          "FleetType": {
-            "shape": "S1a"
-          }
+          "PeerVpcAwsAccountId": {},
+          "PeerVpcId": {},
+          "FleetType": {}
         }
       },
       "output": {
@@ -174,33 +136,19 @@
           "MaximumPlayerSessionCount"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "AliasId": {
-            "shape": "Sf"
-          },
+          "FleetId": {},
+          "AliasId": {},
           "MaximumPlayerSessionCount": {
-            "shape": "S17"
+            "type": "integer"
           },
-          "Name": {
-            "shape": "S4"
-          },
+          "Name": {},
           "GameProperties": {
             "shape": "S1h"
           },
-          "CreatorId": {
-            "shape": "S4"
-          },
-          "GameSessionId": {
-            "shape": "S1l"
-          },
-          "IdempotencyToken": {
-            "shape": "S1l"
-          },
-          "GameSessionData": {
-            "shape": "S1m"
-          }
+          "CreatorId": {},
+          "GameSessionId": {},
+          "IdempotencyToken": {},
+          "GameSessionData": {}
         }
       },
       "output": {
@@ -219,11 +167,9 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S1v"
-          },
+          "Name": {},
           "TimeoutInSeconds": {
-            "shape": "S17"
+            "type": "integer"
           },
           "PlayerLatencyPolicies": {
             "shape": "S1w"
@@ -253,42 +199,30 @@
           "RuleSetName"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Description": {},
           "GameSessionQueueArns": {
             "shape": "S23"
           },
           "RequestTimeoutSeconds": {
-            "shape": "S24"
+            "type": "integer"
           },
           "AcceptanceTimeoutSeconds": {
-            "shape": "S25"
+            "type": "integer"
           },
           "AcceptanceRequired": {
             "type": "boolean"
           },
-          "RuleSetName": {
-            "shape": "S2"
-          },
-          "NotificationTarget": {
-            "shape": "S27"
-          },
+          "RuleSetName": {},
+          "NotificationTarget": {},
           "AdditionalPlayerCount": {
-            "shape": "S17"
+            "type": "integer"
           },
-          "CustomEventData": {
-            "shape": "S28"
-          },
+          "CustomEventData": {},
           "GameProperties": {
             "shape": "S1h"
           },
-          "GameSessionData": {
-            "shape": "S1m"
-          }
+          "GameSessionData": {}
         }
       },
       "output": {
@@ -308,12 +242,8 @@
           "RuleSetBody"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "RuleSetBody": {
-            "shape": "S2c"
-          }
+          "Name": {},
+          "RuleSetBody": {}
         }
       },
       "output": {
@@ -336,15 +266,9 @@
           "PlayerId"
         ],
         "members": {
-          "GameSessionId": {
-            "shape": "Sg"
-          },
-          "PlayerId": {
-            "shape": "S4"
-          },
-          "PlayerData": {
-            "shape": "S2g"
-          }
+          "GameSessionId": {},
+          "PlayerId": {},
+          "PlayerData": {}
         }
       },
       "output": {
@@ -364,25 +288,15 @@
           "PlayerIds"
         ],
         "members": {
-          "GameSessionId": {
-            "shape": "Sg"
-          },
+          "GameSessionId": {},
           "PlayerIds": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           },
           "PlayerDataMap": {
             "type": "map",
-            "key": {
-              "shape": "S4"
-            },
-            "value": {
-              "shape": "S2g"
-            }
+            "key": {},
+            "value": {}
           }
         }
       },
@@ -403,12 +317,8 @@
           "PeerVpcId"
         ],
         "members": {
-          "GameLiftAwsAccountId": {
-            "shape": "S4"
-          },
-          "PeerVpcId": {
-            "shape": "S4"
-          }
+          "GameLiftAwsAccountId": {},
+          "PeerVpcId": {}
         }
       },
       "output": {
@@ -429,15 +339,9 @@
           "PeerVpcId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "PeerVpcAwsAccountId": {
-            "shape": "S4"
-          },
-          "PeerVpcId": {
-            "shape": "S4"
-          }
+          "FleetId": {},
+          "PeerVpcAwsAccountId": {},
+          "PeerVpcId": {}
         }
       },
       "output": {
@@ -452,9 +356,7 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {
-            "shape": "Sf"
-          }
+          "AliasId": {}
         }
       }
     },
@@ -465,9 +367,7 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {
-            "shape": "So"
-          }
+          "BuildId": {}
         }
       }
     },
@@ -478,9 +378,7 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       }
     },
@@ -491,9 +389,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S1v"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -508,9 +404,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -526,12 +420,8 @@
           "FleetId"
         ],
         "members": {
-          "Name": {
-            "shape": "S4"
-          },
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "Name": {},
+          "FleetId": {}
         }
       }
     },
@@ -543,12 +433,8 @@
           "PeerVpcId"
         ],
         "members": {
-          "GameLiftAwsAccountId": {
-            "shape": "S4"
-          },
-          "PeerVpcId": {
-            "shape": "S4"
-          }
+          "GameLiftAwsAccountId": {},
+          "PeerVpcId": {}
         }
       },
       "output": {
@@ -564,12 +450,8 @@
           "VpcPeeringConnectionId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "VpcPeeringConnectionId": {
-            "shape": "S4"
-          }
+          "FleetId": {},
+          "VpcPeeringConnectionId": {}
         }
       },
       "output": {
@@ -584,9 +466,7 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {
-            "shape": "Sf"
-          }
+          "AliasId": {}
         }
       },
       "output": {
@@ -605,9 +485,7 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {
-            "shape": "So"
-          }
+          "BuildId": {}
         }
       },
       "output": {
@@ -623,9 +501,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "EC2InstanceType": {
-            "shape": "St"
-          }
+          "EC2InstanceType": {}
         }
       },
       "output": {
@@ -636,14 +512,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "EC2InstanceType": {
-                  "shape": "St"
-                },
+                "EC2InstanceType": {},
                 "CurrentInstances": {
-                  "shape": "S17"
+                  "type": "integer"
                 },
                 "InstanceLimit": {
-                  "shape": "S17"
+                  "type": "integer"
                 }
               }
             }
@@ -659,11 +533,9 @@
             "shape": "S3g"
           },
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -675,9 +547,7 @@
               "shape": "S1c"
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -689,11 +559,9 @@
             "shape": "S3g"
           },
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -704,44 +572,38 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {
-                  "shape": "Sb"
-                },
-                "InstanceType": {
-                  "shape": "St"
-                },
+                "FleetId": {},
+                "InstanceType": {},
                 "InstanceCounts": {
                   "type": "structure",
                   "members": {
                     "DESIRED": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "MINIMUM": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "MAXIMUM": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "PENDING": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "ACTIVE": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "IDLE": {
-                      "shape": "S17"
+                      "type": "integer"
                     },
                     "TERMINATING": {
-                      "shape": "S17"
+                      "type": "integer"
                     }
                   }
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -752,9 +614,7 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -762,11 +622,9 @@
             "type": "timestamp"
           },
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -777,65 +635,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "EventId": {
-                  "shape": "S4"
-                },
-                "ResourceId": {
-                  "shape": "S4"
-                },
-                "EventCode": {
-                  "type": "string",
-                  "enum": [
-                    "GENERIC_EVENT",
-                    "FLEET_CREATED",
-                    "FLEET_DELETED",
-                    "FLEET_SCALING_EVENT",
-                    "FLEET_STATE_DOWNLOADING",
-                    "FLEET_STATE_VALIDATING",
-                    "FLEET_STATE_BUILDING",
-                    "FLEET_STATE_ACTIVATING",
-                    "FLEET_STATE_ACTIVE",
-                    "FLEET_STATE_ERROR",
-                    "FLEET_INITIALIZATION_FAILED",
-                    "FLEET_BINARY_DOWNLOAD_FAILED",
-                    "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND",
-                    "FLEET_VALIDATION_EXECUTABLE_RUNTIME_FAILURE",
-                    "FLEET_VALIDATION_TIMED_OUT",
-                    "FLEET_ACTIVATION_FAILED",
-                    "FLEET_ACTIVATION_FAILED_NO_INSTANCES",
-                    "FLEET_NEW_GAME_SESSION_PROTECTION_POLICY_UPDATED",
-                    "SERVER_PROCESS_INVALID_PATH",
-                    "SERVER_PROCESS_SDK_INITIALIZATION_TIMEOUT",
-                    "SERVER_PROCESS_PROCESS_READY_TIMEOUT",
-                    "SERVER_PROCESS_CRASHED",
-                    "SERVER_PROCESS_TERMINATED_UNHEALTHY",
-                    "SERVER_PROCESS_FORCE_TERMINATED",
-                    "SERVER_PROCESS_PROCESS_EXIT_TIMEOUT",
-                    "GAME_SESSION_ACTIVATION_TIMEOUT",
-                    "FLEET_CREATION_EXTRACTING_BUILD",
-                    "FLEET_CREATION_RUNNING_INSTALLER",
-                    "FLEET_CREATION_VALIDATING_RUNTIME_CONFIG",
-                    "FLEET_VPC_PEERING_SUCCEEDED",
-                    "FLEET_VPC_PEERING_FAILED",
-                    "FLEET_VPC_PEERING_DELETED",
-                    "INSTANCE_INTERRUPTED"
-                  ]
-                },
-                "Message": {
-                  "shape": "Sk"
-                },
+                "EventId": {},
+                "ResourceId": {},
+                "EventCode": {},
+                "Message": {},
                 "EventTime": {
                   "type": "timestamp"
                 },
-                "PreSignedLogUrl": {
-                  "shape": "S4"
-                }
+                "PreSignedLogUrl": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -846,9 +657,7 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       },
       "output": {
@@ -868,11 +677,9 @@
             "shape": "S3g"
           },
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -883,27 +690,23 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {
-                  "shape": "Sb"
-                },
+                "FleetId": {},
                 "ActiveServerProcessCount": {
-                  "shape": "S17"
+                  "type": "integer"
                 },
                 "ActiveGameSessionCount": {
-                  "shape": "S17"
+                  "type": "integer"
                 },
                 "CurrentPlayerSessionCount": {
-                  "shape": "S17"
+                  "type": "integer"
                 },
                 "MaximumPlayerSessionCount": {
-                  "shape": "S17"
+                  "type": "integer"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -911,24 +714,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "GameSessionId": {
-            "shape": "Sg"
-          },
-          "AliasId": {
-            "shape": "Sf"
-          },
-          "StatusFilter": {
-            "shape": "S4"
-          },
+          "FleetId": {},
+          "GameSessionId": {},
+          "AliasId": {},
+          "StatusFilter": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -942,15 +735,11 @@
                 "GameSession": {
                   "shape": "S1o"
                 },
-                "ProtectionPolicy": {
-                  "shape": "Sz"
-                }
+                "ProtectionPolicy": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -961,9 +750,7 @@
           "PlacementId"
         ],
         "members": {
-          "PlacementId": {
-            "shape": "S1l"
-          }
+          "PlacementId": {}
         }
       },
       "output": {
@@ -981,16 +768,12 @@
         "members": {
           "Names": {
             "type": "list",
-            "member": {
-              "shape": "S1v"
-            }
+            "member": {}
           },
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1002,9 +785,7 @@
               "shape": "S21"
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1012,24 +793,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "GameSessionId": {
-            "shape": "Sg"
-          },
-          "AliasId": {
-            "shape": "Sf"
-          },
-          "StatusFilter": {
-            "shape": "S4"
-          },
+          "FleetId": {},
+          "GameSessionId": {},
+          "AliasId": {},
+          "StatusFilter": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1038,9 +809,7 @@
           "GameSessions": {
             "shape": "S4i"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1051,18 +820,12 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "InstanceId": {
-            "shape": "S4k"
-          },
+          "FleetId": {},
+          "InstanceId": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1073,36 +836,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {
-                  "shape": "Sb"
-                },
-                "InstanceId": {
-                  "shape": "S4k"
-                },
+                "FleetId": {},
+                "InstanceId": {},
                 "IpAddress": {},
-                "OperatingSystem": {
-                  "shape": "Sl"
-                },
-                "Type": {
-                  "shape": "St"
-                },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "PENDING",
-                    "ACTIVE",
-                    "TERMINATING"
-                  ]
-                },
+                "OperatingSystem": {},
+                "Type": {},
+                "Status": {},
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1137,15 +883,11 @@
           "Names": {
             "shape": "S4q"
           },
-          "RuleSetName": {
-            "shape": "S2"
-          },
+          "RuleSetName": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1157,9 +899,7 @@
               "shape": "S2a"
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1169,20 +909,12 @@
         "members": {
           "Names": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            },
-            "max": 10,
-            "min": 1
+            "member": {}
           },
           "Limit": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1197,9 +929,7 @@
               "shape": "S2e"
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1207,24 +937,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "GameSessionId": {
-            "shape": "Sg"
-          },
-          "PlayerId": {
-            "shape": "S4"
-          },
-          "PlayerSessionId": {
-            "shape": "S2j"
-          },
-          "PlayerSessionStatusFilter": {
-            "shape": "S4"
-          },
+          "GameSessionId": {},
+          "PlayerId": {},
+          "PlayerSessionId": {},
+          "PlayerSessionStatusFilter": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1233,9 +953,7 @@
           "PlayerSessions": {
             "shape": "S2p"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1246,9 +964,7 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       },
       "output": {
@@ -1267,18 +983,12 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "StatusFilter": {
-            "shape": "S5j"
-          },
+          "FleetId": {},
+          "StatusFilter": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1289,45 +999,29 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {
-                  "shape": "Sb"
-                },
-                "Name": {
-                  "shape": "S4"
-                },
-                "Status": {
-                  "shape": "S5j"
-                },
+                "FleetId": {},
+                "Name": {},
+                "Status": {},
                 "ScalingAdjustment": {
                   "type": "integer"
                 },
-                "ScalingAdjustmentType": {
-                  "shape": "S5o"
-                },
-                "ComparisonOperator": {
-                  "shape": "S5p"
-                },
+                "ScalingAdjustmentType": {},
+                "ComparisonOperator": {},
                 "Threshold": {
                   "type": "double"
                 },
                 "EvaluationPeriods": {
-                  "shape": "S13"
+                  "type": "integer"
                 },
-                "MetricName": {
-                  "shape": "S5r"
-                },
-                "PolicyType": {
-                  "shape": "S5s"
-                },
+                "MetricName": {},
+                "PolicyType": {},
                 "TargetConfiguration": {
                   "shape": "S5t"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1352,9 +1046,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       },
       "output": {
@@ -1365,32 +1057,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "FleetId": {
-                  "shape": "Sb"
-                },
-                "IpV4CidrBlock": {
-                  "shape": "S4"
-                },
-                "VpcPeeringConnectionId": {
-                  "shape": "S4"
-                },
+                "FleetId": {},
+                "IpV4CidrBlock": {},
+                "VpcPeeringConnectionId": {},
                 "Status": {
                   "type": "structure",
                   "members": {
-                    "Code": {
-                      "shape": "S4"
-                    },
-                    "Message": {
-                      "shape": "S4"
-                    }
+                    "Code": {},
+                    "Message": {}
                   }
                 },
-                "PeerVpcId": {
-                  "shape": "S4"
-                },
-                "GameLiftVpcId": {
-                  "shape": "S4"
-                }
+                "PeerVpcId": {},
+                "GameLiftVpcId": {}
               }
             }
           }
@@ -1404,17 +1082,13 @@
           "GameSessionId"
         ],
         "members": {
-          "GameSessionId": {
-            "shape": "Sg"
-          }
+          "GameSessionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PreSignedUrl": {
-            "shape": "S4"
-          }
+          "PreSignedUrl": {}
         }
       }
     },
@@ -1426,12 +1100,8 @@
           "InstanceId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "InstanceId": {
-            "shape": "S4k"
-          }
+          "FleetId": {},
+          "InstanceId": {}
         }
       },
       "output": {
@@ -1440,25 +1110,15 @@
           "InstanceAccess": {
             "type": "structure",
             "members": {
-              "FleetId": {
-                "shape": "Sb"
-              },
-              "InstanceId": {
-                "shape": "S4k"
-              },
+              "FleetId": {},
+              "InstanceId": {},
               "IpAddress": {},
-              "OperatingSystem": {
-                "shape": "Sl"
-              },
+              "OperatingSystem": {},
               "Credentials": {
                 "type": "structure",
                 "members": {
-                  "UserName": {
-                    "shape": "Sk"
-                  },
-                  "Secret": {
-                    "shape": "Sk"
-                  }
+                  "UserName": {},
+                  "Secret": {}
                 },
                 "sensitive": true
               }
@@ -1471,18 +1131,12 @@
       "input": {
         "type": "structure",
         "members": {
-          "RoutingStrategyType": {
-            "shape": "Sa"
-          },
-          "Name": {
-            "shape": "Sk"
-          },
+          "RoutingStrategyType": {},
+          "Name": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sk"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1494,9 +1148,7 @@
               "shape": "Se"
             }
           },
-          "NextToken": {
-            "shape": "Sk"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1504,15 +1156,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "Sp"
-          },
+          "Status": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sk"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1524,9 +1172,7 @@
               "shape": "Sn"
             }
           },
-          "NextToken": {
-            "shape": "Sk"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1534,15 +1180,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "BuildId": {
-            "shape": "So"
-          },
+          "BuildId": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1551,9 +1193,7 @@
           "FleetIds": {
             "shape": "S3g"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1566,33 +1206,21 @@
           "MetricName"
         ],
         "members": {
-          "Name": {
-            "shape": "S4"
-          },
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "Name": {},
+          "FleetId": {},
           "ScalingAdjustment": {
             "type": "integer"
           },
-          "ScalingAdjustmentType": {
-            "shape": "S5o"
-          },
+          "ScalingAdjustmentType": {},
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {
-            "shape": "S5p"
-          },
+          "ComparisonOperator": {},
           "EvaluationPeriods": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "MetricName": {
-            "shape": "S5r"
-          },
-          "PolicyType": {
-            "shape": "S5s"
-          },
+          "MetricName": {},
+          "PolicyType": {},
           "TargetConfiguration": {
             "shape": "S5t"
           }
@@ -1601,9 +1229,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S4"
-          }
+          "Name": {}
         }
       }
     },
@@ -1614,9 +1240,7 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {
-            "shape": "So"
-          }
+          "BuildId": {}
         }
       },
       "output": {
@@ -1638,17 +1262,13 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {
-            "shape": "Sf"
-          }
+          "AliasId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       }
     },
@@ -1656,24 +1276,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "AliasId": {
-            "shape": "Sf"
-          },
-          "FilterExpression": {
-            "shape": "S4"
-          },
-          "SortExpression": {
-            "shape": "S4"
-          },
+          "FleetId": {},
+          "AliasId": {},
+          "FilterExpression": {},
+          "SortExpression": {},
           "Limit": {
-            "shape": "S13"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -1682,9 +1292,7 @@
           "GameSessions": {
             "shape": "S4i"
           },
-          "NextToken": {
-            "shape": "S4"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1696,9 +1304,7 @@
           "Actions"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "Actions": {
             "shape": "S1e"
           }
@@ -1718,21 +1324,15 @@
           "MaximumPlayerSessionCount"
         ],
         "members": {
-          "PlacementId": {
-            "shape": "S1l"
-          },
-          "GameSessionQueueName": {
-            "shape": "S1v"
-          },
+          "PlacementId": {},
+          "GameSessionQueueName": {},
           "GameProperties": {
             "shape": "S1h"
           },
           "MaximumPlayerSessionCount": {
-            "shape": "S17"
+            "type": "integer"
           },
-          "GameSessionName": {
-            "shape": "S4"
-          },
+          "GameSessionName": {},
           "PlayerLatencies": {
             "shape": "S47"
           },
@@ -1741,18 +1341,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "PlayerId": {
-                  "shape": "S4"
-                },
-                "PlayerData": {
-                  "shape": "S2g"
-                }
+                "PlayerId": {},
+                "PlayerData": {}
               }
             }
           },
-          "GameSessionData": {
-            "shape": "S1m"
-          }
+          "GameSessionData": {}
         }
       },
       "output": {
@@ -1773,15 +1367,9 @@
           "Players"
         ],
         "members": {
-          "TicketId": {
-            "shape": "S2"
-          },
-          "ConfigurationName": {
-            "shape": "S2"
-          },
-          "GameSessionArn": {
-            "shape": "Sg"
-          },
+          "TicketId": {},
+          "ConfigurationName": {},
+          "GameSessionArn": {},
           "Players": {
             "shape": "S4w"
           }
@@ -1804,12 +1392,8 @@
           "Players"
         ],
         "members": {
-          "TicketId": {
-            "shape": "S2"
-          },
-          "ConfigurationName": {
-            "shape": "S2"
-          },
+          "TicketId": {},
+          "ConfigurationName": {},
           "Players": {
             "shape": "S4w"
           }
@@ -1832,9 +1416,7 @@
           "Actions"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "Actions": {
             "shape": "S1e"
           }
@@ -1852,9 +1434,7 @@
           "PlacementId"
         ],
         "members": {
-          "PlacementId": {
-            "shape": "S1l"
-          }
+          "PlacementId": {}
         }
       },
       "output": {
@@ -1873,9 +1453,7 @@
           "TicketId"
         ],
         "members": {
-          "TicketId": {
-            "shape": "S2"
-          }
+          "TicketId": {}
         }
       },
       "output": {
@@ -1890,15 +1468,9 @@
           "AliasId"
         ],
         "members": {
-          "AliasId": {
-            "shape": "Sf"
-          },
-          "Name": {
-            "shape": "S8"
-          },
-          "Description": {
-            "shape": "S4"
-          },
+          "AliasId": {},
+          "Name": {},
+          "Description": {},
           "RoutingStrategy": {
             "shape": "S9"
           }
@@ -1920,15 +1492,9 @@
           "BuildId"
         ],
         "members": {
-          "BuildId": {
-            "shape": "So"
-          },
-          "Name": {
-            "shape": "S4"
-          },
-          "Version": {
-            "shape": "S4"
-          }
+          "BuildId": {},
+          "Name": {},
+          "Version": {}
         }
       },
       "output": {
@@ -1947,18 +1513,10 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
-          "Name": {
-            "shape": "S4"
-          },
-          "Description": {
-            "shape": "S4"
-          },
-          "NewGameSessionProtectionPolicy": {
-            "shape": "Sz"
-          },
+          "FleetId": {},
+          "Name": {},
+          "Description": {},
+          "NewGameSessionProtectionPolicy": {},
           "ResourceCreationLimitPolicy": {
             "shape": "S16"
           },
@@ -1970,9 +1528,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       }
     },
@@ -1983,26 +1539,22 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "DesiredInstances": {
-            "shape": "S17"
+            "type": "integer"
           },
           "MinSize": {
-            "shape": "S17"
+            "type": "integer"
           },
           "MaxSize": {
-            "shape": "S17"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       }
     },
@@ -2013,9 +1565,7 @@
           "FleetId"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "InboundPermissionAuthorizations": {
             "shape": "Su"
           },
@@ -2027,9 +1577,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          }
+          "FleetId": {}
         }
       }
     },
@@ -2040,21 +1588,13 @@
           "GameSessionId"
         ],
         "members": {
-          "GameSessionId": {
-            "shape": "Sg"
-          },
+          "GameSessionId": {},
           "MaximumPlayerSessionCount": {
-            "shape": "S17"
+            "type": "integer"
           },
-          "Name": {
-            "shape": "S4"
-          },
-          "PlayerSessionCreationPolicy": {
-            "shape": "S1s"
-          },
-          "ProtectionPolicy": {
-            "shape": "Sz"
-          }
+          "Name": {},
+          "PlayerSessionCreationPolicy": {},
+          "ProtectionPolicy": {}
         }
       },
       "output": {
@@ -2073,11 +1613,9 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S1v"
-          },
+          "Name": {},
           "TimeoutInSeconds": {
-            "shape": "S17"
+            "type": "integer"
           },
           "PlayerLatencyPolicies": {
             "shape": "S1w"
@@ -2103,42 +1641,30 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Description": {},
           "GameSessionQueueArns": {
             "shape": "S23"
           },
           "RequestTimeoutSeconds": {
-            "shape": "S24"
+            "type": "integer"
           },
           "AcceptanceTimeoutSeconds": {
-            "shape": "S25"
+            "type": "integer"
           },
           "AcceptanceRequired": {
             "type": "boolean"
           },
-          "RuleSetName": {
-            "shape": "S2"
-          },
-          "NotificationTarget": {
-            "shape": "S27"
-          },
+          "RuleSetName": {},
+          "NotificationTarget": {},
           "AdditionalPlayerCount": {
-            "shape": "S17"
+            "type": "integer"
           },
-          "CustomEventData": {
-            "shape": "S28"
-          },
+          "CustomEventData": {},
           "GameProperties": {
             "shape": "S1h"
           },
-          "GameSessionData": {
-            "shape": "S1m"
-          }
+          "GameSessionData": {}
         }
       },
       "output": {
@@ -2158,9 +1684,7 @@
           "RuntimeConfiguration"
         ],
         "members": {
-          "FleetId": {
-            "shape": "Sb"
-          },
+          "FleetId": {},
           "RuntimeConfiguration": {
             "shape": "S10"
           }
@@ -2182,9 +1706,7 @@
           "RuleSetBody"
         ],
         "members": {
-          "RuleSetBody": {
-            "shape": "S2c"
-          }
+          "RuleSetBody": {}
         }
       },
       "output": {
@@ -2198,64 +1720,24 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9-\\.]+"
-    },
     "S3": {
       "type": "list",
-      "member": {
-        "shape": "S4"
-      }
-    },
-    "S4": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S8": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": ".*\\S.*"
+      "member": {}
     },
     "S9": {
       "type": "structure",
       "members": {
-        "Type": {
-          "shape": "Sa"
-        },
-        "FleetId": {
-          "shape": "Sb"
-        },
+        "Type": {},
+        "FleetId": {},
         "Message": {}
       }
-    },
-    "Sa": {
-      "type": "string",
-      "enum": [
-        "SIMPLE",
-        "TERMINAL"
-      ]
-    },
-    "Sb": {
-      "type": "string",
-      "pattern": "^fleet-\\S+"
     },
     "Se": {
       "type": "structure",
       "members": {
-        "AliasId": {
-          "shape": "Sf"
-        },
-        "Name": {
-          "shape": "S8"
-        },
-        "AliasArn": {
-          "shape": "Sg"
-        },
+        "AliasId": {},
+        "Name": {},
+        "AliasArn": {},
         "Description": {},
         "RoutingStrategy": {
           "shape": "S9"
@@ -2268,129 +1750,38 @@
         }
       }
     },
-    "Sf": {
-      "type": "string",
-      "pattern": "^alias-\\S+"
-    },
-    "Sg": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:/-]+"
-    },
     "Sj": {
       "type": "structure",
       "members": {
-        "Bucket": {
-          "shape": "Sk"
-        },
-        "Key": {
-          "shape": "Sk"
-        },
-        "RoleArn": {
-          "shape": "Sk"
-        }
+        "Bucket": {},
+        "Key": {},
+        "RoleArn": {}
       }
-    },
-    "Sk": {
-      "type": "string",
-      "min": 1
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "WINDOWS_2012",
-        "AMAZON_LINUX"
-      ]
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "BuildId": {
-          "shape": "So"
-        },
+        "BuildId": {},
         "Name": {},
         "Version": {},
-        "Status": {
-          "shape": "Sp"
-        },
+        "Status": {},
         "SizeOnDisk": {
-          "type": "long",
-          "min": 1
+          "type": "long"
         },
-        "OperatingSystem": {
-          "shape": "Sl"
-        },
+        "OperatingSystem": {},
         "CreationTime": {
           "type": "timestamp"
         }
       }
     },
-    "So": {
-      "type": "string",
-      "pattern": "^build-\\S+"
-    },
-    "Sp": {
-      "type": "string",
-      "enum": [
-        "INITIALIZED",
-        "READY",
-        "FAILED"
-      ]
-    },
     "Sr": {
       "type": "structure",
       "members": {
-        "AccessKeyId": {
-          "shape": "Sk"
-        },
-        "SecretAccessKey": {
-          "shape": "Sk"
-        },
-        "SessionToken": {
-          "shape": "Sk"
-        }
+        "AccessKeyId": {},
+        "SecretAccessKey": {},
+        "SessionToken": {}
       },
       "sensitive": true
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "t2.micro",
-        "t2.small",
-        "t2.medium",
-        "t2.large",
-        "c3.large",
-        "c3.xlarge",
-        "c3.2xlarge",
-        "c3.4xlarge",
-        "c3.8xlarge",
-        "c4.large",
-        "c4.xlarge",
-        "c4.2xlarge",
-        "c4.4xlarge",
-        "c4.8xlarge",
-        "r3.large",
-        "r3.xlarge",
-        "r3.2xlarge",
-        "r3.4xlarge",
-        "r3.8xlarge",
-        "r4.large",
-        "r4.xlarge",
-        "r4.2xlarge",
-        "r4.4xlarge",
-        "r4.8xlarge",
-        "r4.16xlarge",
-        "m3.medium",
-        "m3.large",
-        "m3.xlarge",
-        "m3.2xlarge",
-        "m4.large",
-        "m4.xlarge",
-        "m4.2xlarge",
-        "m4.4xlarge",
-        "m4.10xlarge"
-      ]
     },
     "Su": {
       "type": "list",
@@ -2404,37 +1795,15 @@
         ],
         "members": {
           "FromPort": {
-            "shape": "Sw"
+            "type": "integer"
           },
           "ToPort": {
-            "shape": "Sw"
+            "type": "integer"
           },
-          "IpRange": {
-            "type": "string",
-            "pattern": "[^\\s]+"
-          },
-          "Protocol": {
-            "type": "string",
-            "enum": [
-              "TCP",
-              "UDP"
-            ]
-          }
+          "IpRange": {},
+          "Protocol": {}
         }
-      },
-      "max": 50
-    },
-    "Sw": {
-      "type": "integer",
-      "max": 60000,
-      "min": 1
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "NoProtection",
-        "FullProtection"
-      ]
+      }
     },
     "S10": {
       "type": "structure",
@@ -2448,126 +1817,61 @@
               "ConcurrentExecutions"
             ],
             "members": {
-              "LaunchPath": {
-                "shape": "S4"
-              },
-              "Parameters": {
-                "shape": "S4"
-              },
+              "LaunchPath": {},
+              "Parameters": {},
               "ConcurrentExecutions": {
-                "shape": "S13"
+                "type": "integer"
               }
             }
-          },
-          "max": 50,
-          "min": 1
+          }
         },
         "MaxConcurrentGameSessionActivations": {
-          "type": "integer",
-          "max": 2147483647,
-          "min": 1
+          "type": "integer"
         },
         "GameSessionActivationTimeoutSeconds": {
-          "type": "integer",
-          "max": 600,
-          "min": 1
+          "type": "integer"
         }
       }
-    },
-    "S13": {
-      "type": "integer",
-      "min": 1
     },
     "S16": {
       "type": "structure",
       "members": {
         "NewGameSessionsPerCreator": {
-          "shape": "S17"
+          "type": "integer"
         },
         "PolicyPeriodInMinutes": {
-          "shape": "S17"
+          "type": "integer"
         }
       }
     },
-    "S17": {
-      "type": "integer",
-      "min": 0
-    },
     "S18": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      },
-      "max": 1
-    },
-    "S1a": {
-      "type": "string",
-      "enum": [
-        "ON_DEMAND",
-        "SPOT"
-      ]
+      "member": {}
     },
     "S1c": {
       "type": "structure",
       "members": {
-        "FleetId": {
-          "shape": "Sb"
-        },
-        "FleetArn": {
-          "shape": "Sg"
-        },
-        "FleetType": {
-          "shape": "S1a"
-        },
-        "InstanceType": {
-          "shape": "St"
-        },
-        "Description": {
-          "shape": "S4"
-        },
-        "Name": {
-          "shape": "S4"
-        },
+        "FleetId": {},
+        "FleetArn": {},
+        "FleetType": {},
+        "InstanceType": {},
+        "Description": {},
+        "Name": {},
         "CreationTime": {
           "type": "timestamp"
         },
         "TerminationTime": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "NEW",
-            "DOWNLOADING",
-            "VALIDATING",
-            "BUILDING",
-            "ACTIVATING",
-            "ACTIVE",
-            "DELETING",
-            "ERROR",
-            "TERMINATED"
-          ]
-        },
-        "BuildId": {
-          "shape": "So"
-        },
-        "ServerLaunchPath": {
-          "shape": "S4"
-        },
-        "ServerLaunchParameters": {
-          "shape": "S4"
-        },
+        "Status": {},
+        "BuildId": {},
+        "ServerLaunchPath": {},
+        "ServerLaunchParameters": {},
         "LogPaths": {
           "shape": "S3"
         },
-        "NewGameSessionProtectionPolicy": {
-          "shape": "Sz"
-        },
-        "OperatingSystem": {
-          "shape": "Sl"
-        },
+        "NewGameSessionProtectionPolicy": {},
+        "OperatingSystem": {},
         "ResourceCreationLimitPolicy": {
           "shape": "S16"
         },
@@ -2581,14 +1885,7 @@
     },
     "S1e": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "AUTO_SCALING"
-        ]
-      },
-      "max": 1,
-      "min": 1
+      "member": {}
     },
     "S1h": {
       "type": "list",
@@ -2599,41 +1896,17 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 32
-          },
-          "Value": {
-            "type": "string",
-            "max": 96
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 16
-    },
-    "S1l": {
-      "type": "string",
-      "max": 48,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9-]+"
-    },
-    "S1m": {
-      "type": "string",
-      "max": 4096,
-      "min": 1
+      }
     },
     "S1o": {
       "type": "structure",
       "members": {
-        "GameSessionId": {
-          "shape": "S4"
-        },
-        "Name": {
-          "shape": "S4"
-        },
-        "FleetId": {
-          "shape": "Sb"
-        },
+        "GameSessionId": {},
+        "Name": {},
+        "FleetId": {},
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2641,65 +1914,25 @@
           "type": "timestamp"
         },
         "CurrentPlayerSessionCount": {
-          "shape": "S17"
+          "type": "integer"
         },
         "MaximumPlayerSessionCount": {
-          "shape": "S17"
+          "type": "integer"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "ACTIVE",
-            "ACTIVATING",
-            "TERMINATED",
-            "TERMINATING",
-            "ERROR"
-          ]
-        },
-        "StatusReason": {
-          "type": "string",
-          "enum": [
-            "INTERRUPTED"
-          ]
-        },
+        "Status": {},
+        "StatusReason": {},
         "GameProperties": {
           "shape": "S1h"
         },
         "IpAddress": {},
         "Port": {
-          "shape": "Sw"
+          "type": "integer"
         },
-        "PlayerSessionCreationPolicy": {
-          "shape": "S1s"
-        },
-        "CreatorId": {
-          "shape": "S4"
-        },
-        "GameSessionData": {
-          "shape": "S1m"
-        },
-        "MatchmakerData": {
-          "shape": "S1t"
-        }
+        "PlayerSessionCreationPolicy": {},
+        "CreatorId": {},
+        "GameSessionData": {},
+        "MatchmakerData": {}
       }
-    },
-    "S1s": {
-      "type": "string",
-      "enum": [
-        "ACCEPT_ALL",
-        "DENY_ALL"
-      ]
-    },
-    "S1t": {
-      "type": "string",
-      "max": 390000,
-      "min": 1
-    },
-    "S1v": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9-]+"
     },
     "S1w": {
       "type": "list",
@@ -2707,10 +1940,10 @@
         "type": "structure",
         "members": {
           "MaximumIndividualPlayerLatencyMilliseconds": {
-            "shape": "S17"
+            "type": "integer"
           },
           "PolicyDurationSeconds": {
-            "shape": "S17"
+            "type": "integer"
           }
         }
       }
@@ -2720,23 +1953,17 @@
       "member": {
         "type": "structure",
         "members": {
-          "DestinationArn": {
-            "shape": "Sg"
-          }
+          "DestinationArn": {}
         }
       }
     },
     "S21": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S1v"
-        },
-        "GameSessionQueueArn": {
-          "shape": "Sg"
-        },
+        "Name": {},
+        "GameSessionQueueArn": {},
         "TimeoutInSeconds": {
-          "shape": "S17"
+          "type": "integer"
         },
         "PlayerLatencyPolicies": {
           "shape": "S1w"
@@ -2748,79 +1975,39 @@
     },
     "S23": {
       "type": "list",
-      "member": {
-        "shape": "Sg"
-      }
-    },
-    "S24": {
-      "type": "integer",
-      "max": 43200,
-      "min": 1
-    },
-    "S25": {
-      "type": "integer",
-      "max": 600,
-      "min": 1
-    },
-    "S27": {
-      "type": "string",
-      "max": 300,
-      "min": 0,
-      "pattern": "[a-zA-Z0-9:_/-]*"
-    },
-    "S28": {
-      "type": "string",
-      "max": 256,
-      "min": 0
+      "member": {}
     },
     "S2a": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S2"
-        },
-        "Description": {
-          "shape": "S4"
-        },
+        "Name": {},
+        "Description": {},
         "GameSessionQueueArns": {
           "shape": "S23"
         },
         "RequestTimeoutSeconds": {
-          "shape": "S24"
+          "type": "integer"
         },
         "AcceptanceTimeoutSeconds": {
-          "shape": "S25"
+          "type": "integer"
         },
         "AcceptanceRequired": {
           "type": "boolean"
         },
-        "RuleSetName": {
-          "shape": "S2"
-        },
-        "NotificationTarget": {
-          "shape": "S27"
-        },
+        "RuleSetName": {},
+        "NotificationTarget": {},
         "AdditionalPlayerCount": {
-          "shape": "S17"
+          "type": "integer"
         },
-        "CustomEventData": {
-          "shape": "S28"
-        },
+        "CustomEventData": {},
         "CreationTime": {
           "type": "timestamp"
         },
         "GameProperties": {
           "shape": "S1h"
         },
-        "GameSessionData": {
-          "shape": "S1m"
-        }
+        "GameSessionData": {}
       }
-    },
-    "S2c": {
-      "type": "string",
-      "max": 65535,
-      "min": 1
     },
     "S2e": {
       "type": "structure",
@@ -2828,64 +2015,33 @@
         "RuleSetBody"
       ],
       "members": {
-        "RuleSetName": {
-          "shape": "S2"
-        },
-        "RuleSetBody": {
-          "shape": "S2c"
-        },
+        "RuleSetName": {},
+        "RuleSetBody": {},
         "CreationTime": {
           "type": "timestamp"
         }
       }
     },
-    "S2g": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
     "S2i": {
       "type": "structure",
       "members": {
-        "PlayerSessionId": {
-          "shape": "S2j"
-        },
-        "PlayerId": {
-          "shape": "S4"
-        },
-        "GameSessionId": {
-          "shape": "S4"
-        },
-        "FleetId": {
-          "shape": "Sb"
-        },
+        "PlayerSessionId": {},
+        "PlayerId": {},
+        "GameSessionId": {},
+        "FleetId": {},
         "CreationTime": {
           "type": "timestamp"
         },
         "TerminationTime": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "RESERVED",
-            "ACTIVE",
-            "COMPLETED",
-            "TIMEDOUT"
-          ]
-        },
+        "Status": {},
         "IpAddress": {},
         "Port": {
-          "shape": "Sw"
+          "type": "integer"
         },
-        "PlayerData": {
-          "shape": "S2g"
-        }
+        "PlayerData": {}
       }
-    },
-    "S2j": {
-      "type": "string",
-      "pattern": "^psess-\\S+"
     },
     "S2p": {
       "type": "list",
@@ -2896,15 +2052,9 @@
     "S2s": {
       "type": "structure",
       "members": {
-        "GameLiftAwsAccountId": {
-          "shape": "S4"
-        },
-        "PeerVpcAwsAccountId": {
-          "shape": "S4"
-        },
-        "PeerVpcId": {
-          "shape": "S4"
-        },
+        "GameLiftAwsAccountId": {},
+        "PeerVpcAwsAccountId": {},
+        "PeerVpcId": {},
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2915,47 +2065,24 @@
     },
     "S3g": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      },
-      "min": 1
+      "member": {}
     },
     "S45": {
       "type": "structure",
       "members": {
-        "PlacementId": {
-          "shape": "S1l"
-        },
-        "GameSessionQueueName": {
-          "shape": "S1v"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "FULFILLED",
-            "CANCELLED",
-            "TIMED_OUT"
-          ]
-        },
+        "PlacementId": {},
+        "GameSessionQueueName": {},
+        "Status": {},
         "GameProperties": {
           "shape": "S1h"
         },
         "MaximumPlayerSessionCount": {
-          "shape": "S17"
+          "type": "integer"
         },
-        "GameSessionName": {
-          "shape": "S4"
-        },
-        "GameSessionId": {
-          "shape": "S4"
-        },
-        "GameSessionArn": {
-          "shape": "S4"
-        },
-        "GameSessionRegion": {
-          "shape": "S4"
-        },
+        "GameSessionName": {},
+        "GameSessionId": {},
+        "GameSessionArn": {},
+        "GameSessionRegion": {},
         "PlayerLatencies": {
           "shape": "S47"
         },
@@ -2967,28 +2094,20 @@
         },
         "IpAddress": {},
         "Port": {
-          "shape": "Sw"
+          "type": "integer"
         },
         "PlacedPlayerSessions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "PlayerId": {
-                "shape": "S4"
-              },
-              "PlayerSessionId": {
-                "shape": "S2j"
-              }
+              "PlayerId": {},
+              "PlayerSessionId": {}
             }
           }
         },
-        "GameSessionData": {
-          "shape": "S1m"
-        },
-        "MatchmakerData": {
-          "shape": "S1t"
-        }
+        "GameSessionData": {},
+        "MatchmakerData": {}
       }
     },
     "S47": {
@@ -2996,12 +2115,8 @@
       "member": {
         "type": "structure",
         "members": {
-          "PlayerId": {
-            "shape": "S4"
-          },
-          "RegionIdentifier": {
-            "shape": "S4"
-          },
+          "PlayerId": {},
+          "RegionIdentifier": {},
           "LatencyInMilliseconds": {
             "type": "float"
           }
@@ -3014,38 +2129,16 @@
         "shape": "S1o"
       }
     },
-    "S4k": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9\\.-]+"
-    },
     "S4q": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "S4t": {
       "type": "structure",
       "members": {
-        "TicketId": {
-          "shape": "S2"
-        },
-        "ConfigurationName": {
-          "shape": "S2"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "CANCELLED",
-            "COMPLETED",
-            "FAILED",
-            "PLACING",
-            "QUEUED",
-            "REQUIRES_ACCEPTANCE",
-            "SEARCHING",
-            "TIMED_OUT"
-          ]
-        },
+        "TicketId": {},
+        "ConfigurationName": {},
+        "Status": {},
         "StatusReason": {},
         "StatusMessage": {},
         "StartTime": {
@@ -3060,31 +2153,25 @@
         "GameSessionConnectionInfo": {
           "type": "structure",
           "members": {
-            "GameSessionArn": {
-              "shape": "Sg"
-            },
+            "GameSessionArn": {},
             "IpAddress": {},
             "Port": {
-              "shape": "S13"
+              "type": "integer"
             },
             "MatchedPlayerSessions": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "PlayerId": {
-                    "shape": "S4"
-                  },
-                  "PlayerSessionId": {
-                    "shape": "S2j"
-                  }
+                  "PlayerId": {},
+                  "PlayerSessionId": {}
                 }
               }
             }
           }
         },
         "EstimatedWaitTime": {
-          "shape": "S17"
+          "type": "integer"
         }
       }
     },
@@ -3093,20 +2180,14 @@
       "member": {
         "type": "structure",
         "members": {
-          "PlayerId": {
-            "shape": "S4"
-          },
+          "PlayerId": {},
           "PlayerAttributes": {
             "type": "map",
-            "key": {
-              "shape": "S4"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "members": {
-                "S": {
-                  "shape": "S4"
-                },
+                "S": {},
                 "N": {
                   "type": "double"
                 },
@@ -3115,9 +2196,7 @@
                 },
                 "SDM": {
                   "type": "map",
-                  "key": {
-                    "shape": "S4"
-                  },
+                  "key": {},
                   "value": {
                     "type": "double"
                   }
@@ -3125,72 +2204,16 @@
               }
             }
           },
-          "Team": {
-            "shape": "S4"
-          },
+          "Team": {},
           "LatencyInMs": {
             "type": "map",
-            "key": {
-              "shape": "Sk"
-            },
+            "key": {},
             "value": {
-              "shape": "S13"
+              "type": "integer"
             }
           }
         }
       }
-    },
-    "S5j": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "UPDATE_REQUESTED",
-        "UPDATING",
-        "DELETE_REQUESTED",
-        "DELETING",
-        "DELETED",
-        "ERROR"
-      ]
-    },
-    "S5o": {
-      "type": "string",
-      "enum": [
-        "ChangeInCapacity",
-        "ExactCapacity",
-        "PercentChangeInCapacity"
-      ]
-    },
-    "S5p": {
-      "type": "string",
-      "enum": [
-        "GreaterThanOrEqualToThreshold",
-        "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold"
-      ]
-    },
-    "S5r": {
-      "type": "string",
-      "enum": [
-        "ActivatingGameSessions",
-        "ActiveGameSessions",
-        "ActiveInstances",
-        "AvailableGameSessions",
-        "AvailablePlayerSessions",
-        "CurrentPlayerSessions",
-        "IdleInstances",
-        "PercentAvailableGameSessions",
-        "PercentIdleInstances",
-        "QueueDepth",
-        "WaitTime"
-      ]
-    },
-    "S5s": {
-      "type": "string",
-      "enum": [
-        "RuleBased",
-        "TargetBased"
-      ]
     },
     "S5t": {
       "type": "structure",

--- a/apis/glacier-2012-06-01.min.json
+++ b/apis/glacier-2012-06-01.min.json
@@ -1200,28 +1200,14 @@
       "members": {
         "JobId": {},
         "JobDescription": {},
-        "Action": {
-          "type": "string",
-          "enum": [
-            "ArchiveRetrieval",
-            "InventoryRetrieval",
-            "Select"
-          ]
-        },
+        "Action": {},
         "ArchiveId": {},
         "VaultARN": {},
         "CreationDate": {},
         "Completed": {
           "type": "boolean"
         },
-        "StatusCode": {
-          "type": "string",
-          "enum": [
-            "InProgress",
-            "Succeeded",
-            "Failed"
-          ]
-        },
+        "StatusCode": {},
         "StatusMessage": {},
         "ArchiveSizeInBytes": {
           "type": "long"
@@ -1263,14 +1249,7 @@
             "csv": {
               "type": "structure",
               "members": {
-                "FileHeaderInfo": {
-                  "type": "string",
-                  "enum": [
-                    "USE",
-                    "IGNORE",
-                    "NONE"
-                  ]
-                },
+                "FileHeaderInfo": {},
                 "Comments": {},
                 "QuoteEscapeCharacter": {},
                 "RecordDelimiter": {},
@@ -1280,12 +1259,7 @@
             }
           }
         },
-        "ExpressionType": {
-          "type": "string",
-          "enum": [
-            "SQL"
-          ]
-        },
+        "ExpressionType": {},
         "Expression": {},
         "OutputSerialization": {
           "type": "structure",
@@ -1293,13 +1267,7 @@
             "csv": {
               "type": "structure",
               "members": {
-                "QuoteFields": {
-                  "type": "string",
-                  "enum": [
-                    "ALWAYS",
-                    "ASNEEDED"
-                  ]
-                },
+                "QuoteFields": {},
                 "QuoteEscapeCharacter": {},
                 "RecordDelimiter": {},
                 "FieldDelimiter": {},
@@ -1321,29 +1289,12 @@
             "Encryption": {
               "type": "structure",
               "members": {
-                "EncryptionType": {
-                  "type": "string",
-                  "enum": [
-                    "aws:kms",
-                    "AES256"
-                  ]
-                },
+                "EncryptionType": {},
                 "KMSKeyId": {},
                 "KMSContext": {}
               }
             },
-            "CannedACL": {
-              "type": "string",
-              "enum": [
-                "private",
-                "public-read",
-                "public-read-write",
-                "aws-exec-read",
-                "authenticated-read",
-                "bucket-owner-read",
-                "bucket-owner-full-control"
-              ]
-            },
+            "CannedACL": {},
             "AccessControlList": {
               "type": "list",
               "member": {
@@ -1355,30 +1306,14 @@
                       "Type"
                     ],
                     "members": {
-                      "Type": {
-                        "type": "string",
-                        "enum": [
-                          "AmazonCustomerByEmail",
-                          "CanonicalUser",
-                          "Group"
-                        ]
-                      },
+                      "Type": {},
                       "DisplayName": {},
                       "URI": {},
                       "ID": {},
                       "EmailAddress": {}
                     }
                   },
-                  "Permission": {
-                    "type": "string",
-                    "enum": [
-                      "FULL_CONTROL",
-                      "WRITE",
-                      "WRITE_ACP",
-                      "READ",
-                      "READ_ACP"
-                    ]
-                  }
+                  "Permission": {}
                 }
               }
             },
@@ -1388,14 +1323,7 @@
             "UserMetadata": {
               "shape": "S17"
             },
-            "StorageClass": {
-              "type": "string",
-              "enum": [
-                "STANDARD",
-                "REDUCED_REDUNDANCY",
-                "STANDARD_IA"
-              ]
-            }
+            "StorageClass": {}
           }
         }
       }

--- a/apis/glue-2017-03-31.min.json
+++ b/apis/glue-2017-03-31.min.json
@@ -21,22 +21,14 @@
           "PartitionInputList"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionInputList": {
             "type": "list",
             "member": {
               "shape": "S5"
-            },
-            "max": 100,
-            "min": 0
+            }
           }
         }
       },
@@ -56,16 +48,10 @@
           "ConnectionNameList"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "ConnectionNameList": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "max": 25,
-            "min": 0
+            "member": {}
           }
         }
       },
@@ -77,9 +63,7 @@
           },
           "Errors": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "shape": "Sx"
             }
@@ -96,22 +80,14 @@
           "PartitionsToDelete"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionsToDelete": {
             "type": "list",
             "member": {
               "shape": "S15"
-            },
-            "max": 25,
-            "min": 0
+            }
           }
         }
       },
@@ -132,19 +108,11 @@
           "TablesToDelete"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
           "TablesToDelete": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           }
         }
       },
@@ -156,9 +124,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {
-                  "shape": "S3"
-                },
+                "TableName": {},
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -177,22 +143,12 @@
           "VersionIds"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "VersionIds": {
             "type": "list",
-            "member": {
-              "shape": "S1e"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           }
         }
       },
@@ -204,12 +160,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "TableName": {
-                  "shape": "S3"
-                },
-                "VersionId": {
-                  "shape": "S1e"
-                },
+                "TableName": {},
+                "VersionId": {},
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -228,15 +180,9 @@
           "PartitionsToGet"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionsToGet": {
             "shape": "S1j"
           }
@@ -262,16 +208,10 @@
           "JobRunIds"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
+          "JobName": {},
           "JobRunIds": {
             "type": "list",
-            "member": {
-              "shape": "S1p"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -283,12 +223,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "JobName": {
-                  "shape": "S3"
-                },
-                "JobRunId": {
-                  "shape": "S1p"
-                }
+                "JobName": {},
+                "JobRunId": {}
               }
             }
           },
@@ -297,12 +233,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "JobName": {
-                  "shape": "S3"
-                },
-                "JobRunId": {
-                  "shape": "S1p"
-                },
+                "JobName": {},
+                "JobRunId": {},
                 "ErrorDetail": {
                   "shape": "Sx"
                 }
@@ -325,15 +257,9 @@
             ],
             "members": {
               "Classification": {},
-              "Name": {
-                "shape": "S3"
-              },
-              "GrokPattern": {
-                "shape": "S1y"
-              },
-              "CustomPatterns": {
-                "shape": "S1z"
-              }
+              "Name": {},
+              "GrokPattern": {},
+              "CustomPatterns": {}
             }
           },
           "XMLClassifier": {
@@ -344,9 +270,7 @@
             ],
             "members": {
               "Classification": {},
-              "Name": {
-                "shape": "S3"
-              },
+              "Name": {},
               "RowTag": {}
             }
           },
@@ -357,9 +281,7 @@
               "JsonPath"
             ],
             "members": {
-              "Name": {
-                "shape": "S3"
-              },
+              "Name": {},
               "JsonPath": {}
             }
           }
@@ -377,9 +299,7 @@
           "ConnectionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "ConnectionInput": {
             "shape": "S26"
           }
@@ -400,14 +320,10 @@
           "Targets"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
+          "Name": {},
           "Role": {},
           "DatabaseName": {},
-          "Description": {
-            "shape": "Sy"
-          },
+          "Description": {},
           "Targets": {
             "shape": "S2h"
           },
@@ -415,16 +331,12 @@
           "Classifiers": {
             "shape": "S2s"
           },
-          "TablePrefix": {
-            "shape": "S2t"
-          },
+          "TablePrefix": {},
           "SchemaChangePolicy": {
             "shape": "S2u"
           },
           "Configuration": {},
-          "CrawlerSecurityConfiguration": {
-            "shape": "S2y"
-          }
+          "CrawlerSecurityConfiguration": {}
         }
       },
       "output": {
@@ -439,9 +351,7 @@
           "DatabaseInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "DatabaseInput": {
             "shape": "S31"
           }
@@ -461,9 +371,7 @@
         ],
         "members": {
           "EndpointName": {},
-          "RoleArn": {
-            "shape": "S36"
-          },
+          "RoleArn": {},
           "SecurityGroupIds": {
             "shape": "S37"
           },
@@ -477,9 +385,7 @@
           },
           "ExtraPythonLibsS3Path": {},
           "ExtraJarsS3Path": {},
-          "SecurityConfiguration": {
-            "shape": "S3"
-          }
+          "SecurityConfiguration": {}
         }
       },
       "output": {
@@ -491,9 +397,7 @@
             "shape": "S37"
           },
           "SubnetId": {},
-          "RoleArn": {
-            "shape": "S36"
-          },
+          "RoleArn": {},
           "YarnEndpointAddress": {},
           "ZeppelinRemoteSparkInterpreterPort": {
             "type": "integer"
@@ -506,9 +410,7 @@
           "ExtraPythonLibsS3Path": {},
           "ExtraJarsS3Path": {},
           "FailureReason": {},
-          "SecurityConfiguration": {
-            "shape": "S3"
-          },
+          "SecurityConfiguration": {},
           "CreatedTimestamp": {
             "type": "timestamp"
           }
@@ -524,12 +426,8 @@
           "Command"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
-          "Description": {
-            "shape": "Sy"
-          },
+          "Name": {},
+          "Description": {},
           "LogUri": {},
           "Role": {},
           "ExecutionProperty": {
@@ -551,22 +449,18 @@
             "type": "integer"
           },
           "Timeout": {
-            "shape": "S3m"
+            "type": "integer"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {
-            "shape": "S3"
-          }
+          "SecurityConfiguration": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       }
     },
@@ -579,15 +473,9 @@
           "PartitionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionInput": {
             "shape": "S5"
           }
@@ -608,9 +496,7 @@
           "DagEdges": {
             "shape": "S41"
           },
-          "Language": {
-            "shape": "S43"
-          }
+          "Language": {}
         }
       },
       "output": {
@@ -629,9 +515,7 @@
           "EncryptionConfiguration"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
+          "Name": {},
           "EncryptionConfiguration": {
             "shape": "S48"
           }
@@ -640,9 +524,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
+          "Name": {},
           "CreatedTimestamp": {
             "type": "timestamp"
           }
@@ -657,12 +539,8 @@
           "TableInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
           "TableInput": {
             "shape": "S4j"
           }
@@ -682,12 +560,8 @@
           "Actions"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
-          "Type": {
-            "shape": "S4p"
-          },
+          "Name": {},
+          "Type": {},
           "Schedule": {},
           "Predicate": {
             "shape": "S4q"
@@ -695,9 +569,7 @@
           "Actions": {
             "shape": "S4w"
           },
-          "Description": {
-            "shape": "Sy"
-          },
+          "Description": {},
           "StartOnCreation": {
             "type": "boolean"
           }
@@ -706,9 +578,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       }
     },
@@ -720,12 +590,8 @@
           "FunctionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
           "FunctionInput": {
             "shape": "S51"
           }
@@ -743,9 +609,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -760,12 +624,8 @@
           "ConnectionName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "ConnectionName": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "ConnectionName": {}
         }
       },
       "output": {
@@ -780,9 +640,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -797,12 +655,8 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "Name": {}
         }
       },
       "output": {
@@ -832,17 +686,13 @@
           "JobName"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          }
+          "JobName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobName": {
-            "shape": "S3"
-          }
+          "JobName": {}
         }
       }
     },
@@ -855,15 +705,9 @@
           "PartitionValues"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionValues": {
             "shape": "S6"
           }
@@ -881,9 +725,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -899,15 +741,9 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "Name": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "Name": {}
         }
       },
       "output": {
@@ -924,18 +760,10 @@
           "VersionId"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
-          "VersionId": {
-            "shape": "S1e"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
+          "VersionId": {}
         }
       },
       "output": {
@@ -950,17 +778,13 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       }
     },
@@ -972,15 +796,9 @@
           "FunctionName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "FunctionName": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "FunctionName": {}
         }
       },
       "output": {
@@ -992,9 +810,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          }
+          "CatalogId": {}
         }
       },
       "output": {
@@ -1009,9 +825,7 @@
               "ImportTime": {
                 "type": "timestamp"
               },
-              "ImportedBy": {
-                "shape": "S3"
-              }
+              "ImportedBy": {}
             }
           }
         }
@@ -1024,9 +838,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1043,7 +855,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1068,12 +880,8 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "Name": {}
         }
       },
       "output": {
@@ -1089,23 +897,19 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "Filter": {
             "type": "structure",
             "members": {
               "MatchCriteria": {
                 "shape": "S28"
               },
-              "ConnectionType": {
-                "shape": "S27"
-              }
+              "ConnectionType": {}
             }
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1129,9 +933,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1149,14 +951,10 @@
         "members": {
           "CrawlerNameList": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           },
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1169,29 +967,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "CrawlerName": {
-                  "shape": "S3"
-                },
+                "CrawlerName": {},
                 "TimeLeftSeconds": {
-                  "shape": "S6y"
+                  "type": "double"
                 },
                 "StillEstimating": {
                   "type": "boolean"
                 },
                 "LastRuntimeSeconds": {
-                  "shape": "S6y"
+                  "type": "double"
                 },
                 "MedianRuntimeSeconds": {
-                  "shape": "S6y"
+                  "type": "double"
                 },
                 "TablesCreated": {
-                  "shape": "S4k"
+                  "type": "integer"
                 },
                 "TablesUpdated": {
-                  "shape": "S4k"
+                  "type": "integer"
                 },
                 "TablesDeleted": {
-                  "shape": "S4k"
+                  "type": "integer"
                 }
               }
             }
@@ -1205,7 +1001,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1230,12 +1026,8 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "Name": {}
         }
       },
       "output": {
@@ -1251,12 +1043,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1319,7 +1109,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1344,9 +1134,7 @@
           "JobName"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          }
+          "JobName": {}
         }
       },
       "output": {
@@ -1366,12 +1154,8 @@
           "RunId"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
-          "RunId": {
-            "shape": "S1p"
-          },
+          "JobName": {},
+          "RunId": {},
           "PredecessorsIncluded": {
             "type": "boolean"
           }
@@ -1393,12 +1177,10 @@
           "JobName"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
+          "JobName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1421,7 +1203,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1477,15 +1259,9 @@
           "PartitionValues"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionValues": {
             "shape": "S6"
           }
@@ -1508,21 +1284,10 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
-          "Expression": {
-            "type": "string",
-            "max": 2048,
-            "min": 0,
-            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
+          "Expression": {},
           "NextToken": {},
           "Segment": {
             "type": "structure",
@@ -1532,17 +1297,15 @@
             ],
             "members": {
               "SegmentNumber": {
-                "shape": "S4k"
+                "type": "integer"
               },
               "TotalSegments": {
-                "type": "integer",
-                "max": 10,
-                "min": 1
+                "type": "integer"
               }
             }
           },
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1576,9 +1339,7 @@
           "Location": {
             "shape": "S80"
           },
-          "Language": {
-            "shape": "S43"
-          }
+          "Language": {}
         }
       },
       "output": {
@@ -1596,9 +1357,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1615,7 +1374,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1641,15 +1400,9 @@
           "Name"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "Name": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "Name": {}
         }
       },
       "output": {
@@ -1669,18 +1422,10 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
-          "VersionId": {
-            "shape": "S1e"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
+          "VersionId": {}
         }
       },
       "output": {
@@ -1700,18 +1445,12 @@
           "TableName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1735,21 +1474,12 @@
           "DatabaseName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "Expression": {
-            "type": "string",
-            "max": 2048,
-            "min": 0,
-            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "Expression": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1773,9 +1503,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1792,11 +1520,9 @@
         "type": "structure",
         "members": {
           "NextToken": {},
-          "DependentJobName": {
-            "shape": "S3"
-          },
+          "DependentJobName": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1821,15 +1547,9 @@
           "FunctionName"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "FunctionName": {
-            "shape": "S3"
-          }
+          "CatalogId": {},
+          "DatabaseName": {},
+          "FunctionName": {}
         }
       },
       "output": {
@@ -1849,18 +1569,12 @@
           "Pattern"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "Pattern": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "Pattern": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S66"
+            "type": "integer"
           }
         }
       },
@@ -1881,9 +1595,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          }
+          "CatalogId": {}
         }
       },
       "output": {
@@ -1898,9 +1610,7 @@
           "DataCatalogEncryptionSettings"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
+          "CatalogId": {},
           "DataCatalogEncryptionSettings": {
             "type": "structure",
             "members": {
@@ -1910,16 +1620,8 @@
                   "CatalogEncryptionMode"
                 ],
                 "members": {
-                  "CatalogEncryptionMode": {
-                    "type": "string",
-                    "enum": [
-                      "DISABLED",
-                      "SSE-KMS"
-                    ]
-                  },
-                  "SseAwsKmsKeyId": {
-                    "shape": "S3"
-                  }
+                  "CatalogEncryptionMode": {},
+                  "SseAwsKmsKeyId": {}
                 }
               }
             }
@@ -1970,9 +1672,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1987,9 +1687,7 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {
-            "shape": "S3"
-          }
+          "CrawlerName": {}
         }
       },
       "output": {
@@ -2004,12 +1702,8 @@
           "JobName"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
-          "JobRunId": {
-            "shape": "S1p"
-          },
+          "JobName": {},
+          "JobRunId": {},
           "Arguments": {
             "shape": "S3j"
           },
@@ -2017,22 +1711,18 @@
             "type": "integer"
           },
           "Timeout": {
-            "shape": "S3m"
+            "type": "integer"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {
-            "shape": "S3"
-          }
+          "SecurityConfiguration": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobRunId": {
-            "shape": "S1p"
-          }
+          "JobRunId": {}
         }
       }
     },
@@ -2043,17 +1733,13 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       }
     },
@@ -2064,9 +1750,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -2081,9 +1765,7 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {
-            "shape": "S3"
-          }
+          "CrawlerName": {}
         }
       },
       "output": {
@@ -2098,17 +1780,13 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S3"
-          }
+          "Name": {}
         }
       }
     },
@@ -2122,16 +1800,10 @@
               "Name"
             ],
             "members": {
-              "Name": {
-                "shape": "S3"
-              },
+              "Name": {},
               "Classification": {},
-              "GrokPattern": {
-                "shape": "S1y"
-              },
-              "CustomPatterns": {
-                "shape": "S1z"
-              }
+              "GrokPattern": {},
+              "CustomPatterns": {}
             }
           },
           "XMLClassifier": {
@@ -2140,9 +1812,7 @@
               "Name"
             ],
             "members": {
-              "Name": {
-                "shape": "S3"
-              },
+              "Name": {},
               "Classification": {},
               "RowTag": {}
             }
@@ -2153,9 +1823,7 @@
               "Name"
             ],
             "members": {
-              "Name": {
-                "shape": "S3"
-              },
+              "Name": {},
               "JsonPath": {}
             }
           }
@@ -2174,12 +1842,8 @@
           "ConnectionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "Name": {},
           "ConnectionInput": {
             "shape": "S26"
           }
@@ -2197,17 +1861,10 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
+          "Name": {},
           "Role": {},
           "DatabaseName": {},
-          "Description": {
-            "type": "string",
-            "max": 2048,
-            "min": 0,
-            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-          },
+          "Description": {},
           "Targets": {
             "shape": "S2h"
           },
@@ -2215,16 +1872,12 @@
           "Classifiers": {
             "shape": "S2s"
           },
-          "TablePrefix": {
-            "shape": "S2t"
-          },
+          "TablePrefix": {},
           "SchemaChangePolicy": {
             "shape": "S2u"
           },
           "Configuration": {},
-          "CrawlerSecurityConfiguration": {
-            "shape": "S2y"
-          }
+          "CrawlerSecurityConfiguration": {}
         }
       },
       "output": {
@@ -2239,9 +1892,7 @@
           "CrawlerName"
         ],
         "members": {
-          "CrawlerName": {
-            "shape": "S3"
-          },
+          "CrawlerName": {},
           "Schedule": {}
         }
       },
@@ -2258,12 +1909,8 @@
           "DatabaseInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "Name": {},
           "DatabaseInput": {
             "shape": "S31"
           }
@@ -2314,15 +1961,11 @@
           "JobUpdate"
         ],
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
+          "JobName": {},
           "JobUpdate": {
             "type": "structure",
             "members": {
-              "Description": {
-                "shape": "Sy"
-              },
+              "Description": {},
               "LogUri": {},
               "Role": {},
               "ExecutionProperty": {
@@ -2344,14 +1987,12 @@
                 "type": "integer"
               },
               "Timeout": {
-                "shape": "S3m"
+                "type": "integer"
               },
               "NotificationProperty": {
                 "shape": "S3n"
               },
-              "SecurityConfiguration": {
-                "shape": "S3"
-              }
+              "SecurityConfiguration": {}
             }
           }
         }
@@ -2359,9 +2000,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "JobName": {
-            "shape": "S3"
-          }
+          "JobName": {}
         }
       }
     },
@@ -2375,22 +2014,12 @@
           "PartitionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "TableName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "TableName": {},
           "PartitionValueList": {
             "type": "list",
-            "member": {
-              "shape": "S7"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           },
           "PartitionInput": {
             "shape": "S5"
@@ -2410,12 +2039,8 @@
           "TableInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
           "TableInput": {
             "shape": "S4j"
           },
@@ -2437,18 +2062,12 @@
           "TriggerUpdate"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
+          "Name": {},
           "TriggerUpdate": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "S3"
-              },
-              "Description": {
-                "shape": "Sy"
-              },
+              "Name": {},
+              "Description": {},
               "Schedule": {},
               "Actions": {
                 "shape": "S4w"
@@ -2478,15 +2097,9 @@
           "FunctionInput"
         ],
         "members": {
-          "CatalogId": {
-            "shape": "S2"
-          },
-          "DatabaseName": {
-            "shape": "S3"
-          },
-          "FunctionName": {
-            "shape": "S3"
-          },
+          "CatalogId": {},
+          "DatabaseName": {},
+          "FunctionName": {},
           "FunctionInput": {
             "shape": "S51"
           }
@@ -2499,18 +2112,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-    },
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-    },
     "S5": {
       "type": "structure",
       "members": {
@@ -2533,13 +2134,7 @@
     },
     "S6": {
       "type": "list",
-      "member": {
-        "shape": "S7"
-      }
-    },
-    "S7": {
-      "type": "string",
-      "max": 1024
+      "member": {}
     },
     "S9": {
       "type": "structure",
@@ -2547,17 +2142,9 @@
         "Columns": {
           "shape": "Sa"
         },
-        "Location": {
-          "type": "string",
-          "max": 2056,
-          "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-        },
-        "InputFormat": {
-          "shape": "Sf"
-        },
-        "OutputFormat": {
-          "shape": "Sf"
-        },
+        "Location": {},
+        "InputFormat": {},
+        "OutputFormat": {},
         "Compressed": {
           "type": "boolean"
         },
@@ -2567,12 +2154,8 @@
         "SerdeInfo": {
           "type": "structure",
           "members": {
-            "Name": {
-              "shape": "S3"
-            },
-            "SerializationLibrary": {
-              "shape": "S3"
-            },
+            "Name": {},
+            "SerializationLibrary": {},
             "Parameters": {
               "shape": "Sj"
             }
@@ -2590,13 +2173,9 @@
               "SortOrder"
             ],
             "members": {
-              "Column": {
-                "shape": "S3"
-              },
+              "Column": {},
               "SortOrder": {
-                "type": "integer",
-                "max": 1,
-                "min": 0
+                "type": "integer"
               }
             }
           }
@@ -2634,47 +2213,20 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S3"
-          },
-          "Type": {
-            "type": "string",
-            "max": 131072,
-            "min": 0,
-            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-          },
-          "Comment": {
-            "type": "string",
-            "max": 255,
-            "min": 0,
-            "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-          }
+          "Name": {},
+          "Type": {},
+          "Comment": {}
         }
       }
     },
-    "Sf": {
-      "type": "string",
-      "max": 128,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-    },
     "Sj": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 255,
-        "min": 1,
-        "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-      },
-      "value": {
-        "type": "string",
-        "max": 512000
-      }
+      "key": {},
+      "value": {}
     },
     "Sm": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
+      "member": {}
     },
     "Sv": {
       "type": "list",
@@ -2693,19 +2245,9 @@
     "Sx": {
       "type": "structure",
       "members": {
-        "ErrorCode": {
-          "shape": "S3"
-        },
-        "ErrorMessage": {
-          "shape": "Sy"
-        }
+        "ErrorCode": {},
+        "ErrorMessage": {}
       }
-    },
-    "Sy": {
-      "type": "string",
-      "max": 2048,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
     },
     "S15": {
       "type": "structure",
@@ -2718,19 +2260,11 @@
         }
       }
     },
-    "S1e": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-    },
     "S1j": {
       "type": "list",
       "member": {
         "shape": "S15"
-      },
-      "max": 1000,
-      "min": 0
+      }
     },
     "S1l": {
       "type": "list",
@@ -2744,12 +2278,8 @@
         "Values": {
           "shape": "S6"
         },
-        "DatabaseName": {
-          "shape": "S3"
-        },
-        "TableName": {
-          "shape": "S3"
-        },
+        "DatabaseName": {},
+        "TableName": {},
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2767,24 +2297,6 @@
         }
       }
     },
-    "S1p": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-    },
-    "S1y": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\t]*"
-    },
-    "S1z": {
-      "type": "string",
-      "max": 16000,
-      "min": 0,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
     "S26": {
       "type": "structure",
       "required": [
@@ -2793,15 +2305,9 @@
         "ConnectionProperties"
       ],
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "ConnectionType": {
-          "shape": "S27"
-        },
+        "Name": {},
+        "Description": {},
+        "ConnectionType": {},
         "MatchCriteria": {
           "shape": "S28"
         },
@@ -2813,63 +2319,24 @@
         }
       }
     },
-    "S27": {
-      "type": "string",
-      "enum": [
-        "JDBC",
-        "SFTP"
-      ]
-    },
     "S28": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 10,
-      "min": 0
+      "member": {}
     },
     "S29": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "HOST",
-          "PORT",
-          "USERNAME",
-          "PASSWORD",
-          "JDBC_DRIVER_JAR_URI",
-          "JDBC_DRIVER_CLASS_NAME",
-          "JDBC_ENGINE",
-          "JDBC_ENGINE_VERSION",
-          "CONFIG_FILES",
-          "INSTANCE_ID",
-          "JDBC_CONNECTION_URL",
-          "JDBC_ENFORCE_SSL"
-        ]
-      },
-      "value": {
-        "shape": "S7"
-      },
-      "max": 100,
-      "min": 0
+      "key": {},
+      "value": {}
     },
     "S2b": {
       "type": "structure",
       "members": {
-        "SubnetId": {
-          "shape": "S3"
-        },
+        "SubnetId": {},
         "SecurityGroupIdList": {
           "type": "list",
-          "member": {
-            "shape": "S3"
-          },
-          "max": 50,
-          "min": 0
+          "member": {}
         },
-        "AvailabilityZone": {
-          "shape": "S3"
-        }
+        "AvailabilityZone": {}
       }
     },
     "S2h": {
@@ -2917,39 +2384,14 @@
     },
     "S2s": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
-    },
-    "S2t": {
-      "type": "string",
-      "max": 128,
-      "min": 0
+      "member": {}
     },
     "S2u": {
       "type": "structure",
       "members": {
-        "UpdateBehavior": {
-          "type": "string",
-          "enum": [
-            "LOG",
-            "UPDATE_IN_DATABASE"
-          ]
-        },
-        "DeleteBehavior": {
-          "type": "string",
-          "enum": [
-            "LOG",
-            "DELETE_FROM_DATABASE",
-            "DEPRECATE_IN_DATABASE"
-          ]
-        }
+        "UpdateBehavior": {},
+        "DeleteBehavior": {}
       }
-    },
-    "S2y": {
-      "type": "string",
-      "max": 128,
-      "min": 0
     },
     "S31": {
       "type": "structure",
@@ -2957,29 +2399,13 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "LocationUri": {
-          "shape": "S32"
-        },
+        "Name": {},
+        "Description": {},
+        "LocationUri": {},
         "Parameters": {
           "shape": "Sj"
         }
       }
-    },
-    "S32": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]*"
-    },
-    "S36": {
-      "type": "string",
-      "pattern": "arn:aws:iam::\\d{12}:role/.*"
     },
     "S37": {
       "type": "list",
@@ -2987,8 +2413,7 @@
     },
     "S38": {
       "type": "list",
-      "member": {},
-      "max": 5
+      "member": {}
     },
     "S3f": {
       "type": "structure",
@@ -3018,16 +2443,11 @@
         }
       }
     },
-    "S3m": {
-      "type": "integer",
-      "min": 1
-    },
     "S3n": {
       "type": "structure",
       "members": {
         "NotifyDelayAfter": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -3041,9 +2461,7 @@
           "Args"
         ],
         "members": {
-          "Id": {
-            "shape": "S3v"
-          },
+          "Id": {},
           "NodeType": {},
           "Args": {
             "shape": "S3x"
@@ -3053,12 +2471,6 @@
           }
         }
       }
-    },
-    "S3v": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[A-Za-z_][A-Za-z0-9_]*"
     },
     "S3x": {
       "type": "list",
@@ -3075,9 +2487,7 @@
             "type": "boolean"
           }
         }
-      },
-      "max": 50,
-      "min": 0
+      }
     },
     "S41": {
       "type": "list",
@@ -3088,22 +2498,11 @@
           "Target"
         ],
         "members": {
-          "Source": {
-            "shape": "S3v"
-          },
-          "Target": {
-            "shape": "S3v"
-          },
+          "Source": {},
+          "Target": {},
           "TargetParameter": {}
         }
       }
-    },
-    "S43": {
-      "type": "string",
-      "enum": [
-        "PYTHON",
-        "SCALA"
-      ]
     },
     "S48": {
       "type": "structure",
@@ -3113,55 +2512,26 @@
           "member": {
             "type": "structure",
             "members": {
-              "S3EncryptionMode": {
-                "type": "string",
-                "enum": [
-                  "DISABLED",
-                  "SSE-KMS",
-                  "SSE-S3"
-                ]
-              },
-              "KmsKeyArn": {
-                "shape": "S4c"
-              }
+              "S3EncryptionMode": {},
+              "KmsKeyArn": {}
             }
           }
         },
         "CloudWatchEncryption": {
           "type": "structure",
           "members": {
-            "CloudWatchEncryptionMode": {
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "SSE-KMS"
-              ]
-            },
-            "KmsKeyArn": {
-              "shape": "S4c"
-            }
+            "CloudWatchEncryptionMode": {},
+            "KmsKeyArn": {}
           }
         },
         "JobBookmarksEncryption": {
           "type": "structure",
           "members": {
-            "JobBookmarksEncryptionMode": {
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "CSE-KMS"
-              ]
-            },
-            "KmsKeyArn": {
-              "shape": "S4c"
-            }
+            "JobBookmarksEncryptionMode": {},
+            "KmsKeyArn": {}
           }
         }
       }
-    },
-    "S4c": {
-      "type": "string",
-      "pattern": "arn:aws:kms:.*"
     },
     "S4j": {
       "type": "structure",
@@ -3169,15 +2539,9 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "Owner": {
-          "shape": "S3"
-        },
+        "Name": {},
+        "Description": {},
+        "Owner": {},
         "LastAccessTime": {
           "type": "timestamp"
         },
@@ -3185,7 +2549,7 @@
           "type": "timestamp"
         },
         "Retention": {
-          "shape": "S4k"
+          "type": "integer"
         },
         "StorageDescriptor": {
           "shape": "S9"
@@ -3193,155 +2557,71 @@
         "PartitionKeys": {
           "shape": "Sa"
         },
-        "ViewOriginalText": {
-          "shape": "S4l"
-        },
-        "ViewExpandedText": {
-          "shape": "S4l"
-        },
-        "TableType": {
-          "shape": "S4m"
-        },
+        "ViewOriginalText": {},
+        "ViewExpandedText": {},
+        "TableType": {},
         "Parameters": {
           "shape": "Sj"
         }
       }
     },
-    "S4k": {
-      "type": "integer",
-      "min": 0
-    },
-    "S4l": {
-      "type": "string",
-      "max": 409600
-    },
-    "S4m": {
-      "type": "string",
-      "max": 255
-    },
-    "S4p": {
-      "type": "string",
-      "enum": [
-        "SCHEDULED",
-        "CONDITIONAL",
-        "ON_DEMAND"
-      ]
-    },
     "S4q": {
       "type": "structure",
       "members": {
-        "Logical": {
-          "type": "string",
-          "enum": [
-            "AND",
-            "ANY"
-          ]
-        },
+        "Logical": {},
         "Conditions": {
           "type": "list",
           "member": {
             "type": "structure",
             "members": {
-              "LogicalOperator": {
-                "type": "string",
-                "enum": [
-                  "EQUALS"
-                ]
-              },
-              "JobName": {
-                "shape": "S3"
-              },
-              "State": {
-                "shape": "S4v"
-              }
+              "LogicalOperator": {},
+              "JobName": {},
+              "State": {}
             }
           }
         }
       }
-    },
-    "S4v": {
-      "type": "string",
-      "enum": [
-        "STARTING",
-        "RUNNING",
-        "STOPPING",
-        "STOPPED",
-        "SUCCEEDED",
-        "FAILED",
-        "TIMEOUT"
-      ]
     },
     "S4w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "JobName": {
-            "shape": "S3"
-          },
+          "JobName": {},
           "Arguments": {
             "shape": "S3j"
           },
           "Timeout": {
-            "shape": "S3m"
+            "type": "integer"
           },
           "NotificationProperty": {
             "shape": "S3n"
           },
-          "SecurityConfiguration": {
-            "shape": "S3"
-          }
+          "SecurityConfiguration": {}
         }
       }
     },
     "S51": {
       "type": "structure",
       "members": {
-        "FunctionName": {
-          "shape": "S3"
-        },
-        "ClassName": {
-          "shape": "S3"
-        },
-        "OwnerName": {
-          "shape": "S3"
-        },
-        "OwnerType": {
-          "shape": "S52"
-        },
+        "FunctionName": {},
+        "ClassName": {},
+        "OwnerName": {},
+        "OwnerType": {},
         "ResourceUris": {
           "shape": "S53"
         }
       }
-    },
-    "S52": {
-      "type": "string",
-      "enum": [
-        "USER",
-        "ROLE",
-        "GROUP"
-      ]
     },
     "S53": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceType": {
-            "type": "string",
-            "enum": [
-              "JAR",
-              "FILE",
-              "ARCHIVE"
-            ]
-          },
-          "Uri": {
-            "shape": "S32"
-          }
+          "ResourceType": {},
+          "Uri": {}
         }
-      },
-      "max": 1000,
-      "min": 0
+      }
     },
     "S60": {
       "type": "structure",
@@ -3354,9 +2634,7 @@
             "GrokPattern"
           ],
           "members": {
-            "Name": {
-              "shape": "S3"
-            },
+            "Name": {},
             "Classification": {},
             "CreationTime": {
               "type": "timestamp"
@@ -3367,12 +2645,8 @@
             "Version": {
               "type": "long"
             },
-            "GrokPattern": {
-              "shape": "S1y"
-            },
-            "CustomPatterns": {
-              "shape": "S1z"
-            }
+            "GrokPattern": {},
+            "CustomPatterns": {}
           }
         },
         "XMLClassifier": {
@@ -3382,9 +2656,7 @@
             "Classification"
           ],
           "members": {
-            "Name": {
-              "shape": "S3"
-            },
+            "Name": {},
             "Classification": {},
             "CreationTime": {
               "type": "timestamp"
@@ -3405,9 +2677,7 @@
             "JsonPath"
           ],
           "members": {
-            "Name": {
-              "shape": "S3"
-            },
+            "Name": {},
             "CreationTime": {
               "type": "timestamp"
             },
@@ -3422,23 +2692,12 @@
         }
       }
     },
-    "S66": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
     "S6c": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "ConnectionType": {
-          "shape": "S27"
-        },
+        "Name": {},
+        "Description": {},
+        "ConnectionType": {},
         "MatchCriteria": {
           "shape": "S28"
         },
@@ -3454,54 +2713,32 @@
         "LastUpdatedTime": {
           "type": "timestamp"
         },
-        "LastUpdatedBy": {
-          "shape": "S3"
-        }
+        "LastUpdatedBy": {}
       }
     },
     "S6j": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
+        "Name": {},
         "Role": {},
         "Targets": {
           "shape": "S2h"
         },
         "DatabaseName": {},
-        "Description": {
-          "shape": "Sy"
-        },
+        "Description": {},
         "Classifiers": {
           "shape": "S2s"
         },
         "SchemaChangePolicy": {
           "shape": "S2u"
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "READY",
-            "RUNNING",
-            "STOPPING"
-          ]
-        },
-        "TablePrefix": {
-          "shape": "S2t"
-        },
+        "State": {},
+        "TablePrefix": {},
         "Schedule": {
           "type": "structure",
           "members": {
             "ScheduleExpression": {},
-            "State": {
-              "type": "string",
-              "enum": [
-                "SCHEDULED",
-                "NOT_SCHEDULED",
-                "TRANSITIONING"
-              ]
-            }
+            "State": {}
           }
         },
         "CrawlElapsedTime": {
@@ -3516,35 +2753,11 @@
         "LastCrawl": {
           "type": "structure",
           "members": {
-            "Status": {
-              "type": "string",
-              "enum": [
-                "SUCCEEDED",
-                "CANCELLED",
-                "FAILED"
-              ]
-            },
-            "ErrorMessage": {
-              "shape": "Sy"
-            },
-            "LogGroup": {
-              "type": "string",
-              "max": 512,
-              "min": 1,
-              "pattern": "[\\.\\-_/#A-Za-z0-9]+"
-            },
-            "LogStream": {
-              "type": "string",
-              "max": 512,
-              "min": 1,
-              "pattern": "[^:*]*"
-            },
-            "MessagePrefix": {
-              "type": "string",
-              "max": 255,
-              "min": 1,
-              "pattern": "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\t]*"
-            },
+            "Status": {},
+            "ErrorMessage": {},
+            "LogGroup": {},
+            "LogStream": {},
+            "MessagePrefix": {},
             "StartTime": {
               "type": "timestamp"
             }
@@ -3554,14 +2767,8 @@
           "type": "long"
         },
         "Configuration": {},
-        "CrawlerSecurityConfiguration": {
-          "shape": "S2y"
-        }
+        "CrawlerSecurityConfiguration": {}
       }
-    },
-    "S6y": {
-      "type": "double",
-      "min": 0
     },
     "S74": {
       "type": "structure",
@@ -3569,15 +2776,9 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "LocationUri": {
-          "shape": "S32"
-        },
+        "Name": {},
+        "Description": {},
+        "LocationUri": {},
         "Parameters": {
           "shape": "Sj"
         },
@@ -3590,9 +2791,7 @@
       "type": "structure",
       "members": {
         "EndpointName": {},
-        "RoleArn": {
-          "shape": "S36"
-        },
+        "RoleArn": {},
         "SecurityGroupIds": {
           "shape": "S37"
         },
@@ -3623,20 +2822,14 @@
         "PublicKeys": {
           "shape": "S38"
         },
-        "SecurityConfiguration": {
-          "shape": "S3"
-        }
+        "SecurityConfiguration": {}
       }
     },
     "S7i": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
+        "Name": {},
+        "Description": {},
         "LogUri": {},
         "Role": {},
         "CreatedOn": {
@@ -3664,34 +2857,24 @@
           "type": "integer"
         },
         "Timeout": {
-          "shape": "S3m"
+          "type": "integer"
         },
         "NotificationProperty": {
           "shape": "S3n"
         },
-        "SecurityConfiguration": {
-          "shape": "S3"
-        }
+        "SecurityConfiguration": {}
       }
     },
     "S7l": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S1p"
-        },
+        "Id": {},
         "Attempt": {
           "type": "integer"
         },
-        "PreviousRunId": {
-          "shape": "S1p"
-        },
-        "TriggerName": {
-          "shape": "S3"
-        },
-        "JobName": {
-          "shape": "S3"
-        },
+        "PreviousRunId": {},
+        "TriggerName": {},
+        "JobName": {},
         "StartedOn": {
           "type": "timestamp"
         },
@@ -3701,9 +2884,7 @@
         "CompletedOn": {
           "type": "timestamp"
         },
-        "JobRunState": {
-          "shape": "S4v"
-        },
+        "JobRunState": {},
         "Arguments": {
           "shape": "S3j"
         },
@@ -3713,12 +2894,8 @@
           "member": {
             "type": "structure",
             "members": {
-              "JobName": {
-                "shape": "S3"
-              },
-              "RunId": {
-                "shape": "S1p"
-              }
+              "JobName": {},
+              "RunId": {}
             }
           }
         },
@@ -3729,14 +2906,12 @@
           "type": "integer"
         },
         "Timeout": {
-          "shape": "S3m"
+          "type": "integer"
         },
         "NotificationProperty": {
           "shape": "S3n"
         },
-        "SecurityConfiguration": {
-          "shape": "S3"
-        },
+        "SecurityConfiguration": {},
         "LogGroupName": {}
       }
     },
@@ -3747,12 +2922,8 @@
         "TableName"
       ],
       "members": {
-        "DatabaseName": {
-          "shape": "S3"
-        },
-        "TableName": {
-          "shape": "S3"
-        }
+        "DatabaseName": {},
+        "TableName": {}
       }
     },
     "S7z": {
@@ -3792,9 +2963,7 @@
     "S8i": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
+        "Name": {},
         "CreatedTimeStamp": {
           "type": "timestamp"
         },
@@ -3809,18 +2978,10 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "DatabaseName": {
-          "shape": "S3"
-        },
-        "Description": {
-          "shape": "Sy"
-        },
-        "Owner": {
-          "shape": "S3"
-        },
+        "Name": {},
+        "DatabaseName": {},
+        "Description": {},
+        "Owner": {},
         "CreateTime": {
           "type": "timestamp"
         },
@@ -3834,7 +2995,7 @@
           "type": "timestamp"
         },
         "Retention": {
-          "shape": "S4k"
+          "type": "integer"
         },
         "StorageDescriptor": {
           "shape": "S9"
@@ -3842,21 +3003,13 @@
         "PartitionKeys": {
           "shape": "Sa"
         },
-        "ViewOriginalText": {
-          "shape": "S4l"
-        },
-        "ViewExpandedText": {
-          "shape": "S4l"
-        },
-        "TableType": {
-          "shape": "S4m"
-        },
+        "ViewOriginalText": {},
+        "ViewExpandedText": {},
+        "TableType": {},
         "Parameters": {
           "shape": "Sj"
         },
-        "CreatedBy": {
-          "shape": "S3"
-        }
+        "CreatedBy": {}
       }
     },
     "S8r": {
@@ -3865,39 +3018,17 @@
         "Table": {
           "shape": "S8o"
         },
-        "VersionId": {
-          "shape": "S1e"
-        }
+        "VersionId": {}
       }
     },
     "S91": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3"
-        },
-        "Id": {
-          "shape": "S1p"
-        },
-        "Type": {
-          "shape": "S4p"
-        },
-        "State": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "CREATED",
-            "ACTIVATING",
-            "ACTIVATED",
-            "DEACTIVATING",
-            "DEACTIVATED",
-            "DELETING",
-            "UPDATING"
-          ]
-        },
-        "Description": {
-          "shape": "Sy"
-        },
+        "Name": {},
+        "Id": {},
+        "Type": {},
+        "State": {},
+        "Description": {},
         "Schedule": {},
         "Actions": {
           "shape": "S4w"
@@ -3910,18 +3041,10 @@
     "S98": {
       "type": "structure",
       "members": {
-        "FunctionName": {
-          "shape": "S3"
-        },
-        "ClassName": {
-          "shape": "S3"
-        },
-        "OwnerName": {
-          "shape": "S3"
-        },
-        "OwnerType": {
-          "shape": "S52"
-        },
+        "FunctionName": {},
+        "ClassName": {},
+        "OwnerName": {},
+        "OwnerType": {},
         "CreateTime": {
           "type": "timestamp"
         },

--- a/apis/greengrass-2017-06-07.min.json
+++ b/apis/greengrass-2017-06-07.min.json
@@ -133,9 +133,7 @@
             "locationName": "X-Amzn-Client-Token"
           },
           "DeploymentId": {},
-          "DeploymentType": {
-            "shape": "Sf"
-          },
+          "DeploymentType": {},
           "GroupId": {
             "location": "uri",
             "locationName": "GroupId"
@@ -523,46 +521,14 @@
             "locationName": "X-Amzn-Client-Token"
           },
           "S3UrlSignerRole": {},
-          "SoftwareToUpdate": {
-            "type": "string",
-            "enum": [
-              "core",
-              "ota_agent"
-            ]
-          },
-          "UpdateAgentLogLevel": {
-            "type": "string",
-            "enum": [
-              "NONE",
-              "TRACE",
-              "DEBUG",
-              "VERBOSE",
-              "INFO",
-              "WARN",
-              "ERROR",
-              "FATAL"
-            ]
-          },
+          "SoftwareToUpdate": {},
+          "UpdateAgentLogLevel": {},
           "UpdateTargets": {
             "type": "list",
             "member": {}
           },
-          "UpdateTargetsArchitecture": {
-            "type": "string",
-            "enum": [
-              "armv7l",
-              "x86_64",
-              "aarch64"
-            ]
-          },
-          "UpdateTargetsOperatingSystem": {
-            "type": "string",
-            "enum": [
-              "ubuntu",
-              "raspbian",
-              "amazon_linux"
-            ]
-          }
+          "UpdateTargetsArchitecture": {},
+          "UpdateTargetsOperatingSystem": {}
         }
       },
       "output": {
@@ -991,9 +957,7 @@
         "type": "structure",
         "members": {
           "DeploymentStatus": {},
-          "DeploymentType": {
-            "shape": "Sf"
-          },
+          "DeploymentType": {},
           "ErrorDetails": {
             "type": "list",
             "member": {
@@ -1590,9 +1554,7 @@
                 "CreatedAt": {},
                 "DeploymentArn": {},
                 "DeploymentId": {},
-                "DeploymentType": {
-                  "shape": "Sf"
-                },
+                "DeploymentType": {},
                 "GroupArn": {}
               }
             }
@@ -2321,15 +2283,6 @@
         "required": []
       }
     },
-    "Sf": {
-      "type": "string",
-      "enum": [
-        "NewDeployment",
-        "Redeployment",
-        "ResetDeployment",
-        "ForceResetDeployment"
-      ]
-    },
     "Si": {
       "type": "structure",
       "members": {
@@ -2370,13 +2323,7 @@
           "FunctionConfiguration": {
             "type": "structure",
             "members": {
-              "EncodingType": {
-                "type": "string",
-                "enum": [
-                  "binary",
-                  "json"
-                ]
-              },
+              "EncodingType": {},
               "Environment": {
                 "type": "structure",
                 "members": {
@@ -2388,13 +2335,7 @@
                     "member": {
                       "type": "structure",
                       "members": {
-                        "Permission": {
-                          "type": "string",
-                          "enum": [
-                            "ro",
-                            "rw"
-                          ]
-                        },
+                        "Permission": {},
                         "ResourceId": {}
                       },
                       "required": []
@@ -2449,34 +2390,13 @@
       "member": {
         "type": "structure",
         "members": {
-          "Component": {
-            "type": "string",
-            "enum": [
-              "GreengrassSystem",
-              "Lambda"
-            ]
-          },
+          "Component": {},
           "Id": {},
-          "Level": {
-            "type": "string",
-            "enum": [
-              "DEBUG",
-              "INFO",
-              "WARN",
-              "ERROR",
-              "FATAL"
-            ]
-          },
+          "Level": {},
           "Space": {
             "type": "integer"
           },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "FileSystem",
-              "AWSCloudWatch"
-            ]
-          }
+          "Type": {}
         },
         "required": []
       }

--- a/apis/guardduty-2017-11-28.min.json
+++ b/apis/guardduty-2017-11-28.min.json
@@ -97,15 +97,11 @@
         "type": "structure",
         "members": {
           "Action": {
-            "shape": "Sf",
             "locationName": "action"
           },
           "ClientToken": {
             "locationName": "clientToken",
-            "idempotencyToken": true,
-            "type": "string",
-            "min": 0,
-            "max": 64
+            "idempotencyToken": true
           },
           "Description": {
             "locationName": "description"
@@ -156,7 +152,6 @@
             "locationName": "detectorId"
           },
           "Format": {
-            "shape": "St",
             "locationName": "format"
           },
           "Location": {
@@ -269,7 +264,6 @@
             "locationName": "detectorId"
           },
           "Format": {
-            "shape": "S1b",
             "locationName": "format"
           },
           "Location": {
@@ -559,12 +553,7 @@
             "locationName": "serviceRole"
           },
           "Status": {
-            "locationName": "status",
-            "type": "string",
-            "enum": [
-              "ENABLED",
-              "DISABLED"
-            ]
+            "locationName": "status"
           },
           "UpdatedAt": {
             "locationName": "updatedAt"
@@ -599,7 +588,6 @@
         "type": "structure",
         "members": {
           "Action": {
-            "shape": "Sf",
             "locationName": "action"
           },
           "Description": {
@@ -1033,12 +1021,7 @@
           "FindingStatisticTypes": {
             "locationName": "findingStatisticTypes",
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "COUNT_BY_SEVERITY"
-              ]
-            }
+            "member": {}
           }
         },
         "required": [
@@ -1092,7 +1075,6 @@
         "type": "structure",
         "members": {
           "Format": {
-            "shape": "St",
             "locationName": "format"
           },
           "Location": {
@@ -1102,17 +1084,7 @@
             "locationName": "name"
           },
           "Status": {
-            "locationName": "status",
-            "type": "string",
-            "enum": [
-              "INACTIVE",
-              "ACTIVATING",
-              "ACTIVE",
-              "DEACTIVATING",
-              "ERROR",
-              "DELETE_PENDING",
-              "DELETED"
-            ]
+            "locationName": "status"
           }
         }
       }
@@ -1241,7 +1213,6 @@
         "type": "structure",
         "members": {
           "Format": {
-            "shape": "S1b",
             "locationName": "format"
           },
           "Location": {
@@ -1251,17 +1222,7 @@
             "locationName": "name"
           },
           "Status": {
-            "locationName": "status",
-            "type": "string",
-            "enum": [
-              "INACTIVE",
-              "ACTIVATING",
-              "ACTIVE",
-              "DEACTIVATING",
-              "ERROR",
-              "DELETE_PENDING",
-              "DELETED"
-            ]
+            "locationName": "status"
           }
         }
       }
@@ -1314,9 +1275,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1352,9 +1313,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1396,8 +1357,8 @@
             "locationName": "findingCriteria"
           },
           "MaxResults": {
-            "shape": "S44",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -1438,9 +1399,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1475,9 +1436,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1529,9 +1490,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1573,9 +1534,9 @@
             "locationName": "detectorId"
           },
           "MaxResults": {
-            "shape": "S44",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -1723,7 +1684,6 @@
         "type": "structure",
         "members": {
           "Action": {
-            "shape": "Sf",
             "locationName": "action"
           },
           "Description": {
@@ -1776,12 +1736,7 @@
             "locationName": "detectorId"
           },
           "Feedback": {
-            "locationName": "feedback",
-            "type": "string",
-            "enum": [
-              "USEFUL",
-              "NOT_USEFUL"
-            ]
+            "locationName": "feedback"
           },
           "FindingIds": {
             "shape": "S7",
@@ -1877,13 +1832,6 @@
       "type": "list",
       "member": {}
     },
-    "Sf": {
-      "type": "string",
-      "enum": [
-        "NOOP",
-        "ARCHIVE"
-      ]
-    },
     "Si": {
       "type": "structure",
       "members": {
@@ -1925,17 +1873,6 @@
         }
       }
     },
-    "St": {
-      "type": "string",
-      "enum": [
-        "TXT",
-        "STIX",
-        "OTX_CSV",
-        "ALIEN_VAULT",
-        "PROOF_POINT",
-        "FIRE_EYE"
-      ]
-    },
     "S14": {
       "type": "list",
       "member": {
@@ -1954,17 +1891,6 @@
         ]
       }
     },
-    "S1b": {
-      "type": "string",
-      "enum": [
-        "TXT",
-        "STIX",
-        "OTX_CSV",
-        "ALIEN_VAULT",
-        "PROOF_POINT",
-        "FIRE_EYE"
-      ]
-    },
     "S1f": {
       "type": "list",
       "member": {}
@@ -1976,12 +1902,7 @@
           "locationName": "attributeName"
         },
         "OrderBy": {
-          "locationName": "orderBy",
-          "type": "string",
-          "enum": [
-            "ASC",
-            "DESC"
-          ]
+          "locationName": "orderBy"
         }
       }
     },
@@ -2093,11 +2014,6 @@
           "RelationshipStatus"
         ]
       }
-    },
-    "S44": {
-      "type": "integer",
-      "min": 1,
-      "max": 50
     }
   }
 }

--- a/apis/health-2016-08-04.min.json
+++ b/apis/health-2016-08-04.min.json
@@ -43,22 +43,14 @@
               },
               "statusCodes": {
                 "type": "list",
-                "member": {
-                  "shape": "Sh"
-                },
-                "max": 3,
-                "min": 1
+                "member": {}
               }
             }
           },
-          "locale": {
-            "shape": "Si"
-          },
-          "nextToken": {
-            "shape": "Sj"
-          },
+          "locale": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sk"
+            "type": "integer"
           }
         }
       },
@@ -70,34 +62,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "entityArn": {
-                  "shape": "S6"
-                },
-                "eventArn": {
-                  "shape": "S4"
-                },
-                "entityValue": {
-                  "shape": "S8"
-                },
-                "awsAccountId": {
-                  "type": "string",
-                  "pattern": "[0-9]{12}"
-                },
+                "entityArn": {},
+                "eventArn": {},
+                "entityValue": {},
+                "awsAccountId": {},
                 "lastUpdatedTime": {
                   "type": "timestamp"
                 },
-                "statusCode": {
-                  "shape": "Sh"
-                },
+                "statusCode": {},
                 "tags": {
                   "shape": "Sd"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "Sj"
-          }
+          "nextToken": {}
         }
       },
       "idempotent": true
@@ -108,11 +87,7 @@
         "members": {
           "eventArns": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -124,9 +99,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "eventArn": {
-                  "shape": "S4"
-                },
+                "eventArn": {},
                 "count": {
                   "type": "integer"
                 }
@@ -147,18 +120,11 @@
           "filter": {
             "shape": "Sw"
           },
-          "aggregateField": {
-            "type": "string",
-            "enum": [
-              "eventTypeCategory"
-            ]
-          },
+          "aggregateField": {},
           "maxResults": {
-            "shape": "Sk"
+            "type": "integer"
           },
-          "nextToken": {
-            "shape": "Sj"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -176,9 +142,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "Sj"
-          }
+          "nextToken": {}
         }
       },
       "idempotent": true
@@ -193,9 +157,7 @@
           "eventArns": {
             "shape": "S3"
           },
-          "locale": {
-            "shape": "Si"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -218,10 +180,7 @@
                 "eventMetadata": {
                   "type": "map",
                   "key": {},
-                  "value": {
-                    "type": "string",
-                    "max": 10240
-                  }
+                  "value": {}
                 }
               }
             }
@@ -231,9 +190,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "eventArn": {
-                  "shape": "S4"
-                },
+                "eventArn": {},
                 "errorName": {},
                 "errorMessage": {}
               }
@@ -252,33 +209,21 @@
             "members": {
               "eventTypeCodes": {
                 "type": "list",
-                "member": {
-                  "shape": "S1j"
-                },
-                "max": 10,
-                "min": 1
+                "member": {}
               },
               "services": {
                 "shape": "Sz"
               },
               "eventTypeCategories": {
                 "type": "list",
-                "member": {
-                  "shape": "S16"
-                },
-                "max": 10,
-                "min": 1
+                "member": {}
               }
             }
           },
-          "locale": {
-            "shape": "Si"
-          },
-          "nextToken": {
-            "shape": "Sj"
-          },
+          "locale": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sk"
+            "type": "integer"
           }
         }
       },
@@ -290,21 +235,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "service": {
-                  "shape": "S10"
-                },
-                "code": {
-                  "shape": "S1j"
-                },
-                "category": {
-                  "shape": "S16"
-                }
+                "service": {},
+                "code": {},
+                "category": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "Sj"
-          }
+          "nextToken": {}
         }
       },
       "idempotent": true
@@ -316,15 +253,11 @@
           "filter": {
             "shape": "Sw"
           },
-          "nextToken": {
-            "shape": "Sj"
-          },
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sk"
+            "type": "integer"
           },
-          "locale": {
-            "shape": "Si"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -336,9 +269,7 @@
               "shape": "S1i"
             }
           },
-          "nextToken": {
-            "shape": "Sj"
-          }
+          "nextToken": {}
         }
       },
       "idempotent": true
@@ -347,40 +278,15 @@
   "shapes": {
     "S3": {
       "type": "list",
-      "member": {
-        "shape": "S4"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S4": {
-      "type": "string",
-      "max": 1600,
-      "pattern": "arn:aws:health:[^:]*:[^:]*:event(?:/[\\w-]+){1}((?:/[\\w-]+){2})?"
+      "member": {}
     },
     "S5": {
       "type": "list",
-      "member": {
-        "shape": "S6"
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 1600
+      "member": {}
     },
     "S7": {
       "type": "list",
-      "member": {
-        "shape": "S8"
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S8": {
-      "type": "string",
-      "max": 256
+      "member": {}
     },
     "S9": {
       "type": "list",
@@ -394,50 +300,18 @@
             "type": "timestamp"
           }
         }
-      },
-      "max": 10,
-      "min": 1
+      }
     },
     "Sc": {
       "type": "list",
       "member": {
         "shape": "Sd"
-      },
-      "max": 50
+      }
     },
     "Sd": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 127
-      },
-      "value": {
-        "type": "string",
-        "max": 255
-      },
-      "max": 50
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "IMPAIRED",
-        "UNIMPAIRED",
-        "UNKNOWN"
-      ]
-    },
-    "Si": {
-      "type": "string",
-      "max": 256,
-      "min": 2
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9=/+_.-]{4,512}"
-    },
-    "Sk": {
-      "type": "integer",
-      "max": 100,
-      "min": 10
+      "key": {},
+      "value": {}
     },
     "Sw": {
       "type": "structure",
@@ -447,30 +321,18 @@
         },
         "eventTypeCodes": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "max": 100,
-            "min": 3
-          },
-          "max": 10,
-          "min": 1
+          "member": {}
         },
         "services": {
           "shape": "Sz"
         },
         "regions": {
           "type": "list",
-          "member": {
-            "shape": "S12"
-          },
-          "max": 10,
-          "min": 1
+          "member": {}
         },
         "availabilityZones": {
           "type": "list",
-          "member": {
-            "shape": "S14"
-          }
+          "member": {}
         },
         "startTimes": {
           "shape": "S9"
@@ -489,85 +351,30 @@
         },
         "eventTypeCategories": {
           "type": "list",
-          "member": {
-            "shape": "S16"
-          },
-          "max": 10,
-          "min": 1
+          "member": {}
         },
         "tags": {
           "shape": "Sc"
         },
         "eventStatusCodes": {
           "type": "list",
-          "member": {
-            "shape": "S18"
-          },
-          "max": 6,
-          "min": 1
+          "member": {}
         }
       }
     },
     "Sz": {
       "type": "list",
-      "member": {
-        "shape": "S10"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "max": 30,
-      "min": 2
-    },
-    "S12": {
-      "type": "string",
-      "pattern": "[^:/]{2,25}"
-    },
-    "S14": {
-      "type": "string",
-      "pattern": "[a-z]{2}\\-[0-9a-z\\-]{4,16}"
-    },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "issue",
-        "accountNotification",
-        "scheduledChange"
-      ],
-      "max": 255,
-      "min": 3
-    },
-    "S18": {
-      "type": "string",
-      "enum": [
-        "open",
-        "closed",
-        "upcoming"
-      ]
+      "member": {}
     },
     "S1i": {
       "type": "structure",
       "members": {
-        "arn": {
-          "shape": "S4"
-        },
-        "service": {
-          "shape": "S10"
-        },
-        "eventTypeCode": {
-          "shape": "S1j"
-        },
-        "eventTypeCategory": {
-          "shape": "S16"
-        },
-        "region": {
-          "shape": "S12"
-        },
-        "availabilityZone": {
-          "shape": "S14"
-        },
+        "arn": {},
+        "service": {},
+        "eventTypeCode": {},
+        "eventTypeCategory": {},
+        "region": {},
+        "availabilityZone": {},
         "startTime": {
           "type": "timestamp"
         },
@@ -577,15 +384,8 @@
         "lastUpdatedTime": {
           "type": "timestamp"
         },
-        "statusCode": {
-          "shape": "S18"
-        }
+        "statusCode": {}
       }
-    },
-    "S1j": {
-      "type": "string",
-      "max": 100,
-      "min": 3
     }
   }
 }

--- a/apis/iam-2010-05-08.min.json
+++ b/apis/iam-2010-05-08.min.json
@@ -21,12 +21,8 @@
           "ClientID"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          },
-          "ClientID": {
-            "shape": "S3"
-          }
+          "OpenIDConnectProviderArn": {},
+          "ClientID": {}
         }
       }
     },
@@ -38,12 +34,8 @@
           "RoleName"
         ],
         "members": {
-          "InstanceProfileName": {
-            "shape": "S5"
-          },
-          "RoleName": {
-            "shape": "S6"
-          }
+          "InstanceProfileName": {},
+          "RoleName": {}
         }
       }
     },
@@ -55,12 +47,8 @@
           "UserName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "UserName": {
-            "shape": "S9"
-          }
+          "GroupName": {},
+          "UserName": {}
         }
       }
     },
@@ -72,12 +60,8 @@
           "PolicyArn"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "GroupName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -89,12 +73,8 @@
           "PolicyArn"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "RoleName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -106,12 +86,8 @@
           "PolicyArn"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "UserName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -136,9 +112,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          }
+          "UserName": {}
         }
       },
       "output": {
@@ -157,15 +131,9 @@
               "SecretAccessKey"
             ],
             "members": {
-              "UserName": {
-                "shape": "Sd"
-              },
-              "AccessKeyId": {
-                "shape": "Sj"
-              },
-              "Status": {
-                "shape": "Sk"
-              },
+              "UserName": {},
+              "AccessKeyId": {},
+              "Status": {},
               "SecretAccessKey": {
                 "type": "string",
                 "sensitive": true
@@ -185,9 +153,7 @@
           "AccountAlias"
         ],
         "members": {
-          "AccountAlias": {
-            "shape": "So"
-          }
+          "AccountAlias": {}
         }
       }
     },
@@ -198,12 +164,8 @@
           "GroupName"
         ],
         "members": {
-          "Path": {
-            "shape": "Sq"
-          },
-          "GroupName": {
-            "shape": "S8"
-          }
+          "Path": {},
+          "GroupName": {}
         }
       },
       "output": {
@@ -226,12 +188,8 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {
-            "shape": "S5"
-          },
-          "Path": {
-            "shape": "Sq"
-          }
+          "InstanceProfileName": {},
+          "Path": {}
         }
       },
       "output": {
@@ -255,9 +213,7 @@
           "Password"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
+          "UserName": {},
           "Password": {
             "shape": "Sf"
           },
@@ -287,9 +243,7 @@
           "ThumbprintList"
         ],
         "members": {
-          "Url": {
-            "shape": "S19"
-          },
+          "Url": {},
           "ClientIDList": {
             "shape": "S1a"
           },
@@ -302,9 +256,7 @@
         "resultWrapper": "CreateOpenIDConnectProviderResult",
         "type": "structure",
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          }
+          "OpenIDConnectProviderArn": {}
         }
       }
     },
@@ -316,18 +268,10 @@
           "PolicyDocument"
         ],
         "members": {
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "Path": {
-            "shape": "S1g"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          },
-          "Description": {
-            "shape": "S1h"
-          }
+          "PolicyName": {},
+          "Path": {},
+          "PolicyDocument": {},
+          "Description": {}
         }
       },
       "output": {
@@ -348,12 +292,8 @@
           "PolicyDocument"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          },
+          "PolicyArn": {},
+          "PolicyDocument": {},
           "SetAsDefault": {
             "type": "boolean"
           }
@@ -377,24 +317,14 @@
           "AssumeRolePolicyDocument"
         ],
         "members": {
-          "Path": {
-            "shape": "Sq"
-          },
-          "RoleName": {
-            "shape": "S6"
-          },
-          "AssumeRolePolicyDocument": {
-            "shape": "Sz"
-          },
-          "Description": {
-            "shape": "S10"
-          },
+          "Path": {},
+          "RoleName": {},
+          "AssumeRolePolicyDocument": {},
+          "Description": {},
           "MaxSessionDuration": {
-            "shape": "S11"
+            "type": "integer"
           },
-          "PermissionsBoundary": {
-            "shape": "S2"
-          }
+          "PermissionsBoundary": {}
         }
       },
       "output": {
@@ -418,24 +348,15 @@
           "Name"
         ],
         "members": {
-          "SAMLMetadataDocument": {
-            "shape": "S1s"
-          },
-          "Name": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[\\w._-]+"
-          }
+          "SAMLMetadataDocument": {},
+          "Name": {}
         }
       },
       "output": {
         "resultWrapper": "CreateSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLProviderArn": {
-            "shape": "S2"
-          }
+          "SAMLProviderArn": {}
         }
       }
     },
@@ -446,18 +367,9 @@
           "AWSServiceName"
         ],
         "members": {
-          "AWSServiceName": {
-            "shape": "S8"
-          },
-          "Description": {
-            "shape": "S10"
-          },
-          "CustomSuffix": {
-            "type": "string",
-            "max": 64,
-            "min": 1,
-            "pattern": "[\\w+=,.@-]+"
-          }
+          "AWSServiceName": {},
+          "Description": {},
+          "CustomSuffix": {}
         }
       },
       "output": {
@@ -478,9 +390,7 @@
           "ServiceName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
+          "UserName": {},
           "ServiceName": {}
         }
       },
@@ -501,15 +411,9 @@
           "UserName"
         ],
         "members": {
-          "Path": {
-            "shape": "Sq"
-          },
-          "UserName": {
-            "shape": "Sd"
-          },
-          "PermissionsBoundary": {
-            "shape": "S2"
-          }
+          "Path": {},
+          "UserName": {},
+          "PermissionsBoundary": {}
         }
       },
       "output": {
@@ -529,14 +433,8 @@
           "VirtualMFADeviceName"
         ],
         "members": {
-          "Path": {
-            "shape": "Sq"
-          },
-          "VirtualMFADeviceName": {
-            "type": "string",
-            "min": 1,
-            "pattern": "[\\w+=,.@-]+"
-          }
+          "Path": {},
+          "VirtualMFADeviceName": {}
         }
       },
       "output": {
@@ -560,12 +458,8 @@
           "SerialNumber"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "SerialNumber": {
-            "shape": "S2c"
-          }
+          "UserName": {},
+          "SerialNumber": {}
         }
       }
     },
@@ -576,12 +470,8 @@
           "AccessKeyId"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "AccessKeyId": {
-            "shape": "Sj"
-          }
+          "UserName": {},
+          "AccessKeyId": {}
         }
       }
     },
@@ -592,9 +482,7 @@
           "AccountAlias"
         ],
         "members": {
-          "AccountAlias": {
-            "shape": "So"
-          }
+          "AccountAlias": {}
         }
       }
     },
@@ -606,9 +494,7 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          }
+          "GroupName": {}
         }
       }
     },
@@ -620,12 +506,8 @@
           "PolicyName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "GroupName": {},
+          "PolicyName": {}
         }
       }
     },
@@ -636,9 +518,7 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {
-            "shape": "S5"
-          }
+          "InstanceProfileName": {}
         }
       }
     },
@@ -649,9 +529,7 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          }
+          "UserName": {}
         }
       }
     },
@@ -662,9 +540,7 @@
           "OpenIDConnectProviderArn"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          }
+          "OpenIDConnectProviderArn": {}
         }
       }
     },
@@ -675,9 +551,7 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "PolicyArn": {}
         }
       }
     },
@@ -689,12 +563,8 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "VersionId": {
-            "shape": "S1k"
-          }
+          "PolicyArn": {},
+          "VersionId": {}
         }
       }
     },
@@ -705,9 +575,7 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          }
+          "RoleName": {}
         }
       }
     },
@@ -718,9 +586,7 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          }
+          "RoleName": {}
         }
       }
     },
@@ -732,12 +598,8 @@
           "PolicyName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "RoleName": {},
+          "PolicyName": {}
         }
       }
     },
@@ -748,9 +610,7 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLProviderArn": {
-            "shape": "S2"
-          }
+          "SAMLProviderArn": {}
         }
       }
     },
@@ -762,12 +622,8 @@
           "SSHPublicKeyId"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "SSHPublicKeyId": {
-            "shape": "S2t"
-          }
+          "UserName": {},
+          "SSHPublicKeyId": {}
         }
       }
     },
@@ -778,9 +634,7 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {
-            "shape": "S2v"
-          }
+          "ServerCertificateName": {}
         }
       }
     },
@@ -791,9 +645,7 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          }
+          "RoleName": {}
         }
       },
       "output": {
@@ -803,9 +655,7 @@
           "DeletionTaskId"
         ],
         "members": {
-          "DeletionTaskId": {
-            "shape": "S2y"
-          }
+          "DeletionTaskId": {}
         }
       }
     },
@@ -816,12 +666,8 @@
           "ServiceSpecificCredentialId"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "ServiceSpecificCredentialId": {
-            "shape": "S24"
-          }
+          "UserName": {},
+          "ServiceSpecificCredentialId": {}
         }
       }
     },
@@ -832,12 +678,8 @@
           "CertificateId"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "CertificateId": {
-            "shape": "S31"
-          }
+          "UserName": {},
+          "CertificateId": {}
         }
       }
     },
@@ -848,9 +690,7 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          }
+          "UserName": {}
         }
       }
     },
@@ -861,9 +701,7 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          }
+          "UserName": {}
         }
       }
     },
@@ -875,12 +713,8 @@
           "PolicyName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "UserName": {},
+          "PolicyName": {}
         }
       }
     },
@@ -891,9 +725,7 @@
           "SerialNumber"
         ],
         "members": {
-          "SerialNumber": {
-            "shape": "S2c"
-          }
+          "SerialNumber": {}
         }
       }
     },
@@ -905,12 +737,8 @@
           "PolicyArn"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "GroupName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -922,12 +750,8 @@
           "PolicyArn"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "RoleName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -939,12 +763,8 @@
           "PolicyArn"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "UserName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -958,18 +778,10 @@
           "AuthenticationCode2"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "SerialNumber": {
-            "shape": "S2c"
-          },
-          "AuthenticationCode1": {
-            "shape": "S3a"
-          },
-          "AuthenticationCode2": {
-            "shape": "S3a"
-          }
+          "UserName": {},
+          "SerialNumber": {},
+          "AuthenticationCode1": {},
+          "AuthenticationCode2": {}
         }
       }
     },
@@ -978,14 +790,7 @@
         "resultWrapper": "GenerateCredentialReportResult",
         "type": "structure",
         "members": {
-          "State": {
-            "type": "string",
-            "enum": [
-              "STARTED",
-              "INPROGRESS",
-              "COMPLETE"
-            ]
-          },
+          "State": {},
           "Description": {}
         }
       }
@@ -997,18 +802,14 @@
           "AccessKeyId"
         ],
         "members": {
-          "AccessKeyId": {
-            "shape": "Sj"
-          }
+          "AccessKeyId": {}
         }
       },
       "output": {
         "resultWrapper": "GetAccessKeyLastUsedResult",
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
+          "UserName": {},
           "AccessKeyLastUsed": {
             "type": "structure",
             "required": [
@@ -1033,16 +834,12 @@
         "members": {
           "Filter": {
             "type": "list",
-            "member": {
-              "shape": "S3k"
-            }
+            "member": {}
           },
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -1054,18 +851,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {
-                  "shape": "Sq"
-                },
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "UserId": {
-                  "shape": "St"
-                },
-                "Arn": {
-                  "shape": "S2"
-                },
+                "Path": {},
+                "UserName": {},
+                "UserId": {},
+                "Arn": {},
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -1074,9 +863,7 @@
                 },
                 "GroupList": {
                   "type": "list",
-                  "member": {
-                    "shape": "S8"
-                  }
+                  "member": {}
                 },
                 "AttachedManagedPolicies": {
                   "shape": "S3t"
@@ -1092,18 +879,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {
-                  "shape": "Sq"
-                },
-                "GroupName": {
-                  "shape": "S8"
-                },
-                "GroupId": {
-                  "shape": "St"
-                },
-                "Arn": {
-                  "shape": "S2"
-                },
+                "Path": {},
+                "GroupName": {},
+                "GroupId": {},
+                "Arn": {},
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -1121,24 +900,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Path": {
-                  "shape": "Sq"
-                },
-                "RoleName": {
-                  "shape": "S6"
-                },
-                "RoleId": {
-                  "shape": "St"
-                },
-                "Arn": {
-                  "shape": "S2"
-                },
+                "Path": {},
+                "RoleName": {},
+                "RoleId": {},
+                "Arn": {},
                 "CreateDate": {
                   "type": "timestamp"
                 },
-                "AssumeRolePolicyDocument": {
-                  "shape": "Sz"
-                },
+                "AssumeRolePolicyDocument": {},
                 "InstanceProfileList": {
                   "shape": "S3z"
                 },
@@ -1159,21 +928,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "PolicyName": {
-                  "shape": "S1f"
-                },
-                "PolicyId": {
-                  "shape": "St"
-                },
-                "Arn": {
-                  "shape": "S2"
-                },
-                "Path": {
-                  "shape": "S1g"
-                },
-                "DefaultVersionId": {
-                  "shape": "S1k"
-                },
+                "PolicyName": {},
+                "PolicyId": {},
+                "Arn": {},
+                "Path": {},
+                "DefaultVersionId": {},
                 "AttachmentCount": {
                   "type": "integer"
                 },
@@ -1183,9 +942,7 @@
                 "IsAttachable": {
                   "type": "boolean"
                 },
-                "Description": {
-                  "shape": "S1h"
-                },
+                "Description": {},
                 "CreateDate": {
                   "type": "timestamp"
                 },
@@ -1201,9 +958,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1219,7 +974,7 @@
             "type": "structure",
             "members": {
               "MinimumPasswordLength": {
-                "shape": "S45"
+                "type": "integer"
               },
               "RequireSymbols": {
                 "type": "boolean"
@@ -1240,10 +995,10 @@
                 "type": "boolean"
               },
               "MaxPasswordAge": {
-                "shape": "S46"
+                "type": "integer"
               },
               "PasswordReusePrevention": {
-                "shape": "S47"
+                "type": "integer"
               },
               "HardExpiry": {
                 "type": "boolean"
@@ -1260,36 +1015,7 @@
         "members": {
           "SummaryMap": {
             "type": "map",
-            "key": {
-              "type": "string",
-              "enum": [
-                "Users",
-                "UsersQuota",
-                "Groups",
-                "GroupsQuota",
-                "ServerCertificates",
-                "ServerCertificatesQuota",
-                "UserPolicySizeQuota",
-                "GroupPolicySizeQuota",
-                "GroupsPerUserQuota",
-                "SigningCertificatesPerUserQuota",
-                "AccessKeysPerUserQuota",
-                "MFADevices",
-                "MFADevicesInUse",
-                "AccountMFAEnabled",
-                "AccountAccessKeysPresent",
-                "AccountSigningCertificatesPresent",
-                "AttachedPoliciesPerGroupQuota",
-                "AttachedPoliciesPerRoleQuota",
-                "AttachedPoliciesPerUserQuota",
-                "Policies",
-                "PoliciesQuota",
-                "PolicySizeQuota",
-                "PolicyVersionsInUse",
-                "PolicyVersionsInUseQuota",
-                "VersionsPerPolicyQuota"
-              ]
-            },
+            "key": {},
             "value": {
               "type": "integer"
             }
@@ -1321,9 +1047,7 @@
           "PolicySourceArn"
         ],
         "members": {
-          "PolicySourceArn": {
-            "shape": "S2"
-          },
+          "PolicySourceArn": {},
           "PolicyInputList": {
             "shape": "S4e"
           }
@@ -1342,12 +1066,7 @@
           "Content": {
             "type": "blob"
           },
-          "ReportFormat": {
-            "type": "string",
-            "enum": [
-              "text/csv"
-            ]
-          },
+          "ReportFormat": {},
           "GeneratedTime": {
             "type": "timestamp"
           }
@@ -1361,14 +1080,10 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "GroupName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -1389,9 +1104,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1403,12 +1116,8 @@
           "PolicyName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "GroupName": {},
+          "PolicyName": {}
         }
       },
       "output": {
@@ -1420,15 +1129,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "GroupName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -1439,9 +1142,7 @@
           "InstanceProfileName"
         ],
         "members": {
-          "InstanceProfileName": {
-            "shape": "S5"
-          }
+          "InstanceProfileName": {}
         }
       },
       "output": {
@@ -1464,9 +1165,7 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          }
+          "UserName": {}
         }
       },
       "output": {
@@ -1489,18 +1188,14 @@
           "OpenIDConnectProviderArn"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          }
+          "OpenIDConnectProviderArn": {}
         }
       },
       "output": {
         "resultWrapper": "GetOpenIDConnectProviderResult",
         "type": "structure",
         "members": {
-          "Url": {
-            "shape": "S19"
-          },
+          "Url": {},
           "ClientIDList": {
             "shape": "S1a"
           },
@@ -1520,9 +1215,7 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "PolicyArn": {}
         }
       },
       "output": {
@@ -1543,12 +1236,8 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "VersionId": {
-            "shape": "S1k"
-          }
+          "PolicyArn": {},
+          "VersionId": {}
         }
       },
       "output": {
@@ -1568,9 +1257,7 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          }
+          "RoleName": {}
         }
       },
       "output": {
@@ -1594,12 +1281,8 @@
           "PolicyName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "RoleName": {},
+          "PolicyName": {}
         }
       },
       "output": {
@@ -1611,15 +1294,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "RoleName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -1630,18 +1307,14 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLProviderArn": {
-            "shape": "S2"
-          }
+          "SAMLProviderArn": {}
         }
       },
       "output": {
         "resultWrapper": "GetSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLMetadataDocument": {
-            "shape": "S1s"
-          },
+          "SAMLMetadataDocument": {},
           "CreateDate": {
             "type": "timestamp"
           },
@@ -1660,19 +1333,9 @@
           "Encoding"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "SSHPublicKeyId": {
-            "shape": "S2t"
-          },
-          "Encoding": {
-            "type": "string",
-            "enum": [
-              "SSH",
-              "PEM"
-            ]
-          }
+          "UserName": {},
+          "SSHPublicKeyId": {},
+          "Encoding": {}
         }
       },
       "output": {
@@ -1692,9 +1355,7 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {
-            "shape": "S2v"
-          }
+          "ServerCertificateName": {}
         }
       },
       "output": {
@@ -1714,12 +1375,8 @@
               "ServerCertificateMetadata": {
                 "shape": "S5g"
               },
-              "CertificateBody": {
-                "shape": "S5h"
-              },
-              "CertificateChain": {
-                "shape": "S5i"
-              }
+              "CertificateBody": {},
+              "CertificateChain": {}
             }
           }
         }
@@ -1732,9 +1389,7 @@
           "DeletionTaskId"
         ],
         "members": {
-          "DeletionTaskId": {
-            "shape": "S2y"
-          }
+          "DeletionTaskId": {}
         }
       },
       "output": {
@@ -1744,37 +1399,20 @@
           "Status"
         ],
         "members": {
-          "Status": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "IN_PROGRESS",
-              "FAILED",
-              "NOT_STARTED"
-            ]
-          },
+          "Status": {},
           "Reason": {
             "type": "structure",
             "members": {
-              "Reason": {
-                "type": "string",
-                "max": 1000
-              },
+              "Reason": {},
               "RoleUsageList": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Region": {
-                      "type": "string",
-                      "max": 100,
-                      "min": 1
-                    },
+                    "Region": {},
                     "Resources": {
                       "type": "list",
-                      "member": {
-                        "shape": "S2"
-                      }
+                      "member": {}
                     }
                   }
                 }
@@ -1788,9 +1426,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          }
+          "UserName": {}
         }
       },
       "output": {
@@ -1814,12 +1450,8 @@
           "PolicyName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          }
+          "UserName": {},
+          "PolicyName": {}
         }
       },
       "output": {
@@ -1831,15 +1463,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "UserName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -1847,14 +1473,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -1870,15 +1492,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "AccessKeyId": {
-                  "shape": "Sj"
-                },
-                "Status": {
-                  "shape": "Sk"
-                },
+                "UserName": {},
+                "AccessKeyId": {},
+                "Status": {},
                 "CreateDate": {
                   "type": "timestamp"
                 }
@@ -1888,9 +1504,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1898,11 +1512,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {
-            "shape": "S3m"
-          },
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -1915,16 +1527,12 @@
         "members": {
           "AccountAliases": {
             "type": "list",
-            "member": {
-              "shape": "So"
-            }
+            "member": {}
           },
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1935,17 +1543,11 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PathPrefix": {
-            "shape": "S1g"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "GroupName": {},
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -1959,9 +1561,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1972,17 +1572,11 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PathPrefix": {
-            "shape": "S1g"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "RoleName": {},
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -1996,9 +1590,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2009,17 +1601,11 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "PathPrefix": {
-            "shape": "S1g"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2033,9 +1619,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2046,23 +1630,13 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "EntityFilter": {
-            "shape": "S3k"
-          },
-          "PathPrefix": {
-            "shape": "Sq"
-          },
-          "PolicyUsageFilter": {
-            "shape": "S6a"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PolicyArn": {},
+          "EntityFilter": {},
+          "PathPrefix": {},
+          "PolicyUsageFilter": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2075,12 +1649,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "GroupName": {
-                  "shape": "S8"
-                },
-                "GroupId": {
-                  "shape": "St"
-                }
+                "GroupName": {},
+                "GroupId": {}
               }
             }
           },
@@ -2089,12 +1659,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "UserId": {
-                  "shape": "St"
-                }
+                "UserName": {},
+                "UserId": {}
               }
             }
           },
@@ -2103,21 +1669,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "RoleName": {
-                  "shape": "S6"
-                },
-                "RoleId": {
-                  "shape": "St"
-                }
+                "RoleName": {},
+                "RoleId": {}
               }
             }
           },
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2128,14 +1688,10 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "GroupName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2152,9 +1708,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2162,14 +1716,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {
-            "shape": "S6m"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2186,9 +1736,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2199,14 +1747,10 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2223,9 +1767,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2233,14 +1775,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {
-            "shape": "S6m"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2257,9 +1795,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2270,14 +1806,10 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "RoleName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2294,9 +1826,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2304,14 +1834,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2332,12 +1858,8 @@
                 "EnableDate"
               ],
               "members": {
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "SerialNumber": {
-                  "shape": "S2c"
-                },
+                "UserName": {},
+                "SerialNumber": {},
                 "EnableDate": {
                   "type": "timestamp"
                 }
@@ -2347,9 +1869,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2367,9 +1887,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Arn": {
-                  "shape": "S2"
-                }
+                "Arn": {}
               }
             }
           }
@@ -2380,28 +1898,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "Scope": {
-            "type": "string",
-            "enum": [
-              "All",
-              "AWS",
-              "Local"
-            ]
-          },
+          "Scope": {},
           "OnlyAttached": {
             "type": "boolean"
           },
-          "PathPrefix": {
-            "shape": "S1g"
-          },
-          "PolicyUsageFilter": {
-            "shape": "S6a"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "PolicyUsageFilter": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2418,9 +1923,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2431,14 +1934,10 @@
           "PolicyArn"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PolicyArn": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2452,9 +1951,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2465,14 +1962,10 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "RoleName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2489,9 +1982,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2499,14 +1990,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {
-            "shape": "S6m"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2523,9 +2010,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2543,9 +2028,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Arn": {
-                  "shape": "S2"
-                },
+                "Arn": {},
                 "ValidUntil": {
                   "type": "timestamp"
                 },
@@ -2562,14 +2045,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2588,15 +2067,9 @@
                 "UploadDate"
               ],
               "members": {
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "SSHPublicKeyId": {
-                  "shape": "S2t"
-                },
-                "Status": {
-                  "shape": "Sk"
-                },
+                "UserName": {},
+                "SSHPublicKeyId": {},
+                "Status": {},
                 "UploadDate": {
                   "type": "timestamp"
                 }
@@ -2606,9 +2079,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2616,14 +2087,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {
-            "shape": "S6m"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2643,9 +2110,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2653,9 +2118,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
+          "UserName": {},
           "ServiceName": {}
         }
       },
@@ -2676,21 +2139,13 @@
                 "ServiceName"
               ],
               "members": {
-                "UserName": {
-                  "shape": "Sd"
-                },
-                "Status": {
-                  "shape": "Sk"
-                },
-                "ServiceUserName": {
-                  "shape": "S22"
-                },
+                "UserName": {},
+                "Status": {},
+                "ServiceUserName": {},
                 "CreateDate": {
                   "type": "timestamp"
                 },
-                "ServiceSpecificCredentialId": {
-                  "shape": "S24"
-                },
+                "ServiceSpecificCredentialId": {},
                 "ServiceName": {}
               }
             }
@@ -2702,14 +2157,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2729,9 +2180,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2742,14 +2191,10 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "UserName": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2766,9 +2211,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2776,14 +2219,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "PathPrefix": {
-            "shape": "S6m"
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "PathPrefix": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2800,9 +2239,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2810,19 +2247,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "AssignmentStatus": {
-            "type": "string",
-            "enum": [
-              "Assigned",
-              "Unassigned",
-              "Any"
-            ]
-          },
-          "Marker": {
-            "shape": "S3m"
-          },
+          "AssignmentStatus": {},
+          "Marker": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           }
         }
       },
@@ -2842,9 +2270,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       }
     },
@@ -2857,15 +2283,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "GroupName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -2877,12 +2297,8 @@
           "PermissionsBoundary"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PermissionsBoundary": {
-            "shape": "S2"
-          }
+          "RoleName": {},
+          "PermissionsBoundary": {}
         }
       }
     },
@@ -2895,15 +2311,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "RoleName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -2915,12 +2325,8 @@
           "PermissionsBoundary"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "PermissionsBoundary": {
-            "shape": "S2"
-          }
+          "UserName": {},
+          "PermissionsBoundary": {}
         }
       }
     },
@@ -2933,15 +2339,9 @@
           "PolicyDocument"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "UserName": {},
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -2953,12 +2353,8 @@
           "ClientID"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          },
-          "ClientID": {
-            "shape": "S3"
-          }
+          "OpenIDConnectProviderArn": {},
+          "ClientID": {}
         }
       }
     },
@@ -2970,12 +2366,8 @@
           "RoleName"
         ],
         "members": {
-          "InstanceProfileName": {
-            "shape": "S5"
-          },
-          "RoleName": {
-            "shape": "S6"
-          }
+          "InstanceProfileName": {},
+          "RoleName": {}
         }
       }
     },
@@ -2987,12 +2379,8 @@
           "UserName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "UserName": {
-            "shape": "S9"
-          }
+          "GroupName": {},
+          "UserName": {}
         }
       }
     },
@@ -3003,12 +2391,8 @@
           "ServiceSpecificCredentialId"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "ServiceSpecificCredentialId": {
-            "shape": "S24"
-          }
+          "UserName": {},
+          "ServiceSpecificCredentialId": {}
         }
       },
       "output": {
@@ -3031,18 +2415,10 @@
           "AuthenticationCode2"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "SerialNumber": {
-            "shape": "S2c"
-          },
-          "AuthenticationCode1": {
-            "shape": "S3a"
-          },
-          "AuthenticationCode2": {
-            "shape": "S3a"
-          }
+          "UserName": {},
+          "SerialNumber": {},
+          "AuthenticationCode1": {},
+          "AuthenticationCode2": {}
         }
       }
     },
@@ -3054,12 +2430,8 @@
           "VersionId"
         ],
         "members": {
-          "PolicyArn": {
-            "shape": "S2"
-          },
-          "VersionId": {
-            "shape": "S1k"
-          }
+          "PolicyArn": {},
+          "VersionId": {}
         }
       }
     },
@@ -3080,27 +2452,17 @@
           "ResourceArns": {
             "shape": "S8j"
           },
-          "ResourcePolicy": {
-            "shape": "Sz"
-          },
-          "ResourceOwner": {
-            "shape": "S8k"
-          },
-          "CallerArn": {
-            "shape": "S8k"
-          },
+          "ResourcePolicy": {},
+          "ResourceOwner": {},
+          "CallerArn": {},
           "ContextEntries": {
             "shape": "S8l"
           },
-          "ResourceHandlingOption": {
-            "shape": "S8q"
-          },
+          "ResourceHandlingOption": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -3116,9 +2478,7 @@
           "ActionNames"
         ],
         "members": {
-          "PolicySourceArn": {
-            "shape": "S2"
-          },
+          "PolicySourceArn": {},
           "PolicyInputList": {
             "shape": "S4e"
           },
@@ -3128,27 +2488,17 @@
           "ResourceArns": {
             "shape": "S8j"
           },
-          "ResourcePolicy": {
-            "shape": "Sz"
-          },
-          "ResourceOwner": {
-            "shape": "S8k"
-          },
-          "CallerArn": {
-            "shape": "S8k"
-          },
+          "ResourcePolicy": {},
+          "ResourceOwner": {},
+          "CallerArn": {},
           "ContextEntries": {
             "shape": "S8l"
           },
-          "ResourceHandlingOption": {
-            "shape": "S8q"
-          },
+          "ResourceHandlingOption": {},
           "MaxItems": {
-            "shape": "S3l"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S3m"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -3164,15 +2514,9 @@
           "Status"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "AccessKeyId": {
-            "shape": "Sj"
-          },
-          "Status": {
-            "shape": "Sk"
-          }
+          "UserName": {},
+          "AccessKeyId": {},
+          "Status": {}
         }
       }
     },
@@ -3181,7 +2525,7 @@
         "type": "structure",
         "members": {
           "MinimumPasswordLength": {
-            "shape": "S45"
+            "type": "integer"
           },
           "RequireSymbols": {
             "type": "boolean"
@@ -3199,10 +2543,10 @@
             "type": "boolean"
           },
           "MaxPasswordAge": {
-            "shape": "S46"
+            "type": "integer"
           },
           "PasswordReusePrevention": {
-            "shape": "S47"
+            "type": "integer"
           },
           "HardExpiry": {
             "type": "boolean"
@@ -3218,12 +2562,8 @@
           "PolicyDocument"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "RoleName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -3234,15 +2574,9 @@
           "GroupName"
         ],
         "members": {
-          "GroupName": {
-            "shape": "S8"
-          },
-          "NewPath": {
-            "shape": "Sq"
-          },
-          "NewGroupName": {
-            "shape": "S8"
-          }
+          "GroupName": {},
+          "NewPath": {},
+          "NewGroupName": {}
         }
       }
     },
@@ -3253,9 +2587,7 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
+          "UserName": {},
           "Password": {
             "shape": "Sf"
           },
@@ -3273,9 +2605,7 @@
           "ThumbprintList"
         ],
         "members": {
-          "OpenIDConnectProviderArn": {
-            "shape": "S2"
-          },
+          "OpenIDConnectProviderArn": {},
           "ThumbprintList": {
             "shape": "S1b"
           }
@@ -3289,14 +2619,10 @@
           "RoleName"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "Description": {
-            "shape": "S10"
-          },
+          "RoleName": {},
+          "Description": {},
           "MaxSessionDuration": {
-            "shape": "S11"
+            "type": "integer"
           }
         }
       },
@@ -3314,12 +2640,8 @@
           "Description"
         ],
         "members": {
-          "RoleName": {
-            "shape": "S6"
-          },
-          "Description": {
-            "shape": "S10"
-          }
+          "RoleName": {},
+          "Description": {}
         }
       },
       "output": {
@@ -3340,21 +2662,15 @@
           "SAMLProviderArn"
         ],
         "members": {
-          "SAMLMetadataDocument": {
-            "shape": "S1s"
-          },
-          "SAMLProviderArn": {
-            "shape": "S2"
-          }
+          "SAMLMetadataDocument": {},
+          "SAMLProviderArn": {}
         }
       },
       "output": {
         "resultWrapper": "UpdateSAMLProviderResult",
         "type": "structure",
         "members": {
-          "SAMLProviderArn": {
-            "shape": "S2"
-          }
+          "SAMLProviderArn": {}
         }
       }
     },
@@ -3367,15 +2683,9 @@
           "Status"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "SSHPublicKeyId": {
-            "shape": "S2t"
-          },
-          "Status": {
-            "shape": "Sk"
-          }
+          "UserName": {},
+          "SSHPublicKeyId": {},
+          "Status": {}
         }
       }
     },
@@ -3386,15 +2696,9 @@
           "ServerCertificateName"
         ],
         "members": {
-          "ServerCertificateName": {
-            "shape": "S2v"
-          },
-          "NewPath": {
-            "shape": "Sq"
-          },
-          "NewServerCertificateName": {
-            "shape": "S2v"
-          }
+          "ServerCertificateName": {},
+          "NewPath": {},
+          "NewServerCertificateName": {}
         }
       }
     },
@@ -3406,15 +2710,9 @@
           "Status"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "ServiceSpecificCredentialId": {
-            "shape": "S24"
-          },
-          "Status": {
-            "shape": "Sk"
-          }
+          "UserName": {},
+          "ServiceSpecificCredentialId": {},
+          "Status": {}
         }
       }
     },
@@ -3426,15 +2724,9 @@
           "Status"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "CertificateId": {
-            "shape": "S31"
-          },
-          "Status": {
-            "shape": "Sk"
-          }
+          "UserName": {},
+          "CertificateId": {},
+          "Status": {}
         }
       }
     },
@@ -3445,15 +2737,9 @@
           "UserName"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "NewPath": {
-            "shape": "Sq"
-          },
-          "NewUserName": {
-            "shape": "Sd"
-          }
+          "UserName": {},
+          "NewPath": {},
+          "NewUserName": {}
         }
       }
     },
@@ -3465,12 +2751,8 @@
           "SSHPublicKeyBody"
         ],
         "members": {
-          "UserName": {
-            "shape": "Sd"
-          },
-          "SSHPublicKeyBody": {
-            "shape": "S5c"
-          }
+          "UserName": {},
+          "SSHPublicKeyBody": {}
         }
       },
       "output": {
@@ -3492,25 +2774,14 @@
           "PrivateKey"
         ],
         "members": {
-          "Path": {
-            "shape": "Sq"
-          },
-          "ServerCertificateName": {
-            "shape": "S2v"
-          },
-          "CertificateBody": {
-            "shape": "S5h"
-          },
+          "Path": {},
+          "ServerCertificateName": {},
+          "CertificateBody": {},
           "PrivateKey": {
             "type": "string",
-            "max": 16384,
-            "min": 1,
-            "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "CertificateChain": {
-            "shape": "S5i"
-          }
+          "CertificateChain": {}
         }
       },
       "output": {
@@ -3530,12 +2801,8 @@
           "CertificateBody"
         ],
         "members": {
-          "UserName": {
-            "shape": "S9"
-          },
-          "CertificateBody": {
-            "shape": "S5h"
-          }
+          "UserName": {},
+          "CertificateBody": {}
         }
       },
       "output": {
@@ -3553,77 +2820,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S6": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S8": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S9": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "Sd": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
     "Sf": {
       "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+",
       "sensitive": true
-    },
-    "Sj": {
-      "type": "string",
-      "max": 128,
-      "min": 16,
-      "pattern": "[\\w]+"
-    },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "Active",
-        "Inactive"
-      ]
-    },
-    "So": {
-      "type": "string",
-      "max": 63,
-      "min": 3,
-      "pattern": "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$"
-    },
-    "Sq": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "(\\u002F)|(\\u002F[\\u0021-\\u007F]+\\u002F)"
     },
     "Ss": {
       "type": "structure",
@@ -3635,28 +2834,14 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {
-          "shape": "Sq"
-        },
-        "GroupName": {
-          "shape": "S8"
-        },
-        "GroupId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
+        "Path": {},
+        "GroupName": {},
+        "GroupId": {},
+        "Arn": {},
         "CreateDate": {
           "type": "timestamp"
         }
       }
-    },
-    "St": {
-      "type": "string",
-      "max": 128,
-      "min": 16,
-      "pattern": "[\\w]+"
     },
     "Sw": {
       "type": "structure",
@@ -3669,18 +2854,10 @@
         "Roles"
       ],
       "members": {
-        "Path": {
-          "shape": "Sq"
-        },
-        "InstanceProfileName": {
-          "shape": "S5"
-        },
-        "InstanceProfileId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
+        "Path": {},
+        "InstanceProfileName": {},
+        "InstanceProfileId": {},
+        "Arn": {},
         "CreateDate": {
           "type": "timestamp"
         },
@@ -3705,63 +2882,28 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {
-          "shape": "Sq"
-        },
-        "RoleName": {
-          "shape": "S6"
-        },
-        "RoleId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
+        "Path": {},
+        "RoleName": {},
+        "RoleId": {},
+        "Arn": {},
         "CreateDate": {
           "type": "timestamp"
         },
-        "AssumeRolePolicyDocument": {
-          "shape": "Sz"
-        },
-        "Description": {
-          "shape": "S10"
-        },
+        "AssumeRolePolicyDocument": {},
+        "Description": {},
         "MaxSessionDuration": {
-          "shape": "S11"
+          "type": "integer"
         },
         "PermissionsBoundary": {
           "shape": "S12"
         }
       }
     },
-    "Sz": {
-      "type": "string",
-      "max": 131072,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "S10": {
-      "type": "string",
-      "max": 1000,
-      "pattern": "[\\p{L}\\p{M}\\p{Z}\\p{S}\\p{N}\\p{P}]*"
-    },
-    "S11": {
-      "type": "integer",
-      "max": 43200,
-      "min": 3600
-    },
     "S12": {
       "type": "structure",
       "members": {
-        "PermissionsBoundaryType": {
-          "type": "string",
-          "enum": [
-            "PermissionsBoundaryPolicy"
-          ]
-        },
-        "PermissionsBoundaryArn": {
-          "shape": "S2"
-        }
+        "PermissionsBoundaryType": {},
+        "PermissionsBoundaryArn": {}
       }
     },
     "S17": {
@@ -3771,9 +2913,7 @@
         "CreateDate"
       ],
       "members": {
-        "UserName": {
-          "shape": "Sd"
-        },
+        "UserName": {},
         "CreateDate": {
           "type": "timestamp"
         },
@@ -3782,57 +2922,22 @@
         }
       }
     },
-    "S19": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
     "S1a": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
+      "member": {}
     },
     "S1b": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 40,
-        "min": 40
-      }
-    },
-    "S1f": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S1g": {
-      "type": "string",
-      "pattern": "((/[A-Za-z0-9\\.,\\+@=_-]+)*)/"
-    },
-    "S1h": {
-      "type": "string",
-      "max": 1000
+      "member": {}
     },
     "S1j": {
       "type": "structure",
       "members": {
-        "PolicyName": {
-          "shape": "S1f"
-        },
-        "PolicyId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
-        "Path": {
-          "shape": "S1g"
-        },
-        "DefaultVersionId": {
-          "shape": "S1k"
-        },
+        "PolicyName": {},
+        "PolicyId": {},
+        "Arn": {},
+        "Path": {},
+        "DefaultVersionId": {},
         "AttachmentCount": {
           "type": "integer"
         },
@@ -3842,9 +2947,7 @@
         "IsAttachable": {
           "type": "boolean"
         },
-        "Description": {
-          "shape": "S1h"
-        },
+        "Description": {},
         "CreateDate": {
           "type": "timestamp"
         },
@@ -3853,19 +2956,11 @@
         }
       }
     },
-    "S1k": {
-      "type": "string",
-      "pattern": "v[1-9][0-9]*(\\.[A-Za-z0-9-]*)?"
-    },
     "S1o": {
       "type": "structure",
       "members": {
-        "Document": {
-          "shape": "Sz"
-        },
-        "VersionId": {
-          "shape": "S1k"
-        },
+        "Document": {},
+        "VersionId": {},
         "IsDefaultVersion": {
           "type": "boolean"
         },
@@ -3873,11 +2968,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S1s": {
-      "type": "string",
-      "max": 10000000,
-      "min": 1000
     },
     "S21": {
       "type": "structure",
@@ -3895,35 +2985,15 @@
           "type": "timestamp"
         },
         "ServiceName": {},
-        "ServiceUserName": {
-          "shape": "S22"
-        },
+        "ServiceUserName": {},
         "ServicePassword": {
           "type": "string",
           "sensitive": true
         },
-        "ServiceSpecificCredentialId": {
-          "shape": "S24"
-        },
-        "UserName": {
-          "shape": "Sd"
-        },
-        "Status": {
-          "shape": "Sk"
-        }
+        "ServiceSpecificCredentialId": {},
+        "UserName": {},
+        "Status": {}
       }
-    },
-    "S22": {
-      "type": "string",
-      "max": 200,
-      "min": 17,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S24": {
-      "type": "string",
-      "max": 128,
-      "min": 20,
-      "pattern": "[\\w]+"
     },
     "S27": {
       "type": "structure",
@@ -3935,18 +3005,10 @@
         "CreateDate"
       ],
       "members": {
-        "Path": {
-          "shape": "Sq"
-        },
-        "UserName": {
-          "shape": "Sd"
-        },
-        "UserId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
+        "Path": {},
+        "UserName": {},
+        "UserId": {},
+        "Arn": {},
         "CreateDate": {
           "type": "timestamp"
         },
@@ -3964,9 +3026,7 @@
         "SerialNumber"
       ],
       "members": {
-        "SerialNumber": {
-          "shape": "S2c"
-        },
+        "SerialNumber": {},
         "Base32StringSeed": {
           "shape": "S2d"
         },
@@ -3981,77 +3041,17 @@
         }
       }
     },
-    "S2c": {
-      "type": "string",
-      "max": 256,
-      "min": 9,
-      "pattern": "[\\w+=/:,.@-]+"
-    },
     "S2d": {
       "type": "blob",
       "sensitive": true
-    },
-    "S2t": {
-      "type": "string",
-      "max": 128,
-      "min": 20,
-      "pattern": "[\\w]+"
-    },
-    "S2v": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "S2y": {
-      "type": "string",
-      "max": 1000,
-      "min": 1
-    },
-    "S31": {
-      "type": "string",
-      "max": 128,
-      "min": 24,
-      "pattern": "[\\w]+"
-    },
-    "S3a": {
-      "type": "string",
-      "max": 6,
-      "min": 6,
-      "pattern": "[\\d]+"
-    },
-    "S3k": {
-      "type": "string",
-      "enum": [
-        "User",
-        "Role",
-        "Group",
-        "LocalManagedPolicy",
-        "AWSManagedPolicy"
-      ]
-    },
-    "S3l": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
-    "S3m": {
-      "type": "string",
-      "max": 320,
-      "min": 1,
-      "pattern": "[\\u0020-\\u00FF]+"
     },
     "S3q": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyDocument": {
-            "shape": "Sz"
-          }
+          "PolicyName": {},
+          "PolicyDocument": {}
         }
       }
     },
@@ -4060,12 +3060,8 @@
       "member": {
         "type": "structure",
         "members": {
-          "PolicyName": {
-            "shape": "S1f"
-          },
-          "PolicyArn": {
-            "shape": "S2"
-          }
+          "PolicyName": {},
+          "PolicyArn": {}
         }
       }
     },
@@ -4081,26 +3077,9 @@
         "shape": "S1o"
       }
     },
-    "S45": {
-      "type": "integer",
-      "max": 128,
-      "min": 6
-    },
-    "S46": {
-      "type": "integer",
-      "max": 1095,
-      "min": 1
-    },
-    "S47": {
-      "type": "integer",
-      "max": 24,
-      "min": 1
-    },
     "S4e": {
       "type": "list",
-      "member": {
-        "shape": "Sz"
-      }
+      "member": {}
     },
     "S4f": {
       "type": "structure",
@@ -4112,14 +3091,7 @@
     },
     "S4g": {
       "type": "list",
-      "member": {
-        "shape": "S4h"
-      }
-    },
-    "S4h": {
-      "type": "string",
-      "max": 256,
-      "min": 5
+      "member": {}
     },
     "S4o": {
       "type": "list",
@@ -4137,34 +3109,15 @@
         "Status"
       ],
       "members": {
-        "UserName": {
-          "shape": "Sd"
-        },
-        "SSHPublicKeyId": {
-          "shape": "S2t"
-        },
-        "Fingerprint": {
-          "type": "string",
-          "max": 48,
-          "min": 48,
-          "pattern": "[:\\w]+"
-        },
-        "SSHPublicKeyBody": {
-          "shape": "S5c"
-        },
-        "Status": {
-          "shape": "Sk"
-        },
+        "UserName": {},
+        "SSHPublicKeyId": {},
+        "Fingerprint": {},
+        "SSHPublicKeyBody": {},
+        "Status": {},
         "UploadDate": {
           "type": "timestamp"
         }
       }
-    },
-    "S5c": {
-      "type": "string",
-      "max": 16384,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
     },
     "S5g": {
       "type": "structure",
@@ -4175,18 +3128,10 @@
         "Arn"
       ],
       "members": {
-        "Path": {
-          "shape": "Sq"
-        },
-        "ServerCertificateName": {
-          "shape": "S2v"
-        },
-        "ServerCertificateId": {
-          "shape": "St"
-        },
-        "Arn": {
-          "shape": "S2"
-        },
+        "Path": {},
+        "ServerCertificateName": {},
+        "ServerCertificateId": {},
+        "Arn": {},
         "UploadDate": {
           "type": "timestamp"
         },
@@ -4195,36 +3140,9 @@
         }
       }
     },
-    "S5h": {
-      "type": "string",
-      "max": 16384,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "S5i": {
-      "type": "string",
-      "max": 2097152,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "S6a": {
-      "type": "string",
-      "enum": [
-        "PermissionsPolicy",
-        "PermissionsBoundary"
-      ]
-    },
     "S6k": {
       "type": "list",
-      "member": {
-        "shape": "S1f"
-      }
-    },
-    "S6m": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "\\u002F[\\u0021-\\u007F]*"
+      "member": {}
     },
     "S6o": {
       "type": "list",
@@ -4241,18 +3159,10 @@
         "Status"
       ],
       "members": {
-        "UserName": {
-          "shape": "Sd"
-        },
-        "CertificateId": {
-          "shape": "S31"
-        },
-        "CertificateBody": {
-          "shape": "S5h"
-        },
-        "Status": {
-          "shape": "Sk"
-        },
+        "UserName": {},
+        "CertificateId": {},
+        "CertificateBody": {},
+        "Status": {},
         "UploadDate": {
           "type": "timestamp"
         }
@@ -4260,62 +3170,25 @@
     },
     "S8h": {
       "type": "list",
-      "member": {
-        "shape": "S8i"
-      }
-    },
-    "S8i": {
-      "type": "string",
-      "max": 128,
-      "min": 3
+      "member": {}
     },
     "S8j": {
       "type": "list",
-      "member": {
-        "shape": "S8k"
-      }
-    },
-    "S8k": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
+      "member": {}
     },
     "S8l": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ContextKeyName": {
-            "shape": "S4h"
-          },
+          "ContextKeyName": {},
           "ContextKeyValues": {
             "type": "list",
             "member": {}
           },
-          "ContextKeyType": {
-            "type": "string",
-            "enum": [
-              "string",
-              "stringList",
-              "numeric",
-              "numericList",
-              "boolean",
-              "booleanList",
-              "ip",
-              "ipList",
-              "binary",
-              "binaryList",
-              "date",
-              "dateList"
-            ]
-          }
+          "ContextKeyType": {}
         }
       }
-    },
-    "S8q": {
-      "type": "string",
-      "max": 64,
-      "min": 1
     },
     "S8r": {
       "type": "structure",
@@ -4329,15 +3202,9 @@
               "EvalDecision"
             ],
             "members": {
-              "EvalActionName": {
-                "shape": "S8i"
-              },
-              "EvalResourceName": {
-                "shape": "S8k"
-              },
-              "EvalDecision": {
-                "shape": "S8u"
-              },
+              "EvalActionName": {},
+              "EvalResourceName": {},
+              "EvalDecision": {},
               "MatchedStatements": {
                 "shape": "S8v"
               },
@@ -4364,12 +3231,8 @@
                     "EvalResourceDecision"
                   ],
                   "members": {
-                    "EvalResourceName": {
-                      "shape": "S8k"
-                    },
-                    "EvalResourceDecision": {
-                      "shape": "S8u"
-                    },
+                    "EvalResourceName": {},
+                    "EvalResourceDecision": {},
                     "MatchedStatements": {
                       "shape": "S8v"
                     },
@@ -4388,18 +3251,8 @@
         "IsTruncated": {
           "type": "boolean"
         },
-        "Marker": {
-          "shape": "S3m"
-        }
+        "Marker": {}
       }
-    },
-    "S8u": {
-      "type": "string",
-      "enum": [
-        "allowed",
-        "explicitDeny",
-        "implicitDeny"
-      ]
     },
     "S8v": {
       "type": "list",
@@ -4407,18 +3260,7 @@
         "type": "structure",
         "members": {
           "SourcePolicyId": {},
-          "SourcePolicyType": {
-            "type": "string",
-            "enum": [
-              "user",
-              "group",
-              "role",
-              "aws-managed",
-              "user-managed",
-              "resource",
-              "none"
-            ]
-          },
+          "SourcePolicyType": {},
           "StartPosition": {
             "shape": "S8z"
           },
@@ -4441,14 +3283,8 @@
     },
     "S93": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 256,
-        "min": 3
-      },
-      "value": {
-        "shape": "S8u"
-      }
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/importexport-2010-06-01.min.json
+++ b/apis/importexport-2010-06-01.min.json
@@ -48,9 +48,7 @@
           "ValidateOnly"
         ],
         "members": {
-          "JobType": {
-            "shape": "S7"
-          },
+          "JobType": {},
           "Manifest": {},
           "ManifestAddendum": {},
           "ValidateOnly": {
@@ -64,9 +62,7 @@
         "type": "structure",
         "members": {
           "JobId": {},
-          "JobType": {
-            "shape": "S7"
-          },
+          "JobType": {},
           "Signature": {},
           "SignatureFileContents": {},
           "WarningMessage": {},
@@ -131,9 +127,7 @@
         "type": "structure",
         "members": {
           "JobId": {},
-          "JobType": {
-            "shape": "S7"
-          },
+          "JobType": {},
           "LocationCode": {},
           "LocationMessage": {},
           "ProgressCode": {},
@@ -187,9 +181,7 @@
                 "IsCanceled": {
                   "type": "boolean"
                 },
-                "JobType": {
-                  "shape": "S7"
-                }
+                "JobType": {}
               }
             }
           },
@@ -214,9 +206,7 @@
         "members": {
           "JobId": {},
           "Manifest": {},
-          "JobType": {
-            "shape": "S7"
-          },
+          "JobType": {},
           "ValidateOnly": {
             "type": "boolean"
           },
@@ -239,13 +229,6 @@
     }
   },
   "shapes": {
-    "S7": {
-      "type": "string",
-      "enum": [
-        "Import",
-        "Export"
-      ]
-    },
     "Sf": {
       "type": "list",
       "member": {

--- a/apis/inspector-2016-02-16.min.json
+++ b/apis/inspector-2016-02-16.min.json
@@ -47,12 +47,8 @@
           "assessmentTargetName"
         ],
         "members": {
-          "assessmentTargetName": {
-            "shape": "Se"
-          },
-          "resourceGroupArn": {
-            "shape": "S3"
-          }
+          "assessmentTargetName": {},
+          "resourceGroupArn": {}
         }
       },
       "output": {
@@ -61,9 +57,7 @@
           "assessmentTargetArn"
         ],
         "members": {
-          "assessmentTargetArn": {
-            "shape": "S3"
-          }
+          "assessmentTargetArn": {}
         }
       }
     },
@@ -77,14 +71,10 @@
           "rulesPackageArns"
         ],
         "members": {
-          "assessmentTargetArn": {
-            "shape": "S3"
-          },
-          "assessmentTemplateName": {
-            "shape": "Sh"
-          },
+          "assessmentTargetArn": {},
+          "assessmentTemplateName": {},
           "durationInSeconds": {
-            "shape": "Si"
+            "type": "integer"
           },
           "rulesPackageArns": {
             "shape": "Sj"
@@ -100,9 +90,7 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {
-            "shape": "S3"
-          }
+          "assessmentTemplateArn": {}
         }
       }
     },
@@ -113,9 +101,7 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {
-            "shape": "S3"
-          }
+          "assessmentTemplateArn": {}
         }
       },
       "output": {
@@ -124,9 +110,7 @@
           "previewToken"
         ],
         "members": {
-          "previewToken": {
-            "shape": "Sn"
-          }
+          "previewToken": {}
         }
       }
     },
@@ -148,9 +132,7 @@
           "resourceGroupArn"
         ],
         "members": {
-          "resourceGroupArn": {
-            "shape": "S3"
-          }
+          "resourceGroupArn": {}
         }
       }
     },
@@ -161,9 +143,7 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          }
+          "assessmentRunArn": {}
         }
       }
     },
@@ -174,9 +154,7 @@
           "assessmentTargetArn"
         ],
         "members": {
-          "assessmentTargetArn": {
-            "shape": "S3"
-          }
+          "assessmentTargetArn": {}
         }
       }
     },
@@ -187,9 +165,7 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {
-            "shape": "S3"
-          }
+          "assessmentTemplateArn": {}
         }
       }
     },
@@ -232,28 +208,16 @@
                 "findingCounts"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
-                "name": {
-                  "shape": "S12"
-                },
-                "assessmentTemplateArn": {
-                  "shape": "S3"
-                },
-                "state": {
-                  "shape": "S13"
-                },
+                "arn": {},
+                "name": {},
+                "assessmentTemplateArn": {},
+                "state": {},
                 "durationInSeconds": {
-                  "shape": "Si"
+                  "type": "integer"
                 },
                 "rulesPackageArns": {
                   "type": "list",
-                  "member": {
-                    "shape": "S3"
-                  },
-                  "max": 50,
-                  "min": 1
+                  "member": {}
                 },
                 "userAttributesForFindings": {
                   "shape": "S4"
@@ -285,13 +249,9 @@
                       "stateChangedAt": {
                         "type": "timestamp"
                       },
-                      "state": {
-                        "shape": "S13"
-                      }
+                      "state": {}
                     }
-                  },
-                  "max": 50,
-                  "min": 0
+                  }
                 },
                 "notifications": {
                   "type": "list",
@@ -306,45 +266,25 @@
                       "date": {
                         "type": "timestamp"
                       },
-                      "event": {
-                        "shape": "S1a"
-                      },
-                      "message": {
-                        "shape": "S1b"
-                      },
+                      "event": {},
+                      "message": {},
                       "error": {
                         "type": "boolean"
                       },
-                      "snsTopicArn": {
-                        "shape": "S3"
-                      },
-                      "snsPublishStatusCode": {
-                        "type": "string",
-                        "enum": [
-                          "SUCCESS",
-                          "TOPIC_DOES_NOT_EXIST",
-                          "ACCESS_DENIED",
-                          "INTERNAL_ERROR"
-                        ]
-                      }
+                      "snsTopicArn": {},
+                      "snsPublishStatusCode": {}
                     }
-                  },
-                  "max": 50,
-                  "min": 0
+                  }
                 },
                 "findingCounts": {
                   "type": "map",
-                  "key": {
-                    "shape": "S1e"
-                  },
+                  "key": {},
                   "value": {
                     "type": "integer"
                   }
                 }
               }
-            },
-            "max": 10,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -382,15 +322,9 @@
                 "updatedAt"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
-                "name": {
-                  "shape": "Se"
-                },
-                "resourceGroupArn": {
-                  "shape": "S3"
-                },
+                "arn": {},
+                "name": {},
+                "resourceGroupArn": {},
                 "createdAt": {
                   "type": "timestamp"
                 },
@@ -398,9 +332,7 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 10,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -442,17 +374,11 @@
                 "createdAt"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
-                "name": {
-                  "shape": "Sh"
-                },
-                "assessmentTargetArn": {
-                  "shape": "S3"
-                },
+                "arn": {},
+                "name": {},
+                "assessmentTargetArn": {},
                 "durationInSeconds": {
-                  "shape": "Si"
+                  "type": "integer"
                 },
                 "rulesPackageArns": {
                   "shape": "Sj"
@@ -460,9 +386,7 @@
                 "userAttributesForFindings": {
                   "shape": "S4"
                 },
-                "lastAssessmentRunArn": {
-                  "shape": "S3"
-                },
+                "lastAssessmentRunArn": {},
                 "assessmentRunCount": {
                   "type": "integer"
                 },
@@ -470,9 +394,7 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 10,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -489,9 +411,7 @@
           "registeredAt"
         ],
         "members": {
-          "roleArn": {
-            "shape": "S3"
-          },
+          "roleArn": {},
           "valid": {
             "type": "boolean"
           },
@@ -510,15 +430,9 @@
         "members": {
           "exclusionArns": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           },
-          "locale": {
-            "shape": "S1s"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -530,9 +444,7 @@
         "members": {
           "exclusions": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
+            "key": {},
             "value": {
               "type": "structure",
               "required": [
@@ -543,18 +455,10 @@
                 "scopes"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
-                "title": {
-                  "shape": "S1w"
-                },
-                "description": {
-                  "shape": "S1w"
-                },
-                "recommendation": {
-                  "shape": "S1w"
-                },
+                "arn": {},
+                "title": {},
+                "description": {},
+                "recommendation": {},
                 "scopes": {
                   "shape": "S1x"
                 },
@@ -562,9 +466,7 @@
                   "shape": "S21"
                 }
               }
-            },
-            "max": 100,
-            "min": 1
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -582,9 +484,7 @@
           "findingArns": {
             "shape": "Sy"
           },
-          "locale": {
-            "shape": "S1s"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -606,17 +506,11 @@
                 "updatedAt"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
+                "arn": {},
                 "schemaVersion": {
-                  "shape": "S26"
+                  "type": "integer"
                 },
-                "service": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 0
-                },
+                "service": {},
                 "serviceAttributes": {
                   "type": "structure",
                   "required": [
@@ -624,22 +518,13 @@
                   ],
                   "members": {
                     "schemaVersion": {
-                      "shape": "S26"
+                      "type": "integer"
                     },
-                    "assessmentRunArn": {
-                      "shape": "S3"
-                    },
-                    "rulesPackageArn": {
-                      "shape": "S3"
-                    }
+                    "assessmentRunArn": {},
+                    "rulesPackageArn": {}
                   }
                 },
-                "assetType": {
-                  "type": "string",
-                  "enum": [
-                    "ec2-instance"
-                  ]
-                },
+                "assetType": {},
                 "assetAttributes": {
                   "type": "structure",
                   "required": [
@@ -647,58 +532,28 @@
                   ],
                   "members": {
                     "schemaVersion": {
-                      "shape": "S26"
+                      "type": "integer"
                     },
-                    "agentId": {
-                      "shape": "S2b"
-                    },
-                    "autoScalingGroup": {
-                      "shape": "S2c"
-                    },
-                    "amiId": {
-                      "type": "string",
-                      "max": 256,
-                      "min": 0
-                    },
-                    "hostname": {
-                      "shape": "S2e"
-                    },
+                    "agentId": {},
+                    "autoScalingGroup": {},
+                    "amiId": {},
+                    "hostname": {},
                     "ipv4Addresses": {
                       "type": "list",
-                      "member": {
-                        "shape": "S2g"
-                      },
-                      "max": 50,
-                      "min": 0
+                      "member": {}
                     }
                   }
                 },
-                "id": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 0
-                },
-                "title": {
-                  "shape": "S1w"
-                },
-                "description": {
-                  "shape": "S1w"
-                },
-                "recommendation": {
-                  "shape": "S1w"
-                },
-                "severity": {
-                  "shape": "S1e"
-                },
+                "id": {},
+                "title": {},
+                "description": {},
+                "recommendation": {},
+                "severity": {},
                 "numericSeverity": {
-                  "type": "double",
-                  "max": 10,
-                  "min": 0
+                  "type": "double"
                 },
                 "confidence": {
-                  "type": "integer",
-                  "max": 10,
-                  "min": 0
+                  "type": "integer"
                 },
                 "indicatorOfCompromise": {
                   "type": "boolean"
@@ -716,9 +571,7 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 100,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -755,9 +608,7 @@
                 "createdAt"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
+                "arn": {},
                 "tags": {
                   "shape": "Sp"
                 },
@@ -765,9 +616,7 @@
                   "type": "timestamp"
                 }
               }
-            },
-            "max": 10,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -785,9 +634,7 @@
           "rulesPackageArns": {
             "shape": "Sy"
           },
-          "locale": {
-            "shape": "S1s"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -808,31 +655,13 @@
                 "provider"
               ],
               "members": {
-                "arn": {
-                  "shape": "S3"
-                },
-                "name": {
-                  "type": "string",
-                  "max": 1000,
-                  "min": 0
-                },
-                "version": {
-                  "type": "string",
-                  "max": 1000,
-                  "min": 0
-                },
-                "provider": {
-                  "type": "string",
-                  "max": 1000,
-                  "min": 0
-                },
-                "description": {
-                  "shape": "S1w"
-                }
+                "arn": {},
+                "name": {},
+                "version": {},
+                "provider": {},
+                "description": {}
               }
-            },
-            "max": 10,
-            "min": 0
+            }
           },
           "failedItems": {
             "shape": "S9"
@@ -849,23 +678,9 @@
           "reportType"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          },
-          "reportFileFormat": {
-            "type": "string",
-            "enum": [
-              "HTML",
-              "PDF"
-            ]
-          },
-          "reportType": {
-            "type": "string",
-            "enum": [
-              "FINDING",
-              "FULL"
-            ]
-          }
+          "assessmentRunArn": {},
+          "reportFileFormat": {},
+          "reportType": {}
         }
       },
       "output": {
@@ -874,18 +689,8 @@
           "status"
         ],
         "members": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "WORK_IN_PROGRESS",
-              "FAILED",
-              "COMPLETED"
-            ]
-          },
-          "url": {
-            "type": "string",
-            "max": 2048
-          }
+          "status": {},
+          "url": {}
         }
       }
     },
@@ -897,21 +702,13 @@
           "previewToken"
         ],
         "members": {
-          "assessmentTemplateArn": {
-            "shape": "S3"
-          },
-          "previewToken": {
-            "shape": "Sn"
-          },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "assessmentTemplateArn": {},
+          "previewToken": {},
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           },
-          "locale": {
-            "shape": "S1s"
-          }
+          "locale": {}
         }
       },
       "output": {
@@ -920,13 +717,7 @@
           "previewStatus"
         ],
         "members": {
-          "previewStatus": {
-            "type": "string",
-            "enum": [
-              "WORK_IN_PROGRESS",
-              "COMPLETED"
-            ]
-          },
+          "previewStatus": {},
           "exclusionPreviews": {
             "type": "list",
             "member": {
@@ -938,15 +729,9 @@
                 "scopes"
               ],
               "members": {
-                "title": {
-                  "shape": "S1w"
-                },
-                "description": {
-                  "shape": "S1w"
-                },
-                "recommendation": {
-                  "shape": "S1w"
-                },
+                "title": {},
+                "description": {},
+                "recommendation": {},
                 "scopes": {
                   "shape": "S1x"
                 },
@@ -954,13 +739,9 @@
                   "shape": "S21"
                 }
               }
-            },
-            "max": 100,
-            "min": 0
+            }
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -971,9 +752,7 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          }
+          "assessmentRunArn": {}
         }
       },
       "output": {
@@ -995,9 +774,7 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          },
+          "assessmentRunArn": {},
           "filter": {
             "type": "structure",
             "required": [
@@ -1007,25 +784,15 @@
             "members": {
               "agentHealths": {
                 "type": "list",
-                "member": {
-                  "shape": "S3h"
-                },
-                "max": 10,
-                "min": 0
+                "member": {}
               },
               "agentHealthCodes": {
                 "type": "list",
-                "member": {
-                  "shape": "S3j"
-                },
-                "max": 10,
-                "min": 0
+                "member": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1049,35 +816,19 @@
                 "telemetryMetadata"
               ],
               "members": {
-                "agentId": {
-                  "shape": "S2b"
-                },
-                "assessmentRunArn": {
-                  "shape": "S3"
-                },
-                "agentHealth": {
-                  "shape": "S3h"
-                },
-                "agentHealthCode": {
-                  "shape": "S3j"
-                },
-                "agentHealthDetails": {
-                  "shape": "S1b"
-                },
-                "autoScalingGroup": {
-                  "shape": "S2c"
-                },
+                "agentId": {},
+                "assessmentRunArn": {},
+                "agentHealth": {},
+                "agentHealthCode": {},
+                "agentHealthDetails": {},
+                "autoScalingGroup": {},
                 "telemetryMetadata": {
                   "shape": "S3a"
                 }
               }
-            },
-            "max": 500,
-            "min": 0
+            }
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1091,16 +842,10 @@
           "filter": {
             "type": "structure",
             "members": {
-              "namePattern": {
-                "shape": "S3q"
-              },
+              "namePattern": {},
               "states": {
                 "type": "list",
-                "member": {
-                  "shape": "S13"
-                },
-                "max": 50,
-                "min": 0
+                "member": {}
               },
               "durationRange": {
                 "shape": "S3s"
@@ -1119,9 +864,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1136,9 +879,7 @@
           "assessmentRunArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1149,14 +890,10 @@
           "filter": {
             "type": "structure",
             "members": {
-              "assessmentTargetNamePattern": {
-                "shape": "S3q"
-              }
+              "assessmentTargetNamePattern": {}
             }
           },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1171,9 +908,7 @@
           "assessmentTargetArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1187,9 +922,7 @@
           "filter": {
             "type": "structure",
             "members": {
-              "namePattern": {
-                "shape": "S3q"
-              },
+              "namePattern": {},
               "durationRange": {
                 "shape": "S3s"
               },
@@ -1198,9 +931,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1215,9 +946,7 @@
           "assessmentTemplateArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1225,12 +954,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "resourceArn": {
-            "shape": "S3"
-          },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "resourceArn": {},
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1252,12 +977,8 @@
                 "eventSubscriptions"
               ],
               "members": {
-                "resourceArn": {
-                  "shape": "S3"
-                },
-                "topicArn": {
-                  "shape": "S3"
-                },
+                "resourceArn": {},
+                "topicArn": {},
                 "eventSubscriptions": {
                   "type": "list",
                   "member": {
@@ -1267,25 +988,17 @@
                       "subscribedAt"
                     ],
                     "members": {
-                      "event": {
-                        "shape": "S1a"
-                      },
+                      "event": {},
                       "subscribedAt": {
                         "type": "timestamp"
                       }
                     }
-                  },
-                  "max": 50,
-                  "min": 1
+                  }
                 }
               }
-            },
-            "max": 50,
-            "min": 0
+            }
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1296,12 +1009,8 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "assessmentRunArn": {},
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1316,9 +1025,7 @@
           "exclusionArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1334,36 +1041,19 @@
             "members": {
               "agentIds": {
                 "type": "list",
-                "member": {
-                  "shape": "S2b"
-                },
-                "max": 500,
-                "min": 0
+                "member": {}
               },
               "autoScalingGroups": {
                 "type": "list",
-                "member": {
-                  "shape": "S2c"
-                },
-                "max": 20,
-                "min": 0
+                "member": {}
               },
               "ruleNames": {
                 "type": "list",
-                "member": {
-                  "type": "string",
-                  "max": 1000
-                },
-                "max": 50,
-                "min": 0
+                "member": {}
               },
               "severities": {
                 "type": "list",
-                "member": {
-                  "shape": "S1e"
-                },
-                "max": 50,
-                "min": 0
+                "member": {}
               },
               "rulesPackageArns": {
                 "shape": "S3t"
@@ -1379,9 +1069,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1396,9 +1084,7 @@
           "findingArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1406,9 +1092,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "S32"
-          },
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1423,9 +1107,7 @@
           "rulesPackageArns": {
             "shape": "S3w"
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1436,9 +1118,7 @@
           "resourceArn"
         ],
         "members": {
-          "resourceArn": {
-            "shape": "S3"
-          }
+          "resourceArn": {}
         }
       },
       "output": {
@@ -1460,12 +1140,8 @@
           "previewAgentsArn"
         ],
         "members": {
-          "previewAgentsArn": {
-            "shape": "S3"
-          },
-          "nextToken": {
-            "shape": "S32"
-          },
+          "previewAgentsArn": {},
+          "nextToken": {},
           "maxResults": {
             "type": "integer"
           }
@@ -1485,44 +1161,18 @@
                 "agentId"
               ],
               "members": {
-                "hostname": {
-                  "shape": "S2e"
-                },
-                "agentId": {
-                  "shape": "S2b"
-                },
-                "autoScalingGroup": {
-                  "shape": "S2c"
-                },
-                "agentHealth": {
-                  "shape": "S3h"
-                },
-                "agentVersion": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
-                "operatingSystem": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1
-                },
-                "kernelVersion": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
-                "ipv4Address": {
-                  "shape": "S2g"
-                }
+                "hostname": {},
+                "agentId": {},
+                "autoScalingGroup": {},
+                "agentHealth": {},
+                "agentVersion": {},
+                "operatingSystem": {},
+                "kernelVersion": {},
+                "ipv4Address": {}
               }
-            },
-            "max": 100,
-            "min": 0
+            }
           },
-          "nextToken": {
-            "shape": "S32"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -1533,9 +1183,7 @@
           "roleArn"
         ],
         "members": {
-          "roleArn": {
-            "shape": "S3"
-          }
+          "roleArn": {}
         }
       }
     },
@@ -1552,11 +1200,7 @@
           },
           "attributeKeys": {
             "type": "list",
-            "member": {
-              "shape": "S6"
-            },
-            "max": 10,
-            "min": 0
+            "member": {}
           }
         }
       },
@@ -1579,9 +1223,7 @@
           "resourceArn"
         ],
         "members": {
-          "resourceArn": {
-            "shape": "S3"
-          },
+          "resourceArn": {},
           "tags": {
             "shape": "S4o"
           }
@@ -1595,12 +1237,8 @@
           "assessmentTemplateArn"
         ],
         "members": {
-          "assessmentTemplateArn": {
-            "shape": "S3"
-          },
-          "assessmentRunName": {
-            "shape": "S12"
-          }
+          "assessmentTemplateArn": {},
+          "assessmentRunName": {}
         }
       },
       "output": {
@@ -1609,9 +1247,7 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          }
+          "assessmentRunArn": {}
         }
       }
     },
@@ -1622,16 +1258,8 @@
           "assessmentRunArn"
         ],
         "members": {
-          "assessmentRunArn": {
-            "shape": "S3"
-          },
-          "stopAction": {
-            "type": "string",
-            "enum": [
-              "START_EVALUATION",
-              "SKIP_EVALUATION"
-            ]
-          }
+          "assessmentRunArn": {},
+          "stopAction": {}
         }
       }
     },
@@ -1644,15 +1272,9 @@
           "topicArn"
         ],
         "members": {
-          "resourceArn": {
-            "shape": "S3"
-          },
-          "event": {
-            "shape": "S1a"
-          },
-          "topicArn": {
-            "shape": "S3"
-          }
+          "resourceArn": {},
+          "event": {},
+          "topicArn": {}
         }
       }
     },
@@ -1665,15 +1287,9 @@
           "topicArn"
         ],
         "members": {
-          "resourceArn": {
-            "shape": "S3"
-          },
-          "event": {
-            "shape": "S1a"
-          },
-          "topicArn": {
-            "shape": "S3"
-          }
+          "resourceArn": {},
+          "event": {},
+          "topicArn": {}
         }
       }
     },
@@ -1685,15 +1301,9 @@
           "assessmentTargetName"
         ],
         "members": {
-          "assessmentTargetArn": {
-            "shape": "S3"
-          },
-          "assessmentTargetName": {
-            "shape": "Se"
-          },
-          "resourceGroupArn": {
-            "shape": "S3"
-          }
+          "assessmentTargetArn": {},
+          "assessmentTargetName": {},
+          "resourceGroupArn": {}
         }
       }
     }
@@ -1701,24 +1311,13 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "max": 300,
-      "min": 1
+      "member": {}
     },
     "S4": {
       "type": "list",
       "member": {
         "shape": "S5"
-      },
-      "max": 10,
-      "min": 0
+      }
     },
     "S5": {
       "type": "structure",
@@ -1726,26 +1325,13 @@
         "key"
       ],
       "members": {
-        "key": {
-          "shape": "S6"
-        },
-        "value": {
-          "type": "string",
-          "max": 256,
-          "min": 1
-        }
+        "key": {},
+        "value": {}
       }
-    },
-    "S6": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S9": {
       "type": "map",
-      "key": {
-        "shape": "S3"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "required": [
@@ -1753,49 +1339,16 @@
           "retryable"
         ],
         "members": {
-          "failureCode": {
-            "type": "string",
-            "enum": [
-              "INVALID_ARN",
-              "DUPLICATE_ARN",
-              "ITEM_DOES_NOT_EXIST",
-              "ACCESS_DENIED",
-              "LIMIT_EXCEEDED",
-              "INTERNAL_ERROR"
-            ]
-          },
+          "failureCode": {},
           "retryable": {
             "type": "boolean"
           }
         }
       }
     },
-    "Se": {
-      "type": "string",
-      "max": 140,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 140,
-      "min": 1
-    },
-    "Si": {
-      "type": "integer",
-      "max": 86400,
-      "min": 180
-    },
     "Sj": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "Sn": {
-      "type": "string",
-      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+      "member": {}
     },
     "Sp": {
       "type": "list",
@@ -1805,147 +1358,30 @@
           "key"
         ],
         "members": {
-          "key": {
-            "shape": "Sr"
-          },
-          "value": {
-            "shape": "Ss"
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "max": 10,
-      "min": 1
-    },
-    "Sr": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Ss": {
-      "type": "string",
-      "max": 256,
-      "min": 1
+      }
     },
     "Sy": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S12": {
-      "type": "string",
-      "max": 140,
-      "min": 1
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "CREATED",
-        "START_DATA_COLLECTION_PENDING",
-        "START_DATA_COLLECTION_IN_PROGRESS",
-        "COLLECTING_DATA",
-        "STOP_DATA_COLLECTION_PENDING",
-        "DATA_COLLECTED",
-        "START_EVALUATING_RULES_PENDING",
-        "EVALUATING_RULES",
-        "FAILED",
-        "ERROR",
-        "COMPLETED",
-        "COMPLETED_WITH_ERRORS",
-        "CANCELED"
-      ]
-    },
-    "S1a": {
-      "type": "string",
-      "enum": [
-        "ASSESSMENT_RUN_STARTED",
-        "ASSESSMENT_RUN_COMPLETED",
-        "ASSESSMENT_RUN_STATE_CHANGED",
-        "FINDING_REPORTED",
-        "OTHER"
-      ]
-    },
-    "S1b": {
-      "type": "string",
-      "max": 1000,
-      "min": 0
-    },
-    "S1e": {
-      "type": "string",
-      "enum": [
-        "Low",
-        "Medium",
-        "High",
-        "Informational",
-        "Undefined"
-      ]
-    },
-    "S1s": {
-      "type": "string",
-      "enum": [
-        "EN_US"
-      ]
-    },
-    "S1w": {
-      "type": "string",
-      "max": 20000,
-      "min": 0
+      "member": {}
     },
     "S1x": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "key": {
-            "type": "string",
-            "enum": [
-              "INSTANCE_ID",
-              "RULES_PACKAGE_ARN"
-            ]
-          },
+          "key": {},
           "value": {}
         }
-      },
-      "min": 1
+      }
     },
     "S21": {
       "type": "list",
       "member": {
         "shape": "S5"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "S26": {
-      "type": "integer",
-      "min": 0
-    },
-    "S2b": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S2c": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S2e": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "S2g": {
-      "type": "string",
-      "max": 15,
-      "min": 7
-    },
-    "S32": {
-      "type": "string",
-      "max": 300,
-      "min": 1
+      }
     },
     "S3a": {
       "type": "list",
@@ -1956,11 +1392,7 @@
           "count"
         ],
         "members": {
-          "messageType": {
-            "type": "string",
-            "max": 300,
-            "min": 1
-          },
+          "messageType": {},
           "count": {
             "type": "long"
           },
@@ -1968,60 +1400,26 @@
             "type": "long"
           }
         }
-      },
-      "max": 5000,
-      "min": 0
-    },
-    "S3h": {
-      "type": "string",
-      "enum": [
-        "HEALTHY",
-        "UNHEALTHY",
-        "UNKNOWN"
-      ]
-    },
-    "S3j": {
-      "type": "string",
-      "enum": [
-        "IDLE",
-        "RUNNING",
-        "SHUTDOWN",
-        "UNHEALTHY",
-        "THROTTLED",
-        "UNKNOWN"
-      ]
+      }
     },
     "S3o": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "S3q": {
-      "type": "string",
-      "max": 140,
-      "min": 1
+      "member": {}
     },
     "S3s": {
       "type": "structure",
       "members": {
         "minSeconds": {
-          "shape": "Si"
+          "type": "integer"
         },
         "maxSeconds": {
-          "shape": "Si"
+          "type": "integer"
         }
       }
     },
     "S3t": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 50,
-      "min": 0
+      "member": {}
     },
     "S3u": {
       "type": "structure",
@@ -2036,11 +1434,7 @@
     },
     "S3w": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 100,
-      "min": 0
+      "member": {}
     },
     "S4o": {
       "type": "list",
@@ -2050,16 +1444,10 @@
           "key"
         ],
         "members": {
-          "key": {
-            "shape": "Sr"
-          },
-          "value": {
-            "shape": "Ss"
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "max": 10,
-      "min": 0
+      }
     }
   }
 }

--- a/apis/iot-2015-05-28.min.json
+++ b/apis/iot-2015-05-28.min.json
@@ -23,7 +23,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
@@ -43,13 +42,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingGroupName": {
-            "shape": "S5"
-          },
+          "thingGroupName": {},
           "thingGroupArn": {},
-          "thingName": {
-            "shape": "S7"
-          },
+          "thingName": {},
           "thingArn": {}
         }
       },
@@ -73,25 +68,18 @@
             "shape": "Sb"
           },
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
-          "comment": {
-            "shape": "Se"
-          }
+          "comment": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {
-            "shape": "Sd"
-          },
-          "description": {
-            "shape": "Sh"
-          }
+          "jobId": {},
+          "description": {}
         }
       }
     },
@@ -108,7 +96,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -129,7 +116,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -154,7 +140,6 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -182,7 +167,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -209,7 +193,6 @@
         ],
         "members": {
           "taskId": {
-            "shape": "Su",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -232,7 +215,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           }
@@ -251,13 +233,10 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
-          "comment": {
-            "shape": "Se"
-          },
+          "comment": {},
           "force": {
             "location": "querystring",
             "locationName": "force",
@@ -269,12 +248,8 @@
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {
-            "shape": "Sd"
-          },
-          "description": {
-            "shape": "Sh"
-          }
+          "jobId": {},
+          "description": {}
         }
       }
     },
@@ -291,12 +266,10 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -342,28 +315,21 @@
         ],
         "members": {
           "authorizerName": {
-            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
           "authorizerFunctionArn": {},
-          "tokenKeyName": {
-            "shape": "S1a"
-          },
+          "tokenKeyName": {},
           "tokenSigningPublicKeys": {
             "shape": "S1b"
           },
-          "status": {
-            "shape": "S1e"
-          }
+          "status": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {
-            "shape": "S18"
-          },
+          "authorizerName": {},
           "authorizerArn": {}
         }
       }
@@ -378,10 +344,7 @@
           "certificateSigningRequest"
         ],
         "members": {
-          "certificateSigningRequest": {
-            "type": "string",
-            "min": 1
-          },
+          "certificateSigningRequest": {},
           "setAsActive": {
             "location": "querystring",
             "locationName": "setAsActive",
@@ -393,12 +356,8 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {
-            "shape": "S2"
-          },
-          "certificatePem": {
-            "shape": "S1l"
-          }
+          "certificateId": {},
+          "certificatePem": {}
         }
       }
     },
@@ -415,28 +374,19 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "targets": {
             "shape": "Sb"
           },
-          "documentSource": {
-            "shape": "S1n"
-          },
-          "document": {
-            "shape": "S1o"
-          },
-          "description": {
-            "shape": "Sh"
-          },
+          "documentSource": {},
+          "document": {},
+          "description": {},
           "presignedUrlConfig": {
             "shape": "S1p"
           },
-          "targetSelection": {
-            "shape": "S1s"
-          },
+          "targetSelection": {},
           "jobExecutionsRolloutConfig": {
             "shape": "S1t"
           }
@@ -446,12 +396,8 @@
         "type": "structure",
         "members": {
           "jobArn": {},
-          "jobId": {
-            "shape": "Sd"
-          },
-          "description": {
-            "shape": "Sh"
-          }
+          "jobId": {},
+          "description": {}
         }
       }
     },
@@ -473,22 +419,14 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {
-            "shape": "S2"
-          },
-          "certificatePem": {
-            "shape": "S1l"
-          },
+          "certificateId": {},
+          "certificatePem": {},
           "keyPair": {
             "type": "structure",
             "members": {
-              "PublicKey": {
-                "type": "string",
-                "min": 1
-              },
+              "PublicKey": {},
               "PrivateKey": {
                 "type": "string",
-                "min": 1,
                 "sensitive": true
               }
             }
@@ -510,28 +448,21 @@
         ],
         "members": {
           "otaUpdateId": {
-            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           },
-          "description": {
-            "shape": "S23"
-          },
+          "description": {},
           "targets": {
             "shape": "S24"
           },
-          "targetSelection": {
-            "shape": "S1s"
-          },
+          "targetSelection": {},
           "awsJobExecutionsRolloutConfig": {
             "shape": "S26"
           },
           "files": {
             "shape": "S28"
           },
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "additionalParameters": {
             "shape": "S35"
           }
@@ -540,15 +471,11 @@
       "output": {
         "type": "structure",
         "members": {
-          "otaUpdateId": {
-            "shape": "S22"
-          },
+          "otaUpdateId": {},
           "awsIotJobId": {},
           "otaUpdateArn": {},
           "awsIotJobArn": {},
-          "otaUpdateStatus": {
-            "shape": "S3a"
-          }
+          "otaUpdateStatus": {}
         }
       }
     },
@@ -564,7 +491,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -574,14 +500,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "policyName": {
-            "shape": "Sj"
-          },
+          "policyName": {},
           "policyArn": {},
           "policyDocument": {},
-          "policyVersionId": {
-            "shape": "S3f"
-          }
+          "policyVersionId": {}
         }
       }
     },
@@ -597,7 +519,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -614,9 +535,7 @@
         "members": {
           "policyArn": {},
           "policyDocument": {},
-          "policyVersionId": {
-            "shape": "S3f"
-          },
+          "policyVersionId": {},
           "isDefaultVersion": {
             "type": "boolean"
           }
@@ -635,24 +554,19 @@
         ],
         "members": {
           "roleAlias": {
-            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           },
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "credentialDurationSeconds": {
-            "shape": "S3m"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "roleAlias": {
-            "shape": "S3l"
-          },
+          "roleAlias": {},
           "roleAliasArn": {}
         }
       }
@@ -669,20 +583,13 @@
           "scheduledAuditName"
         ],
         "members": {
-          "frequency": {
-            "shape": "S3q"
-          },
-          "dayOfMonth": {
-            "shape": "S3r"
-          },
-          "dayOfWeek": {
-            "shape": "S3s"
-          },
+          "frequency": {},
+          "dayOfMonth": {},
+          "dayOfWeek": {},
           "targetCheckNames": {
             "shape": "S3t"
           },
           "scheduledAuditName": {
-            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -707,13 +614,10 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
-          "securityProfileDescription": {
-            "shape": "S3z"
-          },
+          "securityProfileDescription": {},
           "behaviors": {
             "shape": "S40"
           },
@@ -725,9 +629,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {
-            "shape": "So"
-          },
+          "securityProfileName": {},
           "securityProfileArn": {}
         }
       }
@@ -745,33 +647,24 @@
         ],
         "members": {
           "streamId": {
-            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           },
-          "description": {
-            "shape": "S4k"
-          },
+          "description": {},
           "files": {
             "shape": "S4l"
           },
-          "roleArn": {
-            "shape": "S1q"
-          }
+          "roleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "streamId": {
-            "shape": "S2e"
-          },
+          "streamId": {},
           "streamArn": {},
-          "description": {
-            "shape": "S4k"
-          },
+          "description": {},
           "streamVersion": {
-            "shape": "S4p"
+            "type": "integer"
           }
         }
       }
@@ -787,13 +680,10 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
-          "thingTypeName": {
-            "shape": "S4r"
-          },
+          "thingTypeName": {},
           "attributePayload": {
             "shape": "S4s"
           }
@@ -802,9 +692,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingName": {
-            "shape": "S7"
-          },
+          "thingName": {},
           "thingArn": {},
           "thingId": {}
         }
@@ -821,13 +709,10 @@
         ],
         "members": {
           "thingGroupName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
-          "parentGroupName": {
-            "shape": "S5"
-          },
+          "parentGroupName": {},
           "thingGroupProperties": {
             "shape": "S50"
           }
@@ -836,13 +721,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingGroupName": {
-            "shape": "S5"
-          },
+          "thingGroupName": {},
           "thingGroupArn": {},
-          "thingGroupId": {
-            "shape": "S53"
-          }
+          "thingGroupId": {}
         }
       }
     },
@@ -857,7 +738,6 @@
         ],
         "members": {
           "thingTypeName": {
-            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           },
@@ -869,9 +749,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingTypeName": {
-            "shape": "S4r"
-          },
+          "thingTypeName": {},
           "thingTypeArn": {},
           "thingTypeId": {}
         }
@@ -889,7 +767,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           },
@@ -932,7 +809,6 @@
         ],
         "members": {
           "authorizerName": {
-            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           }
@@ -955,7 +831,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           }
@@ -978,7 +853,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
@@ -1002,7 +876,6 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
@@ -1028,12 +901,10 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -1062,7 +933,6 @@
         ],
         "members": {
           "otaUpdateId": {
-            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           },
@@ -1095,7 +965,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -1115,12 +984,10 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
-            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -1153,7 +1020,6 @@
         ],
         "members": {
           "roleAlias": {
-            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           }
@@ -1176,7 +1042,6 @@
         ],
         "members": {
           "scheduledAuditName": {
-            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -1199,7 +1064,6 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -1227,7 +1091,6 @@
         ],
         "members": {
           "streamId": {
-            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           }
@@ -1250,7 +1113,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -1278,7 +1140,6 @@
         ],
         "members": {
           "thingGroupName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -1306,7 +1167,6 @@
         ],
         "members": {
           "thingTypeName": {
-            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           }
@@ -1329,7 +1189,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -1349,7 +1208,6 @@
         ],
         "members": {
           "targetType": {
-            "shape": "S7z",
             "location": "querystring",
             "locationName": "targetType"
           },
@@ -1371,7 +1229,6 @@
         ],
         "members": {
           "thingTypeName": {
-            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           },
@@ -1397,9 +1254,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "auditNotificationTargetConfigurations": {
             "shape": "S86"
           },
@@ -1421,7 +1276,6 @@
         ],
         "members": {
           "taskId": {
-            "shape": "Su",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -1430,12 +1284,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskStatus": {
-            "shape": "S8e"
-          },
-          "taskType": {
-            "shape": "S8f"
-          },
+          "taskStatus": {},
+          "taskType": {},
           "taskStartTime": {
             "type": "timestamp"
           },
@@ -1465,26 +1315,14 @@
               }
             }
           },
-          "scheduledAuditName": {
-            "shape": "S3v"
-          },
+          "scheduledAuditName": {},
           "auditDetails": {
             "type": "map",
             "key": {},
             "value": {
               "type": "structure",
               "members": {
-                "checkRunStatus": {
-                  "type": "string",
-                  "enum": [
-                    "IN_PROGRESS",
-                    "WAITING_FOR_DATA_COLLECTION",
-                    "CANCELED",
-                    "COMPLETED_COMPLIANT",
-                    "COMPLETED_NON_COMPLIANT",
-                    "FAILED"
-                  ]
-                },
+                "checkRunStatus": {},
                 "checkCompliant": {
                   "type": "boolean"
                 },
@@ -1495,9 +1333,7 @@
                   "type": "long"
                 },
                 "errorCode": {},
-                "message": {
-                  "shape": "S8w"
-                }
+                "message": {}
               }
             }
           }
@@ -1516,7 +1352,6 @@
         ],
         "members": {
           "authorizerName": {
-            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           }
@@ -1543,7 +1378,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           }
@@ -1556,29 +1390,19 @@
             "type": "structure",
             "members": {
               "certificateArn": {},
-              "certificateId": {
-                "shape": "S2"
-              },
-              "status": {
-                "shape": "S94"
-              },
-              "certificatePem": {
-                "shape": "S1l"
-              },
-              "ownedBy": {
-                "shape": "S95"
-              },
+              "certificateId": {},
+              "status": {},
+              "certificatePem": {},
+              "ownedBy": {},
               "creationDate": {
                 "type": "timestamp"
               },
-              "autoRegistrationStatus": {
-                "shape": "S96"
-              },
+              "autoRegistrationStatus": {},
               "lastModifiedDate": {
                 "type": "timestamp"
               },
               "customerVersion": {
-                "shape": "S97"
+                "type": "integer"
               },
               "generationId": {},
               "validity": {
@@ -1604,7 +1428,6 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           }
@@ -1617,24 +1440,12 @@
             "type": "structure",
             "members": {
               "certificateArn": {},
-              "certificateId": {
-                "shape": "S2"
-              },
-              "caCertificateId": {
-                "shape": "S2"
-              },
-              "status": {
-                "shape": "S9f"
-              },
-              "certificatePem": {
-                "shape": "S1l"
-              },
-              "ownedBy": {
-                "shape": "S95"
-              },
-              "previousOwnedBy": {
-                "shape": "S95"
-              },
+              "certificateId": {},
+              "caCertificateId": {},
+              "status": {},
+              "certificatePem": {},
+              "ownedBy": {},
+              "previousOwnedBy": {},
               "creationDate": {
                 "type": "timestamp"
               },
@@ -1642,17 +1453,13 @@
                 "type": "timestamp"
               },
               "customerVersion": {
-                "shape": "S97"
+                "type": "integer"
               },
               "transferData": {
                 "type": "structure",
                 "members": {
-                  "transferMessage": {
-                    "shape": "S9h"
-                  },
-                  "rejectReason": {
-                    "shape": "S9h"
-                  },
+                  "transferMessage": {},
+                  "rejectReason": {},
                   "transferDate": {
                     "type": "timestamp"
                   },
@@ -1748,7 +1555,6 @@
         ],
         "members": {
           "indexName": {
-            "shape": "S9w",
             "location": "uri",
             "locationName": "indexName"
           }
@@ -1757,17 +1563,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "indexName": {
-            "shape": "S9w"
-          },
-          "indexStatus": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "BUILDING",
-              "REBUILDING"
-            ]
-          },
+          "indexName": {},
+          "indexStatus": {},
           "schema": {}
         }
       }
@@ -1784,7 +1581,6 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           }
@@ -1793,34 +1589,22 @@
       "output": {
         "type": "structure",
         "members": {
-          "documentSource": {
-            "shape": "S1n"
-          },
+          "documentSource": {},
           "job": {
             "type": "structure",
             "members": {
               "jobArn": {},
-              "jobId": {
-                "shape": "Sd"
-              },
-              "targetSelection": {
-                "shape": "S1s"
-              },
-              "status": {
-                "shape": "Sa3"
-              },
+              "jobId": {},
+              "targetSelection": {},
+              "status": {},
               "forceCanceled": {
                 "type": "boolean"
               },
-              "comment": {
-                "shape": "Se"
-              },
+              "comment": {},
               "targets": {
                 "shape": "Sb"
               },
-              "description": {
-                "shape": "Sh"
-              },
+              "description": {},
               "presignedUrlConfig": {
                 "shape": "S1p"
               },
@@ -1884,12 +1668,10 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -1906,12 +1688,8 @@
           "execution": {
             "type": "structure",
             "members": {
-              "jobId": {
-                "shape": "Sd"
-              },
-              "status": {
-                "shape": "Sai"
-              },
+              "jobId": {},
+              "status": {},
               "forceCanceled": {
                 "type": "boolean"
               },
@@ -1956,7 +1734,6 @@
         ],
         "members": {
           "roleAlias": {
-            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           }
@@ -1968,18 +1745,12 @@
           "roleAliasDescription": {
             "type": "structure",
             "members": {
-              "roleAlias": {
-                "shape": "S3l"
-              },
+              "roleAlias": {},
               "roleAliasArn": {},
-              "roleArn": {
-                "shape": "S1q"
-              },
-              "owner": {
-                "shape": "S95"
-              },
+              "roleArn": {},
+              "owner": {},
               "credentialDurationSeconds": {
-                "shape": "S3m"
+                "type": "integer"
               },
               "creationDate": {
                 "type": "timestamp"
@@ -2004,7 +1775,6 @@
         ],
         "members": {
           "scheduledAuditName": {
-            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -2013,21 +1783,13 @@
       "output": {
         "type": "structure",
         "members": {
-          "frequency": {
-            "shape": "S3q"
-          },
-          "dayOfMonth": {
-            "shape": "S3r"
-          },
-          "dayOfWeek": {
-            "shape": "S3s"
-          },
+          "frequency": {},
+          "dayOfMonth": {},
+          "dayOfWeek": {},
           "targetCheckNames": {
             "shape": "S3t"
           },
-          "scheduledAuditName": {
-            "shape": "S3v"
-          },
+          "scheduledAuditName": {},
           "scheduledAuditArn": {}
         }
       }
@@ -2044,7 +1806,6 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           }
@@ -2053,13 +1814,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {
-            "shape": "So"
-          },
+          "securityProfileName": {},
           "securityProfileArn": {},
-          "securityProfileDescription": {
-            "shape": "S3z"
-          },
+          "securityProfileDescription": {},
           "behaviors": {
             "shape": "S40"
           },
@@ -2090,7 +1847,6 @@
         ],
         "members": {
           "streamId": {
-            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           }
@@ -2102,16 +1858,12 @@
           "streamInfo": {
             "type": "structure",
             "members": {
-              "streamId": {
-                "shape": "S2e"
-              },
+              "streamId": {},
               "streamArn": {},
               "streamVersion": {
-                "shape": "S4p"
+                "type": "integer"
               },
-              "description": {
-                "shape": "S4k"
-              },
+              "description": {},
               "files": {
                 "shape": "S4l"
               },
@@ -2121,9 +1873,7 @@
               "lastUpdatedAt": {
                 "type": "timestamp"
               },
-              "roleArn": {
-                "shape": "S1q"
-              }
+              "roleArn": {}
             }
           }
         }
@@ -2141,7 +1891,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -2151,14 +1900,10 @@
         "type": "structure",
         "members": {
           "defaultClientId": {},
-          "thingName": {
-            "shape": "S7"
-          },
+          "thingName": {},
           "thingId": {},
           "thingArn": {},
-          "thingTypeName": {
-            "shape": "S4r"
-          },
+          "thingTypeName": {},
           "attributes": {
             "shape": "S4t"
           },
@@ -2180,7 +1925,6 @@
         ],
         "members": {
           "thingGroupName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           }
@@ -2189,12 +1933,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingGroupName": {
-            "shape": "S5"
-          },
-          "thingGroupId": {
-            "shape": "S53"
-          },
+          "thingGroupName": {},
+          "thingGroupId": {},
           "thingGroupArn": {},
           "version": {
             "type": "long"
@@ -2205,9 +1945,7 @@
           "thingGroupMetadata": {
             "type": "structure",
             "members": {
-              "parentGroupName": {
-                "shape": "S5"
-              },
+              "parentGroupName": {},
               "rootToParentThingGroups": {
                 "shape": "Sb2"
               },
@@ -2231,7 +1969,6 @@
         ],
         "members": {
           "taskId": {
-            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -2240,9 +1977,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "Sb5"
-          },
+          "taskId": {},
           "creationDate": {
             "type": "timestamp"
           },
@@ -2250,21 +1985,11 @@
             "type": "timestamp"
           },
           "templateBody": {},
-          "inputFileBucket": {
-            "shape": "Sb7"
-          },
-          "inputFileKey": {
-            "shape": "Sb8"
-          },
-          "roleArn": {
-            "shape": "S1q"
-          },
-          "status": {
-            "shape": "Sb9"
-          },
-          "message": {
-            "shape": "S8w"
-          },
+          "inputFileBucket": {},
+          "inputFileKey": {},
+          "roleArn": {},
+          "status": {},
+          "message": {},
           "successCount": {
             "type": "integer"
           },
@@ -2272,9 +1997,7 @@
             "type": "integer"
           },
           "percentageProgress": {
-            "type": "integer",
-            "max": 100,
-            "min": 0
+            "type": "integer"
           }
         }
       }
@@ -2291,7 +2014,6 @@
         ],
         "members": {
           "thingTypeName": {
-            "shape": "S4r",
             "location": "uri",
             "locationName": "thingTypeName"
           }
@@ -2300,9 +2022,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "thingTypeName": {
-            "shape": "S4r"
-          },
+          "thingTypeName": {},
           "thingTypeId": {},
           "thingTypeArn": {},
           "thingTypeProperties": {
@@ -2326,7 +2046,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -2347,7 +2066,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
@@ -2372,7 +2090,6 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -2400,7 +2117,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -2426,7 +2142,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2444,7 +2159,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2461,7 +2175,6 @@
           "principal": {},
           "cognitoIdentityPoolId": {},
           "thingName": {
-            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           }
@@ -2475,9 +2188,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "policyName": {
-                  "shape": "Sj"
-                },
+                "policyName": {},
                 "policyArn": {},
                 "policyDocument": {}
               }
@@ -2519,7 +2230,6 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           }
@@ -2528,9 +2238,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "document": {
-            "shape": "S1o"
-          }
+          "document": {}
         }
       }
     },
@@ -2547,9 +2255,7 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "logLevel": {
-            "shape": "Sc4"
-          }
+          "logLevel": {}
         }
       }
     },
@@ -2565,7 +2271,6 @@
         ],
         "members": {
           "otaUpdateId": {
-            "shape": "S22",
             "location": "uri",
             "locationName": "otaUpdateId"
           }
@@ -2577,9 +2282,7 @@
           "otaUpdateInfo": {
             "type": "structure",
             "members": {
-              "otaUpdateId": {
-                "shape": "S22"
-              },
+              "otaUpdateId": {},
               "otaUpdateArn": {},
               "creationDate": {
                 "type": "timestamp"
@@ -2587,24 +2290,18 @@
               "lastModifiedDate": {
                 "type": "timestamp"
               },
-              "description": {
-                "shape": "S23"
-              },
+              "description": {},
               "targets": {
                 "shape": "S24"
               },
               "awsJobExecutionsRolloutConfig": {
                 "shape": "S26"
               },
-              "targetSelection": {
-                "shape": "S1s"
-              },
+              "targetSelection": {},
               "otaUpdateFiles": {
                 "shape": "S28"
               },
-              "otaUpdateStatus": {
-                "shape": "S3a"
-              },
+              "otaUpdateStatus": {},
               "awsIotJobId": {},
               "awsIotJobArn": {},
               "errorInfo": {
@@ -2634,7 +2331,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -2643,14 +2339,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "policyName": {
-            "shape": "Sj"
-          },
+          "policyName": {},
           "policyArn": {},
           "policyDocument": {},
-          "defaultVersionId": {
-            "shape": "S3f"
-          },
+          "defaultVersionId": {},
           "creationDate": {
             "type": "timestamp"
           },
@@ -2674,12 +2366,10 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
-            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -2689,13 +2379,9 @@
         "type": "structure",
         "members": {
           "policyArn": {},
-          "policyName": {
-            "shape": "Sj"
-          },
+          "policyName": {},
           "policyDocument": {},
-          "policyVersionId": {
-            "shape": "S3f"
-          },
+          "policyVersionId": {},
           "isDefaultVersion": {
             "type": "boolean"
           },
@@ -2721,12 +2407,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "registrationCode": {
-            "type": "string",
-            "max": 64,
-            "min": 64,
-            "pattern": "(0x)?[a-fA-F0-9]+"
-          }
+          "registrationCode": {}
         }
       }
     },
@@ -2742,7 +2423,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           }
@@ -2755,9 +2435,7 @@
           "rule": {
             "type": "structure",
             "members": {
-              "ruleName": {
-                "shape": "S5c"
-              },
+              "ruleName": {},
               "sql": {},
               "description": {},
               "createdAt": {
@@ -2791,9 +2469,7 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "defaultLogLevel": {
-            "shape": "Sc4"
-          },
+          "defaultLogLevel": {},
           "disableAllLogs": {
             "type": "boolean"
           }
@@ -2809,12 +2485,10 @@
         "type": "structure",
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           },
           "securityProfileName": {
-            "shape": "So",
             "location": "querystring",
             "locationName": "securityProfileName"
           },
@@ -2823,9 +2497,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -2837,15 +2511,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "violationId": {
-                  "shape": "Scw"
-                },
-                "thingName": {
-                  "shape": "S7"
-                },
-                "securityProfileName": {
-                  "shape": "So"
-                },
+                "violationId": {},
+                "thingName": {},
+                "securityProfileName": {},
                 "behavior": {
                   "shape": "S41"
                 },
@@ -2885,14 +2553,13 @@
             "type": "boolean"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           }
         }
       },
@@ -2902,9 +2569,7 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -2915,15 +2580,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "Su"
-          },
+          "taskId": {},
           "checkName": {},
           "resourceIdentifier": {
             "shape": "Sd5"
           },
           "maxResults": {
-            "shape": "Scs"
+            "type": "integer"
           },
           "nextToken": {},
           "startTime": {
@@ -2942,9 +2605,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {
-                  "shape": "Su"
-                },
+                "taskId": {},
                 "checkName": {},
                 "taskStartTime": {
                   "type": "timestamp"
@@ -2952,21 +2613,11 @@
                 "findingTime": {
                   "type": "timestamp"
                 },
-                "severity": {
-                  "type": "string",
-                  "enum": [
-                    "CRITICAL",
-                    "HIGH",
-                    "MEDIUM",
-                    "LOW"
-                  ]
-                },
+                "severity": {},
                 "nonCompliantResource": {
                   "type": "structure",
                   "members": {
-                    "resourceType": {
-                      "shape": "Sdc"
-                    },
+                    "resourceType": {},
                     "resourceIdentifier": {
                       "shape": "Sd5"
                     },
@@ -2980,9 +2631,7 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "resourceType": {
-                        "shape": "Sdc"
-                      },
+                      "resourceType": {},
                       "resourceIdentifier": {
                         "shape": "Sd5"
                       },
@@ -3024,12 +2673,10 @@
             "type": "timestamp"
           },
           "taskType": {
-            "shape": "S8f",
             "location": "querystring",
             "locationName": "taskType"
           },
           "taskStatus": {
-            "shape": "S8e",
             "location": "querystring",
             "locationName": "taskStatus"
           },
@@ -3038,9 +2685,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -3052,15 +2699,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {
-                  "shape": "Su"
-                },
-                "taskStatus": {
-                  "shape": "S8e"
-                },
-                "taskType": {
-                  "shape": "S8f"
-                }
+                "taskId": {},
+                "taskStatus": {},
+                "taskType": {}
               }
             }
           },
@@ -3077,12 +2718,11 @@
         "type": "structure",
         "members": {
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3092,7 +2732,6 @@
             "type": "boolean"
           },
           "status": {
-            "shape": "S1e",
             "location": "querystring",
             "locationName": "status"
           }
@@ -3106,16 +2745,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "authorizerName": {
-                  "shape": "S18"
-                },
+                "authorizerName": {},
                 "authorizerArn": {}
               }
             }
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3128,12 +2763,11 @@
         "type": "structure",
         "members": {
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3153,21 +2787,15 @@
               "type": "structure",
               "members": {
                 "certificateArn": {},
-                "certificateId": {
-                  "shape": "S2"
-                },
-                "status": {
-                  "shape": "S94"
-                },
+                "certificateId": {},
+                "status": {},
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3180,12 +2808,11 @@
         "type": "structure",
         "members": {
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3202,9 +2829,7 @@
           "certificates": {
             "shape": "Sdx"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3220,17 +2845,15 @@
         ],
         "members": {
           "caCertificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3247,9 +2870,7 @@
           "certificates": {
             "shape": "Sdx"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3266,9 +2887,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Se2",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -3277,9 +2898,7 @@
         "members": {
           "indexNames": {
             "type": "list",
-            "member": {
-              "shape": "S9w"
-            }
+            "member": {}
           },
           "nextToken": {}
         }
@@ -3297,19 +2916,17 @@
         ],
         "members": {
           "jobId": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "jobId"
           },
           "status": {
-            "shape": "Sai",
             "location": "querystring",
             "locationName": "status"
           },
           "maxResults": {
-            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -3348,19 +2965,17 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
           "status": {
-            "shape": "Sai",
             "location": "querystring",
             "locationName": "status"
           },
           "maxResults": {
-            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -3376,9 +2991,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "jobId": {
-                  "shape": "Sd"
-                },
+                "jobId": {},
                 "jobExecutionSummary": {
                   "shape": "Sea"
                 }
@@ -3398,31 +3011,27 @@
         "type": "structure",
         "members": {
           "status": {
-            "shape": "Sa3",
             "location": "querystring",
             "locationName": "status"
           },
           "targetSelection": {
-            "shape": "S1s",
             "location": "querystring",
             "locationName": "targetSelection"
           },
           "maxResults": {
-            "shape": "Se6",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "thingGroupName": {
-            "shape": "S5",
             "location": "querystring",
             "locationName": "thingGroupName"
           },
           "thingGroupId": {
-            "shape": "S53",
             "location": "querystring",
             "locationName": "thingGroupId"
           }
@@ -3437,18 +3046,10 @@
               "type": "structure",
               "members": {
                 "jobArn": {},
-                "jobId": {
-                  "shape": "Sd"
-                },
-                "thingGroupId": {
-                  "shape": "S53"
-                },
-                "targetSelection": {
-                  "shape": "S1s"
-                },
-                "status": {
-                  "shape": "Sa3"
-                },
+                "jobId": {},
+                "thingGroupId": {},
+                "targetSelection": {},
+                "status": {},
                 "createdAt": {
                   "type": "timestamp"
                 },
@@ -3474,16 +3075,15 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "otaUpdateStatus": {
-            "shape": "S3a",
             "location": "querystring",
             "locationName": "otaUpdateStatus"
           }
@@ -3497,9 +3097,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "otaUpdateId": {
-                  "shape": "S22"
-                },
+                "otaUpdateId": {},
                 "otaUpdateArn": {},
                 "creationDate": {
                   "type": "timestamp"
@@ -3520,12 +3118,11 @@
         "type": "structure",
         "members": {
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3545,27 +3142,19 @@
               "type": "structure",
               "members": {
                 "certificateArn": {},
-                "certificateId": {
-                  "shape": "S2"
-                },
-                "transferredTo": {
-                  "shape": "S95"
-                },
+                "certificateId": {},
+                "transferredTo": {},
                 "transferDate": {
                   "type": "timestamp"
                 },
-                "transferMessage": {
-                  "shape": "S9h"
-                },
+                "transferMessage": {},
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3578,14 +3167,13 @@
         "type": "structure",
         "members": {
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3600,9 +3188,7 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3618,19 +3204,17 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "header",
             "locationName": "x-amzn-iot-policy"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3645,9 +3229,7 @@
           "principals": {
             "shape": "Sev"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       },
       "deprecated": true
@@ -3664,7 +3246,6 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           }
@@ -3678,9 +3259,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "versionId": {
-                  "shape": "S3f"
-                },
+                "versionId": {},
                 "isDefaultVersion": {
                   "type": "boolean"
                 },
@@ -3709,14 +3288,13 @@
             "locationName": "x-amzn-iot-principal"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "ascendingOrder": {
             "location": "querystring",
@@ -3731,9 +3309,7 @@
           "policies": {
             "shape": "Sd2"
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       },
       "deprecated": true
@@ -3754,9 +3330,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "principal": {
             "location": "header",
@@ -3783,12 +3359,11 @@
         "type": "structure",
         "members": {
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -3804,13 +3379,9 @@
         "members": {
           "roleAliases": {
             "type": "list",
-            "member": {
-              "shape": "S3l"
-            }
+            "member": {}
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -3827,9 +3398,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -3841,19 +3412,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "scheduledAuditName": {
-                  "shape": "S3v"
-                },
+                "scheduledAuditName": {},
                 "scheduledAuditArn": {},
-                "frequency": {
-                  "shape": "S3q"
-                },
-                "dayOfMonth": {
-                  "shape": "S3r"
-                },
-                "dayOfWeek": {
-                  "shape": "S3s"
-                }
+                "frequency": {},
+                "dayOfMonth": {},
+                "dayOfWeek": {}
               }
             }
           },
@@ -3874,9 +3437,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -3909,9 +3472,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "recursive": {
             "location": "querystring",
@@ -3954,9 +3517,9 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -3977,16 +3540,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "streamId": {
-                  "shape": "S2e"
-                },
+                "streamId": {},
                 "streamArn": {},
                 "streamVersion": {
-                  "shape": "S4p"
+                  "type": "integer"
                 },
-                "description": {
-                  "shape": "S4k"
-                }
+                "description": {}
               }
             }
           },
@@ -4005,19 +3564,17 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "marker": {
-            "shape": "Scz",
             "location": "querystring",
             "locationName": "marker"
           },
           "pageSize": {
-            "shape": "Sd0",
             "location": "querystring",
-            "locationName": "pageSize"
+            "locationName": "pageSize",
+            "type": "integer"
           }
         }
       },
@@ -4028,9 +3585,7 @@
             "type": "list",
             "member": {}
           },
-          "nextMarker": {
-            "shape": "Scz"
-          }
+          "nextMarker": {}
         }
       }
     },
@@ -4046,7 +3601,6 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
@@ -4055,9 +3609,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -4087,17 +3641,15 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "parentGroup": {
-            "shape": "S5",
             "location": "querystring",
             "locationName": "parentGroup"
           },
           "namePrefixFilter": {
-            "shape": "S5",
             "location": "querystring",
             "locationName": "namePrefixFilter"
           },
@@ -4130,7 +3682,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -4139,9 +3690,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -4167,7 +3718,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -4195,12 +3745,10 @@
         ],
         "members": {
           "taskId": {
-            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           },
           "reportType": {
-            "shape": "Sg5",
             "location": "querystring",
             "locationName": "reportType"
           },
@@ -4209,9 +3757,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -4220,14 +3768,9 @@
         "members": {
           "resourceLinks": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 65535
-            }
+            "member": {}
           },
-          "reportType": {
-            "shape": "Sg5"
-          },
+          "reportType": {},
           "nextToken": {}
         }
       }
@@ -4245,12 +3788,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "status": {
-            "shape": "Sb9",
             "location": "querystring",
             "locationName": "status"
           }
@@ -4261,9 +3803,7 @@
         "members": {
           "taskIds": {
             "type": "list",
-            "member": {
-              "shape": "Sb5"
-            }
+            "member": {}
           },
           "nextToken": {}
         }
@@ -4282,12 +3822,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "thingTypeName": {
-            "shape": "S4r",
             "location": "querystring",
             "locationName": "thingTypeName"
           }
@@ -4301,9 +3840,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingTypeName": {
-                  "shape": "S4r"
-                },
+                "thingTypeName": {},
                 "thingTypeArn": {},
                 "thingTypeProperties": {
                   "shape": "S55"
@@ -4331,22 +3868,19 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "attributeName": {
-            "shape": "S4u",
             "location": "querystring",
             "locationName": "attributeName"
           },
           "attributeValue": {
-            "shape": "S4v",
             "location": "querystring",
             "locationName": "attributeValue"
           },
           "thingTypeName": {
-            "shape": "S4r",
             "location": "querystring",
             "locationName": "thingTypeName"
           }
@@ -4360,12 +3894,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingName": {
-                  "shape": "S7"
-                },
-                "thingTypeName": {
-                  "shape": "S4r"
-                },
+                "thingName": {},
+                "thingTypeName": {},
                 "thingArn": {},
                 "attributes": {
                   "shape": "S4t"
@@ -4392,7 +3922,6 @@
         ],
         "members": {
           "thingGroupName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -4406,9 +3935,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Sf4",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -4437,9 +3966,7 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -4461,9 +3988,7 @@
               "type": "structure",
               "members": {
                 "ruleArn": {},
-                "ruleName": {
-                  "shape": "S5c"
-                },
+                "ruleName": {},
                 "topicPattern": {},
                 "createdAt": {
                   "type": "timestamp"
@@ -4487,7 +4012,6 @@
         "type": "structure",
         "members": {
           "targetType": {
-            "shape": "S7z",
             "location": "querystring",
             "locationName": "targetType"
           },
@@ -4498,9 +4022,7 @@
           "maxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "type": "integer",
-            "max": 250,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -4515,9 +4037,7 @@
                 "logTarget": {
                   "shape": "Sgx"
                 },
-                "logLevel": {
-                  "shape": "Sc4"
-                }
+                "logLevel": {}
               }
             }
           },
@@ -4548,12 +4068,10 @@
             "type": "timestamp"
           },
           "thingName": {
-            "shape": "S7",
             "location": "querystring",
             "locationName": "thingName"
           },
           "securityProfileName": {
-            "shape": "So",
             "location": "querystring",
             "locationName": "securityProfileName"
           },
@@ -4562,9 +4080,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "Scs",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -4576,29 +4094,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "violationId": {
-                  "shape": "Scw"
-                },
-                "thingName": {
-                  "shape": "S7"
-                },
-                "securityProfileName": {
-                  "shape": "So"
-                },
+                "violationId": {},
+                "thingName": {},
+                "securityProfileName": {},
                 "behavior": {
                   "shape": "S41"
                 },
                 "metricValue": {
                   "shape": "S46"
                 },
-                "violationEventType": {
-                  "type": "string",
-                  "enum": [
-                    "in-alarm",
-                    "alarm-cleared",
-                    "alarm-invalidated"
-                  ]
-                },
+                "violationEventType": {},
                 "violationEventTime": {
                   "type": "timestamp"
                 }
@@ -4620,12 +4125,8 @@
           "verificationCertificate"
         ],
         "members": {
-          "caCertificate": {
-            "shape": "S1l"
-          },
-          "verificationCertificate": {
-            "shape": "S1l"
-          },
+          "caCertificate": {},
+          "verificationCertificate": {},
           "setAsActive": {
             "location": "querystring",
             "locationName": "setAsActive",
@@ -4645,9 +4146,7 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {
-            "shape": "S2"
-          }
+          "certificateId": {}
         }
       }
     },
@@ -4661,30 +4160,22 @@
           "certificatePem"
         ],
         "members": {
-          "certificatePem": {
-            "shape": "S1l"
-          },
-          "caCertificatePem": {
-            "shape": "S1l"
-          },
+          "certificatePem": {},
+          "caCertificatePem": {},
           "setAsActive": {
             "deprecated": true,
             "location": "querystring",
             "locationName": "setAsActive",
             "type": "boolean"
           },
-          "status": {
-            "shape": "S9f"
-          }
+          "status": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {
-            "shape": "S2"
-          }
+          "certificateId": {}
         }
       }
     },
@@ -4709,9 +4200,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "certificatePem": {
-            "shape": "S1l"
-          },
+          "certificatePem": {},
           "resourceArns": {
             "type": "map",
             "key": {},
@@ -4732,13 +4221,10 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
-          "rejectReason": {
-            "shape": "S9h"
-          }
+          "rejectReason": {}
         }
       }
     },
@@ -4750,13 +4236,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingGroupName": {
-            "shape": "S5"
-          },
+          "thingGroupName": {},
           "thingGroupArn": {},
-          "thingName": {
-            "shape": "S7"
-          },
+          "thingName": {},
           "thingArn": {}
         }
       },
@@ -4778,7 +4260,6 @@
         ],
         "members": {
           "ruleName": {
-            "shape": "S5c",
             "location": "uri",
             "locationName": "ruleName"
           },
@@ -4799,16 +4280,11 @@
           "queryString"
         ],
         "members": {
-          "indexName": {
-            "shape": "S9w"
-          },
-          "queryString": {
-            "type": "string",
-            "min": 1
-          },
+          "indexName": {},
+          "queryString": {},
           "nextToken": {},
           "maxResults": {
-            "shape": "Se2"
+            "type": "integer"
           },
           "queryVersion": {}
         }
@@ -4822,13 +4298,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingName": {
-                  "shape": "S7"
-                },
+                "thingName": {},
                 "thingId": {},
-                "thingTypeName": {
-                  "shape": "S4r"
-                },
+                "thingTypeName": {},
                 "thingGroupNames": {
                   "shape": "Shq"
                 },
@@ -4844,15 +4316,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "thingGroupName": {
-                  "shape": "S5"
-                },
-                "thingGroupId": {
-                  "shape": "S53"
-                },
-                "thingGroupDescription": {
-                  "shape": "S51"
-                },
+                "thingGroupName": {},
+                "thingGroupId": {},
+                "thingGroupDescription": {},
                 "attributes": {
                   "shape": "S4t"
                 },
@@ -4875,17 +4341,13 @@
           "authorizerName"
         ],
         "members": {
-          "authorizerName": {
-            "shape": "S18"
-          }
+          "authorizerName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {
-            "shape": "S18"
-          },
+          "authorizerName": {},
           "authorizerArn": {}
         }
       }
@@ -4903,12 +4365,10 @@
         ],
         "members": {
           "policyName": {
-            "shape": "Sj",
             "location": "uri",
             "locationName": "policyName"
           },
           "policyVersionId": {
-            "shape": "S3f",
             "location": "uri",
             "locationName": "policyVersionId"
           }
@@ -4932,9 +4392,7 @@
             ],
             "members": {
               "roleArn": {},
-              "logLevel": {
-                "shape": "Sc4"
-              }
+              "logLevel": {}
             }
           }
         },
@@ -4955,9 +4413,7 @@
           "logTarget": {
             "shape": "Sgx"
           },
-          "logLevel": {
-            "shape": "Sc4"
-          }
+          "logLevel": {}
         }
       }
     },
@@ -4969,9 +4425,7 @@
         "type": "structure",
         "members": {
           "roleArn": {},
-          "defaultLogLevel": {
-            "shape": "Sc4"
-          },
+          "defaultLogLevel": {},
           "disableAllLogs": {
             "type": "boolean"
           }
@@ -4996,9 +4450,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "Su"
-          }
+          "taskId": {}
         }
       }
     },
@@ -5016,23 +4468,15 @@
         ],
         "members": {
           "templateBody": {},
-          "inputFileBucket": {
-            "shape": "Sb7"
-          },
-          "inputFileKey": {
-            "shape": "Sb8"
-          },
-          "roleArn": {
-            "shape": "S1q"
-          }
+          "inputFileBucket": {},
+          "inputFileKey": {},
+          "roleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "Sb5"
-          }
+          "taskId": {}
         }
       }
     },
@@ -5048,7 +4492,6 @@
         ],
         "members": {
           "taskId": {
-            "shape": "Sb5",
             "location": "uri",
             "locationName": "taskId"
           }
@@ -5075,9 +4518,7 @@
             "type": "list",
             "member": {
               "shape": "Si9"
-            },
-            "max": 10,
-            "min": 1
+            }
           },
           "clientId": {
             "location": "querystring",
@@ -5131,14 +4572,7 @@
                     }
                   }
                 },
-                "authDecision": {
-                  "type": "string",
-                  "enum": [
-                    "ALLOWED",
-                    "EXPLICIT_DENY",
-                    "IMPLICIT_DENY"
-                  ]
-                },
+                "authDecision": {},
                 "missingContextValues": {
                   "type": "list",
                   "member": {}
@@ -5162,21 +4596,11 @@
         ],
         "members": {
           "authorizerName": {
-            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
-          "token": {
-            "type": "string",
-            "max": 6144,
-            "min": 1
-          },
-          "tokenSignature": {
-            "type": "string",
-            "max": 2560,
-            "min": 1,
-            "pattern": "[A-Za-z0-9+/]+={0,2}"
-          }
+          "token": {},
+          "tokenSignature": {}
         }
       },
       "output": {
@@ -5185,12 +4609,7 @@
           "isAuthenticated": {
             "type": "boolean"
           },
-          "principalId": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "[a-zA-Z0-9]+"
-          },
+          "principalId": {},
           "policyDocuments": {
             "type": "list",
             "member": {}
@@ -5217,18 +4636,14 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
           "targetAwsAccount": {
-            "shape": "S95",
             "location": "querystring",
             "locationName": "targetAwsAccount"
           },
-          "transferMessage": {
-            "shape": "S9h"
-          }
+          "transferMessage": {}
         }
       },
       "output": {
@@ -5246,9 +4661,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "auditNotificationTargetConfigurations": {
             "shape": "S86"
           },
@@ -5274,28 +4687,21 @@
         ],
         "members": {
           "authorizerName": {
-            "shape": "S18",
             "location": "uri",
             "locationName": "authorizerName"
           },
           "authorizerFunctionArn": {},
-          "tokenKeyName": {
-            "shape": "S1a"
-          },
+          "tokenKeyName": {},
           "tokenSigningPublicKeys": {
             "shape": "S1b"
           },
-          "status": {
-            "shape": "S1e"
-          }
+          "status": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "authorizerName": {
-            "shape": "S18"
-          },
+          "authorizerName": {},
           "authorizerArn": {}
         }
       }
@@ -5312,17 +4718,14 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "caCertificateId"
           },
           "newStatus": {
-            "shape": "S94",
             "location": "querystring",
             "locationName": "newStatus"
           },
           "newAutoRegistrationStatus": {
-            "shape": "S96",
             "location": "querystring",
             "locationName": "newAutoRegistrationStatus"
           },
@@ -5348,12 +4751,10 @@
         ],
         "members": {
           "certificateId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "certificateId"
           },
           "newStatus": {
-            "shape": "S9f",
             "location": "querystring",
             "locationName": "newStatus"
           }
@@ -5410,24 +4811,19 @@
         ],
         "members": {
           "roleAlias": {
-            "shape": "S3l",
             "location": "uri",
             "locationName": "roleAlias"
           },
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "credentialDurationSeconds": {
-            "shape": "S3m"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "roleAlias": {
-            "shape": "S3l"
-          },
+          "roleAlias": {},
           "roleAliasArn": {}
         }
       }
@@ -5443,20 +4839,13 @@
           "scheduledAuditName"
         ],
         "members": {
-          "frequency": {
-            "shape": "S3q"
-          },
-          "dayOfMonth": {
-            "shape": "S3r"
-          },
-          "dayOfWeek": {
-            "shape": "S3s"
-          },
+          "frequency": {},
+          "dayOfMonth": {},
+          "dayOfWeek": {},
           "targetCheckNames": {
             "shape": "S3t"
           },
           "scheduledAuditName": {
-            "shape": "S3v",
             "location": "uri",
             "locationName": "scheduledAuditName"
           }
@@ -5481,13 +4870,10 @@
         ],
         "members": {
           "securityProfileName": {
-            "shape": "So",
             "location": "uri",
             "locationName": "securityProfileName"
           },
-          "securityProfileDescription": {
-            "shape": "S3z"
-          },
+          "securityProfileDescription": {},
           "behaviors": {
             "shape": "S40"
           },
@@ -5504,13 +4890,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "securityProfileName": {
-            "shape": "So"
-          },
+          "securityProfileName": {},
           "securityProfileArn": {},
-          "securityProfileDescription": {
-            "shape": "S3z"
-          },
+          "securityProfileDescription": {},
           "behaviors": {
             "shape": "S40"
           },
@@ -5541,33 +4923,24 @@
         ],
         "members": {
           "streamId": {
-            "shape": "S2e",
             "location": "uri",
             "locationName": "streamId"
           },
-          "description": {
-            "shape": "S4k"
-          },
+          "description": {},
           "files": {
             "shape": "S4l"
           },
-          "roleArn": {
-            "shape": "S1q"
-          }
+          "roleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "streamId": {
-            "shape": "S2e"
-          },
+          "streamId": {},
           "streamArn": {},
-          "description": {
-            "shape": "S4k"
-          },
+          "description": {},
           "streamVersion": {
-            "shape": "S4p"
+            "type": "integer"
           }
         }
       }
@@ -5584,13 +4957,10 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S7",
             "location": "uri",
             "locationName": "thingName"
           },
-          "thingTypeName": {
-            "shape": "S4r"
-          },
+          "thingTypeName": {},
           "attributePayload": {
             "shape": "S4s"
           },
@@ -5620,7 +4990,6 @@
         ],
         "members": {
           "thingGroupName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "thingGroupName"
           },
@@ -5649,9 +5018,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "thingName": {
-            "shape": "S7"
-          },
+          "thingName": {},
           "thingGroupsToAdd": {
             "shape": "Sjn"
           },
@@ -5691,9 +5058,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "errorMessage": {
-                  "shape": "S8w"
-                }
+                "errorMessage": {}
               }
             }
           }
@@ -5702,182 +5067,46 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 64,
-      "min": 64,
-      "pattern": "(0x)?[a-fA-F0-9]+"
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
-    },
-    "S7": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
-    },
     "Sb": {
       "type": "list",
-      "member": {},
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
-    "Se": {
-      "type": "string",
-      "max": 2028,
-      "pattern": "[^\\p{C}]+"
-    },
-    "Sh": {
-      "type": "string",
-      "max": 2028,
-      "pattern": "[^\\p{C}]+"
-    },
-    "Sj": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]+"
-    },
-    "So": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
-    },
-    "Su": {
-      "type": "string",
-      "max": 40,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\-]+"
+      "member": {}
     },
     "S12": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 128,
-        "min": 1,
-        "pattern": "[a-zA-Z0-9:_-]+"
-      },
-      "value": {
-        "type": "string",
-        "max": 1024,
-        "min": 1,
-        "pattern": "[^\\p{C}]*+"
-      }
-    },
-    "S18": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w=,@-]+"
-    },
-    "S1a": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
+      "key": {},
+      "value": {}
     },
     "S1b": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 128,
-        "min": 1,
-        "pattern": "[a-zA-Z0-9:_-]+"
-      },
-      "value": {
-        "type": "string",
-        "max": 5120
-      }
-    },
-    "S1e": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "INACTIVE"
-      ]
-    },
-    "S1l": {
-      "type": "string",
-      "max": 65536,
-      "min": 1
-    },
-    "S1n": {
-      "type": "string",
-      "max": 1350,
-      "min": 1
-    },
-    "S1o": {
-      "type": "string",
-      "max": 32768
+      "key": {},
+      "value": {}
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "roleArn": {
-          "shape": "S1q"
-        },
+        "roleArn": {},
         "expiresInSec": {
-          "type": "long",
-          "max": 3600,
-          "min": 60
+          "type": "long"
         }
       }
-    },
-    "S1q": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S1s": {
-      "type": "string",
-      "enum": [
-        "CONTINUOUS",
-        "SNAPSHOT"
-      ]
     },
     "S1t": {
       "type": "structure",
       "members": {
         "maximumPerMinute": {
-          "type": "integer",
-          "max": 1000,
-          "min": 1
+          "type": "integer"
         }
       }
     },
-    "S22": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
-    "S23": {
-      "type": "string",
-      "max": 2028,
-      "pattern": "[^\\p{C}]+"
-    },
     "S24": {
       "type": "list",
-      "member": {},
-      "min": 1
+      "member": {}
     },
     "S26": {
       "type": "structure",
       "members": {
         "maximumPerMinute": {
-          "type": "integer",
-          "max": 1000,
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -5894,11 +5123,9 @@
               "stream": {
                 "type": "structure",
                 "members": {
-                  "streamId": {
-                    "shape": "S2e"
-                  },
+                  "streamId": {},
                   "fileId": {
-                    "shape": "S2f"
+                    "type": "integer"
                   }
                 }
               },
@@ -5929,9 +5156,7 @@
                       "s3Destination": {
                         "type": "structure",
                         "members": {
-                          "bucket": {
-                            "shape": "S2h"
-                          },
+                          "bucket": {},
                           "prefix": {}
                         }
                       }
@@ -5969,113 +5194,30 @@
             "value": {}
           }
         }
-      },
-      "max": 50,
-      "min": 1
-    },
-    "S2e": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
-    "S2f": {
-      "type": "integer",
-      "max": 255,
-      "min": 0
+      }
     },
     "S2g": {
       "type": "structure",
       "members": {
-        "bucket": {
-          "shape": "S2h"
-        },
-        "key": {
-          "type": "string",
-          "min": 1
-        },
+        "bucket": {},
+        "key": {},
         "version": {}
       }
-    },
-    "S2h": {
-      "type": "string",
-      "min": 1
     },
     "S35": {
       "type": "map",
       "key": {},
       "value": {}
     },
-    "S3a": {
-      "type": "string",
-      "enum": [
-        "CREATE_PENDING",
-        "CREATE_IN_PROGRESS",
-        "CREATE_COMPLETE",
-        "CREATE_FAILED"
-      ]
-    },
-    "S3f": {
-      "type": "string",
-      "pattern": "[0-9]+"
-    },
-    "S3l": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w=,@-]+"
-    },
-    "S3m": {
-      "type": "integer",
-      "max": 3600,
-      "min": 900
-    },
-    "S3q": {
-      "type": "string",
-      "enum": [
-        "DAILY",
-        "WEEKLY",
-        "BIWEEKLY",
-        "MONTHLY"
-      ]
-    },
-    "S3r": {
-      "type": "string",
-      "pattern": "^([1-9]|[12][0-9]|3[01])$|^LAST$"
-    },
-    "S3s": {
-      "type": "string",
-      "enum": [
-        "SUN",
-        "MON",
-        "TUE",
-        "WED",
-        "THU",
-        "FRI",
-        "SAT"
-      ]
-    },
     "S3t": {
       "type": "list",
       "member": {}
-    },
-    "S3v": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
-    "S3z": {
-      "type": "string",
-      "max": 1000,
-      "pattern": "[\\p{Graph}\\x20]*"
     },
     "S40": {
       "type": "list",
       "member": {
         "shape": "S41"
-      },
-      "max": 100
+      }
     },
     "S41": {
       "type": "structure",
@@ -6083,29 +5225,12 @@
         "name"
       ],
       "members": {
-        "name": {
-          "type": "string",
-          "max": 128,
-          "min": 1,
-          "pattern": "[a-zA-Z0-9:_-]+"
-        },
+        "name": {},
         "metric": {},
         "criteria": {
           "type": "structure",
           "members": {
-            "comparisonOperator": {
-              "type": "string",
-              "enum": [
-                "less-than",
-                "less-than-equals",
-                "greater-than",
-                "greater-than-equals",
-                "in-cidr-set",
-                "not-in-cidr-set",
-                "in-port-set",
-                "not-in-port-set"
-              ]
-            },
+            "comparisonOperator": {},
             "value": {
               "shape": "S46"
             },
@@ -6120,36 +5245,23 @@
       "type": "structure",
       "members": {
         "count": {
-          "type": "long",
-          "min": 0
+          "type": "long"
         },
         "cidrs": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "max": 43,
-            "min": 2,
-            "pattern": "[a-fA-F0-9:\\.\\/]+"
-          }
+          "member": {}
         },
         "ports": {
           "type": "list",
           "member": {
-            "type": "integer",
-            "max": 65535,
-            "min": 0
+            "type": "integer"
           }
         }
       }
     },
     "S4d": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "SNS"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "required": [
@@ -6158,16 +5270,9 @@
         ],
         "members": {
           "alertTargetArn": {},
-          "roleArn": {
-            "shape": "S1q"
-          }
+          "roleArn": {}
         }
       }
-    },
-    "S4k": {
-      "type": "string",
-      "max": 2028,
-      "pattern": "[^\\p{C}]+"
     },
     "S4l": {
       "type": "list",
@@ -6175,26 +5280,13 @@
         "type": "structure",
         "members": {
           "fileId": {
-            "shape": "S2f"
+            "type": "integer"
           },
           "s3Location": {
             "shape": "S2g"
           }
         }
-      },
-      "max": 50,
-      "min": 1
-    },
-    "S4p": {
-      "type": "integer",
-      "max": 65535,
-      "min": 0
-    },
-    "S4r": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
+      }
     },
     "S4s": {
       "type": "structure",
@@ -6209,66 +5301,27 @@
     },
     "S4t": {
       "type": "map",
-      "key": {
-        "shape": "S4u"
-      },
-      "value": {
-        "shape": "S4v"
-      }
-    },
-    "S4u": {
-      "type": "string",
-      "max": 128,
-      "pattern": "[a-zA-Z0-9_.,@/:#-]+"
-    },
-    "S4v": {
-      "type": "string",
-      "max": 800,
-      "pattern": "[a-zA-Z0-9_.,@/:#-]*"
+      "key": {},
+      "value": {}
     },
     "S50": {
       "type": "structure",
       "members": {
-        "thingGroupDescription": {
-          "shape": "S51"
-        },
+        "thingGroupDescription": {},
         "attributePayload": {
           "shape": "S4s"
         }
       }
     },
-    "S51": {
-      "type": "string",
-      "max": 2028,
-      "pattern": "[\\p{Graph}\\x20]*"
-    },
-    "S53": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\-]+"
-    },
     "S55": {
       "type": "structure",
       "members": {
-        "thingTypeDescription": {
-          "type": "string",
-          "max": 2028,
-          "pattern": "[\\p{Graph}\\x20]*"
-        },
+        "thingTypeDescription": {},
         "searchableAttributes": {
           "type": "list",
-          "member": {
-            "shape": "S4u"
-          }
+          "member": {}
         }
       }
-    },
-    "S5c": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
     },
     "S5d": {
       "type": "structure",
@@ -6295,9 +5348,7 @@
       "type": "list",
       "member": {
         "shape": "S5h"
-      },
-      "max": 10,
-      "min": 0
+      }
     },
     "S5h": {
       "type": "structure",
@@ -6316,14 +5367,10 @@
             "operation": {},
             "hashKeyField": {},
             "hashKeyValue": {},
-            "hashKeyType": {
-              "shape": "S5o"
-            },
+            "hashKeyType": {},
             "rangeKeyField": {},
             "rangeKeyValue": {},
-            "rangeKeyType": {
-              "shape": "S5o"
-            },
+            "rangeKeyType": {},
             "payloadField": {}
           }
         },
@@ -6360,13 +5407,7 @@
           "members": {
             "targetArn": {},
             "roleArn": {},
-            "messageFormat": {
-              "type": "string",
-              "enum": [
-                "RAW",
-                "JSON"
-              ]
-            }
+            "messageFormat": {}
           }
         },
         "sqs": {
@@ -6417,19 +5458,7 @@
             "roleArn": {},
             "bucketName": {},
             "key": {},
-            "cannedAcl": {
-              "type": "string",
-              "enum": [
-                "private",
-                "public-read",
-                "public-read-write",
-                "aws-exec-read",
-                "authenticated-read",
-                "bucket-owner-read",
-                "bucket-owner-full-control",
-                "log-delivery-write"
-              ]
-            }
+            "cannedAcl": {}
           }
         },
         "firehose": {
@@ -6441,10 +5470,7 @@
           "members": {
             "roleArn": {},
             "deliveryStreamName": {},
-            "separator": {
-              "type": "string",
-              "pattern": "([\\n\\t])|(\\r\\n)|(,)"
-            }
+            "separator": {}
           }
         },
         "cloudwatchMetric": {
@@ -6491,10 +5517,7 @@
           ],
           "members": {
             "roleArn": {},
-            "endpoint": {
-              "type": "string",
-              "pattern": "https?://.*"
-            },
+            "endpoint": {},
             "index": {},
             "type": {},
             "id": {}
@@ -6507,15 +5530,8 @@
             "url"
           ],
           "members": {
-            "token": {
-              "type": "string",
-              "min": 40
-            },
-            "url": {
-              "type": "string",
-              "max": 2000,
-              "pattern": "https://ingestion-[a-zA-Z0-9]{1,12}\\.[a-zA-Z0-9]+\\.((sfdc-matrix\\.net)|(sfdcnow\\.com))/streams/\\w{1,20}/\\w{1,20}/event"
-            }
+            "token": {},
+            "url": {}
           }
         },
         "iotAnalytics": {
@@ -6540,35 +5556,14 @@
         }
       }
     },
-    "S5o": {
-      "type": "string",
-      "enum": [
-        "STRING",
-        "NUMBER"
-      ]
-    },
-    "S7z": {
-      "type": "string",
-      "enum": [
-        "DEFAULT",
-        "THING_GROUP"
-      ]
-    },
     "S86": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "SNS"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
           "targetArn": {},
-          "roleArn": {
-            "shape": "S1q"
-          },
+          "roleArn": {},
           "enabled": {
             "type": "boolean"
           }
@@ -6587,43 +5582,17 @@
         }
       }
     },
-    "S8e": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "COMPLETED",
-        "FAILED",
-        "CANCELED"
-      ]
-    },
-    "S8f": {
-      "type": "string",
-      "enum": [
-        "ON_DEMAND_AUDIT_TASK",
-        "SCHEDULED_AUDIT_TASK"
-      ]
-    },
-    "S8w": {
-      "type": "string",
-      "max": 2048
-    },
     "S8z": {
       "type": "structure",
       "members": {
-        "authorizerName": {
-          "shape": "S18"
-        },
+        "authorizerName": {},
         "authorizerArn": {},
         "authorizerFunctionArn": {},
-        "tokenKeyName": {
-          "shape": "S1a"
-        },
+        "tokenKeyName": {},
         "tokenSigningPublicKeys": {
           "shape": "S1b"
         },
-        "status": {
-          "shape": "S1e"
-        },
+        "status": {},
         "creationDate": {
           "type": "timestamp"
         },
@@ -6631,30 +5600,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S94": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "INACTIVE"
-      ]
-    },
-    "S95": {
-      "type": "string",
-      "max": 12,
-      "min": 12,
-      "pattern": "[0-9]+"
-    },
-    "S96": {
-      "type": "string",
-      "enum": [
-        "ENABLE",
-        "DISABLE"
-      ]
-    },
-    "S97": {
-      "type": "integer",
-      "min": 1
     },
     "S99": {
       "type": "structure",
@@ -6671,44 +5616,12 @@
       "type": "structure",
       "members": {
         "templateBody": {},
-        "roleArn": {
-          "shape": "S1q"
-        }
+        "roleArn": {}
       }
-    },
-    "S9f": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "INACTIVE",
-        "REVOKED",
-        "PENDING_TRANSFER",
-        "REGISTER_INACTIVE",
-        "PENDING_ACTIVATION"
-      ]
-    },
-    "S9h": {
-      "type": "string",
-      "max": 128
     },
     "S9q": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "THING",
-          "THING_GROUP",
-          "THING_TYPE",
-          "THING_GROUP_MEMBERSHIP",
-          "THING_GROUP_HIERARCHY",
-          "THING_TYPE_ASSOCIATION",
-          "JOB",
-          "JOB_EXECUTION",
-          "POLICY",
-          "CERTIFICATE",
-          "CA_CERTIFICATE"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
@@ -6718,70 +5631,15 @@
         }
       }
     },
-    "S9w": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
-    },
-    "Sa3": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "CANCELED",
-        "COMPLETED",
-        "DELETION_IN_PROGRESS"
-      ]
-    },
-    "Sai": {
-      "type": "string",
-      "enum": [
-        "QUEUED",
-        "IN_PROGRESS",
-        "SUCCEEDED",
-        "FAILED",
-        "REJECTED",
-        "REMOVED",
-        "CANCELED"
-      ]
-    },
     "Sb2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "groupName": {
-            "shape": "S5"
-          },
+          "groupName": {},
           "groupArn": {}
         }
       }
-    },
-    "Sb5": {
-      "type": "string",
-      "max": 40
-    },
-    "Sb7": {
-      "type": "string",
-      "max": 256,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9._-]+"
-    },
-    "Sb8": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9!_.*'()-\\/]+"
-    },
-    "Sb9": {
-      "type": "string",
-      "enum": [
-        "InProgress",
-        "Completed",
-        "Failed",
-        "Cancelled",
-        "Cancelling"
-      ]
     },
     "Sbe": {
       "type": "structure",
@@ -6803,14 +5661,7 @@
         "thingIndexingMode"
       ],
       "members": {
-        "thingIndexingMode": {
-          "type": "string",
-          "enum": [
-            "OFF",
-            "REGISTRY",
-            "REGISTRY_AND_SHADOW"
-          ]
-        }
+        "thingIndexingMode": {}
       }
     },
     "Sby": {
@@ -6819,53 +5670,15 @@
         "thingGroupIndexingMode"
       ],
       "members": {
-        "thingGroupIndexingMode": {
-          "type": "string",
-          "enum": [
-            "OFF",
-            "ON"
-          ]
-        }
+        "thingGroupIndexingMode": {}
       }
-    },
-    "Sc4": {
-      "type": "string",
-      "enum": [
-        "DEBUG",
-        "INFO",
-        "ERROR",
-        "WARN",
-        "DISABLED"
-      ]
-    },
-    "Scs": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
-    },
-    "Scw": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\-]+"
-    },
-    "Scz": {
-      "type": "string",
-      "pattern": "[A-Za-z0-9+/]+={0,2}"
-    },
-    "Sd0": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
     },
     "Sd2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "policyName": {
-            "shape": "Sj"
-          },
+          "policyName": {},
           "policyArn": {}
         }
       }
@@ -6873,40 +5686,19 @@
     "Sd5": {
       "type": "structure",
       "members": {
-        "deviceCertificateId": {
-          "shape": "S2"
-        },
-        "caCertificateId": {
-          "shape": "S2"
-        },
+        "deviceCertificateId": {},
+        "caCertificateId": {},
         "cognitoIdentityPoolId": {},
         "clientId": {},
         "policyVersionIdentifier": {
           "type": "structure",
           "members": {
-            "policyName": {
-              "shape": "Sj"
-            },
-            "policyVersionId": {
-              "shape": "S3f"
-            }
+            "policyName": {},
+            "policyVersionId": {}
           }
         },
-        "account": {
-          "shape": "S95"
-        }
+        "account": {}
       }
-    },
-    "Sdc": {
-      "type": "string",
-      "enum": [
-        "DEVICE_CERTIFICATE",
-        "CA_CERTIFICATE",
-        "IOT_POLICY",
-        "COGNITO_IDENTITY_POOL",
-        "CLIENT_ID",
-        "ACCOUNT_SETTINGS"
-      ]
     },
     "Sdd": {
       "type": "map",
@@ -6919,34 +5711,18 @@
         "type": "structure",
         "members": {
           "certificateArn": {},
-          "certificateId": {
-            "shape": "S2"
-          },
-          "status": {
-            "shape": "S9f"
-          },
+          "certificateId": {},
+          "status": {},
           "creationDate": {
             "type": "timestamp"
           }
         }
       }
     },
-    "Se2": {
-      "type": "integer",
-      "max": 500,
-      "min": 1
-    },
-    "Se6": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
-    },
     "Sea": {
       "type": "structure",
       "members": {
-        "status": {
-          "shape": "Sai"
-        },
+        "status": {},
         "queuedAt": {
           "type": "timestamp"
         },
@@ -6965,16 +5741,9 @@
       "type": "list",
       "member": {}
     },
-    "Sf4": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
-    },
     "Sf6": {
       "type": "list",
-      "member": {
-        "shape": "S7"
-      }
+      "member": {}
     },
     "Sfh": {
       "type": "structure",
@@ -6983,9 +5752,7 @@
         "arn"
       ],
       "members": {
-        "name": {
-          "shape": "So"
-        },
+        "name": {},
         "arn": {}
       }
     },
@@ -6998,43 +5765,24 @@
         "arn": {}
       }
     },
-    "Sg5": {
-      "type": "string",
-      "enum": [
-        "ERRORS",
-        "RESULTS"
-      ]
-    },
     "Sgx": {
       "type": "structure",
       "required": [
         "targetType"
       ],
       "members": {
-        "targetType": {
-          "shape": "S7z"
-        },
+        "targetType": {},
         "targetName": {}
       }
     },
     "Shq": {
       "type": "list",
-      "member": {
-        "shape": "S5"
-      }
+      "member": {}
     },
     "Si9": {
       "type": "structure",
       "members": {
-        "actionType": {
-          "type": "string",
-          "enum": [
-            "PUBLISH",
-            "SUBSCRIBE",
-            "RECEIVE",
-            "CONNECT"
-          ]
-        },
+        "actionType": {},
         "resources": {
           "type": "list",
           "member": {}
@@ -7043,15 +5791,11 @@
     },
     "Sid": {
       "type": "list",
-      "member": {
-        "shape": "Sj"
-      }
+      "member": {}
     },
     "Sjn": {
       "type": "list",
-      "member": {
-        "shape": "S5"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/iot-data-2015-05-28.min.json
+++ b/apis/iot-data-2015-05-28.min.json
@@ -23,7 +23,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -54,7 +53,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -87,9 +85,7 @@
           "qos": {
             "location": "querystring",
             "locationName": "qos",
-            "type": "integer",
-            "max": 1,
-            "min": 0
+            "type": "integer"
           },
           "payload": {
             "type": "blob"
@@ -110,7 +106,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -131,12 +126,5 @@
       }
     }
   },
-  "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    }
-  }
+  "shapes": {}
 }

--- a/apis/iot-jobs-data-2017-09-29.min.json
+++ b/apis/iot-jobs-data-2017-09-29.min.json
@@ -25,12 +25,9 @@
         "members": {
           "jobId": {
             "location": "uri",
-            "locationName": "jobId",
-            "type": "string",
-            "pattern": "[a-zA-Z0-9_-]+|^\\$next"
+            "locationName": "jobId"
           },
           "thingName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -67,7 +64,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           }
@@ -97,7 +93,6 @@
         ],
         "members": {
           "thingName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
@@ -128,18 +123,14 @@
         ],
         "members": {
           "jobId": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "jobId"
           },
           "thingName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "thingName"
           },
-          "status": {
-            "shape": "S9"
-          },
+          "status": {},
           "statusDetails": {
             "shape": "Sa"
           },
@@ -163,9 +154,7 @@
           "executionState": {
             "type": "structure",
             "members": {
-              "status": {
-                "shape": "S9"
-              },
+              "status": {},
               "statusDetails": {
                 "shape": "Sa"
               },
@@ -174,32 +163,18 @@
               }
             }
           },
-          "jobDocument": {
-            "shape": "Sh"
-          }
+          "jobDocument": {}
         }
       }
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9:_-]+"
-    },
     "S7": {
       "type": "structure",
       "members": {
-        "jobId": {
-          "shape": "S8"
-        },
-        "thingName": {
-          "shape": "S3"
-        },
-        "status": {
-          "shape": "S9"
-        },
+        "jobId": {},
+        "thingName": {},
+        "status": {},
         "statusDetails": {
           "shape": "Sa"
         },
@@ -218,56 +193,20 @@
         "executionNumber": {
           "type": "long"
         },
-        "jobDocument": {
-          "shape": "Sh"
-        }
+        "jobDocument": {}
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_-]+"
-    },
-    "S9": {
-      "type": "string",
-      "enum": [
-        "QUEUED",
-        "IN_PROGRESS",
-        "SUCCEEDED",
-        "FAILED",
-        "REJECTED",
-        "REMOVED",
-        "CANCELED"
-      ]
     },
     "Sa": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 128,
-        "min": 1,
-        "pattern": "[a-zA-Z0-9:_-]+"
-      },
-      "value": {
-        "type": "string",
-        "max": 1024,
-        "min": 1,
-        "pattern": "[^\\p{C}]*+"
-      }
-    },
-    "Sh": {
-      "type": "string",
-      "max": 32768
+      "key": {},
+      "value": {}
     },
     "Sk": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "jobId": {
-            "shape": "S8"
-          },
+          "jobId": {},
           "queuedAt": {
             "type": "long"
           },

--- a/apis/iot1click-devices-2018-05-14.min.json
+++ b/apis/iot1click-devices-2018-05-14.min.json
@@ -33,10 +33,7 @@
         "type": "structure",
         "members": {
           "ClaimCode": {
-            "locationName": "claimCode",
-            "type": "string",
-            "min": 12,
-            "max": 40
+            "locationName": "claimCode"
           },
           "Total": {
             "locationName": "total",
@@ -210,9 +207,9 @@
             "locationName": "fromTimeStamp"
           },
           "MaxResults": {
-            "shape": "So",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -282,9 +279,9 @@
             "locationName": "deviceType"
           },
           "MaxResults": {
-            "shape": "So",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -403,11 +400,6 @@
     "Sn": {
       "type": "timestamp",
       "timestampFormat": "iso8601"
-    },
-    "So": {
-      "type": "integer",
-      "min": 1,
-      "max": 250
     }
   }
 }

--- a/apis/iot1click-projects-2018-05-14.min.json
+++ b/apis/iot1click-projects-2018-05-14.min.json
@@ -28,20 +28,15 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
-          "deviceId": {
-            "shape": "S4"
-          },
+          "deviceId": {},
           "deviceTemplateName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "deviceTemplateName"
           }
@@ -63,11 +58,8 @@
           "projectName"
         ],
         "members": {
-          "placementName": {
-            "shape": "S3"
-          },
+          "placementName": {},
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
@@ -91,12 +83,8 @@
           "projectName"
         ],
         "members": {
-          "projectName": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "Sd"
-          },
+          "projectName": {},
+          "description": {},
           "placementTemplate": {
             "shape": "Se"
           }
@@ -120,12 +108,10 @@
         ],
         "members": {
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -148,7 +134,6 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -172,12 +157,10 @@
         ],
         "members": {
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -199,12 +182,8 @@
               "updatedDate"
             ],
             "members": {
-              "projectName": {
-                "shape": "S2"
-              },
-              "placementName": {
-                "shape": "S3"
-              },
+              "projectName": {},
+              "placementName": {},
               "attributes": {
                 "shape": "S8"
               },
@@ -231,7 +210,6 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           }
@@ -251,12 +229,8 @@
               "updatedDate"
             ],
             "members": {
-              "projectName": {
-                "shape": "S2"
-              },
-              "description": {
-                "shape": "Sd"
-              },
+              "projectName": {},
+              "description": {},
               "createdDate": {
                 "type": "timestamp"
               },
@@ -285,17 +259,14 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "deviceTemplateName": {
-            "shape": "S5",
             "location": "uri",
             "locationName": "deviceTemplateName"
           }
@@ -319,12 +290,10 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           }
@@ -338,12 +307,8 @@
         "members": {
           "devices": {
             "type": "map",
-            "key": {
-              "shape": "S5"
-            },
-            "value": {
-              "shape": "S4"
-            }
+            "key": {},
+            "value": {}
           }
         }
       }
@@ -360,19 +325,17 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
           "nextToken": {
-            "shape": "S15",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S16",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -393,12 +356,8 @@
                 "updatedDate"
               ],
               "members": {
-                "projectName": {
-                  "shape": "S2"
-                },
-                "placementName": {
-                  "shape": "S3"
-                },
+                "projectName": {},
+                "placementName": {},
                 "createdDate": {
                   "type": "timestamp"
                 },
@@ -408,9 +367,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S15"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -423,14 +380,13 @@
         "type": "structure",
         "members": {
           "nextToken": {
-            "shape": "S15",
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S16",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -450,9 +406,7 @@
                 "updatedDate"
               ],
               "members": {
-                "projectName": {
-                  "shape": "S2"
-                },
+                "projectName": {},
                 "createdDate": {
                   "type": "timestamp"
                 },
@@ -462,9 +416,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "S15"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -481,12 +433,10 @@
         ],
         "members": {
           "placementName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "placementName"
           },
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
@@ -512,13 +462,10 @@
         ],
         "members": {
           "projectName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "projectName"
           },
-          "description": {
-            "shape": "Sd"
-          },
+          "description": {},
           "placementTemplate": {
             "shape": "Se"
           }
@@ -531,100 +478,35 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[0-9A-Za-z_-]+$"
-    },
-    "S3": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_-]+$"
-    },
-    "S4": {
-      "type": "string",
-      "max": 32,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_-]+$"
-    },
     "S8": {
       "type": "map",
-      "key": {
-        "shape": "S9"
-      },
-      "value": {
-        "type": "string",
-        "max": 800
-      }
-    },
-    "S9": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 500,
-      "min": 0
+      "key": {},
+      "value": {}
     },
     "Se": {
       "type": "structure",
       "members": {
         "defaultAttributes": {
           "type": "map",
-          "key": {
-            "shape": "S9"
-          },
-          "value": {
-            "type": "string",
-            "max": 800
-          }
+          "key": {},
+          "value": {}
         },
         "deviceTemplates": {
           "type": "map",
-          "key": {
-            "shape": "S5"
-          },
+          "key": {},
           "value": {
             "type": "structure",
             "members": {
-              "deviceType": {
-                "type": "string",
-                "max": 128
-              },
+              "deviceType": {},
               "callbackOverrides": {
                 "type": "map",
-                "key": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
-                "value": {
-                  "type": "string",
-                  "max": 200
-                }
+                "key": {},
+                "value": {}
               }
             }
           }
         }
       }
-    },
-    "S15": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S16": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
     }
   }
 }

--- a/apis/iotanalytics-2017-11-27.min.json
+++ b/apis/iotanalytics-2017-11-27.min.json
@@ -23,9 +23,7 @@
           "messages"
         ],
         "members": {
-          "channelName": {
-            "shape": "S2"
-          },
+          "channelName": {},
           "messages": {
             "type": "list",
             "member": {
@@ -35,9 +33,7 @@
                 "payload"
               ],
               "members": {
-                "messageId": {
-                  "shape": "S5"
-                },
+                "messageId": {},
                 "payload": {
                   "type": "blob"
                 }
@@ -54,9 +50,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "messageId": {
-                  "shape": "S5"
-                },
+                "messageId": {},
                 "errorCode": {},
                 "errorMessage": {}
               }
@@ -78,7 +72,6 @@
         ],
         "members": {
           "pipelineName": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -104,9 +97,7 @@
           "channelName"
         ],
         "members": {
-          "channelName": {
-            "shape": "S2"
-          },
+          "channelName": {},
           "retentionPeriod": {
             "shape": "Sh"
           },
@@ -118,9 +109,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "channelName": {
-            "shape": "S2"
-          },
+          "channelName": {},
           "channelArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -140,9 +129,7 @@
           "actions"
         ],
         "members": {
-          "datasetName": {
-            "shape": "Sr"
-          },
+          "datasetName": {},
           "actions": {
             "shape": "Ss"
           },
@@ -160,9 +147,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "datasetName": {
-            "shape": "Sr"
-          },
+          "datasetName": {},
           "datasetArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -181,7 +166,6 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -190,9 +174,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "versionId": {
-            "shape": "S1p"
-          }
+          "versionId": {}
         }
       }
     },
@@ -207,9 +189,7 @@
           "datastoreName"
         ],
         "members": {
-          "datastoreName": {
-            "shape": "S1r"
-          },
+          "datastoreName": {},
           "retentionPeriod": {
             "shape": "Sh"
           },
@@ -221,9 +201,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "datastoreName": {
-            "shape": "S1r"
-          },
+          "datastoreName": {},
           "datastoreArn": {},
           "retentionPeriod": {
             "shape": "Sh"
@@ -243,9 +221,7 @@
           "pipelineActivities"
         ],
         "members": {
-          "pipelineName": {
-            "shape": "Sd"
-          },
+          "pipelineName": {},
           "pipelineActivities": {
             "shape": "S1v"
           },
@@ -257,9 +233,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "pipelineName": {
-            "shape": "Sd"
-          },
+          "pipelineName": {},
           "pipelineArn": {}
         }
       }
@@ -277,7 +251,6 @@
         ],
         "members": {
           "channelName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           }
@@ -297,7 +270,6 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -317,12 +289,10 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
           "versionId": {
-            "shape": "S1p",
             "location": "querystring",
             "locationName": "versionId"
           }
@@ -342,7 +312,6 @@
         ],
         "members": {
           "datastoreName": {
-            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           }
@@ -362,7 +331,6 @@
         ],
         "members": {
           "pipelineName": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           }
@@ -381,7 +349,6 @@
         ],
         "members": {
           "channelName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
@@ -398,13 +365,9 @@
           "channel": {
             "type": "structure",
             "members": {
-              "name": {
-                "shape": "S2"
-              },
+              "name": {},
               "arn": {},
-              "status": {
-                "shape": "S2q"
-              },
+              "status": {},
               "retentionPeriod": {
                 "shape": "Sh"
               },
@@ -439,7 +402,6 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           }
@@ -451,9 +413,7 @@
           "dataset": {
             "type": "structure",
             "members": {
-              "name": {
-                "shape": "Sr"
-              },
+              "name": {},
               "arn": {},
               "actions": {
                 "shape": "Ss"
@@ -461,9 +421,7 @@
               "triggers": {
                 "shape": "S1g"
               },
-              "status": {
-                "shape": "S2y"
-              },
+              "status": {},
               "creationTime": {
                 "type": "timestamp"
               },
@@ -490,7 +448,6 @@
         ],
         "members": {
           "datastoreName": {
-            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           },
@@ -507,13 +464,9 @@
           "datastore": {
             "type": "structure",
             "members": {
-              "name": {
-                "shape": "S1r"
-              },
+              "name": {},
               "arn": {},
-              "status": {
-                "shape": "S32"
-              },
+              "status": {},
               "retentionPeriod": {
                 "shape": "Sh"
               },
@@ -566,7 +519,6 @@
         ],
         "members": {
           "pipelineName": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           }
@@ -578,9 +530,7 @@
           "pipeline": {
             "type": "structure",
             "members": {
-              "name": {
-                "shape": "Sd"
-              },
+              "name": {},
               "arn": {},
               "activities": {
                 "shape": "S1v"
@@ -611,12 +561,10 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
           "versionId": {
-            "shape": "S1p",
             "location": "querystring",
             "locationName": "versionId"
           }
@@ -657,9 +605,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -671,12 +619,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "channelName": {
-                  "shape": "S2"
-                },
-                "status": {
-                  "shape": "S2q"
-                },
+                "channelName": {},
+                "status": {},
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -702,7 +646,6 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
@@ -711,9 +654,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -725,9 +668,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "version": {
-                  "shape": "S1p"
-                },
+                "version": {},
                 "status": {
                   "shape": "S3l"
                 },
@@ -757,9 +698,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -771,12 +712,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "datasetName": {
-                  "shape": "Sr"
-                },
-                "status": {
-                  "shape": "S2y"
-                },
+                "datasetName": {},
+                "status": {},
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -791,20 +728,10 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "actionName": {
-                        "shape": "Su"
-                      },
-                      "actionType": {
-                        "type": "string",
-                        "enum": [
-                          "QUERY",
-                          "CONTAINER"
-                        ]
-                      }
+                      "actionName": {},
+                      "actionType": {}
                     }
-                  },
-                  "max": 1,
-                  "min": 1
+                  }
                 }
               }
             }
@@ -826,9 +753,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -840,12 +767,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "datastoreName": {
-                  "shape": "S1r"
-                },
-                "status": {
-                  "shape": "S32"
-                },
+                "datastoreName": {},
+                "status": {},
                 "creationTime": {
                   "type": "timestamp"
                 },
@@ -872,9 +795,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S3q",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -886,9 +809,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "pipelineName": {
-                  "shape": "Sd"
-                },
+                "pipelineName": {},
                 "reprocessingSummaries": {
                   "shape": "S3c"
                 },
@@ -917,7 +838,6 @@
         ],
         "members": {
           "resourceArn": {
-            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           }
@@ -990,16 +910,13 @@
         ],
         "members": {
           "channelName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
           "maxMessages": {
             "location": "querystring",
             "locationName": "maxMessages",
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           },
           "startTime": {
             "location": "querystring",
@@ -1033,7 +950,6 @@
         ],
         "members": {
           "pipelineName": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -1065,7 +981,6 @@
         ],
         "members": {
           "resourceArn": {
-            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           },
@@ -1093,7 +1008,6 @@
         ],
         "members": {
           "resourceArn": {
-            "shape": "S4e",
             "location": "querystring",
             "locationName": "resourceArn"
           },
@@ -1101,11 +1015,7 @@
             "location": "querystring",
             "locationName": "tagKeys",
             "type": "list",
-            "member": {
-              "shape": "Sm"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -1126,7 +1036,6 @@
         ],
         "members": {
           "channelName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "channelName"
           },
@@ -1149,7 +1058,6 @@
         ],
         "members": {
           "datasetName": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "datasetName"
           },
@@ -1177,7 +1085,6 @@
         ],
         "members": {
           "datastoreName": {
-            "shape": "S1r",
             "location": "uri",
             "locationName": "datastoreName"
           },
@@ -1200,7 +1107,6 @@
         ],
         "members": {
           "pipelineName": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "pipelineName"
           },
@@ -1212,23 +1118,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
-    },
     "Sh": {
       "type": "structure",
       "members": {
@@ -1236,8 +1125,7 @@
           "type": "boolean"
         },
         "numberOfDays": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -1250,38 +1138,17 @@
           "value"
         ],
         "members": {
-          "key": {
-            "shape": "Sm"
-          },
-          "value": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "max": 50,
-      "min": 1
-    },
-    "Sm": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "Sr": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
+      }
     },
     "Ss": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "actionName": {
-            "shape": "Su"
-          },
+          "actionName": {},
           "queryAction": {
             "type": "structure",
             "required": [
@@ -1308,9 +1175,7 @@
                       }
                     }
                   }
-                },
-                "max": 1,
-                "min": 0
+                }
               }
             }
           },
@@ -1322,13 +1187,8 @@
               "resourceConfiguration"
             ],
             "members": {
-              "image": {
-                "type": "string",
-                "max": 255
-              },
-              "executionRoleArn": {
-                "shape": "S14"
-              },
+              "image": {},
+              "executionRoleArn": {},
               "resourceConfiguration": {
                 "type": "structure",
                 "required": [
@@ -1336,17 +1196,9 @@
                   "volumeSizeInGB"
                 ],
                 "members": {
-                  "computeType": {
-                    "type": "string",
-                    "enum": [
-                      "ACU_1",
-                      "ACU_2"
-                    ]
-                  },
+                  "computeType": {},
                   "volumeSizeInGB": {
-                    "type": "integer",
-                    "max": 50,
-                    "min": 1
+                    "type": "integer"
                   }
                 }
               },
@@ -1358,16 +1210,8 @@
                     "name"
                   ],
                   "members": {
-                    "name": {
-                      "type": "string",
-                      "max": 256,
-                      "min": 1
-                    },
-                    "stringValue": {
-                      "type": "string",
-                      "max": 1024,
-                      "min": 0
-                    },
+                    "name": {},
+                    "stringValue": {},
                     "doubleValue": {
                       "type": "double"
                     },
@@ -1377,9 +1221,7 @@
                         "datasetName"
                       ],
                       "members": {
-                        "datasetName": {
-                          "shape": "Sr"
-                        }
+                        "datasetName": {}
                       }
                     },
                     "outputFileUriValue": {
@@ -1388,34 +1230,16 @@
                         "fileName"
                       ],
                       "members": {
-                        "fileName": {
-                          "type": "string",
-                          "pattern": "[\\w\\.-]{1,255}"
-                        }
+                        "fileName": {}
                       }
                     }
                   }
-                },
-                "max": 50,
-                "min": 0
+                }
               }
             }
           }
         }
-      },
-      "max": 1,
-      "min": 1
-    },
-    "Su": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
-    },
-    "S14": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
+      }
     },
     "S1g": {
       "type": "list",
@@ -1434,34 +1258,17 @@
               "name"
             ],
             "members": {
-              "name": {
-                "shape": "Sr"
-              }
+              "name": {}
             }
           }
         }
-      },
-      "max": 5,
-      "min": 0
-    },
-    "S1p": {
-      "type": "string",
-      "max": 36,
-      "min": 7
-    },
-    "S1r": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9_]+$"
+      }
     },
     "S1v": {
       "type": "list",
       "member": {
         "shape": "S1w"
-      },
-      "max": 25,
-      "min": 1
+      }
     },
     "S1w": {
       "type": "structure",
@@ -1473,15 +1280,9 @@
             "channelName"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "channelName": {
-              "shape": "S2"
-            },
-            "next": {
-              "shape": "S1y"
-            }
+            "name": {},
+            "channelName": {},
+            "next": {}
           }
         },
         "lambda": {
@@ -1492,23 +1293,12 @@
             "batchSize"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "lambdaName": {
-              "type": "string",
-              "max": 64,
-              "min": 1,
-              "pattern": "^[a-zA-Z0-9_-]+$"
-            },
+            "name": {},
+            "lambdaName": {},
             "batchSize": {
-              "type": "integer",
-              "max": 1000,
-              "min": 1
+              "type": "integer"
             },
-            "next": {
-              "shape": "S1y"
-            }
+            "next": {}
           }
         },
         "datastore": {
@@ -1518,12 +1308,8 @@
             "datastoreName"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "datastoreName": {
-              "shape": "S1r"
-            }
+            "name": {},
+            "datastoreName": {}
           }
         },
         "addAttributes": {
@@ -1533,23 +1319,13 @@
             "attributes"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
+            "name": {},
             "attributes": {
               "type": "map",
-              "key": {
-                "shape": "S25"
-              },
-              "value": {
-                "shape": "S25"
-              },
-              "max": 50,
-              "min": 1
+              "key": {},
+              "value": {}
             },
-            "next": {
-              "shape": "S1y"
-            }
+            "next": {}
           }
         },
         "removeAttributes": {
@@ -1559,15 +1335,11 @@
             "attributes"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
+            "name": {},
             "attributes": {
               "shape": "S27"
             },
-            "next": {
-              "shape": "S1y"
-            }
+            "next": {}
           }
         },
         "selectAttributes": {
@@ -1577,15 +1349,11 @@
             "attributes"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
+            "name": {},
             "attributes": {
               "shape": "S27"
             },
-            "next": {
-              "shape": "S1y"
-            }
+            "next": {}
           }
         },
         "filter": {
@@ -1595,17 +1363,9 @@
             "filter"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "filter": {
-              "type": "string",
-              "max": 256,
-              "min": 1
-            },
-            "next": {
-              "shape": "S1y"
-            }
+            "name": {},
+            "filter": {},
+            "next": {}
           }
         },
         "math": {
@@ -1616,20 +1376,10 @@
             "math"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "attribute": {
-              "shape": "S25"
-            },
-            "math": {
-              "type": "string",
-              "max": 256,
-              "min": 1
-            },
-            "next": {
-              "shape": "S1y"
-            }
+            "name": {},
+            "attribute": {},
+            "math": {},
+            "next": {}
           }
         },
         "deviceRegistryEnrich": {
@@ -1641,21 +1391,11 @@
             "roleArn"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "attribute": {
-              "shape": "S25"
-            },
-            "thingName": {
-              "shape": "S25"
-            },
-            "roleArn": {
-              "shape": "S14"
-            },
-            "next": {
-              "shape": "S1y"
-            }
+            "name": {},
+            "attribute": {},
+            "thingName": {},
+            "roleArn": {},
+            "next": {}
           }
         },
         "deviceShadowEnrich": {
@@ -1667,50 +1407,18 @@
             "roleArn"
           ],
           "members": {
-            "name": {
-              "shape": "S1y"
-            },
-            "attribute": {
-              "shape": "S25"
-            },
-            "thingName": {
-              "shape": "S25"
-            },
-            "roleArn": {
-              "shape": "S14"
-            },
-            "next": {
-              "shape": "S1y"
-            }
+            "name": {},
+            "attribute": {},
+            "thingName": {},
+            "roleArn": {},
+            "next": {}
           }
         }
       }
     },
-    "S1y": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S25": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
     "S27": {
       "type": "list",
-      "member": {
-        "shape": "S25"
-      },
-      "max": 50,
-      "min": 1
-    },
-    "S2q": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "ACTIVE",
-        "DELETING"
-      ]
+      "member": {}
     },
     "S2t": {
       "type": "structure",
@@ -1723,22 +1431,6 @@
         }
       }
     },
-    "S2y": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "ACTIVE",
-        "DELETING"
-      ]
-    },
-    "S32": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "ACTIVE",
-        "DELETING"
-      ]
-    },
     "S36": {
       "type": "structure",
       "required": [
@@ -1747,15 +1439,8 @@
         "enabled"
       ],
       "members": {
-        "roleArn": {
-          "shape": "S14"
-        },
-        "level": {
-          "type": "string",
-          "enum": [
-            "ERROR"
-          ]
-        },
+        "roleArn": {},
+        "level": {},
         "enabled": {
           "type": "boolean"
         }
@@ -1767,15 +1452,7 @@
         "type": "structure",
         "members": {
           "id": {},
-          "status": {
-            "type": "string",
-            "enum": [
-              "RUNNING",
-              "SUCCEEDED",
-              "CANCELLED",
-              "FAILED"
-            ]
-          },
+          "status": {},
           "creationTime": {
             "type": "timestamp"
           }
@@ -1785,34 +1462,15 @@
     "S3l": {
       "type": "structure",
       "members": {
-        "state": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "SUCCEEDED",
-            "FAILED"
-          ]
-        },
+        "state": {},
         "reason": {}
       }
-    },
-    "S3q": {
-      "type": "integer",
-      "max": 250,
-      "min": 1
-    },
-    "S4e": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
     },
     "S4i": {
       "type": "list",
       "member": {
         "type": "blob"
-      },
-      "max": 10,
-      "min": 1
+      }
     }
   }
 }

--- a/apis/kinesis-2013-12-02.min.json
+++ b/apis/kinesis-2013-12-02.min.json
@@ -24,19 +24,11 @@
           "Tags"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "Tags": {
             "type": "map",
-            "key": {
-              "shape": "S4"
-            },
-            "value": {
-              "shape": "S5"
-            },
-            "max": 50,
-            "min": 1
+            "key": {},
+            "value": {}
           }
         }
       }
@@ -49,11 +41,9 @@
           "ShardCount"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "ShardCount": {
-            "shape": "S7"
+            "type": "integer"
           }
         }
       }
@@ -66,11 +56,9 @@
           "RetentionPeriodHours"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "RetentionPeriodHours": {
-            "shape": "S9"
+            "type": "integer"
           }
         }
       }
@@ -82,9 +70,7 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "EnforceConsumerDeletion": {
             "type": "boolean"
           }
@@ -95,15 +81,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamARN": {
-            "shape": "Sd"
-          },
-          "ConsumerName": {
-            "shape": "Se"
-          },
-          "ConsumerARN": {
-            "shape": "Sf"
-          }
+          "StreamARN": {},
+          "ConsumerName": {},
+          "ConsumerARN": {}
         }
       }
     },
@@ -120,10 +100,10 @@
         ],
         "members": {
           "ShardLimit": {
-            "shape": "Si"
+            "type": "integer"
           },
           "OpenShardCount": {
-            "shape": "Si"
+            "type": "integer"
           }
         }
       }
@@ -135,17 +115,11 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "Limit": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
-          "ExclusiveStartShardId": {
-            "shape": "Sl"
-          }
+          "ExclusiveStartShardId": {}
         }
       },
       "output": {
@@ -167,15 +141,9 @@
               "EnhancedMonitoring"
             ],
             "members": {
-              "StreamName": {
-                "shape": "S2"
-              },
-              "StreamARN": {
-                "shape": "Sd"
-              },
-              "StreamStatus": {
-                "shape": "So"
-              },
+              "StreamName": {},
+              "StreamARN": {},
+              "StreamStatus": {},
               "Shards": {
                 "shape": "Sp"
               },
@@ -183,7 +151,7 @@
                 "type": "boolean"
               },
               "RetentionPeriodHours": {
-                "shape": "S9"
+                "type": "integer"
               },
               "StreamCreationTimestamp": {
                 "type": "timestamp"
@@ -191,12 +159,8 @@
               "EnhancedMonitoring": {
                 "shape": "Sw"
               },
-              "EncryptionType": {
-                "shape": "S10"
-              },
-              "KeyId": {
-                "shape": "S11"
-              }
+              "EncryptionType": {},
+              "KeyId": {}
             }
           }
         }
@@ -206,15 +170,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamARN": {
-            "shape": "Sd"
-          },
-          "ConsumerName": {
-            "shape": "Se"
-          },
-          "ConsumerARN": {
-            "shape": "Sf"
-          }
+          "StreamARN": {},
+          "ConsumerName": {},
+          "ConsumerARN": {}
         }
       },
       "output": {
@@ -233,21 +191,13 @@
               "StreamARN"
             ],
             "members": {
-              "ConsumerName": {
-                "shape": "Se"
-              },
-              "ConsumerARN": {
-                "shape": "Sf"
-              },
-              "ConsumerStatus": {
-                "shape": "S15"
-              },
+              "ConsumerName": {},
+              "ConsumerARN": {},
+              "ConsumerStatus": {},
               "ConsumerCreationTimestamp": {
                 "type": "timestamp"
               },
-              "StreamARN": {
-                "shape": "Sd"
-              }
+              "StreamARN": {}
             }
           }
         }
@@ -260,9 +210,7 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          }
+          "StreamName": {}
         }
       },
       "output": {
@@ -283,17 +231,11 @@
               "OpenShardCount"
             ],
             "members": {
-              "StreamName": {
-                "shape": "S2"
-              },
-              "StreamARN": {
-                "shape": "Sd"
-              },
-              "StreamStatus": {
-                "shape": "So"
-              },
+              "StreamName": {},
+              "StreamARN": {},
+              "StreamStatus": {},
               "RetentionPeriodHours": {
-                "shape": "S7"
+                "type": "integer"
               },
               "StreamCreationTimestamp": {
                 "type": "timestamp"
@@ -301,19 +243,13 @@
               "EnhancedMonitoring": {
                 "shape": "Sw"
               },
-              "EncryptionType": {
-                "shape": "S10"
-              },
-              "KeyId": {
-                "shape": "S11"
-              },
+              "EncryptionType": {},
+              "KeyId": {},
               "OpenShardCount": {
-                "shape": "Si"
+                "type": "integer"
               },
               "ConsumerCount": {
-                "type": "integer",
-                "max": 1000000,
-                "min": 0
+                "type": "integer"
               }
             }
           }
@@ -328,9 +264,7 @@
           "ShardLevelMetrics"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "ShardLevelMetrics": {
             "shape": "Sy"
           }
@@ -348,9 +282,7 @@
           "ShardLevelMetrics"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "ShardLevelMetrics": {
             "shape": "Sy"
           }
@@ -367,13 +299,9 @@
           "ShardIterator"
         ],
         "members": {
-          "ShardIterator": {
-            "shape": "S1e"
-          },
+          "ShardIterator": {},
           "Limit": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -393,30 +321,21 @@
                 "PartitionKey"
               ],
               "members": {
-                "SequenceNumber": {
-                  "shape": "Su"
-                },
+                "SequenceNumber": {},
                 "ApproximateArrivalTimestamp": {
                   "type": "timestamp"
                 },
                 "Data": {
-                  "shape": "S1j"
+                  "type": "blob"
                 },
-                "PartitionKey": {
-                  "shape": "S1k"
-                },
-                "EncryptionType": {
-                  "shape": "S10"
-                }
+                "PartitionKey": {},
+                "EncryptionType": {}
               }
             }
           },
-          "NextShardIterator": {
-            "shape": "S1e"
-          },
+          "NextShardIterator": {},
           "MillisBehindLatest": {
-            "type": "long",
-            "min": 0
+            "type": "long"
           }
         }
       }
@@ -430,25 +349,10 @@
           "ShardIteratorType"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "ShardId": {
-            "shape": "Sl"
-          },
-          "ShardIteratorType": {
-            "type": "string",
-            "enum": [
-              "AT_SEQUENCE_NUMBER",
-              "AFTER_SEQUENCE_NUMBER",
-              "TRIM_HORIZON",
-              "LATEST",
-              "AT_TIMESTAMP"
-            ]
-          },
-          "StartingSequenceNumber": {
-            "shape": "Su"
-          },
+          "StreamName": {},
+          "ShardId": {},
+          "ShardIteratorType": {},
+          "StartingSequenceNumber": {},
           "Timestamp": {
             "type": "timestamp"
           }
@@ -457,9 +361,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ShardIterator": {
-            "shape": "S1e"
-          }
+          "ShardIterator": {}
         }
       }
     },
@@ -471,11 +373,9 @@
           "RetentionPeriodHours"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "RetentionPeriodHours": {
-            "shape": "S9"
+            "type": "integer"
           }
         }
       }
@@ -484,19 +384,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S1r"
-          },
-          "ExclusiveStartShardId": {
-            "shape": "Sl"
-          },
+          "StreamName": {},
+          "NextToken": {},
+          "ExclusiveStartShardId": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
           "StreamCreationTimestamp": {
             "type": "timestamp"
@@ -509,9 +401,7 @@
           "Shards": {
             "shape": "Sp"
           },
-          "NextToken": {
-            "shape": "S1r"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -522,16 +412,10 @@
           "StreamARN"
         ],
         "members": {
-          "StreamARN": {
-            "shape": "Sd"
-          },
-          "NextToken": {
-            "shape": "S1r"
-          },
+          "StreamARN": {},
+          "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
           "StreamCreationTimestamp": {
             "type": "timestamp"
@@ -547,9 +431,7 @@
               "shape": "S1y"
             }
           },
-          "NextToken": {
-            "shape": "S1r"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -558,13 +440,9 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
-          "ExclusiveStartStreamName": {
-            "shape": "S2"
-          }
+          "ExclusiveStartStreamName": {}
         }
       },
       "output": {
@@ -576,9 +454,7 @@
         "members": {
           "StreamNames": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            }
+            "member": {}
           },
           "HasMoreStreams": {
             "type": "boolean"
@@ -593,16 +469,10 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "ExclusiveStartTagKey": {
-            "shape": "S4"
-          },
+          "StreamName": {},
+          "ExclusiveStartTagKey": {},
           "Limit": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -621,15 +491,10 @@
                 "Key"
               ],
               "members": {
-                "Key": {
-                  "shape": "S4"
-                },
-                "Value": {
-                  "shape": "S5"
-                }
+                "Key": {},
+                "Value": {}
               }
-            },
-            "min": 0
+            }
           },
           "HasMoreTags": {
             "type": "boolean"
@@ -646,15 +511,9 @@
           "AdjacentShardToMerge"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "ShardToMerge": {
-            "shape": "Sl"
-          },
-          "AdjacentShardToMerge": {
-            "shape": "Sl"
-          }
+          "StreamName": {},
+          "ShardToMerge": {},
+          "AdjacentShardToMerge": {}
         }
       }
     },
@@ -667,21 +526,13 @@
           "PartitionKey"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "Data": {
-            "shape": "S1j"
+            "type": "blob"
           },
-          "PartitionKey": {
-            "shape": "S1k"
-          },
-          "ExplicitHashKey": {
-            "shape": "Ss"
-          },
-          "SequenceNumberForOrdering": {
-            "shape": "Su"
-          }
+          "PartitionKey": {},
+          "ExplicitHashKey": {},
+          "SequenceNumberForOrdering": {}
         }
       },
       "output": {
@@ -691,15 +542,9 @@
           "SequenceNumber"
         ],
         "members": {
-          "ShardId": {
-            "shape": "Sl"
-          },
-          "SequenceNumber": {
-            "shape": "Su"
-          },
-          "EncryptionType": {
-            "shape": "S10"
-          }
+          "ShardId": {},
+          "SequenceNumber": {},
+          "EncryptionType": {}
         }
       }
     },
@@ -721,22 +566,14 @@
               ],
               "members": {
                 "Data": {
-                  "shape": "S1j"
+                  "type": "blob"
                 },
-                "ExplicitHashKey": {
-                  "shape": "Ss"
-                },
-                "PartitionKey": {
-                  "shape": "S1k"
-                }
+                "ExplicitHashKey": {},
+                "PartitionKey": {}
               }
-            },
-            "max": 500,
-            "min": 1
+            }
           },
-          "StreamName": {
-            "shape": "S2"
-          }
+          "StreamName": {}
         }
       },
       "output": {
@@ -746,29 +583,21 @@
         ],
         "members": {
           "FailedRecordCount": {
-            "shape": "S7"
+            "type": "integer"
           },
           "Records": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "SequenceNumber": {
-                  "shape": "Su"
-                },
-                "ShardId": {
-                  "shape": "Sl"
-                },
+                "SequenceNumber": {},
+                "ShardId": {},
                 "ErrorCode": {},
                 "ErrorMessage": {}
               }
-            },
-            "max": 500,
-            "min": 1
+            }
           },
-          "EncryptionType": {
-            "shape": "S10"
-          }
+          "EncryptionType": {}
         }
       }
     },
@@ -780,12 +609,8 @@
           "ConsumerName"
         ],
         "members": {
-          "StreamARN": {
-            "shape": "Sd"
-          },
-          "ConsumerName": {
-            "shape": "Se"
-          }
+          "StreamARN": {},
+          "ConsumerName": {}
         }
       },
       "output": {
@@ -808,16 +633,10 @@
           "TagKeys"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       }
@@ -831,15 +650,9 @@
           "NewStartingHashKey"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "ShardToSplit": {
-            "shape": "Sl"
-          },
-          "NewStartingHashKey": {
-            "shape": "Ss"
-          }
+          "StreamName": {},
+          "ShardToSplit": {},
+          "NewStartingHashKey": {}
         }
       }
     },
@@ -852,15 +665,9 @@
           "KeyId"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "EncryptionType": {
-            "shape": "S10"
-          },
-          "KeyId": {
-            "shape": "S11"
-          }
+          "StreamName": {},
+          "EncryptionType": {},
+          "KeyId": {}
         }
       }
     },
@@ -873,15 +680,9 @@
           "KeyId"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "EncryptionType": {
-            "shape": "S10"
-          },
-          "KeyId": {
-            "shape": "S11"
-          }
+          "StreamName": {},
+          "EncryptionType": {},
+          "KeyId": {}
         }
       }
     },
@@ -894,101 +695,28 @@
           "ScalingType"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "TargetShardCount": {
-            "shape": "S7"
+            "type": "integer"
           },
-          "ScalingType": {
-            "type": "string",
-            "enum": [
-              "UNIFORM_SCALING"
-            ]
-          }
+          "ScalingType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "CurrentShardCount": {
-            "shape": "S7"
+            "type": "integer"
           },
           "TargetShardCount": {
-            "shape": "S7"
+            "type": "integer"
           }
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S4": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "S7": {
-      "type": "integer",
-      "max": 100000,
-      "min": 1
-    },
-    "S9": {
-      "type": "integer",
-      "max": 168,
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:aws.*:kinesis:.*:\\d{12}:stream/.*"
-    },
-    "Se": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "^(arn):aws.*:kinesis:.*:\\d{12}:.*stream\\/[a-zA-Z0-9_.-]+\\/consumer\\/[a-zA-Z0-9_.-]+:[0-9]+"
-    },
-    "Si": {
-      "type": "integer",
-      "max": 1000000,
-      "min": 0
-    },
-    "Sl": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "DELETING",
-        "ACTIVE",
-        "UPDATING"
-      ]
-    },
     "Sp": {
       "type": "list",
       "member": {
@@ -999,15 +727,9 @@
           "SequenceNumberRange"
         ],
         "members": {
-          "ShardId": {
-            "shape": "Sl"
-          },
-          "ParentShardId": {
-            "shape": "Sl"
-          },
-          "AdjacentParentShardId": {
-            "shape": "Sl"
-          },
+          "ShardId": {},
+          "ParentShardId": {},
+          "AdjacentParentShardId": {},
           "HashKeyRange": {
             "type": "structure",
             "required": [
@@ -1015,12 +737,8 @@
               "EndingHashKey"
             ],
             "members": {
-              "StartingHashKey": {
-                "shape": "Ss"
-              },
-              "EndingHashKey": {
-                "shape": "Ss"
-              }
+              "StartingHashKey": {},
+              "EndingHashKey": {}
             }
           },
           "SequenceNumberRange": {
@@ -1029,24 +747,12 @@
               "StartingSequenceNumber"
             ],
             "members": {
-              "StartingSequenceNumber": {
-                "shape": "Su"
-              },
-              "EndingSequenceNumber": {
-                "shape": "Su"
-              }
+              "StartingSequenceNumber": {},
+              "EndingSequenceNumber": {}
             }
           }
         }
       }
-    },
-    "Ss": {
-      "type": "string",
-      "pattern": "0|([1-9]\\d{0,38})"
-    },
-    "Su": {
-      "type": "string",
-      "pattern": "0|([1-9]\\d{0,128})"
     },
     "Sw": {
       "type": "list",
@@ -1061,48 +767,12 @@
     },
     "Sy": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "IncomingBytes",
-          "IncomingRecords",
-          "OutgoingBytes",
-          "OutgoingRecords",
-          "WriteProvisionedThroughputExceeded",
-          "ReadProvisionedThroughputExceeded",
-          "IteratorAgeMilliseconds",
-          "ALL"
-        ]
-      },
-      "max": 7,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "KMS"
-      ]
-    },
-    "S11": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "DELETING",
-        "ACTIVE"
-      ]
+      "member": {}
     },
     "S1b": {
       "type": "structure",
       "members": {
-        "StreamName": {
-          "shape": "S2"
-        },
+        "StreamName": {},
         "CurrentShardLevelMetrics": {
           "shape": "Sy"
         },
@@ -1110,26 +780,6 @@
           "shape": "Sy"
         }
       }
-    },
-    "S1e": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
-    "S1j": {
-      "type": "blob",
-      "max": 1048576,
-      "min": 0
-    },
-    "S1k": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S1r": {
-      "type": "string",
-      "max": 1048576,
-      "min": 1
     },
     "S1y": {
       "type": "structure",
@@ -1140,15 +790,9 @@
         "ConsumerCreationTimestamp"
       ],
       "members": {
-        "ConsumerName": {
-          "shape": "Se"
-        },
-        "ConsumerARN": {
-          "shape": "Sf"
-        },
-        "ConsumerStatus": {
-          "shape": "S15"
-        },
+        "ConsumerName": {},
+        "ConsumerARN": {},
+        "ConsumerStatus": {},
         "ConsumerCreationTimestamp": {
           "type": "timestamp"
         }

--- a/apis/kinesis-video-archived-media-2017-09-30.min.json
+++ b/apis/kinesis-video-archived-media-2017-09-30.min.json
@@ -18,32 +18,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
-          "StreamARN": {
-            "type": "string",
-            "max": 1024,
-            "min": 1,
-            "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
-          },
-          "PlaybackMode": {
-            "type": "string",
-            "enum": [
-              "LIVE",
-              "ON_DEMAND"
-            ]
-          },
+          "StreamName": {},
+          "StreamARN": {},
+          "PlaybackMode": {},
           "HLSFragmentSelector": {
             "type": "structure",
             "members": {
-              "FragmentSelectorType": {
-                "type": "string",
-                "enum": [
-                  "PRODUCER_TIMESTAMP",
-                  "SERVER_TIMESTAMP"
-                ]
-              },
+              "FragmentSelectorType": {},
               "TimestampRange": {
                 "type": "structure",
                 "members": {
@@ -57,20 +38,12 @@
               }
             }
           },
-          "DiscontinuityMode": {
-            "type": "string",
-            "enum": [
-              "ALWAYS",
-              "NEVER"
-            ]
-          },
+          "DiscontinuityMode": {},
           "Expires": {
-            "type": "integer",
-            "max": 43200,
-            "min": 300
+            "type": "integer"
           },
           "MaxMediaPlaylistFragmentResults": {
-            "shape": "Sb"
+            "type": "long"
           }
         }
       },
@@ -92,19 +65,10 @@
           "Fragments"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "Fragments": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 128,
-              "min": 1,
-              "pattern": "^[0-9]+$"
-            },
-            "max": 1000,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -113,11 +77,7 @@
         "members": {
           "ContentType": {
             "location": "header",
-            "locationName": "Content-Type",
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
+            "locationName": "Content-Type"
           },
           "Payload": {
             "type": "blob",
@@ -137,15 +97,11 @@
           "StreamName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S2"
-          },
+          "StreamName": {},
           "MaxResults": {
-            "shape": "Sb"
+            "type": "long"
           },
-          "NextToken": {
-            "shape": "Sl"
-          },
+          "NextToken": {},
           "FragmentSelector": {
             "type": "structure",
             "required": [
@@ -153,13 +109,7 @@
               "TimestampRange"
             ],
             "members": {
-              "FragmentSelectorType": {
-                "type": "string",
-                "enum": [
-                  "PRODUCER_TIMESTAMP",
-                  "SERVER_TIMESTAMP"
-                ]
-              },
+              "FragmentSelectorType": {},
               "TimestampRange": {
                 "type": "structure",
                 "required": [
@@ -187,9 +137,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "FragmentNumber": {
-                  "shape": "Sl"
-                },
+                "FragmentNumber": {},
                 "FragmentSizeInBytes": {
                   "type": "long"
                 },
@@ -205,28 +153,10 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sl"
-          }
+          "NextToken": {}
         }
       }
     }
   },
-  "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "Sb": {
-      "type": "long",
-      "max": 1000,
-      "min": 1
-    },
-    "Sl": {
-      "type": "string",
-      "min": 1
-    }
-  }
+  "shapes": {}
 }

--- a/apis/kinesis-video-media-2017-09-30.min.json
+++ b/apis/kinesis-video-media-2017-09-30.min.json
@@ -21,50 +21,20 @@
           "StartSelector"
         ],
         "members": {
-          "StreamName": {
-            "type": "string",
-            "max": 256,
-            "min": 1,
-            "pattern": "[a-zA-Z0-9_.-]+"
-          },
-          "StreamARN": {
-            "type": "string",
-            "max": 1024,
-            "min": 1,
-            "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
-          },
+          "StreamName": {},
+          "StreamARN": {},
           "StartSelector": {
             "type": "structure",
             "required": [
               "StartSelectorType"
             ],
             "members": {
-              "StartSelectorType": {
-                "type": "string",
-                "enum": [
-                  "FRAGMENT_NUMBER",
-                  "SERVER_TIMESTAMP",
-                  "PRODUCER_TIMESTAMP",
-                  "NOW",
-                  "EARLIEST",
-                  "CONTINUATION_TOKEN"
-                ]
-              },
-              "AfterFragmentNumber": {
-                "type": "string",
-                "max": 128,
-                "min": 1,
-                "pattern": "^[0-9]+$"
-              },
+              "StartSelectorType": {},
+              "AfterFragmentNumber": {},
               "StartTimestamp": {
                 "type": "timestamp"
               },
-              "ContinuationToken": {
-                "type": "string",
-                "max": 128,
-                "min": 1,
-                "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
-              }
+              "ContinuationToken": {}
             }
           }
         }
@@ -74,11 +44,7 @@
         "members": {
           "ContentType": {
             "location": "header",
-            "locationName": "Content-Type",
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "^[a-zA-Z0-9_\\.\\-]+$"
+            "locationName": "Content-Type"
           },
           "Payload": {
             "type": "blob",

--- a/apis/kinesisanalytics-2015-08-14.min.json
+++ b/apis/kinesisanalytics-2015-08-14.min.json
@@ -23,11 +23,9 @@
           "CloudWatchLoggingOption"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
           "CloudWatchLoggingOption": {
             "shape": "S4"
@@ -48,11 +46,9 @@
           "Input"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
           "Input": {
             "shape": "S9"
@@ -74,15 +70,11 @@
           "InputProcessingConfiguration"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
-          "InputId": {
-            "shape": "Sz"
-          },
+          "InputId": {},
           "InputProcessingConfiguration": {
             "shape": "Sb"
           }
@@ -102,11 +94,9 @@
           "Output"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
           "Output": {
             "shape": "S12"
@@ -127,11 +117,9 @@
           "ReferenceDataSource"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
           "ReferenceDataSource": {
             "type": "structure",
@@ -140,9 +128,7 @@
               "ReferenceSchema"
             ],
             "members": {
-              "TableName": {
-                "shape": "S1a"
-              },
+              "TableName": {},
               "S3ReferenceDataSource": {
                 "type": "structure",
                 "required": [
@@ -151,15 +137,9 @@
                   "ReferenceRoleARN"
                 ],
                 "members": {
-                  "BucketARN": {
-                    "shape": "S1c"
-                  },
-                  "FileKey": {
-                    "shape": "S1d"
-                  },
-                  "ReferenceRoleARN": {
-                    "shape": "S6"
-                  }
+                  "BucketARN": {},
+                  "FileKey": {},
+                  "ReferenceRoleARN": {}
                 }
               },
               "ReferenceSchema": {
@@ -181,12 +161,8 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
-          "ApplicationDescription": {
-            "shape": "S1g"
-          },
+          "ApplicationName": {},
+          "ApplicationDescription": {},
           "Inputs": {
             "type": "list",
             "member": {
@@ -205,9 +181,7 @@
               "shape": "S4"
             }
           },
-          "ApplicationCode": {
-            "shape": "S1k"
-          }
+          "ApplicationCode": {}
         }
       },
       "output": {
@@ -230,9 +204,7 @@
           "CreateTimestamp"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CreateTimestamp": {
             "type": "timestamp"
           }
@@ -252,15 +224,11 @@
           "CloudWatchLoggingOptionId"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
-          "CloudWatchLoggingOptionId": {
-            "shape": "Sz"
-          }
+          "CloudWatchLoggingOptionId": {}
         }
       },
       "output": {
@@ -277,15 +245,11 @@
           "InputId"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
-          "InputId": {
-            "shape": "Sz"
-          }
+          "InputId": {}
         }
       },
       "output": {
@@ -302,15 +266,11 @@
           "OutputId"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
-          "OutputId": {
-            "shape": "Sz"
-          }
+          "OutputId": {}
         }
       },
       "output": {
@@ -327,15 +287,11 @@
           "ReferenceId"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
-          "ReferenceId": {
-            "shape": "Sz"
-          }
+          "ReferenceId": {}
         }
       },
       "output": {
@@ -350,9 +306,7 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          }
+          "ApplicationName": {}
         }
       },
       "output": {
@@ -370,18 +324,10 @@
               "ApplicationVersionId"
             ],
             "members": {
-              "ApplicationName": {
-                "shape": "S2"
-              },
-              "ApplicationDescription": {
-                "shape": "S1g"
-              },
-              "ApplicationARN": {
-                "shape": "Sd"
-              },
-              "ApplicationStatus": {
-                "shape": "S1n"
-              },
+              "ApplicationName": {},
+              "ApplicationDescription": {},
+              "ApplicationARN": {},
+              "ApplicationStatus": {},
               "CreateTimestamp": {
                 "type": "timestamp"
               },
@@ -393,17 +339,11 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "InputId": {
-                      "shape": "Sz"
-                    },
-                    "NamePrefix": {
-                      "shape": "Sa"
-                    },
+                    "InputId": {},
+                    "NamePrefix": {},
                     "InAppStreamNames": {
                       "type": "list",
-                      "member": {
-                        "shape": "Sa"
-                      }
+                      "member": {}
                     },
                     "InputProcessingConfigurationDescription": {
                       "type": "structure",
@@ -411,12 +351,8 @@
                         "InputLambdaProcessorDescription": {
                           "type": "structure",
                           "members": {
-                            "ResourceARN": {
-                              "shape": "Sd"
-                            },
-                            "RoleARN": {
-                              "shape": "S6"
-                            }
+                            "ResourceARN": {},
+                            "RoleARN": {}
                           }
                         }
                       }
@@ -424,23 +360,15 @@
                     "KinesisStreamsInputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {
-                          "shape": "Sd"
-                        },
-                        "RoleARN": {
-                          "shape": "S6"
-                        }
+                        "ResourceARN": {},
+                        "RoleARN": {}
                       }
                     },
                     "KinesisFirehoseInputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {
-                          "shape": "Sd"
-                        },
-                        "RoleARN": {
-                          "shape": "S6"
-                        }
+                        "ResourceARN": {},
+                        "RoleARN": {}
                       }
                     },
                     "InputSchema": {
@@ -460,43 +388,27 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "OutputId": {
-                      "shape": "Sz"
-                    },
-                    "Name": {
-                      "shape": "Sa"
-                    },
+                    "OutputId": {},
+                    "Name": {},
                     "KinesisStreamsOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {
-                          "shape": "Sd"
-                        },
-                        "RoleARN": {
-                          "shape": "S6"
-                        }
+                        "ResourceARN": {},
+                        "RoleARN": {}
                       }
                     },
                     "KinesisFirehoseOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {
-                          "shape": "Sd"
-                        },
-                        "RoleARN": {
-                          "shape": "S6"
-                        }
+                        "ResourceARN": {},
+                        "RoleARN": {}
                       }
                     },
                     "LambdaOutputDescription": {
                       "type": "structure",
                       "members": {
-                        "ResourceARN": {
-                          "shape": "Sd"
-                        },
-                        "RoleARN": {
-                          "shape": "S6"
-                        }
+                        "ResourceARN": {},
+                        "RoleARN": {}
                       }
                     },
                     "DestinationSchema": {
@@ -515,12 +427,8 @@
                     "S3ReferenceDataSourceDescription"
                   ],
                   "members": {
-                    "ReferenceId": {
-                      "shape": "Sz"
-                    },
-                    "TableName": {
-                      "shape": "S1a"
-                    },
+                    "ReferenceId": {},
+                    "TableName": {},
                     "S3ReferenceDataSourceDescription": {
                       "type": "structure",
                       "required": [
@@ -529,15 +437,9 @@
                         "ReferenceRoleARN"
                       ],
                       "members": {
-                        "BucketARN": {
-                          "shape": "S1c"
-                        },
-                        "FileKey": {
-                          "shape": "S1d"
-                        },
-                        "ReferenceRoleARN": {
-                          "shape": "S6"
-                        }
+                        "BucketARN": {},
+                        "FileKey": {},
+                        "ReferenceRoleARN": {}
                       }
                     },
                     "ReferenceSchema": {
@@ -555,23 +457,15 @@
                     "RoleARN"
                   ],
                   "members": {
-                    "CloudWatchLoggingOptionId": {
-                      "shape": "Sz"
-                    },
-                    "LogStreamARN": {
-                      "shape": "S5"
-                    },
-                    "RoleARN": {
-                      "shape": "S6"
-                    }
+                    "CloudWatchLoggingOptionId": {},
+                    "LogStreamARN": {},
+                    "RoleARN": {}
                   }
                 }
               },
-              "ApplicationCode": {
-                "shape": "S1k"
-              },
+              "ApplicationCode": {},
               "ApplicationVersionId": {
-                "shape": "S3"
+                "type": "long"
               }
             }
           }
@@ -582,12 +476,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "ResourceARN": {
-            "shape": "Sd"
-          },
-          "RoleARN": {
-            "shape": "S6"
-          },
+          "ResourceARN": {},
+          "RoleARN": {},
           "InputStartingPositionConfiguration": {
             "shape": "S29"
           },
@@ -599,15 +489,9 @@
               "FileKey"
             ],
             "members": {
-              "RoleARN": {
-                "shape": "S6"
-              },
-              "BucketARN": {
-                "shape": "S1c"
-              },
-              "FileKey": {
-                "shape": "S1d"
-              }
+              "RoleARN": {},
+              "BucketARN": {},
+              "FileKey": {}
             }
           },
           "InputProcessingConfiguration": {
@@ -644,13 +528,9 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "type": "integer",
-            "max": 50,
-            "min": 1
+            "type": "integer"
           },
-          "ExclusiveStartApplicationName": {
-            "shape": "S2"
-          }
+          "ExclusiveStartApplicationName": {}
         }
       },
       "output": {
@@ -680,9 +560,7 @@
           "InputConfigurations"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "InputConfigurations": {
             "type": "list",
             "member": {
@@ -692,9 +570,7 @@
                 "InputStartingPositionConfiguration"
               ],
               "members": {
-                "Id": {
-                  "shape": "Sz"
-                },
+                "Id": {},
                 "InputStartingPositionConfiguration": {
                   "shape": "S29"
                 }
@@ -715,9 +591,7 @@
           "ApplicationName"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          }
+          "ApplicationName": {}
         }
       },
       "output": {
@@ -734,11 +608,9 @@
           "ApplicationUpdate"
         ],
         "members": {
-          "ApplicationName": {
-            "shape": "S2"
-          },
+          "ApplicationName": {},
           "CurrentApplicationVersionId": {
-            "shape": "S3"
+            "type": "long"
           },
           "ApplicationUpdate": {
             "type": "structure",
@@ -751,12 +623,8 @@
                     "InputId"
                   ],
                   "members": {
-                    "InputId": {
-                      "shape": "Sz"
-                    },
-                    "NamePrefixUpdate": {
-                      "shape": "Sa"
-                    },
+                    "InputId": {},
+                    "NamePrefixUpdate": {},
                     "InputProcessingConfigurationUpdate": {
                       "type": "structure",
                       "required": [
@@ -766,12 +634,8 @@
                         "InputLambdaProcessorUpdate": {
                           "type": "structure",
                           "members": {
-                            "ResourceARNUpdate": {
-                              "shape": "Sd"
-                            },
-                            "RoleARNUpdate": {
-                              "shape": "S6"
-                            }
+                            "ResourceARNUpdate": {},
+                            "RoleARNUpdate": {}
                           }
                         }
                       }
@@ -779,23 +643,15 @@
                     "KinesisStreamsInputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {
-                          "shape": "Sd"
-                        },
-                        "RoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "ResourceARNUpdate": {},
+                        "RoleARNUpdate": {}
                       }
                     },
                     "KinesisFirehoseInputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {
-                          "shape": "Sd"
-                        },
-                        "RoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "ResourceARNUpdate": {},
+                        "RoleARNUpdate": {}
                       }
                     },
                     "InputSchemaUpdate": {
@@ -804,9 +660,7 @@
                         "RecordFormatUpdate": {
                           "shape": "Sj"
                         },
-                        "RecordEncodingUpdate": {
-                          "shape": "Sr"
-                        },
+                        "RecordEncodingUpdate": {},
                         "RecordColumnUpdates": {
                           "shape": "Ss"
                         }
@@ -816,16 +670,14 @@
                       "type": "structure",
                       "members": {
                         "CountUpdate": {
-                          "shape": "Sh"
+                          "type": "integer"
                         }
                       }
                     }
                   }
                 }
               },
-              "ApplicationCodeUpdate": {
-                "shape": "S1k"
-              },
+              "ApplicationCodeUpdate": {},
               "OutputUpdates": {
                 "type": "list",
                 "member": {
@@ -834,43 +686,27 @@
                     "OutputId"
                   ],
                   "members": {
-                    "OutputId": {
-                      "shape": "Sz"
-                    },
-                    "NameUpdate": {
-                      "shape": "Sa"
-                    },
+                    "OutputId": {},
+                    "NameUpdate": {},
                     "KinesisStreamsOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {
-                          "shape": "Sd"
-                        },
-                        "RoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "ResourceARNUpdate": {},
+                        "RoleARNUpdate": {}
                       }
                     },
                     "KinesisFirehoseOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {
-                          "shape": "Sd"
-                        },
-                        "RoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "ResourceARNUpdate": {},
+                        "RoleARNUpdate": {}
                       }
                     },
                     "LambdaOutputUpdate": {
                       "type": "structure",
                       "members": {
-                        "ResourceARNUpdate": {
-                          "shape": "Sd"
-                        },
-                        "RoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "ResourceARNUpdate": {},
+                        "RoleARNUpdate": {}
                       }
                     },
                     "DestinationSchemaUpdate": {
@@ -887,24 +723,14 @@
                     "ReferenceId"
                   ],
                   "members": {
-                    "ReferenceId": {
-                      "shape": "Sz"
-                    },
-                    "TableNameUpdate": {
-                      "shape": "S1a"
-                    },
+                    "ReferenceId": {},
+                    "TableNameUpdate": {},
                     "S3ReferenceDataSourceUpdate": {
                       "type": "structure",
                       "members": {
-                        "BucketARNUpdate": {
-                          "shape": "S1c"
-                        },
-                        "FileKeyUpdate": {
-                          "shape": "S1d"
-                        },
-                        "ReferenceRoleARNUpdate": {
-                          "shape": "S6"
-                        }
+                        "BucketARNUpdate": {},
+                        "FileKeyUpdate": {},
+                        "ReferenceRoleARNUpdate": {}
                       }
                     },
                     "ReferenceSchemaUpdate": {
@@ -921,15 +747,9 @@
                     "CloudWatchLoggingOptionId"
                   ],
                   "members": {
-                    "CloudWatchLoggingOptionId": {
-                      "shape": "Sz"
-                    },
-                    "LogStreamARNUpdate": {
-                      "shape": "S5"
-                    },
-                    "RoleARNUpdate": {
-                      "shape": "S6"
-                    }
+                    "CloudWatchLoggingOptionId": {},
+                    "LogStreamARNUpdate": {},
+                    "RoleARNUpdate": {}
                   }
                 }
               }
@@ -944,17 +764,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S3": {
-      "type": "long",
-      "max": 999999999,
-      "min": 1
-    },
     "S4": {
       "type": "structure",
       "required": [
@@ -962,25 +771,9 @@
         "RoleARN"
       ],
       "members": {
-        "LogStreamARN": {
-          "shape": "S5"
-        },
-        "RoleARN": {
-          "shape": "S6"
-        }
+        "LogStreamARN": {},
+        "RoleARN": {}
       }
-    },
-    "S5": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
-    "S6": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
     },
     "S9": {
       "type": "structure",
@@ -989,9 +782,7 @@
         "InputSchema"
       ],
       "members": {
-        "NamePrefix": {
-          "shape": "Sa"
-        },
+        "NamePrefix": {},
         "InputProcessingConfiguration": {
           "shape": "Sb"
         },
@@ -1002,12 +793,8 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         },
         "KinesisFirehoseInput": {
@@ -1017,12 +804,8 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         },
         "InputParallelism": {
@@ -1032,12 +815,6 @@
           "shape": "Si"
         }
       }
-    },
-    "Sa": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "[a-zA-Z][a-zA-Z0-9_]+"
     },
     "Sb": {
       "type": "structure",
@@ -1052,34 +829,19 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         }
       }
-    },
-    "Sd": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:.*"
     },
     "Sg": {
       "type": "structure",
       "members": {
         "Count": {
-          "shape": "Sh"
+          "type": "integer"
         }
       }
-    },
-    "Sh": {
-      "type": "integer",
-      "max": 64,
-      "min": 1
     },
     "Si": {
       "type": "structure",
@@ -1091,9 +853,7 @@
         "RecordFormat": {
           "shape": "Sj"
         },
-        "RecordEncoding": {
-          "shape": "Sr"
-        },
+        "RecordEncoding": {},
         "RecordColumns": {
           "shape": "Ss"
         }
@@ -1105,9 +865,7 @@
         "RecordFormatType"
       ],
       "members": {
-        "RecordFormatType": {
-          "shape": "Sk"
-        },
+        "RecordFormatType": {},
         "MappingParameters": {
           "type": "structure",
           "members": {
@@ -1117,10 +875,7 @@
                 "RecordRowPath"
               ],
               "members": {
-                "RecordRowPath": {
-                  "type": "string",
-                  "min": 1
-                }
+                "RecordRowPath": {}
               }
             },
             "CSVMappingParameters": {
@@ -1130,30 +885,13 @@
                 "RecordColumnDelimiter"
               ],
               "members": {
-                "RecordRowDelimiter": {
-                  "type": "string",
-                  "min": 1
-                },
-                "RecordColumnDelimiter": {
-                  "type": "string",
-                  "min": 1
-                }
+                "RecordRowDelimiter": {},
+                "RecordColumnDelimiter": {}
               }
             }
           }
         }
       }
-    },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "JSON",
-        "CSV"
-      ]
-    },
-    "Sr": {
-      "type": "string",
-      "pattern": "UTF-8"
     },
     "Ss": {
       "type": "list",
@@ -1164,25 +902,11 @@
           "SqlType"
         ],
         "members": {
-          "Name": {
-            "type": "string",
-            "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
-          },
+          "Name": {},
           "Mapping": {},
-          "SqlType": {
-            "type": "string",
-            "min": 1
-          }
+          "SqlType": {}
         }
-      },
-      "max": 1000,
-      "min": 1
-    },
-    "Sz": {
-      "type": "string",
-      "max": 50,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
+      }
     },
     "S12": {
       "type": "structure",
@@ -1191,9 +915,7 @@
         "DestinationSchema"
       ],
       "members": {
-        "Name": {
-          "shape": "Sa"
-        },
+        "Name": {},
         "KinesisStreamsOutput": {
           "type": "structure",
           "required": [
@@ -1201,12 +923,8 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         },
         "KinesisFirehoseOutput": {
@@ -1216,12 +934,8 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         },
         "LambdaOutput": {
@@ -1231,12 +945,8 @@
             "RoleARN"
           ],
           "members": {
-            "ResourceARN": {
-              "shape": "Sd"
-            },
-            "RoleARN": {
-              "shape": "S6"
-            }
+            "ResourceARN": {},
+            "RoleARN": {}
           }
         },
         "DestinationSchema": {
@@ -1247,37 +957,8 @@
     "S16": {
       "type": "structure",
       "members": {
-        "RecordFormatType": {
-          "shape": "Sk"
-        }
+        "RecordFormatType": {}
       }
-    },
-    "S1a": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "[a-zA-Z][a-zA-Z0-9_]+"
-    },
-    "S1c": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "arn:.*"
-    },
-    "S1d": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S1g": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
-    "S1k": {
-      "type": "string",
-      "max": 51200,
-      "min": 0
     },
     "S1m": {
       "type": "structure",
@@ -1287,39 +968,15 @@
         "ApplicationStatus"
       ],
       "members": {
-        "ApplicationName": {
-          "shape": "S2"
-        },
-        "ApplicationARN": {
-          "shape": "Sd"
-        },
-        "ApplicationStatus": {
-          "shape": "S1n"
-        }
+        "ApplicationName": {},
+        "ApplicationARN": {},
+        "ApplicationStatus": {}
       }
-    },
-    "S1n": {
-      "type": "string",
-      "enum": [
-        "DELETING",
-        "STARTING",
-        "STOPPING",
-        "READY",
-        "RUNNING",
-        "UPDATING"
-      ]
     },
     "S29": {
       "type": "structure",
       "members": {
-        "InputStartingPosition": {
-          "type": "string",
-          "enum": [
-            "NOW",
-            "TRIM_HORIZON",
-            "LAST_STOPPED_POINT"
-          ]
-        }
+        "InputStartingPosition": {}
       }
     }
   }

--- a/apis/kinesisvideo-2017-09-30.min.json
+++ b/apis/kinesisvideo-2017-09-30.min.json
@@ -21,29 +21,19 @@
           "StreamName"
         ],
         "members": {
-          "DeviceName": {
-            "shape": "S2"
-          },
-          "StreamName": {
-            "shape": "S3"
-          },
-          "MediaType": {
-            "shape": "S4"
-          },
-          "KmsKeyId": {
-            "shape": "S5"
-          },
+          "DeviceName": {},
+          "StreamName": {},
+          "MediaType": {},
+          "KmsKeyId": {},
           "DataRetentionInHours": {
-            "shape": "S6"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamARN": {
-            "shape": "S8"
-          }
+          "StreamARN": {}
         }
       }
     },
@@ -57,12 +47,8 @@
           "StreamARN"
         ],
         "members": {
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "CurrentVersion": {
-            "shape": "Sa"
-          }
+          "StreamARN": {},
+          "CurrentVersion": {}
         }
       },
       "output": {
@@ -77,12 +63,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "StreamName": {
-            "shape": "S3"
-          },
-          "StreamARN": {
-            "shape": "S8"
-          }
+          "StreamName": {},
+          "StreamARN": {}
         }
       },
       "output": {
@@ -104,22 +86,9 @@
           "APIName"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S3"
-          },
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "APIName": {
-            "type": "string",
-            "enum": [
-              "PUT_MEDIA",
-              "GET_MEDIA",
-              "LIST_FRAGMENTS",
-              "GET_MEDIA_FOR_FRAGMENT_LIST",
-              "GET_HLS_STREAMING_SESSION_URL"
-            ]
-          }
+          "StreamName": {},
+          "StreamARN": {},
+          "APIName": {}
         }
       },
       "output": {
@@ -137,25 +106,14 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "type": "integer",
-            "max": 10000,
-            "min": 1
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sn"
-          },
+          "NextToken": {},
           "StreamNameCondition": {
             "type": "structure",
             "members": {
-              "ComparisonOperator": {
-                "type": "string",
-                "enum": [
-                  "BEGINS_WITH"
-                ]
-              },
-              "ComparisonValue": {
-                "shape": "S3"
-              }
+              "ComparisonOperator": {},
+              "ComparisonValue": {}
             }
           }
         }
@@ -169,9 +127,7 @@
               "shape": "Se"
             }
           },
-          "NextToken": {
-            "shape": "Sn"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -182,23 +138,15 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "Sn"
-          },
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "StreamName": {
-            "shape": "S3"
-          }
+          "NextToken": {},
+          "StreamARN": {},
+          "StreamName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "Sn"
-          },
+          "NextToken": {},
           "Tags": {
             "shape": "Su"
           }
@@ -215,12 +163,8 @@
           "Tags"
         ],
         "members": {
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "StreamName": {
-            "shape": "S3"
-          },
+          "StreamARN": {},
+          "StreamName": {},
           "Tags": {
             "shape": "Su"
           }
@@ -241,19 +185,11 @@
           "TagKeyList"
         ],
         "members": {
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "StreamName": {
-            "shape": "S3"
-          },
+          "StreamARN": {},
+          "StreamName": {},
           "TagKeyList": {
             "type": "list",
-            "member": {
-              "shape": "Sv"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -274,25 +210,12 @@
           "DataRetentionChangeInHours"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S3"
-          },
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "CurrentVersion": {
-            "shape": "Sa"
-          },
-          "Operation": {
-            "type": "string",
-            "enum": [
-              "INCREASE_DATA_RETENTION",
-              "DECREASE_DATA_RETENTION"
-            ]
-          },
+          "StreamName": {},
+          "StreamARN": {},
+          "CurrentVersion": {},
+          "Operation": {},
           "DataRetentionChangeInHours": {
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -311,21 +234,11 @@
           "CurrentVersion"
         ],
         "members": {
-          "StreamName": {
-            "shape": "S3"
-          },
-          "StreamARN": {
-            "shape": "S8"
-          },
-          "CurrentVersion": {
-            "shape": "Sa"
-          },
-          "DeviceName": {
-            "shape": "S2"
-          },
-          "MediaType": {
-            "shape": "S4"
-          }
+          "StreamName": {},
+          "StreamARN": {},
+          "CurrentVersion": {},
+          "DeviceName": {},
+          "MediaType": {}
         }
       },
       "output": {
@@ -335,105 +248,28 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S3": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S4": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w\\-\\.\\+]+/[\\w\\-\\.\\+]+"
-    },
-    "S5": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S6": {
-      "type": "integer",
-      "min": 0
-    },
-    "S8": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "arn:aws:kinesisvideo:[a-z0-9-]+:[0-9]+:[a-z]+/[a-zA-Z0-9_.-]+/[0-9]+"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9]+"
-    },
     "Se": {
       "type": "structure",
       "members": {
-        "DeviceName": {
-          "shape": "S2"
-        },
-        "StreamName": {
-          "shape": "S3"
-        },
-        "StreamARN": {
-          "shape": "S8"
-        },
-        "MediaType": {
-          "shape": "S4"
-        },
-        "KmsKeyId": {
-          "shape": "S5"
-        },
-        "Version": {
-          "shape": "Sa"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "CREATING",
-            "ACTIVE",
-            "UPDATING",
-            "DELETING"
-          ]
-        },
+        "DeviceName": {},
+        "StreamName": {},
+        "StreamARN": {},
+        "MediaType": {},
+        "KmsKeyId": {},
+        "Version": {},
+        "Status": {},
         "CreationTime": {
           "type": "timestamp"
         },
         "DataRetentionInHours": {
-          "shape": "S6"
+          "type": "integer"
         }
       }
     },
-    "Sn": {
-      "type": "string",
-      "max": 512,
-      "min": 0
-    },
     "Su": {
       "type": "map",
-      "key": {
-        "shape": "Sv"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "min": 0
-      },
-      "max": 50,
-      "min": 1
-    },
-    "Sv": {
-      "type": "string",
-      "max": 128,
-      "min": 1
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/kms-2014-11-01.min.json
+++ b/apis/kms-2014-11-01.min.json
@@ -20,17 +20,13 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -42,12 +38,8 @@
           "TargetKeyId"
         ],
         "members": {
-          "AliasName": {
-            "shape": "S5"
-          },
-          "TargetKeyId": {
-            "shape": "S2"
-          }
+          "AliasName": {},
+          "TargetKeyId": {}
         }
       }
     },
@@ -60,15 +52,9 @@
           "Operations"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "GranteePrincipal": {
-            "shape": "S7"
-          },
-          "RetiringPrincipal": {
-            "shape": "S7"
-          },
+          "KeyId": {},
+          "GranteePrincipal": {},
+          "RetiringPrincipal": {},
           "Operations": {
             "shape": "S8"
           },
@@ -78,20 +64,14 @@
           "GrantTokens": {
             "shape": "Se"
           },
-          "Name": {
-            "shape": "Sg"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GrantToken": {
-            "shape": "Sf"
-          },
-          "GrantId": {
-            "shape": "Si"
-          }
+          "GrantToken": {},
+          "GrantId": {}
         }
       }
     },
@@ -99,18 +79,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "Policy": {
-            "shape": "Sk"
-          },
-          "Description": {
-            "shape": "Sl"
-          },
-          "KeyUsage": {
-            "shape": "Sm"
-          },
-          "Origin": {
-            "shape": "Sn"
-          },
+          "Policy": {},
+          "Description": {},
+          "KeyUsage": {},
+          "Origin": {},
           "BypassPolicyLockoutSafetyCheck": {
             "type": "boolean"
           },
@@ -136,7 +108,7 @@
         ],
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
           "EncryptionContext": {
             "shape": "Sb"
@@ -149,9 +121,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Plaintext": {
             "shape": "S14"
           }
@@ -165,9 +135,7 @@
           "AliasName"
         ],
         "members": {
-          "AliasName": {
-            "shape": "S5"
-          }
+          "AliasName": {}
         }
       }
     },
@@ -178,9 +146,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -191,9 +157,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "GrantTokens": {
             "shape": "Se"
           }
@@ -215,9 +179,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -228,9 +190,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -241,9 +201,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -254,9 +212,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -268,9 +224,7 @@
           "Plaintext"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Plaintext": {
             "shape": "S14"
           },
@@ -286,11 +240,9 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -301,18 +253,14 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "EncryptionContext": {
             "shape": "Sb"
           },
           "NumberOfBytes": {
-            "shape": "S1g"
+            "type": "integer"
           },
-          "KeySpec": {
-            "shape": "S1h"
-          },
+          "KeySpec": {},
           "GrantTokens": {
             "shape": "Se"
           }
@@ -322,14 +270,12 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
           "Plaintext": {
             "shape": "S14"
           },
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -340,17 +286,13 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "EncryptionContext": {
             "shape": "Sb"
           },
-          "KeySpec": {
-            "shape": "S1h"
-          },
+          "KeySpec": {},
           "NumberOfBytes": {
-            "shape": "S1g"
+            "type": "integer"
           },
           "GrantTokens": {
             "shape": "Se"
@@ -361,11 +303,9 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       }
     },
@@ -374,7 +314,7 @@
         "type": "structure",
         "members": {
           "NumberOfBytes": {
-            "shape": "S1g"
+            "type": "integer"
           }
         }
       },
@@ -395,20 +335,14 @@
           "PolicyName"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "PolicyName": {
-            "shape": "S1o"
-          }
+          "KeyId": {},
+          "PolicyName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {
-            "shape": "Sk"
-          }
+          "Policy": {}
         }
       }
     },
@@ -419,9 +353,7 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          }
+          "KeyId": {}
         }
       },
       "output": {
@@ -442,33 +374,17 @@
           "WrappingKeySpec"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "WrappingAlgorithm": {
-            "type": "string",
-            "enum": [
-              "RSAES_PKCS1_V1_5",
-              "RSAES_OAEP_SHA_1",
-              "RSAES_OAEP_SHA_256"
-            ]
-          },
-          "WrappingKeySpec": {
-            "type": "string",
-            "enum": [
-              "RSA_2048"
-            ]
-          }
+          "KeyId": {},
+          "WrappingAlgorithm": {},
+          "WrappingKeySpec": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "ImportToken": {
-            "shape": "S12"
+            "type": "blob"
           },
           "PublicKey": {
             "shape": "S14"
@@ -488,21 +404,17 @@
           "EncryptedKeyMaterial"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "ImportToken": {
-            "shape": "S12"
+            "type": "blob"
           },
           "EncryptedKeyMaterial": {
-            "shape": "S12"
+            "type": "blob"
           },
           "ValidTo": {
             "type": "timestamp"
           },
-          "ExpirationModel": {
-            "shape": "Sz"
-          }
+          "ExpirationModel": {}
         }
       },
       "output": {
@@ -514,15 +426,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -533,21 +441,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "AliasName": {
-                  "shape": "S5"
-                },
-                "AliasArn": {
-                  "shape": "Sw"
-                },
-                "TargetKeyId": {
-                  "shape": "S2"
-                }
+                "AliasName": {},
+                "AliasArn": {},
+                "TargetKeyId": {}
               }
             }
           },
-          "NextMarker": {
-            "shape": "S20"
-          },
+          "NextMarker": {},
           "Truncated": {
             "type": "boolean"
           }
@@ -562,14 +462,10 @@
         ],
         "members": {
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          },
-          "KeyId": {
-            "shape": "S2"
-          }
+          "Marker": {},
+          "KeyId": {}
         }
       },
       "output": {
@@ -583,15 +479,11 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -599,13 +491,9 @@
         "members": {
           "PolicyNames": {
             "type": "list",
-            "member": {
-              "shape": "S1o"
-            }
+            "member": {}
           },
-          "NextMarker": {
-            "shape": "S20"
-          },
+          "NextMarker": {},
           "Truncated": {
             "type": "boolean"
           }
@@ -617,11 +505,9 @@
         "type": "structure",
         "members": {
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -632,18 +518,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "KeyId": {
-                  "shape": "S2"
-                },
-                "KeyArn": {
-                  "shape": "Sw"
-                }
+                "KeyId": {},
+                "KeyArn": {}
               }
             }
           },
-          "NextMarker": {
-            "shape": "S20"
-          },
+          "NextMarker": {},
           "Truncated": {
             "type": "boolean"
           }
@@ -657,15 +537,11 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          }
+          "Marker": {}
         }
       },
       "output": {
@@ -674,9 +550,7 @@
           "Tags": {
             "shape": "Sp"
           },
-          "NextMarker": {
-            "shape": "S20"
-          },
+          "NextMarker": {},
           "Truncated": {
             "type": "boolean"
           }
@@ -691,14 +565,10 @@
         ],
         "members": {
           "Limit": {
-            "shape": "S1z"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S20"
-          },
-          "RetiringPrincipal": {
-            "shape": "S7"
-          }
+          "Marker": {},
+          "RetiringPrincipal": {}
         }
       },
       "output": {
@@ -714,15 +584,9 @@
           "Policy"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "PolicyName": {
-            "shape": "S1o"
-          },
-          "Policy": {
-            "shape": "Sk"
-          },
+          "KeyId": {},
+          "PolicyName": {},
+          "Policy": {},
           "BypassPolicyLockoutSafetyCheck": {
             "type": "boolean"
           }
@@ -738,14 +602,12 @@
         ],
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
           "SourceEncryptionContext": {
             "shape": "Sb"
           },
-          "DestinationKeyId": {
-            "shape": "S2"
-          },
+          "DestinationKeyId": {},
           "DestinationEncryptionContext": {
             "shape": "Sb"
           },
@@ -758,14 +620,10 @@
         "type": "structure",
         "members": {
           "CiphertextBlob": {
-            "shape": "S12"
+            "type": "blob"
           },
-          "SourceKeyId": {
-            "shape": "S2"
-          },
-          "KeyId": {
-            "shape": "S2"
-          }
+          "SourceKeyId": {},
+          "KeyId": {}
         }
       }
     },
@@ -773,15 +631,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "GrantToken": {
-            "shape": "Sf"
-          },
-          "KeyId": {
-            "shape": "S2"
-          },
-          "GrantId": {
-            "shape": "Si"
-          }
+          "GrantToken": {},
+          "KeyId": {},
+          "GrantId": {}
         }
       }
     },
@@ -793,12 +645,8 @@
           "GrantId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "GrantId": {
-            "shape": "Si"
-          }
+          "KeyId": {},
+          "GrantId": {}
         }
       }
     },
@@ -809,22 +657,16 @@
           "KeyId"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "PendingWindowInDays": {
-            "type": "integer",
-            "max": 365,
-            "min": 1
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "DeletionDate": {
             "type": "timestamp"
           }
@@ -839,9 +681,7 @@
           "Tags"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "Tags": {
             "shape": "Sp"
           }
@@ -856,14 +696,10 @@
           "TagKeys"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
+          "KeyId": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sr"
-            }
+            "member": {}
           }
         }
       }
@@ -876,12 +712,8 @@
           "TargetKeyId"
         ],
         "members": {
-          "AliasName": {
-            "shape": "S5"
-          },
-          "TargetKeyId": {
-            "shape": "S2"
-          }
+          "AliasName": {},
+          "TargetKeyId": {}
         }
       }
     },
@@ -893,49 +725,16 @@
           "Description"
         ],
         "members": {
-          "KeyId": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "Sl"
-          }
+          "KeyId": {},
+          "Description": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9:/_-]+$"
-    },
-    "S7": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
     "S8": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "Decrypt",
-          "Encrypt",
-          "GenerateDataKey",
-          "GenerateDataKeyWithoutPlaintext",
-          "ReEncryptFrom",
-          "ReEncryptTo",
-          "CreateGrant",
-          "RetireGrant",
-          "DescribeKey"
-        ]
-      }
+      "member": {}
     },
     "Sa": {
       "type": "structure",
@@ -955,51 +754,7 @@
     },
     "Se": {
       "type": "list",
-      "member": {
-        "shape": "Sf"
-      },
-      "max": 10,
-      "min": 0
-    },
-    "Sf": {
-      "type": "string",
-      "max": 8192,
-      "min": 1
-    },
-    "Sg": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9:/_-]+$"
-    },
-    "Si": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "Sk": {
-      "type": "string",
-      "max": 131072,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "Sl": {
-      "type": "string",
-      "max": 8192,
-      "min": 0
-    },
-    "Sm": {
-      "type": "string",
-      "enum": [
-        "ENCRYPT_DECRYPT"
-      ]
-    },
-    "Sn": {
-      "type": "string",
-      "enum": [
-        "AWS_KMS",
-        "EXTERNAL"
-      ]
+      "member": {}
     },
     "Sp": {
       "type": "list",
@@ -1010,21 +765,10 @@
           "TagValue"
         ],
         "members": {
-          "TagKey": {
-            "shape": "Sr"
-          },
-          "TagValue": {
-            "type": "string",
-            "max": 256,
-            "min": 0
-          }
+          "TagKey": {},
+          "TagValue": {}
         }
       }
-    },
-    "Sr": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "Su": {
       "type": "structure",
@@ -1033,105 +777,31 @@
       ],
       "members": {
         "AWSAccountId": {},
-        "KeyId": {
-          "shape": "S2"
-        },
-        "Arn": {
-          "shape": "Sw"
-        },
+        "KeyId": {},
+        "Arn": {},
         "CreationDate": {
           "type": "timestamp"
         },
         "Enabled": {
           "type": "boolean"
         },
-        "Description": {
-          "shape": "Sl"
-        },
-        "KeyUsage": {
-          "shape": "Sm"
-        },
-        "KeyState": {
-          "type": "string",
-          "enum": [
-            "Enabled",
-            "Disabled",
-            "PendingDeletion",
-            "PendingImport"
-          ]
-        },
+        "Description": {},
+        "KeyUsage": {},
+        "KeyState": {},
         "DeletionDate": {
           "type": "timestamp"
         },
         "ValidTo": {
           "type": "timestamp"
         },
-        "Origin": {
-          "shape": "Sn"
-        },
-        "ExpirationModel": {
-          "shape": "Sz"
-        },
-        "KeyManager": {
-          "type": "string",
-          "enum": [
-            "AWS",
-            "CUSTOMER"
-          ]
-        }
+        "Origin": {},
+        "ExpirationModel": {},
+        "KeyManager": {}
       }
-    },
-    "Sw": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "KEY_MATERIAL_EXPIRES",
-        "KEY_MATERIAL_DOES_NOT_EXPIRE"
-      ]
-    },
-    "S12": {
-      "type": "blob",
-      "max": 6144,
-      "min": 1
     },
     "S14": {
       "type": "blob",
-      "max": 4096,
-      "min": 1,
       "sensitive": true
-    },
-    "S1g": {
-      "type": "integer",
-      "max": 1024,
-      "min": 1
-    },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "AES_256",
-        "AES_128"
-      ]
-    },
-    "S1o": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w]+"
-    },
-    "S1z": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
-    "S20": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "[\\u0020-\\u00FF]*"
     },
     "S25": {
       "type": "structure",
@@ -1141,27 +811,15 @@
           "member": {
             "type": "structure",
             "members": {
-              "KeyId": {
-                "shape": "S2"
-              },
-              "GrantId": {
-                "shape": "Si"
-              },
-              "Name": {
-                "shape": "Sg"
-              },
+              "KeyId": {},
+              "GrantId": {},
+              "Name": {},
               "CreationDate": {
                 "type": "timestamp"
               },
-              "GranteePrincipal": {
-                "shape": "S7"
-              },
-              "RetiringPrincipal": {
-                "shape": "S7"
-              },
-              "IssuingAccount": {
-                "shape": "S7"
-              },
+              "GranteePrincipal": {},
+              "RetiringPrincipal": {},
+              "IssuingAccount": {},
               "Operations": {
                 "shape": "S8"
               },
@@ -1171,9 +829,7 @@
             }
           }
         },
-        "NextMarker": {
-          "shape": "S20"
-        },
+        "NextMarker": {},
         "Truncated": {
           "type": "boolean"
         }

--- a/apis/lambda-2014-11-11.min.json
+++ b/apis/lambda-2014-11-11.min.json
@@ -21,12 +21,8 @@
         ],
         "members": {
           "EventSource": {},
-          "FunctionName": {
-            "shape": "S3"
-          },
-          "Role": {
-            "shape": "S4"
-          },
+          "FunctionName": {},
+          "Role": {},
           "BatchSize": {
             "type": "integer"
           },
@@ -52,7 +48,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -94,7 +89,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -129,7 +123,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -152,7 +145,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -186,7 +178,6 @@
             "locationName": "EventSource"
           },
           "FunctionName": {
-            "shape": "S3",
             "location": "querystring",
             "locationName": "FunctionName"
           },
@@ -195,9 +186,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "Su",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -228,9 +219,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "Su",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -279,34 +270,30 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Role": {
-            "shape": "S4",
             "location": "querystring",
             "locationName": "Role"
           },
           "Handler": {
-            "shape": "Sh",
             "location": "querystring",
             "locationName": "Handler"
           },
           "Description": {
-            "shape": "Sk",
             "location": "querystring",
             "locationName": "Description"
           },
           "Timeout": {
-            "shape": "Sl",
             "location": "querystring",
-            "locationName": "Timeout"
+            "locationName": "Timeout",
+            "type": "integer"
           },
           "MemorySize": {
-            "shape": "Sm",
             "location": "querystring",
-            "locationName": "MemorySize"
+            "locationName": "MemorySize",
+            "type": "integer"
           }
         }
       },
@@ -332,7 +319,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -340,39 +326,34 @@
             "shape": "Sq"
           },
           "Runtime": {
-            "shape": "Sg",
             "location": "querystring",
             "locationName": "Runtime"
           },
           "Role": {
-            "shape": "S4",
             "location": "querystring",
             "locationName": "Role"
           },
           "Handler": {
-            "shape": "Sh",
             "location": "querystring",
             "locationName": "Handler"
           },
           "Mode": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "Mode"
           },
           "Description": {
-            "shape": "Sk",
             "location": "querystring",
             "locationName": "Description"
           },
           "Timeout": {
-            "shape": "Sl",
             "location": "querystring",
-            "locationName": "Timeout"
+            "locationName": "Timeout",
+            "type": "integer"
           },
           "MemorySize": {
-            "shape": "Sm",
             "location": "querystring",
-            "locationName": "MemorySize"
+            "locationName": "MemorySize",
+            "type": "integer"
           }
         },
         "payload": "FunctionZip"
@@ -383,16 +364,6 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "[a-zA-Z0-9-_]+"
-    },
-    "S4": {
-      "type": "string",
-      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
-    },
     "S6": {
       "type": "map",
       "key": {},
@@ -406,15 +377,11 @@
           "type": "integer"
         },
         "EventSource": {},
-        "FunctionName": {
-          "shape": "S3"
-        },
+        "FunctionName": {},
         "Parameters": {
           "shape": "S6"
         },
-        "Role": {
-          "shape": "S4"
-        },
+        "Role": {},
         "LastModified": {
           "type": "timestamp"
         },
@@ -427,82 +394,31 @@
     "Se": {
       "type": "structure",
       "members": {
-        "FunctionName": {
-          "shape": "S3"
-        },
-        "FunctionARN": {
-          "type": "string",
-          "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_]+(\\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?"
-        },
+        "FunctionName": {},
+        "FunctionARN": {},
         "ConfigurationId": {},
-        "Runtime": {
-          "shape": "Sg"
-        },
-        "Role": {
-          "shape": "S4"
-        },
-        "Handler": {
-          "shape": "Sh"
-        },
-        "Mode": {
-          "shape": "Si"
-        },
+        "Runtime": {},
+        "Role": {},
+        "Handler": {},
+        "Mode": {},
         "CodeSize": {
           "type": "long"
         },
-        "Description": {
-          "shape": "Sk"
-        },
+        "Description": {},
         "Timeout": {
-          "shape": "Sl"
+          "type": "integer"
         },
         "MemorySize": {
-          "shape": "Sm"
+          "type": "integer"
         },
         "LastModified": {
           "type": "timestamp"
         }
       }
     },
-    "Sg": {
-      "type": "string",
-      "enum": [
-        "nodejs"
-      ]
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "[a-zA-Z0-9./\\-_]+"
-    },
-    "Si": {
-      "type": "string",
-      "enum": [
-        "event"
-      ]
-    },
-    "Sk": {
-      "type": "string",
-      "min": 0,
-      "max": 256
-    },
-    "Sl": {
-      "type": "integer",
-      "min": 1,
-      "max": 60
-    },
-    "Sm": {
-      "type": "integer",
-      "min": 128,
-      "max": 1024
-    },
     "Sq": {
       "type": "blob",
       "streaming": true
-    },
-    "Su": {
-      "type": "integer",
-      "min": 1,
-      "max": 10000
     }
   }
 }

--- a/apis/lambda-2015-03-31.min.json
+++ b/apis/lambda-2015-03-31.min.json
@@ -25,39 +25,16 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "StatementId": {
-            "type": "string",
-            "max": 100,
-            "min": 1,
-            "pattern": "([a-zA-Z0-9-_]+)"
-          },
-          "Action": {
-            "type": "string",
-            "pattern": "(lambda:[*]|lambda:[a-zA-Z]+|[*])"
-          },
-          "Principal": {
-            "type": "string",
-            "pattern": ".*"
-          },
-          "SourceArn": {
-            "shape": "S6"
-          },
-          "SourceAccount": {
-            "type": "string",
-            "pattern": "\\d{12}"
-          },
-          "EventSourceToken": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "[a-zA-Z0-9._\\-]+"
-          },
+          "StatementId": {},
+          "Action": {},
+          "Principal": {},
+          "SourceArn": {},
+          "SourceAccount": {},
+          "EventSourceToken": {},
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           },
@@ -85,19 +62,12 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "Name": {
-            "shape": "Sd"
-          },
-          "FunctionVersion": {
-            "shape": "Se"
-          },
-          "Description": {
-            "shape": "Sf"
-          },
+          "Name": {},
+          "FunctionVersion": {},
+          "Description": {},
           "RoutingConfig": {
             "shape": "Sg"
           }
@@ -119,26 +89,15 @@
           "FunctionName"
         ],
         "members": {
-          "EventSourceArn": {
-            "shape": "S6"
-          },
-          "FunctionName": {
-            "shape": "S2"
-          },
+          "EventSourceArn": {},
+          "FunctionName": {},
           "Enabled": {
             "type": "boolean"
           },
           "BatchSize": {
-            "shape": "So"
+            "type": "integer"
           },
-          "StartingPosition": {
-            "type": "string",
-            "enum": [
-              "TRIM_HORIZON",
-              "LATEST",
-              "AT_TIMESTAMP"
-            ]
-          },
+          "StartingPosition": {},
           "StartingPositionTimestamp": {
             "type": "timestamp"
           }
@@ -163,43 +122,27 @@
           "Code"
         ],
         "members": {
-          "FunctionName": {
-            "shape": "S2"
-          },
-          "Runtime": {
-            "shape": "St"
-          },
-          "Role": {
-            "shape": "Su"
-          },
-          "Handler": {
-            "shape": "Sv"
-          },
+          "FunctionName": {},
+          "Runtime": {},
+          "Role": {},
+          "Handler": {},
           "Code": {
             "type": "structure",
             "members": {
               "ZipFile": {
                 "shape": "Sx"
               },
-              "S3Bucket": {
-                "shape": "Sy"
-              },
-              "S3Key": {
-                "shape": "Sz"
-              },
-              "S3ObjectVersion": {
-                "shape": "S10"
-              }
+              "S3Bucket": {},
+              "S3Key": {},
+              "S3ObjectVersion": {}
             }
           },
-          "Description": {
-            "shape": "Sf"
-          },
+          "Description": {},
           "Timeout": {
-            "shape": "S11"
+            "type": "integer"
           },
           "MemorySize": {
-            "shape": "S12"
+            "type": "integer"
           },
           "Publish": {
             "type": "boolean"
@@ -213,9 +156,7 @@
           "Environment": {
             "shape": "S1b"
           },
-          "KMSKeyArn": {
-            "shape": "S1f"
-          },
+          "KMSKeyArn": {},
           "TracingConfig": {
             "shape": "S1g"
           },
@@ -242,12 +183,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           }
@@ -289,12 +228,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -314,7 +251,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           }
@@ -350,8 +286,7 @@
                 "type": "integer"
               },
               "UnreservedConcurrentExecutions": {
-                "type": "integer",
-                "min": 0
+                "type": "integer"
               }
             }
           },
@@ -383,12 +318,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           }
@@ -433,12 +366,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -479,12 +410,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -507,12 +436,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -537,28 +464,16 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "InvocationType": {
             "location": "header",
-            "locationName": "X-Amz-Invocation-Type",
-            "type": "string",
-            "enum": [
-              "Event",
-              "RequestResponse",
-              "DryRun"
-            ]
+            "locationName": "X-Amz-Invocation-Type"
           },
           "LogType": {
             "location": "header",
-            "locationName": "X-Amz-Log-Type",
-            "type": "string",
-            "enum": [
-              "None",
-              "Tail"
-            ]
+            "locationName": "X-Amz-Log-Type"
           },
           "ClientContext": {
             "location": "header",
@@ -568,7 +483,6 @@
             "shape": "Sx"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           }
@@ -594,7 +508,6 @@
             "shape": "Sx"
           },
           "ExecutedVersion": {
-            "shape": "Se",
             "location": "header",
             "locationName": "X-Amz-Executed-Version"
           }
@@ -615,7 +528,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -652,12 +564,10 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "FunctionVersion": {
-            "shape": "Se",
             "location": "querystring",
             "locationName": "FunctionVersion"
           },
@@ -666,9 +576,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -695,12 +605,10 @@
         "type": "structure",
         "members": {
           "EventSourceArn": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "EventSourceArn"
           },
           "FunctionName": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "FunctionName"
           },
@@ -709,9 +617,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -739,26 +647,20 @@
         "members": {
           "MasterRegion": {
             "location": "querystring",
-            "locationName": "MasterRegion",
-            "type": "string",
-            "pattern": "ALL|[a-z]{2}(-gov)?-[a-z]+-\\d{1}"
+            "locationName": "MasterRegion"
           },
           "FunctionVersion": {
             "location": "querystring",
-            "locationName": "FunctionVersion",
-            "type": "string",
-            "enum": [
-              "ALL"
-            ]
+            "locationName": "FunctionVersion"
           },
           "Marker": {
             "location": "querystring",
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -784,7 +686,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           }
@@ -812,7 +713,6 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S1m",
             "location": "uri",
             "locationName": "FunctionName"
           },
@@ -821,9 +721,9 @@
             "locationName": "Marker"
           },
           "MaxItems": {
-            "shape": "S2p",
             "location": "querystring",
-            "locationName": "MaxItems"
+            "locationName": "MaxItems",
+            "type": "integer"
           }
         }
       },
@@ -849,14 +749,11 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "CodeSha256": {},
-          "Description": {
-            "shape": "Sf"
-          },
+          "Description": {},
           "RevisionId": {}
         }
       },
@@ -878,12 +775,11 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "ReservedConcurrentExecutions": {
-            "shape": "S2c"
+            "type": "integer"
           }
         }
       },
@@ -905,20 +801,14 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "StatementId": {
             "location": "uri",
-            "locationName": "StatementId",
-            "type": "string",
-            "max": 100,
-            "min": 1,
-            "pattern": "([a-zA-Z0-9-_.]+)"
+            "locationName": "StatementId"
           },
           "Qualifier": {
-            "shape": "S9",
             "location": "querystring",
             "locationName": "Qualifier"
           },
@@ -942,7 +832,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           },
@@ -966,7 +855,6 @@
         ],
         "members": {
           "Resource": {
-            "shape": "Sl",
             "location": "uri",
             "locationName": "ARN"
           },
@@ -993,21 +881,15 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "Name": {
-            "shape": "Sd",
             "location": "uri",
             "locationName": "Name"
           },
-          "FunctionVersion": {
-            "shape": "Se"
-          },
-          "Description": {
-            "shape": "Sf"
-          },
+          "FunctionVersion": {},
+          "Description": {},
           "RoutingConfig": {
             "shape": "Sg"
           },
@@ -1034,14 +916,12 @@
             "location": "uri",
             "locationName": "UUID"
           },
-          "FunctionName": {
-            "shape": "S2"
-          },
+          "FunctionName": {},
           "Enabled": {
             "type": "boolean"
           },
           "BatchSize": {
-            "shape": "So"
+            "type": "integer"
           }
         }
       },
@@ -1062,22 +942,15 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
           "ZipFile": {
             "shape": "Sx"
           },
-          "S3Bucket": {
-            "shape": "Sy"
-          },
-          "S3Key": {
-            "shape": "Sz"
-          },
-          "S3ObjectVersion": {
-            "shape": "S10"
-          },
+          "S3Bucket": {},
+          "S3Key": {},
+          "S3ObjectVersion": {},
           "Publish": {
             "type": "boolean"
           },
@@ -1104,24 +977,17 @@
         ],
         "members": {
           "FunctionName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "FunctionName"
           },
-          "Role": {
-            "shape": "Su"
-          },
-          "Handler": {
-            "shape": "Sv"
-          },
-          "Description": {
-            "shape": "Sf"
-          },
+          "Role": {},
+          "Handler": {},
+          "Description": {},
           "Timeout": {
-            "shape": "S11"
+            "type": "integer"
           },
           "MemorySize": {
-            "shape": "S12"
+            "type": "integer"
           },
           "VpcConfig": {
             "shape": "S14"
@@ -1129,15 +995,11 @@
           "Environment": {
             "shape": "S1b"
           },
-          "Runtime": {
-            "shape": "St"
-          },
+          "Runtime": {},
           "DeadLetterConfig": {
             "shape": "S19"
           },
-          "KMSKeyArn": {
-            "shape": "S1f"
-          },
+          "KMSKeyArn": {},
           "TracingConfig": {
             "shape": "S1g"
           },
@@ -1150,54 +1012,14 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 140,
-      "min": 1,
-      "pattern": "(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
-    },
-    "S6": {
-      "type": "string",
-      "pattern": "arn:aws:([a-zA-Z0-9\\-])+:([a-z]{2}-[a-z]+-\\d{1})?:(\\d{12})?:(.*)"
-    },
-    "S9": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "(|[a-zA-Z0-9$_-]+)"
-    },
-    "Sd": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "(?!^[0-9]+$)([a-zA-Z0-9-_]+)"
-    },
-    "Se": {
-      "type": "string",
-      "max": 1024,
-      "min": 1,
-      "pattern": "(\\$LATEST|[0-9]+)"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
     "Sg": {
       "type": "structure",
       "members": {
         "AdditionalVersionWeights": {
           "type": "map",
-          "key": {
-            "type": "string",
-            "max": 1024,
-            "min": 1,
-            "pattern": "[0-9]+"
-          },
+          "key": {},
           "value": {
-            "type": "double",
-            "max": 1,
-            "min": 0
+            "type": "double"
           }
         }
       }
@@ -1205,46 +1027,25 @@
     "Sk": {
       "type": "structure",
       "members": {
-        "AliasArn": {
-          "shape": "Sl"
-        },
-        "Name": {
-          "shape": "Sd"
-        },
-        "FunctionVersion": {
-          "shape": "Se"
-        },
-        "Description": {
-          "shape": "Sf"
-        },
+        "AliasArn": {},
+        "Name": {},
+        "FunctionVersion": {},
+        "Description": {},
         "RoutingConfig": {
           "shape": "Sg"
         },
         "RevisionId": {}
       }
     },
-    "Sl": {
-      "type": "string",
-      "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
-    },
-    "So": {
-      "type": "integer",
-      "max": 10000,
-      "min": 1
-    },
     "Sr": {
       "type": "structure",
       "members": {
         "UUID": {},
         "BatchSize": {
-          "shape": "So"
+          "type": "integer"
         },
-        "EventSourceArn": {
-          "shape": "S6"
-        },
-        "FunctionArn": {
-          "shape": "Sl"
-        },
+        "EventSourceArn": {},
+        "FunctionArn": {},
         "LastModified": {
           "type": "timestamp"
         },
@@ -1253,60 +1054,9 @@
         "StateTransitionReason": {}
       }
     },
-    "St": {
-      "type": "string",
-      "enum": [
-        "nodejs",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
-        "java8",
-        "python2.7",
-        "python3.6",
-        "dotnetcore1.0",
-        "dotnetcore2.0",
-        "dotnetcore2.1",
-        "nodejs4.3-edge",
-        "go1.x"
-      ]
-    },
-    "Su": {
-      "type": "string",
-      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
-    },
-    "Sv": {
-      "type": "string",
-      "max": 128,
-      "pattern": "[^\\s]+"
-    },
     "Sx": {
       "type": "blob",
       "sensitive": true
-    },
-    "Sy": {
-      "type": "string",
-      "max": 63,
-      "min": 3,
-      "pattern": "^[0-9A-Za-z\\.\\-_]*(?<!\\.)$"
-    },
-    "Sz": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S11": {
-      "type": "integer",
-      "min": 1
-    },
-    "S12": {
-      "type": "integer",
-      "max": 3008,
-      "min": 128
     },
     "S14": {
       "type": "structure",
@@ -1321,21 +1071,16 @@
     },
     "S15": {
       "type": "list",
-      "member": {},
-      "max": 16
+      "member": {}
     },
     "S17": {
       "type": "list",
-      "member": {},
-      "max": 5
+      "member": {}
     },
     "S19": {
       "type": "structure",
       "members": {
-        "TargetArn": {
-          "type": "string",
-          "pattern": "(arn:aws:[a-z0-9-.]+:.*)|()"
-        }
+        "TargetArn": {}
       }
     },
     "S1b": {
@@ -1350,7 +1095,6 @@
       "type": "map",
       "key": {
         "type": "string",
-        "pattern": "[a-zA-Z]([a-zA-Z0-9_])+",
         "sensitive": true
       },
       "value": {
@@ -1359,24 +1103,11 @@
       },
       "sensitive": true
     },
-    "S1f": {
-      "type": "string",
-      "pattern": "(arn:aws:[a-z0-9-.]+:.*)|()"
-    },
     "S1g": {
       "type": "structure",
       "members": {
-        "Mode": {
-          "shape": "S1h"
-        }
+        "Mode": {}
       }
-    },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "Active",
-        "PassThrough"
-      ]
     },
     "S1i": {
       "type": "map",
@@ -1386,39 +1117,24 @@
     "S1l": {
       "type": "structure",
       "members": {
-        "FunctionName": {
-          "shape": "S1m"
-        },
-        "FunctionArn": {
-          "type": "string",
-          "pattern": "arn:aws:lambda:[a-z]{2}-[a-z]+-\\d{1}:\\d{12}:function:[a-zA-Z0-9-_\\.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
-        },
-        "Runtime": {
-          "shape": "St"
-        },
-        "Role": {
-          "shape": "Su"
-        },
-        "Handler": {
-          "shape": "Sv"
-        },
+        "FunctionName": {},
+        "FunctionArn": {},
+        "Runtime": {},
+        "Role": {},
+        "Handler": {},
         "CodeSize": {
           "type": "long"
         },
-        "Description": {
-          "shape": "Sf"
-        },
+        "Description": {},
         "Timeout": {
-          "shape": "S11"
+          "type": "integer"
         },
         "MemorySize": {
-          "shape": "S12"
+          "type": "integer"
         },
         "LastModified": {},
         "CodeSha256": {},
-        "Version": {
-          "shape": "Se"
-        },
+        "Version": {},
         "VpcConfig": {
           "type": "structure",
           "members": {
@@ -1452,45 +1168,24 @@
             }
           }
         },
-        "KMSKeyArn": {
-          "shape": "S1f"
-        },
+        "KMSKeyArn": {},
         "TracingConfig": {
           "type": "structure",
           "members": {
-            "Mode": {
-              "shape": "S1h"
-            }
+            "Mode": {}
           }
         },
-        "MasterArn": {
-          "shape": "Sl"
-        },
+        "MasterArn": {},
         "RevisionId": {}
       }
-    },
-    "S1m": {
-      "type": "string",
-      "max": 170,
-      "min": 1,
-      "pattern": "(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\\d{1}:)?(\\d{12}:)?(function:)?([a-zA-Z0-9-_\\.]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?"
     },
     "S2b": {
       "type": "structure",
       "members": {
         "ReservedConcurrentExecutions": {
-          "shape": "S2c"
+          "type": "integer"
         }
       }
-    },
-    "S2c": {
-      "type": "integer",
-      "min": 0
-    },
-    "S2p": {
-      "type": "integer",
-      "max": 10000,
-      "min": 1
     },
     "S2z": {
       "type": "list",

--- a/apis/lex-models-2017-04-19.min.json
+++ b/apis/lex-models-2017-04-19.min.json
@@ -24,7 +24,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -34,12 +33,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "intents": {
             "shape": "S6"
           },
@@ -49,9 +44,7 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {
-            "shape": "Sj"
-          },
+          "status": {},
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -60,16 +53,12 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {
-            "shape": "S9"
-          },
-          "locale": {
-            "shape": "Sm"
-          },
+          "version": {},
+          "locale": {},
           "childDirected": {
             "type": "boolean"
           }
@@ -88,7 +77,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
@@ -98,12 +86,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S8"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "slots": {
             "shape": "Sq"
           },
@@ -135,9 +119,7 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {}
         }
       }
@@ -154,7 +136,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
@@ -164,12 +145,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S17"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "enumerationValues": {
             "shape": "S19"
           },
@@ -179,13 +156,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {},
-          "valueSelectionStrategy": {
-            "shape": "S1d"
-          }
+          "valueSelectionStrategy": {}
         }
       }
     },
@@ -202,7 +175,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           }
@@ -223,12 +195,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           }
@@ -250,17 +220,14 @@
         ],
         "members": {
           "name": {
-            "shape": "S1i",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
-            "shape": "S1g",
             "location": "uri",
             "locationName": "aliasName"
           }
@@ -281,12 +248,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
-            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -306,7 +271,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           }
@@ -327,12 +291,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
-            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -352,7 +314,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           }
@@ -373,12 +334,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
-            "shape": "S1k",
             "location": "uri",
             "locationName": "version"
           }
@@ -399,16 +358,12 @@
         ],
         "members": {
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "userId": {
             "location": "uri",
-            "locationName": "userId",
-            "type": "string",
-            "max": 100,
-            "min": 2
+            "locationName": "userId"
           }
         }
       }
@@ -427,7 +382,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -440,12 +394,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "intents": {
             "shape": "S6"
           },
@@ -455,9 +405,7 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {
-            "shape": "Sj"
-          },
+          "status": {},
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -466,16 +414,12 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {
-            "shape": "S9"
-          },
-          "locale": {
-            "shape": "Sm"
-          },
+          "version": {},
+          "locale": {},
           "childDirected": {
             "type": "boolean"
           }
@@ -496,12 +440,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           }
@@ -510,18 +452,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S1g"
-          },
-          "description": {
-            "shape": "S5"
-          },
-          "botVersion": {
-            "shape": "S9"
-          },
-          "botName": {
-            "shape": "S2"
-          },
+          "name": {},
+          "description": {},
+          "botVersion": {},
+          "botName": {},
           "lastUpdatedDate": {
             "type": "timestamp"
           },
@@ -545,7 +479,6 @@
         ],
         "members": {
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
@@ -554,12 +487,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nameContains": {
-            "shape": "S1g",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -573,18 +505,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {
-                  "shape": "S1g"
-                },
-                "description": {
-                  "shape": "S5"
-                },
-                "botVersion": {
-                  "shape": "S9"
-                },
-                "botName": {
-                  "shape": "S2"
-                },
+                "name": {},
+                "description": {},
+                "botVersion": {},
+                "botName": {},
                 "lastUpdatedDate": {
                   "type": "timestamp"
                 },
@@ -614,17 +538,14 @@
         ],
         "members": {
           "name": {
-            "shape": "S1i",
             "location": "uri",
             "locationName": "name"
           },
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
-            "shape": "S1g",
             "location": "uri",
             "locationName": "aliasName"
           }
@@ -633,30 +554,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S1i"
-          },
-          "description": {
-            "shape": "S5"
-          },
-          "botAlias": {
-            "shape": "S1g"
-          },
-          "botName": {
-            "shape": "S2"
-          },
+          "name": {},
+          "description": {},
+          "botAlias": {},
+          "botName": {},
           "createdDate": {
             "type": "timestamp"
           },
-          "type": {
-            "shape": "S23"
-          },
+          "type": {},
           "botConfiguration": {
             "shape": "S24"
           },
-          "status": {
-            "shape": "S25"
-          },
+          "status": {},
           "failureReason": {}
         }
       }
@@ -675,29 +584,23 @@
         ],
         "members": {
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
           "botAlias": {
             "location": "uri",
-            "locationName": "aliasName",
-            "type": "string",
-            "max": 100,
-            "min": 1,
-            "pattern": "^(-|^([A-Za-z]_?)+$)$"
+            "locationName": "aliasName"
           },
           "nextToken": {
             "location": "querystring",
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nameContains": {
-            "shape": "S1i",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -711,30 +614,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {
-                  "shape": "S1i"
-                },
-                "description": {
-                  "shape": "S5"
-                },
-                "botAlias": {
-                  "shape": "S1g"
-                },
-                "botName": {
-                  "shape": "S2"
-                },
+                "name": {},
+                "description": {},
+                "botAlias": {},
+                "botName": {},
                 "createdDate": {
                   "type": "timestamp"
                 },
-                "type": {
-                  "shape": "S23"
-                },
+                "type": {},
                 "botConfiguration": {
                   "shape": "S24"
                 },
-                "status": {
-                  "shape": "S25"
-                },
+                "status": {},
                 "failureReason": {}
               }
             }
@@ -756,7 +647,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
@@ -765,9 +655,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -795,12 +685,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nameContains": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -863,7 +752,6 @@
         "type": "structure",
         "members": {
           "locale": {
-            "shape": "Sm",
             "location": "querystring",
             "locationName": "locale"
           },
@@ -876,9 +764,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -911,7 +799,6 @@
         "type": "structure",
         "members": {
           "locale": {
-            "shape": "Sm",
             "location": "querystring",
             "locationName": "locale"
           },
@@ -924,9 +811,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -965,22 +852,18 @@
         ],
         "members": {
           "name": {
-            "shape": "S2w",
             "location": "querystring",
             "locationName": "name"
           },
           "version": {
-            "shape": "S1k",
             "location": "querystring",
             "locationName": "version"
           },
           "resourceType": {
-            "shape": "S2x",
             "location": "querystring",
             "locationName": "resourceType"
           },
           "exportType": {
-            "shape": "S2y",
             "location": "querystring",
             "locationName": "exportType"
           }
@@ -989,26 +872,11 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2w"
-          },
-          "version": {
-            "shape": "S1k"
-          },
-          "resourceType": {
-            "shape": "S2x"
-          },
-          "exportType": {
-            "shape": "S2y"
-          },
-          "exportStatus": {
-            "type": "string",
-            "enum": [
-              "IN_PROGRESS",
-              "READY",
-              "FAILED"
-            ]
-          },
+          "name": {},
+          "version": {},
+          "resourceType": {},
+          "exportType": {},
+          "exportStatus": {},
           "failureReason": {},
           "url": {}
         }
@@ -1035,19 +903,11 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2w"
-          },
-          "resourceType": {
-            "shape": "S2x"
-          },
-          "mergeStrategy": {
-            "shape": "S33"
-          },
+          "name": {},
+          "resourceType": {},
+          "mergeStrategy": {},
           "importId": {},
-          "importStatus": {
-            "shape": "S34"
-          },
+          "importStatus": {},
           "failureReason": {
             "type": "list",
             "member": {}
@@ -1072,12 +932,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
-            "shape": "S9",
             "location": "uri",
             "locationName": "version"
           }
@@ -1086,12 +944,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S8"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "slots": {
             "shape": "Sq"
           },
@@ -1123,9 +977,7 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {}
         }
       }
@@ -1143,7 +995,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
@@ -1152,9 +1003,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -1182,12 +1033,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nameContains": {
-            "shape": "S8",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -1217,12 +1067,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
           "version": {
-            "shape": "S9",
             "location": "uri",
             "locationName": "version"
           }
@@ -1231,12 +1079,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S17"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "enumerationValues": {
             "shape": "S19"
           },
@@ -1246,13 +1090,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {},
-          "valueSelectionStrategy": {
-            "shape": "S1d"
-          }
+          "valueSelectionStrategy": {}
         }
       }
     },
@@ -1269,7 +1109,6 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
@@ -1278,9 +1117,9 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           }
         }
       },
@@ -1308,12 +1147,11 @@
             "locationName": "nextToken"
           },
           "maxResults": {
-            "shape": "S1x",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nameContains": {
-            "shape": "S17",
             "location": "querystring",
             "locationName": "nameContains"
           }
@@ -1344,7 +1182,6 @@
         ],
         "members": {
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botname"
           },
@@ -1352,47 +1189,30 @@
             "location": "querystring",
             "locationName": "bot_versions",
             "type": "list",
-            "member": {
-              "shape": "S9"
-            },
-            "max": 5,
-            "min": 1
+            "member": {}
           },
           "statusType": {
             "location": "querystring",
-            "locationName": "status_type",
-            "type": "string",
-            "enum": [
-              "Detected",
-              "Missed"
-            ]
+            "locationName": "status_type"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "botName": {
-            "shape": "S2"
-          },
+          "botName": {},
           "utterances": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "botVersion": {
-                  "shape": "S9"
-                },
+                "botVersion": {},
                 "utterances": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "utteranceString": {
-                        "type": "string",
-                        "max": 2000,
-                        "min": 1
-                      },
+                      "utteranceString": {},
                       "count": {
                         "type": "integer"
                       },
@@ -1429,13 +1249,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {
-            "shape": "S5"
-          },
+          "description": {},
           "intents": {
             "shape": "S6"
           },
@@ -1446,20 +1263,12 @@
             "shape": "Si"
           },
           "idleSessionTTLInSeconds": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "voiceId": {},
           "checksum": {},
-          "processBehavior": {
-            "type": "string",
-            "enum": [
-              "SAVE",
-              "BUILD"
-            ]
-          },
-          "locale": {
-            "shape": "Sm"
-          },
+          "processBehavior": {},
+          "locale": {},
           "childDirected": {
             "type": "boolean"
           },
@@ -1471,12 +1280,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "intents": {
             "shape": "S6"
           },
@@ -1486,9 +1291,7 @@
           "abortStatement": {
             "shape": "Si"
           },
-          "status": {
-            "shape": "Sj"
-          },
+          "status": {},
           "failureReason": {},
           "lastUpdatedDate": {
             "type": "timestamp"
@@ -1497,16 +1300,12 @@
             "type": "timestamp"
           },
           "idleSessionTTLInSeconds": {
-            "shape": "Sl"
+            "type": "integer"
           },
           "voiceId": {},
           "checksum": {},
-          "version": {
-            "shape": "S9"
-          },
-          "locale": {
-            "shape": "Sm"
-          },
+          "version": {},
+          "locale": {},
           "childDirected": {
             "type": "boolean"
           },
@@ -1531,18 +1330,12 @@
         ],
         "members": {
           "name": {
-            "shape": "S1g",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {
-            "shape": "S5"
-          },
-          "botVersion": {
-            "shape": "S9"
-          },
+          "description": {},
+          "botVersion": {},
           "botName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "botName"
           },
@@ -1552,18 +1345,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S1g"
-          },
-          "description": {
-            "shape": "S5"
-          },
-          "botVersion": {
-            "shape": "S9"
-          },
-          "botName": {
-            "shape": "S2"
-          },
+          "name": {},
+          "description": {},
+          "botVersion": {},
+          "botName": {},
           "lastUpdatedDate": {
             "type": "timestamp"
           },
@@ -1587,13 +1372,10 @@
         ],
         "members": {
           "name": {
-            "shape": "S8",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {
-            "shape": "S5"
-          },
+          "description": {},
           "slots": {
             "shape": "Sq"
           },
@@ -1628,12 +1410,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S8"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "slots": {
             "shape": "Sq"
           },
@@ -1665,9 +1443,7 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {},
           "createVersion": {
             "type": "boolean"
@@ -1688,20 +1464,15 @@
         ],
         "members": {
           "name": {
-            "shape": "S17",
             "location": "uri",
             "locationName": "name"
           },
-          "description": {
-            "shape": "S5"
-          },
+          "description": {},
           "enumerationValues": {
             "shape": "S19"
           },
           "checksum": {},
-          "valueSelectionStrategy": {
-            "shape": "S1d"
-          },
+          "valueSelectionStrategy": {},
           "createVersion": {
             "type": "boolean"
           }
@@ -1710,12 +1481,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S17"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "enumerationValues": {
             "shape": "S19"
           },
@@ -1725,13 +1492,9 @@
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          },
+          "version": {},
           "checksum": {},
-          "valueSelectionStrategy": {
-            "shape": "S1d"
-          },
+          "valueSelectionStrategy": {},
           "createVersion": {
             "type": "boolean"
           }
@@ -1754,30 +1517,18 @@
           "payload": {
             "type": "blob"
           },
-          "resourceType": {
-            "shape": "S2x"
-          },
-          "mergeStrategy": {
-            "shape": "S33"
-          }
+          "resourceType": {},
+          "mergeStrategy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2w"
-          },
-          "resourceType": {
-            "shape": "S2x"
-          },
-          "mergeStrategy": {
-            "shape": "S33"
-          },
+          "name": {},
+          "resourceType": {},
+          "mergeStrategy": {},
           "importId": {},
-          "importStatus": {
-            "shape": "S34"
-          },
+          "importStatus": {},
           "createdDate": {
             "type": "timestamp"
           }
@@ -1786,17 +1537,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 50,
-      "min": 2,
-      "pattern": "^([A-Za-z]_?)+$"
-    },
-    "S5": {
-      "type": "string",
-      "max": 200,
-      "min": 0
-    },
     "S6": {
       "type": "list",
       "member": {
@@ -1806,26 +1546,10 @@
           "intentVersion"
         ],
         "members": {
-          "intentName": {
-            "shape": "S8"
-          },
-          "intentVersion": {
-            "shape": "S9"
-          }
+          "intentName": {},
+          "intentVersion": {}
         }
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^([A-Za-z]_?)+$"
-    },
-    "S9": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "\\$LATEST|[0-9]+"
     },
     "Sa": {
       "type": "structure",
@@ -1838,13 +1562,9 @@
           "shape": "Sb"
         },
         "maxAttempts": {
-          "type": "integer",
-          "max": 5,
-          "min": 1
+          "type": "integer"
         },
-        "responseCard": {
-          "shape": "Sh"
-        }
+        "responseCard": {}
       }
     },
     "Sb": {
@@ -1856,33 +1576,13 @@
           "content"
         ],
         "members": {
-          "contentType": {
-            "type": "string",
-            "enum": [
-              "PlainText",
-              "SSML",
-              "CustomPayload"
-            ]
-          },
-          "content": {
-            "type": "string",
-            "max": 1000,
-            "min": 1
-          },
+          "contentType": {},
+          "content": {},
           "groupNumber": {
-            "type": "integer",
-            "max": 5,
-            "min": 1
+            "type": "integer"
           }
         }
-      },
-      "max": 15,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 50000,
-      "min": 1
+      }
     },
     "Si": {
       "type": "structure",
@@ -1893,33 +1593,8 @@
         "messages": {
           "shape": "Sb"
         },
-        "responseCard": {
-          "shape": "Sh"
-        }
+        "responseCard": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "enum": [
-        "BUILDING",
-        "READY",
-        "READY_BASIC_TESTING",
-        "FAILED",
-        "NOT_BUILT"
-      ]
-    },
-    "Sl": {
-      "type": "integer",
-      "max": 86400,
-      "min": 60
-    },
-    "Sm": {
-      "type": "string",
-      "enum": [
-        "en-US",
-        "en-GB",
-        "de-DE"
-      ]
     },
     "Sq": {
       "type": "list",
@@ -1930,67 +1605,28 @@
           "slotConstraint"
         ],
         "members": {
-          "name": {
-            "type": "string",
-            "max": 100,
-            "min": 1,
-            "pattern": "^([A-Za-z](-|_|.)?)+$"
-          },
-          "description": {
-            "shape": "S5"
-          },
-          "slotConstraint": {
-            "type": "string",
-            "enum": [
-              "Required",
-              "Optional"
-            ]
-          },
-          "slotType": {
-            "type": "string",
-            "max": 100,
-            "min": 1,
-            "pattern": "^((AMAZON\\.)_?|[A-Za-z]_?)+"
-          },
-          "slotTypeVersion": {
-            "shape": "S9"
-          },
+          "name": {},
+          "description": {},
+          "slotConstraint": {},
+          "slotType": {},
+          "slotTypeVersion": {},
           "valueElicitationPrompt": {
             "shape": "Sa"
           },
           "priority": {
-            "type": "integer",
-            "max": 100,
-            "min": 0
+            "type": "integer"
           },
           "sampleUtterances": {
             "type": "list",
-            "member": {
-              "shape": "Sx"
-            },
-            "max": 10,
-            "min": 0
+            "member": {}
           },
-          "responseCard": {
-            "shape": "Sh"
-          }
+          "responseCard": {}
         }
-      },
-      "max": 100,
-      "min": 0
-    },
-    "Sx": {
-      "type": "string",
-      "max": 200,
-      "min": 1
+      }
     },
     "Sy": {
       "type": "list",
-      "member": {
-        "shape": "Sx"
-      },
-      "max": 1500,
-      "min": 0
+      "member": {}
     },
     "Sz": {
       "type": "structure",
@@ -2014,17 +1650,8 @@
         "messageVersion"
       ],
       "members": {
-        "uri": {
-          "type": "string",
-          "max": 2048,
-          "min": 20,
-          "pattern": "arn:aws:lambda:[a-z]+-[a-z]+-[0-9]:[0-9]{12}:function:[a-zA-Z0-9-_]+(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?(:[a-zA-Z0-9-_]+)?"
-        },
-        "messageVersion": {
-          "type": "string",
-          "max": 5,
-          "min": 1
-        }
+        "uri": {},
+        "messageVersion": {}
       }
     },
     "S13": {
@@ -2033,23 +1660,11 @@
         "type"
       ],
       "members": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "ReturnIntent",
-            "CodeHook"
-          ]
-        },
+        "type": {},
         "codeHook": {
           "shape": "S10"
         }
       }
-    },
-    "S17": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^([A-Za-z]_?)+$"
     },
     "S19": {
       "type": "list",
@@ -2059,168 +1674,56 @@
           "value"
         ],
         "members": {
-          "value": {
-            "shape": "S1b"
-          },
+          "value": {},
           "synonyms": {
             "type": "list",
-            "member": {
-              "shape": "S1b"
-            }
+            "member": {}
           }
         }
-      },
-      "max": 10000,
-      "min": 1
-    },
-    "S1b": {
-      "type": "string",
-      "max": 140,
-      "min": 1
-    },
-    "S1d": {
-      "type": "string",
-      "enum": [
-        "ORIGINAL_VALUE",
-        "TOP_RESOLUTION"
-      ]
-    },
-    "S1g": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^([A-Za-z]_?)+$"
-    },
-    "S1i": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^([A-Za-z]_?)+$"
-    },
-    "S1k": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[0-9]+"
-    },
-    "S1x": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
-    },
-    "S23": {
-      "type": "string",
-      "enum": [
-        "Facebook",
-        "Slack",
-        "Twilio-Sms",
-        "Kik"
-      ]
+      }
     },
     "S24": {
       "type": "map",
       "key": {},
       "value": {},
-      "max": 10,
-      "min": 1,
       "sensitive": true
-    },
-    "S25": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "CREATED",
-        "FAILED"
-      ]
     },
     "S2d": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "S5"
-          },
-          "status": {
-            "shape": "Sj"
-          },
+          "name": {},
+          "description": {},
+          "status": {},
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          }
+          "version": {}
         }
       }
     },
     "S2j": {
       "type": "list",
-      "member": {
-        "shape": "Sm"
-      }
-    },
-    "S2w": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[a-zA-Z_]+"
-    },
-    "S2x": {
-      "type": "string",
-      "enum": [
-        "BOT",
-        "INTENT",
-        "SLOT_TYPE"
-      ]
-    },
-    "S2y": {
-      "type": "string",
-      "enum": [
-        "ALEXA_SKILLS_KIT",
-        "LEX"
-      ]
-    },
-    "S33": {
-      "type": "string",
-      "enum": [
-        "OVERWRITE_LATEST",
-        "FAIL_ON_CONFLICT"
-      ]
-    },
-    "S34": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "COMPLETE",
-        "FAILED"
-      ]
+      "member": {}
     },
     "S3a": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S8"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          }
+          "version": {}
         }
       }
     },
@@ -2229,21 +1732,15 @@
       "member": {
         "type": "structure",
         "members": {
-          "name": {
-            "shape": "S17"
-          },
-          "description": {
-            "shape": "S5"
-          },
+          "name": {},
+          "description": {},
           "lastUpdatedDate": {
             "type": "timestamp"
           },
           "createdDate": {
             "type": "timestamp"
           },
-          "version": {
-            "shape": "S9"
-          }
+          "version": {}
         }
       }
     }

--- a/apis/lightsail-2016-11-28.min.json
+++ b/apis/lightsail-2016-11-28.min.json
@@ -19,9 +19,7 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {
-            "shape": "S2"
-          }
+          "staticIpName": {}
         }
       },
       "output": {
@@ -42,15 +40,9 @@
           "diskPath"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          },
-          "instanceName": {
-            "shape": "S2"
-          },
-          "diskPath": {
-            "shape": "S6"
-          }
+          "diskName": {},
+          "instanceName": {},
+          "diskPath": {}
         }
       },
       "output": {
@@ -70,9 +62,7 @@
           "instanceNames"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
+          "loadBalancerName": {},
           "instanceNames": {
             "shape": "Si"
           }
@@ -95,12 +85,8 @@
           "certificateName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
-          "certificateName": {
-            "shape": "S2"
-          }
+          "loadBalancerName": {},
+          "certificateName": {}
         }
       },
       "output": {
@@ -120,12 +106,8 @@
           "instanceName"
         ],
         "members": {
-          "staticIpName": {
-            "shape": "S2"
-          },
-          "instanceName": {
-            "shape": "S2"
-          }
+          "staticIpName": {},
+          "instanceName": {}
         }
       },
       "output": {
@@ -148,9 +130,7 @@
           "portInfo": {
             "shape": "Sp"
           },
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -171,12 +151,8 @@
           "sizeInGb"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          },
-          "availabilityZone": {
-            "shape": "S6"
-          },
+          "diskName": {},
+          "availabilityZone": {},
           "sizeInGb": {
             "type": "integer"
           }
@@ -201,15 +177,9 @@
           "sizeInGb"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          },
-          "diskSnapshotName": {
-            "shape": "S2"
-          },
-          "availabilityZone": {
-            "shape": "S6"
-          },
+          "diskName": {},
+          "diskSnapshotName": {},
+          "availabilityZone": {},
           "sizeInGb": {
             "type": "integer"
           }
@@ -232,12 +202,8 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          },
-          "diskSnapshotName": {
-            "shape": "S2"
-          }
+          "diskName": {},
+          "diskSnapshotName": {}
         }
       },
       "output": {
@@ -299,12 +265,8 @@
           "instanceName"
         ],
         "members": {
-          "instanceSnapshotName": {
-            "shape": "S2"
-          },
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceSnapshotName": {},
+          "instanceName": {}
         }
       },
       "output": {
@@ -331,19 +293,12 @@
           },
           "availabilityZone": {},
           "customImageName": {
-            "shape": "S2",
             "deprecated": true
           },
-          "blueprintId": {
-            "shape": "S6"
-          },
-          "bundleId": {
-            "shape": "S6"
-          },
+          "blueprintId": {},
+          "bundleId": {},
           "userData": {},
-          "keyPairName": {
-            "shape": "S2"
-          }
+          "keyPairName": {}
         }
       },
       "output": {
@@ -370,35 +325,23 @@
           },
           "attachedDiskMapping": {
             "type": "map",
-            "key": {
-              "shape": "S2"
-            },
+            "key": {},
             "value": {
               "type": "list",
               "member": {
                 "type": "structure",
                 "members": {
-                  "originalDiskPath": {
-                    "shape": "S6"
-                  },
-                  "newDiskName": {
-                    "shape": "S2"
-                  }
+                  "originalDiskPath": {},
+                  "newDiskName": {}
                 }
               }
             }
           },
           "availabilityZone": {},
-          "instanceSnapshotName": {
-            "shape": "S2"
-          },
-          "bundleId": {
-            "shape": "S6"
-          },
+          "instanceSnapshotName": {},
+          "bundleId": {},
           "userData": {},
-          "keyPairName": {
-            "shape": "S2"
-          }
+          "keyPairName": {}
         }
       },
       "output": {
@@ -417,9 +360,7 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {
-            "shape": "S2"
-          }
+          "keyPairName": {}
         }
       },
       "output": {
@@ -444,16 +385,12 @@
           "instancePort"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
+          "loadBalancerName": {},
           "instancePort": {
-            "shape": "Sq"
+            "type": "integer"
           },
           "healthCheckPath": {},
-          "certificateName": {
-            "shape": "S2"
-          },
+          "certificateName": {},
           "certificateDomainName": {},
           "certificateAlternativeNames": {
             "shape": "S1o"
@@ -478,12 +415,8 @@
           "certificateDomainName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
-          "certificateName": {
-            "shape": "S2"
-          },
+          "loadBalancerName": {},
+          "certificateName": {},
           "certificateDomainName": {},
           "certificateAlternativeNames": {
             "shape": "S1o"
@@ -506,9 +439,7 @@
           "diskName"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          }
+          "diskName": {}
         }
       },
       "output": {
@@ -527,9 +458,7 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskSnapshotName": {
-            "shape": "S2"
-          }
+          "diskSnapshotName": {}
         }
       },
       "output": {
@@ -590,9 +519,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -611,9 +538,7 @@
           "instanceSnapshotName"
         ],
         "members": {
-          "instanceSnapshotName": {
-            "shape": "S2"
-          }
+          "instanceSnapshotName": {}
         }
       },
       "output": {
@@ -632,9 +557,7 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {
-            "shape": "S2"
-          }
+          "keyPairName": {}
         }
       },
       "output": {
@@ -653,9 +576,7 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          }
+          "loadBalancerName": {}
         }
       },
       "output": {
@@ -675,12 +596,8 @@
           "certificateName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
-          "certificateName": {
-            "shape": "S2"
-          },
+          "loadBalancerName": {},
+          "certificateName": {},
           "force": {
             "type": "boolean"
           }
@@ -702,9 +619,7 @@
           "diskName"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          }
+          "diskName": {}
         }
       },
       "output": {
@@ -724,9 +639,7 @@
           "instanceNames"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
+          "loadBalancerName": {},
           "instanceNames": {
             "shape": "Si"
           }
@@ -748,9 +661,7 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {
-            "shape": "S2"
-          }
+          "staticIpName": {}
         }
       },
       "output": {
@@ -810,22 +721,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "blueprintId": {
-                  "shape": "S6"
-                },
-                "name": {
-                  "shape": "S2"
-                },
-                "group": {
-                  "shape": "S6"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "os",
-                    "app"
-                  ]
-                },
+                "blueprintId": {},
+                "name": {},
+                "group": {},
+                "type": {},
                 "description": {},
                 "isActive": {
                   "type": "boolean"
@@ -837,9 +736,7 @@
                 "versionCode": {},
                 "productUrl": {},
                 "licenseUrl": {},
-                "platform": {
-                  "shape": "S2p"
-                }
+                "platform": {}
               }
             }
           },
@@ -874,9 +771,7 @@
                 "diskSizeInGb": {
                   "type": "integer"
                 },
-                "bundleId": {
-                  "shape": "S6"
-                },
+                "bundleId": {},
                 "instanceType": {},
                 "isActive": {
                   "type": "boolean"
@@ -893,9 +788,7 @@
                 },
                 "supportedPlatforms": {
                   "type": "list",
-                  "member": {
-                    "shape": "S2p"
-                  }
+                  "member": {}
                 }
               }
             }
@@ -911,9 +804,7 @@
           "diskName"
         ],
         "members": {
-          "diskName": {
-            "shape": "S2"
-          }
+          "diskName": {}
         }
       },
       "output": {
@@ -932,9 +823,7 @@
           "diskSnapshotName"
         ],
         "members": {
-          "diskSnapshotName": {
-            "shape": "S2"
-          }
+          "diskSnapshotName": {}
         }
       },
       "output": {
@@ -1029,9 +918,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1050,12 +937,8 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          },
-          "protocol": {
-            "shape": "S3v"
-          }
+          "instanceName": {},
+          "protocol": {}
         }
       },
       "output": {
@@ -1068,26 +951,18 @@
               "expiresAt": {
                 "type": "timestamp"
               },
-              "ipAddress": {
-                "shape": "S3k"
-              },
+              "ipAddress": {},
               "password": {},
               "passwordData": {
                 "type": "structure",
                 "members": {
                   "ciphertext": {},
-                  "keyPairName": {
-                    "shape": "S2"
-                  }
+                  "keyPairName": {}
                 }
               },
               "privateKey": {},
-              "protocol": {
-                "shape": "S3v"
-              },
-              "instanceName": {
-                "shape": "S2"
-              },
+              "protocol": {},
+              "instanceName": {},
               "username": {}
             }
           }
@@ -1107,14 +982,10 @@
           "statistics"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          },
-          "metricName": {
-            "shape": "S40"
-          },
+          "instanceName": {},
+          "metricName": {},
           "period": {
-            "shape": "S41"
+            "type": "integer"
           },
           "startTime": {
             "type": "timestamp"
@@ -1122,9 +993,7 @@
           "endTime": {
             "type": "timestamp"
           },
-          "unit": {
-            "shape": "S43"
-          },
+          "unit": {},
           "statistics": {
             "shape": "S44"
           }
@@ -1133,9 +1002,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "metricName": {
-            "shape": "S40"
-          },
+          "metricName": {},
           "metricData": {
             "shape": "S47"
           }
@@ -1149,9 +1016,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1163,21 +1028,13 @@
               "type": "structure",
               "members": {
                 "fromPort": {
-                  "shape": "Sq"
+                  "type": "integer"
                 },
                 "toPort": {
-                  "shape": "Sq"
+                  "type": "integer"
                 },
-                "protocol": {
-                  "shape": "Sr"
-                },
-                "state": {
-                  "type": "string",
-                  "enum": [
-                    "open",
-                    "closed"
-                  ]
-                }
+                "protocol": {},
+                "state": {}
               }
             }
           }
@@ -1191,9 +1048,7 @@
           "instanceSnapshotName"
         ],
         "members": {
-          "instanceSnapshotName": {
-            "shape": "S2"
-          }
+          "instanceSnapshotName": {}
         }
       },
       "output": {
@@ -1232,9 +1087,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1273,9 +1126,7 @@
           "keyPairName"
         ],
         "members": {
-          "keyPairName": {
-            "shape": "S2"
-          }
+          "keyPairName": {}
         }
       },
       "output": {
@@ -1314,9 +1165,7 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          }
+          "loadBalancerName": {}
         }
       },
       "output": {
@@ -1341,14 +1190,10 @@
           "statistics"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
-          "metricName": {
-            "shape": "S5b"
-          },
+          "loadBalancerName": {},
+          "metricName": {},
           "period": {
-            "shape": "S41"
+            "type": "integer"
           },
           "startTime": {
             "type": "timestamp"
@@ -1356,9 +1201,7 @@
           "endTime": {
             "type": "timestamp"
           },
-          "unit": {
-            "shape": "S43"
-          },
+          "unit": {},
           "statistics": {
             "shape": "S44"
           }
@@ -1367,9 +1210,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "metricName": {
-            "shape": "S5b"
-          },
+          "metricName": {},
           "metricData": {
             "shape": "S47"
           }
@@ -1383,9 +1224,7 @@
           "loadBalancerName"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          }
+          "loadBalancerName": {}
         }
       },
       "output": {
@@ -1396,12 +1235,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "name": {
-                  "shape": "S2"
-                },
-                "arn": {
-                  "shape": "S6"
-                },
+                "name": {},
+                "arn": {},
                 "supportCode": {},
                 "createdAt": {
                   "type": "timestamp"
@@ -1409,69 +1244,32 @@
                 "location": {
                   "shape": "S9"
                 },
-                "resourceType": {
-                  "shape": "S7"
-                },
-                "loadBalancerName": {
-                  "shape": "S2"
-                },
+                "resourceType": {},
+                "loadBalancerName": {},
                 "isAttached": {
                   "type": "boolean"
                 },
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "PENDING_VALIDATION",
-                    "ISSUED",
-                    "INACTIVE",
-                    "EXPIRED",
-                    "VALIDATION_TIMED_OUT",
-                    "REVOKED",
-                    "FAILED",
-                    "UNKNOWN"
-                  ]
-                },
+                "status": {},
                 "domainName": {},
                 "domainValidationRecords": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "name": {
-                        "shape": "S6"
-                      },
-                      "type": {
-                        "shape": "S6"
-                      },
-                      "value": {
-                        "shape": "S6"
-                      },
-                      "validationStatus": {
-                        "shape": "S5k"
-                      },
+                      "name": {},
+                      "type": {},
+                      "value": {},
+                      "validationStatus": {},
                       "domainName": {}
                     }
                   }
                 },
-                "failureReason": {
-                  "type": "string",
-                  "enum": [
-                    "NO_AVAILABLE_CONTACTS",
-                    "ADDITIONAL_VERIFICATION_REQUIRED",
-                    "DOMAIN_NOT_ALLOWED",
-                    "INVALID_PUBLIC_DOMAIN",
-                    "OTHER"
-                  ]
-                },
+                "failureReason": {},
                 "issuedAt": {
                   "type": "timestamp"
                 },
-                "issuer": {
-                  "shape": "S6"
-                },
-                "keyAlgorithm": {
-                  "shape": "S6"
-                },
+                "issuer": {},
+                "keyAlgorithm": {},
                 "notAfter": {
                   "type": "timestamp"
                 },
@@ -1481,56 +1279,26 @@
                 "renewalSummary": {
                   "type": "structure",
                   "members": {
-                    "renewalStatus": {
-                      "type": "string",
-                      "enum": [
-                        "PENDING_AUTO_RENEWAL",
-                        "PENDING_VALIDATION",
-                        "SUCCESS",
-                        "FAILED"
-                      ]
-                    },
+                    "renewalStatus": {},
                     "domainValidationOptions": {
                       "type": "list",
                       "member": {
                         "type": "structure",
                         "members": {
                           "domainName": {},
-                          "validationStatus": {
-                            "shape": "S5k"
-                          }
+                          "validationStatus": {}
                         }
                       }
                     }
                   }
                 },
-                "revocationReason": {
-                  "type": "string",
-                  "enum": [
-                    "UNSPECIFIED",
-                    "KEY_COMPROMISE",
-                    "CA_COMPROMISE",
-                    "AFFILIATION_CHANGED",
-                    "SUPERCEDED",
-                    "CESSATION_OF_OPERATION",
-                    "CERTIFICATE_HOLD",
-                    "REMOVE_FROM_CRL",
-                    "PRIVILEGE_WITHDRAWN",
-                    "A_A_COMPROMISE"
-                  ]
-                },
+                "revocationReason": {},
                 "revokedAt": {
                   "type": "timestamp"
                 },
-                "serial": {
-                  "shape": "S6"
-                },
-                "signatureAlgorithm": {
-                  "shape": "S6"
-                },
-                "subject": {
-                  "shape": "S6"
-                },
+                "serial": {},
+                "signatureAlgorithm": {},
+                "subject": {},
                 "subjectAlternativeNames": {
                   "shape": "S1c"
                 }
@@ -1567,9 +1335,7 @@
           "operationId"
         ],
         "members": {
-          "operationId": {
-            "shape": "S6"
-          }
+          "operationId": {}
         }
       },
       "output": {
@@ -1605,9 +1371,7 @@
           "resourceName"
         ],
         "members": {
-          "resourceName": {
-            "shape": "S2"
-          },
+          "resourceName": {},
           "pageToken": {}
         }
       },
@@ -1644,20 +1408,14 @@
                 "continentCode": {},
                 "description": {},
                 "displayName": {},
-                "name": {
-                  "shape": "Sb"
-                },
+                "name": {},
                 "availabilityZones": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "zoneName": {
-                        "shape": "S6"
-                      },
-                      "state": {
-                        "shape": "S6"
-                      }
+                      "zoneName": {},
+                      "state": {}
                     }
                   }
                 }
@@ -1674,9 +1432,7 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {
-            "shape": "S2"
-          }
+          "staticIpName": {}
         }
       },
       "output": {
@@ -1716,9 +1472,7 @@
           "publicKeyBase64"
         ],
         "members": {
-          "keyPairName": {
-            "shape": "S2"
-          },
+          "keyPairName": {},
           "publicKeyBase64": {}
         }
       },
@@ -1756,9 +1510,7 @@
           "portInfo": {
             "shape": "Sp"
           },
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1798,9 +1550,7 @@
               "shape": "Sp"
             }
           },
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1819,9 +1569,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1840,9 +1588,7 @@
           "staticIpName"
         ],
         "members": {
-          "staticIpName": {
-            "shape": "S2"
-          }
+          "staticIpName": {}
         }
       },
       "output": {
@@ -1861,9 +1607,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          }
+          "instanceName": {}
         }
       },
       "output": {
@@ -1882,9 +1626,7 @@
           "instanceName"
         ],
         "members": {
-          "instanceName": {
-            "shape": "S2"
-          },
+          "instanceName": {},
           "force": {
             "type": "boolean"
           }
@@ -1945,17 +1687,9 @@
           "attributeValue"
         ],
         "members": {
-          "loadBalancerName": {
-            "shape": "S2"
-          },
-          "attributeName": {
-            "shape": "S59"
-          },
-          "attributeValue": {
-            "type": "string",
-            "max": 256,
-            "min": 1
-          }
+          "loadBalancerName": {},
+          "attributeName": {},
+          "attributeValue": {}
         }
       },
       "output": {
@@ -1969,10 +1703,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "\\w[\\w\\-]*\\w"
-    },
     "S4": {
       "type": "list",
       "member": {
@@ -1982,15 +1712,9 @@
     "S5": {
       "type": "structure",
       "members": {
-        "id": {
-          "shape": "S6"
-        },
-        "resourceName": {
-          "shape": "S2"
-        },
-        "resourceType": {
-          "shape": "S7"
-        },
+        "id": {},
+        "resourceName": {},
+        "resourceType": {},
         "createdAt": {
           "type": "timestamp"
         },
@@ -2001,55 +1725,8 @@
           "type": "boolean"
         },
         "operationDetails": {},
-        "operationType": {
-          "type": "string",
-          "enum": [
-            "DeleteInstance",
-            "CreateInstance",
-            "StopInstance",
-            "StartInstance",
-            "RebootInstance",
-            "OpenInstancePublicPorts",
-            "PutInstancePublicPorts",
-            "CloseInstancePublicPorts",
-            "AllocateStaticIp",
-            "ReleaseStaticIp",
-            "AttachStaticIp",
-            "DetachStaticIp",
-            "UpdateDomainEntry",
-            "DeleteDomainEntry",
-            "CreateDomain",
-            "DeleteDomain",
-            "CreateInstanceSnapshot",
-            "DeleteInstanceSnapshot",
-            "CreateInstancesFromSnapshot",
-            "CreateLoadBalancer",
-            "DeleteLoadBalancer",
-            "AttachInstancesToLoadBalancer",
-            "DetachInstancesFromLoadBalancer",
-            "UpdateLoadBalancerAttribute",
-            "CreateLoadBalancerTlsCertificate",
-            "DeleteLoadBalancerTlsCertificate",
-            "AttachLoadBalancerTlsCertificate",
-            "CreateDisk",
-            "DeleteDisk",
-            "AttachDisk",
-            "DetachDisk",
-            "CreateDiskSnapshot",
-            "DeleteDiskSnapshot",
-            "CreateDiskFromSnapshot"
-          ]
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "NotStarted",
-            "Started",
-            "Failed",
-            "Completed",
-            "Succeeded"
-          ]
-        },
+        "operationType": {},
+        "status": {},
         "statusChangedAt": {
           "type": "timestamp"
         },
@@ -2057,90 +1734,33 @@
         "errorDetails": {}
       }
     },
-    "S6": {
-      "type": "string",
-      "pattern": ".*\\S.*"
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "Instance",
-        "StaticIp",
-        "KeyPair",
-        "InstanceSnapshot",
-        "Domain",
-        "PeeredVpc",
-        "LoadBalancer",
-        "LoadBalancerTlsCertificate",
-        "Disk",
-        "DiskSnapshot"
-      ]
-    },
     "S9": {
       "type": "structure",
       "members": {
         "availabilityZone": {},
-        "regionName": {
-          "shape": "Sb"
-        }
+        "regionName": {}
       }
-    },
-    "Sb": {
-      "type": "string",
-      "enum": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "eu-central-1",
-        "eu-west-1",
-        "eu-west-2",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-northeast-1",
-        "ap-northeast-2"
-      ]
     },
     "Si": {
       "type": "list",
-      "member": {
-        "shape": "S2"
-      }
+      "member": {}
     },
     "Sp": {
       "type": "structure",
       "members": {
         "fromPort": {
-          "shape": "Sq"
+          "type": "integer"
         },
         "toPort": {
-          "shape": "Sq"
+          "type": "integer"
         },
-        "protocol": {
-          "shape": "Sr"
-        }
+        "protocol": {}
       }
-    },
-    "Sq": {
-      "type": "integer",
-      "max": 65535,
-      "min": 0
-    },
-    "Sr": {
-      "type": "string",
-      "enum": [
-        "tcp",
-        "all",
-        "udp"
-      ]
     },
     "S14": {
       "type": "structure",
       "members": {
-        "id": {
-          "shape": "S6"
-        },
+        "id": {},
         "name": {},
         "target": {},
         "isAlias": {
@@ -2162,12 +1782,8 @@
     "S1l": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2175,9 +1791,7 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
+        "resourceType": {},
         "fingerprint": {}
       }
     },
@@ -2185,22 +1799,11 @@
       "type": "list",
       "member": {}
     },
-    "S2p": {
-      "type": "string",
-      "enum": [
-        "LINUX_UNIX",
-        "WINDOWS"
-      ]
-    },
     "S2y": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2208,9 +1811,7 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
+        "resourceType": {},
         "sizeInGb": {
           "type": "integer"
         },
@@ -2221,19 +1822,8 @@
           "type": "integer"
         },
         "path": {},
-        "state": {
-          "type": "string",
-          "enum": [
-            "pending",
-            "error",
-            "available",
-            "in-use",
-            "unknown"
-          ]
-        },
-        "attachedTo": {
-          "shape": "S2"
-        },
+        "state": {},
+        "attachedTo": {},
         "isAttached": {
           "type": "boolean"
         },
@@ -2249,12 +1839,8 @@
     "S32": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2262,28 +1848,14 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
+        "resourceType": {},
         "sizeInGb": {
           "type": "integer"
         },
-        "state": {
-          "type": "string",
-          "enum": [
-            "pending",
-            "completed",
-            "error",
-            "unknown"
-          ]
-        },
+        "state": {},
         "progress": {},
-        "fromDiskName": {
-          "shape": "S2"
-        },
-        "fromDiskArn": {
-          "shape": "S6"
-        }
+        "fromDiskName": {},
+        "fromDiskArn": {}
       }
     },
     "S39": {
@@ -2295,12 +1867,8 @@
     "S3c": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2308,9 +1876,7 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
+        "resourceType": {},
         "domainEntries": {
           "type": "list",
           "member": {
@@ -2322,12 +1888,8 @@
     "S3j": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2335,31 +1897,16 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
-        "blueprintId": {
-          "shape": "S6"
-        },
-        "blueprintName": {
-          "shape": "S6"
-        },
-        "bundleId": {
-          "shape": "S6"
-        },
+        "resourceType": {},
+        "blueprintId": {},
+        "blueprintName": {},
+        "bundleId": {},
         "isStaticIp": {
           "type": "boolean"
         },
-        "privateIpAddress": {
-          "shape": "S3k"
-        },
-        "publicIpAddress": {
-          "shape": "S3k"
-        },
-        "ipv6Address": {
-          "type": "string",
-          "pattern": "([A-F0-9]{1,4}:){7}[A-F0-9]{1,4}"
-        },
+        "privateIpAddress": {},
+        "publicIpAddress": {},
+        "ipv6Address": {},
         "hardware": {
           "type": "structure",
           "members": {
@@ -2391,30 +1938,16 @@
                 "type": "structure",
                 "members": {
                   "fromPort": {
-                    "shape": "Sq"
+                    "type": "integer"
                   },
                   "toPort": {
-                    "shape": "Sq"
+                    "type": "integer"
                   },
-                  "protocol": {
-                    "shape": "Sr"
-                  },
+                  "protocol": {},
                   "accessFrom": {},
-                  "accessType": {
-                    "type": "string",
-                    "enum": [
-                      "Public",
-                      "Private"
-                    ]
-                  },
+                  "accessType": {},
                   "commonName": {},
-                  "accessDirection": {
-                    "type": "string",
-                    "enum": [
-                      "inbound",
-                      "outbound"
-                    ]
-                  }
+                  "accessDirection": {}
                 }
               }
             }
@@ -2423,17 +1956,9 @@
         "state": {
           "shape": "S3t"
         },
-        "username": {
-          "shape": "S6"
-        },
-        "sshKeyName": {
-          "shape": "S2"
-        }
+        "username": {},
+        "sshKeyName": {}
       }
-    },
-    "S3k": {
-      "type": "string",
-      "pattern": "([0-9]{1,3}\\.){3}[0-9]{1,3}"
     },
     "S3t": {
       "type": "structure",
@@ -2444,73 +1969,9 @@
         "name": {}
       }
     },
-    "S3v": {
-      "type": "string",
-      "enum": [
-        "ssh",
-        "rdp"
-      ]
-    },
-    "S40": {
-      "type": "string",
-      "enum": [
-        "CPUUtilization",
-        "NetworkIn",
-        "NetworkOut",
-        "StatusCheckFailed",
-        "StatusCheckFailed_Instance",
-        "StatusCheckFailed_System"
-      ]
-    },
-    "S41": {
-      "type": "integer",
-      "max": 86400,
-      "min": 60
-    },
-    "S43": {
-      "type": "string",
-      "enum": [
-        "Seconds",
-        "Microseconds",
-        "Milliseconds",
-        "Bytes",
-        "Kilobytes",
-        "Megabytes",
-        "Gigabytes",
-        "Terabytes",
-        "Bits",
-        "Kilobits",
-        "Megabits",
-        "Gigabits",
-        "Terabits",
-        "Percent",
-        "Count",
-        "Bytes/Second",
-        "Kilobytes/Second",
-        "Megabytes/Second",
-        "Gigabytes/Second",
-        "Terabytes/Second",
-        "Bits/Second",
-        "Kilobits/Second",
-        "Megabits/Second",
-        "Gigabits/Second",
-        "Terabits/Second",
-        "Count/Second",
-        "None"
-      ]
-    },
     "S44": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "Minimum",
-          "Maximum",
-          "Sum",
-          "Average",
-          "SampleCount"
-        ]
-      }
+      "member": {}
     },
     "S47": {
       "type": "list",
@@ -2535,21 +1996,15 @@
           "timestamp": {
             "type": "timestamp"
           },
-          "unit": {
-            "shape": "S43"
-          }
+          "unit": {}
         }
       }
     },
     "S4h": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2557,27 +2012,14 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "pending",
-            "error",
-            "available"
-          ]
-        },
+        "resourceType": {},
+        "state": {},
         "progress": {},
         "fromAttachedDisks": {
           "shape": "S39"
         },
-        "fromInstanceName": {
-          "shape": "S2"
-        },
-        "fromInstanceArn": {
-          "shape": "S6"
-        },
+        "fromInstanceName": {},
+        "fromInstanceArn": {},
         "fromBlueprintId": {},
         "fromBundleId": {},
         "sizeInGb": {
@@ -2588,12 +2030,8 @@
     "S4y": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2601,38 +2039,17 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
-        "dnsName": {
-          "shape": "S6"
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "active",
-            "provisioning",
-            "active_impaired",
-            "failed",
-            "unknown"
-          ]
-        },
-        "protocol": {
-          "type": "string",
-          "enum": [
-            "HTTP_HTTPS",
-            "HTTP"
-          ]
-        },
+        "resourceType": {},
+        "dnsName": {},
+        "state": {},
+        "protocol": {},
         "publicPorts": {
           "type": "list",
           "member": {
-            "shape": "Sq"
+            "type": "integer"
           }
         },
-        "healthCheckPath": {
-          "shape": "S6"
-        },
+        "healthCheckPath": {},
         "instancePort": {
           "type": "integer"
         },
@@ -2641,36 +2058,9 @@
           "member": {
             "type": "structure",
             "members": {
-              "instanceName": {
-                "shape": "S2"
-              },
-              "instanceHealth": {
-                "type": "string",
-                "enum": [
-                  "initial",
-                  "healthy",
-                  "unhealthy",
-                  "unused",
-                  "draining",
-                  "unavailable"
-                ]
-              },
-              "instanceHealthReason": {
-                "type": "string",
-                "enum": [
-                  "Lb.RegistrationInProgress",
-                  "Lb.InitialHealthChecking",
-                  "Lb.InternalError",
-                  "Instance.ResponseCodeMismatch",
-                  "Instance.Timeout",
-                  "Instance.FailedHealthChecks",
-                  "Instance.NotRegistered",
-                  "Instance.NotInUse",
-                  "Instance.DeregistrationInProgress",
-                  "Instance.InvalidState",
-                  "Instance.IpUnusable"
-                ]
-              }
+              "instanceName": {},
+              "instanceHealth": {},
+              "instanceHealthReason": {}
             }
           }
         },
@@ -2679,9 +2069,7 @@
           "member": {
             "type": "structure",
             "members": {
-              "name": {
-                "shape": "S2"
-              },
+              "name": {},
               "isAttached": {
                 "type": "boolean"
               }
@@ -2690,55 +2078,16 @@
         },
         "configurationOptions": {
           "type": "map",
-          "key": {
-            "shape": "S59"
-          },
+          "key": {},
           "value": {}
         }
       }
     },
-    "S59": {
-      "type": "string",
-      "enum": [
-        "HealthCheckPath",
-        "SessionStickinessEnabled",
-        "SessionStickiness_LB_CookieDurationSeconds"
-      ]
-    },
-    "S5b": {
-      "type": "string",
-      "enum": [
-        "ClientTLSNegotiationErrorCount",
-        "HealthyHostCount",
-        "UnhealthyHostCount",
-        "HTTPCode_LB_4XX_Count",
-        "HTTPCode_LB_5XX_Count",
-        "HTTPCode_Instance_2XX_Count",
-        "HTTPCode_Instance_3XX_Count",
-        "HTTPCode_Instance_4XX_Count",
-        "HTTPCode_Instance_5XX_Count",
-        "InstanceResponseTime",
-        "RejectedConnectionCount",
-        "RequestCount"
-      ]
-    },
-    "S5k": {
-      "type": "string",
-      "enum": [
-        "PENDING_VALIDATION",
-        "FAILED",
-        "SUCCESS"
-      ]
-    },
     "S68": {
       "type": "structure",
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "arn": {
-          "shape": "S6"
-        },
+        "name": {},
+        "arn": {},
         "supportCode": {},
         "createdAt": {
           "type": "timestamp"
@@ -2746,15 +2095,9 @@
         "location": {
           "shape": "S9"
         },
-        "resourceType": {
-          "shape": "S7"
-        },
-        "ipAddress": {
-          "shape": "S3k"
-        },
-        "attachedTo": {
-          "shape": "S2"
-        },
+        "resourceType": {},
+        "ipAddress": {},
+        "attachedTo": {},
         "isAttached": {
           "type": "boolean"
         }

--- a/apis/logs-2014-03-28.min.json
+++ b/apis/logs-2014-03-28.min.json
@@ -20,12 +20,8 @@
           "kmsKeyId"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "kmsKeyId": {
-            "shape": "S3"
-          }
+          "logGroupName": {},
+          "kmsKeyId": {}
         }
       }
     },
@@ -36,9 +32,7 @@
           "taskId"
         ],
         "members": {
-          "taskId": {
-            "shape": "S5"
-          }
+          "taskId": {}
         }
       }
     },
@@ -52,33 +46,23 @@
           "destination"
         ],
         "members": {
-          "taskName": {
-            "shape": "S7"
-          },
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamNamePrefix": {
-            "shape": "S8"
-          },
+          "taskName": {},
+          "logGroupName": {},
+          "logStreamNamePrefix": {},
           "from": {
-            "shape": "S9"
+            "type": "long"
           },
           "to": {
-            "shape": "S9"
+            "type": "long"
           },
-          "destination": {
-            "shape": "Sa"
-          },
+          "destination": {},
           "destinationPrefix": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "S5"
-          }
+          "taskId": {}
         }
       }
     },
@@ -89,12 +73,8 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "kmsKeyId": {
-            "shape": "S3"
-          },
+          "logGroupName": {},
+          "kmsKeyId": {},
           "tags": {
             "shape": "Se"
           }
@@ -109,12 +89,8 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamName": {
-            "shape": "S8"
-          }
+          "logGroupName": {},
+          "logStreamName": {}
         }
       }
     },
@@ -125,9 +101,7 @@
           "destinationName"
         ],
         "members": {
-          "destinationName": {
-            "shape": "Sj"
-          }
+          "destinationName": {}
         }
       }
     },
@@ -138,9 +112,7 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          }
+          "logGroupName": {}
         }
       }
     },
@@ -152,12 +124,8 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamName": {
-            "shape": "S8"
-          }
+          "logGroupName": {},
+          "logStreamName": {}
         }
       }
     },
@@ -169,12 +137,8 @@
           "filterName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterName": {
-            "shape": "Sn"
-          }
+          "logGroupName": {},
+          "filterName": {}
         }
       }
     },
@@ -193,9 +157,7 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          }
+          "logGroupName": {}
         }
       }
     },
@@ -207,12 +169,8 @@
           "filterName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterName": {
-            "shape": "Sn"
-          }
+          "logGroupName": {},
+          "filterName": {}
         }
       }
     },
@@ -220,14 +178,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "DestinationNamePrefix": {
-            "shape": "Sj"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "DestinationNamePrefix": {},
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -240,9 +194,7 @@
               "shape": "Sx"
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -250,17 +202,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "taskId": {
-            "shape": "S5"
-          },
-          "statusCode": {
-            "shape": "S13"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "taskId": {},
+          "statusCode": {},
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -272,31 +218,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "taskId": {
-                  "shape": "S5"
-                },
-                "taskName": {
-                  "shape": "S7"
-                },
-                "logGroupName": {
-                  "shape": "S2"
-                },
+                "taskId": {},
+                "taskName": {},
+                "logGroupName": {},
                 "from": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "to": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "destination": {
-                  "shape": "Sa"
-                },
+                "destination": {},
                 "destinationPrefix": {},
                 "status": {
                   "type": "structure",
                   "members": {
-                    "code": {
-                      "shape": "S13"
-                    },
+                    "code": {},
                     "message": {}
                   }
                 },
@@ -304,19 +240,17 @@
                   "type": "structure",
                   "members": {
                     "creationTime": {
-                      "shape": "S9"
+                      "type": "long"
                     },
                     "completionTime": {
-                      "shape": "S9"
+                      "type": "long"
                     }
                   }
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -324,14 +258,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "logGroupNamePrefix": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "logGroupNamePrefix": {},
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -343,11 +273,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "logGroupName": {
-                  "shape": "S2"
-                },
+                "logGroupName": {},
                 "creationTime": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "retentionInDays": {
                   "type": "integer"
@@ -357,17 +285,13 @@
                 },
                 "arn": {},
                 "storedBytes": {
-                  "shape": "S1g"
+                  "type": "long"
                 },
-                "kmsKeyId": {
-                  "shape": "S3"
-                }
+                "kmsKeyId": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -378,27 +302,15 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamNamePrefix": {
-            "shape": "S8"
-          },
-          "orderBy": {
-            "type": "string",
-            "enum": [
-              "LogStreamName",
-              "LastEventTime"
-            ]
-          },
+          "logGroupName": {},
+          "logStreamNamePrefix": {},
+          "orderBy": {},
           "descending": {
             "type": "boolean"
           },
-          "nextToken": {
-            "shape": "St"
-          },
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -410,34 +322,28 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {
-                  "shape": "S8"
-                },
+                "logStreamName": {},
                 "creationTime": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "firstEventTimestamp": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "lastEventTimestamp": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "lastIngestionTime": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "uploadSequenceToken": {
-                  "shape": "S1n"
-                },
+                "uploadSequenceToken": {},
                 "arn": {},
                 "storedBytes": {
-                  "shape": "S1g"
+                  "type": "long"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -445,24 +351,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterNamePrefix": {
-            "shape": "Sn"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "logGroupName": {},
+          "filterNamePrefix": {},
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           },
-          "metricName": {
-            "shape": "S1p"
-          },
-          "metricNamespace": {
-            "shape": "S1q"
-          }
+          "metricName": {},
+          "metricNamespace": {}
         }
       },
       "output": {
@@ -473,27 +369,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "filterName": {
-                  "shape": "Sn"
-                },
-                "filterPattern": {
-                  "shape": "S1u"
-                },
+                "filterName": {},
+                "filterPattern": {},
                 "metricTransformations": {
                   "shape": "S1v"
                 },
                 "creationTime": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "logGroupName": {
-                  "shape": "S2"
-                }
+                "logGroupName": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -501,11 +389,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "St"
-          },
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -518,9 +404,7 @@
               "shape": "S22"
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -531,17 +415,11 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterNamePrefix": {
-            "shape": "Sn"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "logGroupName": {},
+          "filterNamePrefix": {},
+          "nextToken": {},
           "limit": {
-            "shape": "Su"
+            "type": "integer"
           }
         }
       },
@@ -553,33 +431,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "filterName": {
-                  "shape": "Sn"
-                },
-                "logGroupName": {
-                  "shape": "S2"
-                },
-                "filterPattern": {
-                  "shape": "S1u"
-                },
-                "destinationArn": {
-                  "shape": "S28"
-                },
-                "roleArn": {
-                  "shape": "Sz"
-                },
-                "distribution": {
-                  "shape": "S29"
-                },
+                "filterName": {},
+                "logGroupName": {},
+                "filterPattern": {},
+                "destinationArn": {},
+                "roleArn": {},
+                "distribution": {},
                 "creationTime": {
-                  "shape": "S9"
+                  "type": "long"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -590,9 +454,7 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          }
+          "logGroupName": {}
         }
       }
     },
@@ -603,34 +465,22 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
+          "logGroupName": {},
           "logStreamNames": {
             "type": "list",
-            "member": {
-              "shape": "S8"
-            },
-            "max": 100,
-            "min": 1
+            "member": {}
           },
-          "logStreamNamePrefix": {
-            "shape": "S8"
-          },
+          "logStreamNamePrefix": {},
           "startTime": {
-            "shape": "S9"
+            "type": "long"
           },
           "endTime": {
-            "shape": "S9"
+            "type": "long"
           },
-          "filterPattern": {
-            "shape": "S1u"
-          },
-          "nextToken": {
-            "shape": "St"
-          },
+          "filterPattern": {},
+          "nextToken": {},
           "limit": {
-            "shape": "S2d"
+            "type": "integer"
           },
           "interleaved": {
             "type": "boolean"
@@ -645,17 +495,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {
-                  "shape": "S8"
-                },
+                "logStreamName": {},
                 "timestamp": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "message": {
-                  "shape": "S2i"
-                },
+                "message": {},
                 "ingestionTime": {
-                  "shape": "S9"
+                  "type": "long"
                 },
                 "eventId": {}
               }
@@ -666,18 +512,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "logStreamName": {
-                  "shape": "S8"
-                },
+                "logStreamName": {},
                 "searchedCompletely": {
                   "type": "boolean"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "St"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -689,23 +531,17 @@
           "logStreamName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamName": {
-            "shape": "S8"
-          },
+          "logGroupName": {},
+          "logStreamName": {},
           "startTime": {
-            "shape": "S9"
+            "type": "long"
           },
           "endTime": {
-            "shape": "S9"
+            "type": "long"
           },
-          "nextToken": {
-            "shape": "St"
-          },
+          "nextToken": {},
           "limit": {
-            "shape": "S2d"
+            "type": "integer"
           },
           "startFromHead": {
             "type": "boolean"
@@ -721,23 +557,17 @@
               "type": "structure",
               "members": {
                 "timestamp": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "message": {
-                  "shape": "S2i"
-                },
+                "message": {},
                 "ingestionTime": {
-                  "shape": "S9"
+                  "type": "long"
                 }
               }
             }
           },
-          "nextForwardToken": {
-            "shape": "St"
-          },
-          "nextBackwardToken": {
-            "shape": "St"
-          }
+          "nextForwardToken": {},
+          "nextBackwardToken": {}
         }
       }
     },
@@ -748,9 +578,7 @@
           "logGroupName"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          }
+          "logGroupName": {}
         }
       },
       "output": {
@@ -771,15 +599,9 @@
           "roleArn"
         ],
         "members": {
-          "destinationName": {
-            "shape": "Sj"
-          },
-          "targetArn": {
-            "shape": "Sy"
-          },
-          "roleArn": {
-            "shape": "Sz"
-          }
+          "destinationName": {},
+          "targetArn": {},
+          "roleArn": {}
         }
       },
       "output": {
@@ -799,12 +621,8 @@
           "accessPolicy"
         ],
         "members": {
-          "destinationName": {
-            "shape": "Sj"
-          },
-          "accessPolicy": {
-            "shape": "S10"
-          }
+          "destinationName": {},
+          "accessPolicy": {}
         }
       }
     },
@@ -817,12 +635,8 @@
           "logEvents"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "logStreamName": {
-            "shape": "S8"
-          },
+          "logGroupName": {},
+          "logStreamName": {},
           "logEvents": {
             "type": "list",
             "member": {
@@ -833,27 +647,19 @@
               ],
               "members": {
                 "timestamp": {
-                  "shape": "S9"
+                  "type": "long"
                 },
-                "message": {
-                  "shape": "S2i"
-                }
+                "message": {}
               }
-            },
-            "max": 10000,
-            "min": 1
+            }
           },
-          "sequenceToken": {
-            "shape": "S1n"
-          }
+          "sequenceToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "nextSequenceToken": {
-            "shape": "S1n"
-          },
+          "nextSequenceToken": {},
           "rejectedLogEventsInfo": {
             "type": "structure",
             "members": {
@@ -881,15 +687,9 @@
           "metricTransformations"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterName": {
-            "shape": "Sn"
-          },
-          "filterPattern": {
-            "shape": "S1u"
-          },
+          "logGroupName": {},
+          "filterName": {},
+          "filterPattern": {},
           "metricTransformations": {
             "shape": "S1v"
           }
@@ -901,9 +701,7 @@
         "type": "structure",
         "members": {
           "policyName": {},
-          "policyDocument": {
-            "shape": "S23"
-          }
+          "policyDocument": {}
         }
       },
       "output": {
@@ -923,9 +721,7 @@
           "retentionInDays"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
+          "logGroupName": {},
           "retentionInDays": {
             "type": "integer"
           }
@@ -942,24 +738,12 @@
           "destinationArn"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
-          "filterName": {
-            "shape": "Sn"
-          },
-          "filterPattern": {
-            "shape": "S1u"
-          },
-          "destinationArn": {
-            "shape": "S28"
-          },
-          "roleArn": {
-            "shape": "Sz"
-          },
-          "distribution": {
-            "shape": "S29"
-          }
+          "logGroupName": {},
+          "filterName": {},
+          "filterPattern": {},
+          "destinationArn": {},
+          "roleArn": {},
+          "distribution": {}
         }
       }
     },
@@ -971,9 +755,7 @@
           "tags"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
+          "logGroupName": {},
           "tags": {
             "shape": "Se"
           }
@@ -988,16 +770,10 @@
           "logEventMessages"
         ],
         "members": {
-          "filterPattern": {
-            "shape": "S1u"
-          },
+          "filterPattern": {},
           "logEventMessages": {
             "type": "list",
-            "member": {
-              "shape": "S2i"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -1012,9 +788,7 @@
                 "eventNumber": {
                   "type": "long"
                 },
-                "eventMessage": {
-                  "shape": "S2i"
-                },
+                "eventMessage": {},
                 "extractedValues": {
                   "type": "map",
                   "key": {},
@@ -1034,162 +808,33 @@
           "tags"
         ],
         "members": {
-          "logGroupName": {
-            "shape": "S2"
-          },
+          "logGroupName": {},
           "tags": {
             "type": "list",
-            "member": {
-              "shape": "Sf"
-            },
-            "min": 1
+            "member": {}
           }
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[\\.\\-_/#A-Za-z0-9]+"
-    },
-    "S3": {
-      "type": "string",
-      "max": 256
-    },
-    "S5": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
-    "S8": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[^:*]*"
-    },
-    "S9": {
-      "type": "long",
-      "min": 0
-    },
-    "Sa": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
     "Se": {
       "type": "map",
-      "key": {
-        "shape": "Sf"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-      },
-      "max": 50,
-      "min": 1
-    },
-    "Sf": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]+)$"
-    },
-    "Sj": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[^:*]*"
-    },
-    "Sn": {
-      "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[^:*]*"
-    },
-    "St": {
-      "type": "string",
-      "min": 1
-    },
-    "Su": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
+      "key": {},
+      "value": {}
     },
     "Sx": {
       "type": "structure",
       "members": {
-        "destinationName": {
-          "shape": "Sj"
-        },
-        "targetArn": {
-          "shape": "Sy"
-        },
-        "roleArn": {
-          "shape": "Sz"
-        },
-        "accessPolicy": {
-          "shape": "S10"
-        },
+        "destinationName": {},
+        "targetArn": {},
+        "roleArn": {},
+        "accessPolicy": {},
         "arn": {},
         "creationTime": {
-          "shape": "S9"
+          "type": "long"
         }
       }
-    },
-    "Sy": {
-      "type": "string",
-      "min": 1
-    },
-    "Sz": {
-      "type": "string",
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "min": 1
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "CANCELLED",
-        "COMPLETED",
-        "FAILED",
-        "PENDING",
-        "PENDING_CANCEL",
-        "RUNNING"
-      ]
-    },
-    "S1g": {
-      "type": "long",
-      "min": 0
-    },
-    "S1n": {
-      "type": "string",
-      "min": 1
-    },
-    "S1p": {
-      "type": "string",
-      "max": 255,
-      "pattern": "[^:*$]*"
-    },
-    "S1q": {
-      "type": "string",
-      "max": 255,
-      "pattern": "[^:*$]*"
-    },
-    "S1u": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
     },
     "S1v": {
       "type": "list",
@@ -1201,60 +846,24 @@
           "metricValue"
         ],
         "members": {
-          "metricName": {
-            "shape": "S1p"
-          },
-          "metricNamespace": {
-            "shape": "S1q"
-          },
-          "metricValue": {
-            "type": "string",
-            "max": 100
-          },
+          "metricName": {},
+          "metricNamespace": {},
+          "metricValue": {},
           "defaultValue": {
             "type": "double"
           }
         }
-      },
-      "max": 1,
-      "min": 1
+      }
     },
     "S22": {
       "type": "structure",
       "members": {
         "policyName": {},
-        "policyDocument": {
-          "shape": "S23"
-        },
+        "policyDocument": {},
         "lastUpdatedTime": {
-          "shape": "S9"
+          "type": "long"
         }
       }
-    },
-    "S23": {
-      "type": "string",
-      "max": 5120,
-      "min": 1
-    },
-    "S28": {
-      "type": "string",
-      "min": 1
-    },
-    "S29": {
-      "type": "string",
-      "enum": [
-        "Random",
-        "ByLogStream"
-      ]
-    },
-    "S2d": {
-      "type": "integer",
-      "max": 10000,
-      "min": 1
-    },
-    "S2i": {
-      "type": "string",
-      "min": 1
     }
   }
 }

--- a/apis/machinelearning-2014-12-12.min.json
+++ b/apis/machinelearning-2014-12-12.min.json
@@ -24,23 +24,15 @@
           "Tags": {
             "shape": "S2"
           },
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          }
+          "ResourceId": {},
+          "ResourceType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          }
+          "ResourceId": {},
+          "ResourceType": {}
         }
       }
     },
@@ -54,29 +46,17 @@
           "OutputUri"
         ],
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          },
-          "BatchPredictionName": {
-            "shape": "Sa"
-          },
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "BatchPredictionDataSourceId": {
-            "shape": "S6"
-          },
-          "OutputUri": {
-            "shape": "Sb"
-          }
+          "BatchPredictionId": {},
+          "BatchPredictionName": {},
+          "MLModelId": {},
+          "BatchPredictionDataSourceId": {},
+          "OutputUri": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          }
+          "BatchPredictionId": {}
         }
       }
     },
@@ -89,12 +69,8 @@
           "RoleARN"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
-          "DataSourceName": {
-            "shape": "Sa"
-          },
+          "DataSourceId": {},
+          "DataSourceName": {},
           "RDSData": {
             "type": "structure",
             "required": [
@@ -111,9 +87,7 @@
               "DatabaseInformation": {
                 "shape": "Sf"
               },
-              "SelectSqlQuery": {
-                "shape": "Si"
-              },
+              "SelectSqlQuery": {},
               "DatabaseCredentials": {
                 "type": "structure",
                 "required": [
@@ -121,50 +95,24 @@
                   "Password"
                 ],
                 "members": {
-                  "Username": {
-                    "shape": "Sk"
-                  },
-                  "Password": {
-                    "type": "string",
-                    "min": 8,
-                    "max": 128
-                  }
+                  "Username": {},
+                  "Password": {}
                 }
               },
-              "S3StagingLocation": {
-                "shape": "Sb"
-              },
+              "S3StagingLocation": {},
               "DataRearrangement": {},
-              "DataSchema": {
-                "shape": "Sn"
-              },
-              "DataSchemaUri": {
-                "shape": "Sb"
-              },
-              "ResourceRole": {
-                "shape": "So"
-              },
-              "ServiceRole": {
-                "shape": "Sp"
-              },
-              "SubnetId": {
-                "type": "string",
-                "min": 1,
-                "max": 255
-              },
+              "DataSchema": {},
+              "DataSchemaUri": {},
+              "ResourceRole": {},
+              "ServiceRole": {},
+              "SubnetId": {},
               "SecurityGroupIds": {
                 "type": "list",
-                "member": {
-                  "type": "string",
-                  "min": 1,
-                  "max": 255
-                }
+                "member": {}
               }
             }
           },
-          "RoleARN": {
-            "shape": "St"
-          },
+          "RoleARN": {},
           "ComputeStatistics": {
             "type": "boolean"
           }
@@ -173,9 +121,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       }
     },
@@ -188,12 +134,8 @@
           "RoleARN"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
-          "DataSourceName": {
-            "shape": "Sa"
-          },
+          "DataSourceId": {},
+          "DataSourceName": {},
           "DataSpec": {
             "type": "structure",
             "required": [
@@ -206,9 +148,7 @@
               "DatabaseInformation": {
                 "shape": "Sy"
               },
-              "SelectSqlQuery": {
-                "shape": "S11"
-              },
+              "SelectSqlQuery": {},
               "DatabaseCredentials": {
                 "type": "structure",
                 "required": [
@@ -216,31 +156,17 @@
                   "Password"
                 ],
                 "members": {
-                  "Username": {
-                    "shape": "S13"
-                  },
-                  "Password": {
-                    "type": "string",
-                    "min": 8,
-                    "max": 64
-                  }
+                  "Username": {},
+                  "Password": {}
                 }
               },
-              "S3StagingLocation": {
-                "shape": "Sb"
-              },
+              "S3StagingLocation": {},
               "DataRearrangement": {},
-              "DataSchema": {
-                "shape": "Sn"
-              },
-              "DataSchemaUri": {
-                "shape": "Sb"
-              }
+              "DataSchema": {},
+              "DataSchemaUri": {}
             }
           },
-          "RoleARN": {
-            "shape": "St"
-          },
+          "RoleARN": {},
           "ComputeStatistics": {
             "type": "boolean"
           }
@@ -249,9 +175,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       }
     },
@@ -263,28 +187,18 @@
           "DataSpec"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
-          "DataSourceName": {
-            "shape": "Sa"
-          },
+          "DataSourceId": {},
+          "DataSourceName": {},
           "DataSpec": {
             "type": "structure",
             "required": [
               "DataLocationS3"
             ],
             "members": {
-              "DataLocationS3": {
-                "shape": "Sb"
-              },
+              "DataLocationS3": {},
               "DataRearrangement": {},
-              "DataSchema": {
-                "shape": "Sn"
-              },
-              "DataSchemaLocationS3": {
-                "shape": "Sb"
-              }
+              "DataSchema": {},
+              "DataSchemaLocationS3": {}
             }
           },
           "ComputeStatistics": {
@@ -295,9 +209,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       }
     },
@@ -310,26 +222,16 @@
           "EvaluationDataSourceId"
         ],
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          },
-          "EvaluationName": {
-            "shape": "Sa"
-          },
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "EvaluationDataSourceId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {},
+          "EvaluationName": {},
+          "MLModelId": {},
+          "EvaluationDataSourceId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {}
         }
       }
     },
@@ -342,35 +244,21 @@
           "TrainingDataSourceId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "MLModelName": {
-            "shape": "Sa"
-          },
-          "MLModelType": {
-            "shape": "S1c"
-          },
+          "MLModelId": {},
+          "MLModelName": {},
+          "MLModelType": {},
           "Parameters": {
             "shape": "S1d"
           },
-          "TrainingDataSourceId": {
-            "shape": "S6"
-          },
-          "Recipe": {
-            "shape": "S1f"
-          },
-          "RecipeUri": {
-            "shape": "Sb"
-          }
+          "TrainingDataSourceId": {},
+          "Recipe": {},
+          "RecipeUri": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       }
     },
@@ -381,17 +269,13 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
+          "MLModelId": {},
           "RealtimeEndpointInfo": {
             "shape": "S1j"
           }
@@ -405,17 +289,13 @@
           "BatchPredictionId"
         ],
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          }
+          "BatchPredictionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          }
+          "BatchPredictionId": {}
         }
       }
     },
@@ -426,17 +306,13 @@
           "DataSourceId"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       }
     },
@@ -447,17 +323,13 @@
           "EvaluationId"
         ],
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {}
         }
       }
     },
@@ -468,17 +340,13 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       }
     },
@@ -489,17 +357,13 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
+          "MLModelId": {},
           "RealtimeEndpointInfo": {
             "shape": "S1j"
           }
@@ -517,28 +381,17 @@
         "members": {
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S4"
-            },
-            "max": 100
+            "member": {}
           },
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          }
+          "ResourceId": {},
+          "ResourceType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          }
+          "ResourceId": {},
+          "ResourceType": {}
         }
       }
     },
@@ -546,46 +399,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {
-            "type": "string",
-            "enum": [
-              "CreatedAt",
-              "LastUpdatedAt",
-              "Status",
-              "Name",
-              "IAMUser",
-              "MLModelId",
-              "DataSourceId",
-              "DataURI"
-            ]
-          },
-          "EQ": {
-            "shape": "S23"
-          },
-          "GT": {
-            "shape": "S23"
-          },
-          "LT": {
-            "shape": "S23"
-          },
-          "GE": {
-            "shape": "S23"
-          },
-          "LE": {
-            "shape": "S23"
-          },
-          "NE": {
-            "shape": "S23"
-          },
-          "Prefix": {
-            "shape": "S23"
-          },
-          "SortOrder": {
-            "shape": "S24"
-          },
+          "FilterVariable": {},
+          "EQ": {},
+          "GT": {},
+          "LT": {},
+          "GE": {},
+          "LE": {},
+          "NE": {},
+          "Prefix": {},
+          "SortOrder": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S25"
+            "type": "integer"
           }
         }
       },
@@ -597,39 +422,21 @@
             "member": {
               "type": "structure",
               "members": {
-                "BatchPredictionId": {
-                  "shape": "S6"
-                },
-                "MLModelId": {
-                  "shape": "S6"
-                },
-                "BatchPredictionDataSourceId": {
-                  "shape": "S6"
-                },
-                "InputDataLocationS3": {
-                  "shape": "Sb"
-                },
-                "CreatedByIamUser": {
-                  "shape": "S29"
-                },
+                "BatchPredictionId": {},
+                "MLModelId": {},
+                "BatchPredictionDataSourceId": {},
+                "InputDataLocationS3": {},
+                "CreatedByIamUser": {},
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {
-                  "shape": "Sa"
-                },
-                "Status": {
-                  "shape": "S2a"
-                },
-                "OutputUri": {
-                  "shape": "Sb"
-                },
-                "Message": {
-                  "shape": "S2b"
-                },
+                "Name": {},
+                "Status": {},
+                "OutputUri": {},
+                "Message": {},
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -656,44 +463,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {
-            "type": "string",
-            "enum": [
-              "CreatedAt",
-              "LastUpdatedAt",
-              "Status",
-              "Name",
-              "DataLocationS3",
-              "IAMUser"
-            ]
-          },
-          "EQ": {
-            "shape": "S23"
-          },
-          "GT": {
-            "shape": "S23"
-          },
-          "LT": {
-            "shape": "S23"
-          },
-          "GE": {
-            "shape": "S23"
-          },
-          "LE": {
-            "shape": "S23"
-          },
-          "NE": {
-            "shape": "S23"
-          },
-          "Prefix": {
-            "shape": "S23"
-          },
-          "SortOrder": {
-            "shape": "S24"
-          },
+          "FilterVariable": {},
+          "EQ": {},
+          "GT": {},
+          "LT": {},
+          "GE": {},
+          "LE": {},
+          "NE": {},
+          "Prefix": {},
+          "SortOrder": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S25"
+            "type": "integer"
           }
         }
       },
@@ -705,16 +486,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "DataSourceId": {
-                  "shape": "S6"
-                },
-                "DataLocationS3": {
-                  "shape": "Sb"
-                },
+                "DataSourceId": {},
+                "DataLocationS3": {},
                 "DataRearrangement": {},
-                "CreatedByIamUser": {
-                  "shape": "S29"
-                },
+                "CreatedByIamUser": {},
                 "CreatedAt": {
                   "type": "timestamp"
                 },
@@ -727,24 +502,16 @@
                 "NumberOfFiles": {
                   "type": "long"
                 },
-                "Name": {
-                  "shape": "Sa"
-                },
-                "Status": {
-                  "shape": "S2a"
-                },
-                "Message": {
-                  "shape": "S2b"
-                },
+                "Name": {},
+                "Status": {},
+                "Message": {},
                 "RedshiftMetadata": {
                   "shape": "S2i"
                 },
                 "RDSMetadata": {
                   "shape": "S2j"
                 },
-                "RoleARN": {
-                  "shape": "St"
-                },
+                "RoleARN": {},
                 "ComputeStatistics": {
                   "type": "boolean"
                 },
@@ -768,46 +535,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {
-            "type": "string",
-            "enum": [
-              "CreatedAt",
-              "LastUpdatedAt",
-              "Status",
-              "Name",
-              "IAMUser",
-              "MLModelId",
-              "DataSourceId",
-              "DataURI"
-            ]
-          },
-          "EQ": {
-            "shape": "S23"
-          },
-          "GT": {
-            "shape": "S23"
-          },
-          "LT": {
-            "shape": "S23"
-          },
-          "GE": {
-            "shape": "S23"
-          },
-          "LE": {
-            "shape": "S23"
-          },
-          "NE": {
-            "shape": "S23"
-          },
-          "Prefix": {
-            "shape": "S23"
-          },
-          "SortOrder": {
-            "shape": "S24"
-          },
+          "FilterVariable": {},
+          "EQ": {},
+          "GT": {},
+          "LT": {},
+          "GE": {},
+          "LE": {},
+          "NE": {},
+          "Prefix": {},
+          "SortOrder": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S25"
+            "type": "integer"
           }
         }
       },
@@ -819,39 +558,23 @@
             "member": {
               "type": "structure",
               "members": {
-                "EvaluationId": {
-                  "shape": "S6"
-                },
-                "MLModelId": {
-                  "shape": "S6"
-                },
-                "EvaluationDataSourceId": {
-                  "shape": "S6"
-                },
-                "InputDataLocationS3": {
-                  "shape": "Sb"
-                },
-                "CreatedByIamUser": {
-                  "shape": "S29"
-                },
+                "EvaluationId": {},
+                "MLModelId": {},
+                "EvaluationDataSourceId": {},
+                "InputDataLocationS3": {},
+                "CreatedByIamUser": {},
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {
-                  "shape": "Sa"
-                },
-                "Status": {
-                  "shape": "S2a"
-                },
+                "Name": {},
+                "Status": {},
                 "PerformanceMetrics": {
                   "shape": "S2q"
                 },
-                "Message": {
-                  "shape": "S2b"
-                },
+                "Message": {},
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -872,48 +595,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "FilterVariable": {
-            "type": "string",
-            "enum": [
-              "CreatedAt",
-              "LastUpdatedAt",
-              "Status",
-              "Name",
-              "IAMUser",
-              "TrainingDataSourceId",
-              "RealtimeEndpointStatus",
-              "MLModelType",
-              "Algorithm",
-              "TrainingDataURI"
-            ]
-          },
-          "EQ": {
-            "shape": "S23"
-          },
-          "GT": {
-            "shape": "S23"
-          },
-          "LT": {
-            "shape": "S23"
-          },
-          "GE": {
-            "shape": "S23"
-          },
-          "LE": {
-            "shape": "S23"
-          },
-          "NE": {
-            "shape": "S23"
-          },
-          "Prefix": {
-            "shape": "S23"
-          },
-          "SortOrder": {
-            "shape": "S24"
-          },
+          "FilterVariable": {},
+          "EQ": {},
+          "GT": {},
+          "LT": {},
+          "GE": {},
+          "LE": {},
+          "NE": {},
+          "Prefix": {},
+          "SortOrder": {},
           "NextToken": {},
           "Limit": {
-            "shape": "S25"
+            "type": "integer"
           }
         }
       },
@@ -925,27 +618,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "MLModelId": {
-                  "shape": "S6"
-                },
-                "TrainingDataSourceId": {
-                  "shape": "S6"
-                },
-                "CreatedByIamUser": {
-                  "shape": "S29"
-                },
+                "MLModelId": {},
+                "TrainingDataSourceId": {},
+                "CreatedByIamUser": {},
                 "CreatedAt": {
                   "type": "timestamp"
                 },
                 "LastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Name": {
-                  "shape": "S2z"
-                },
-                "Status": {
-                  "shape": "S2a"
-                },
+                "Name": {},
+                "Status": {},
                 "SizeInBytes": {
                   "type": "long"
                 },
@@ -955,27 +638,16 @@
                 "TrainingParameters": {
                   "shape": "S1d"
                 },
-                "InputDataLocationS3": {
-                  "shape": "Sb"
-                },
-                "Algorithm": {
-                  "type": "string",
-                  "enum": [
-                    "sgd"
-                  ]
-                },
-                "MLModelType": {
-                  "shape": "S1c"
-                },
+                "InputDataLocationS3": {},
+                "Algorithm": {},
+                "MLModelType": {},
                 "ScoreThreshold": {
                   "type": "float"
                 },
                 "ScoreThresholdLastUpdatedAt": {
                   "type": "timestamp"
                 },
-                "Message": {
-                  "shape": "S2b"
-                },
+                "Message": {},
                 "ComputeTime": {
                   "type": "long"
                 },
@@ -1000,23 +672,15 @@
           "ResourceType"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          }
+          "ResourceId": {},
+          "ResourceType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "S6"
-          },
-          "ResourceType": {
-            "shape": "S7"
-          },
+          "ResourceId": {},
+          "ResourceType": {},
           "Tags": {
             "shape": "S2"
           }
@@ -1030,48 +694,28 @@
           "BatchPredictionId"
         ],
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          }
+          "BatchPredictionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          },
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "BatchPredictionDataSourceId": {
-            "shape": "S6"
-          },
-          "InputDataLocationS3": {
-            "shape": "Sb"
-          },
-          "CreatedByIamUser": {
-            "shape": "S29"
-          },
+          "BatchPredictionId": {},
+          "MLModelId": {},
+          "BatchPredictionDataSourceId": {},
+          "InputDataLocationS3": {},
+          "CreatedByIamUser": {},
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {
-            "shape": "Sa"
-          },
-          "Status": {
-            "shape": "S2a"
-          },
-          "OutputUri": {
-            "shape": "Sb"
-          },
+          "Name": {},
+          "Status": {},
+          "OutputUri": {},
           "LogUri": {},
-          "Message": {
-            "shape": "S2b"
-          },
+          "Message": {},
           "ComputeTime": {
             "type": "long"
           },
@@ -1097,9 +741,7 @@
           "DataSourceId"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
+          "DataSourceId": {},
           "Verbose": {
             "type": "boolean"
           }
@@ -1108,16 +750,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
-          "DataLocationS3": {
-            "shape": "Sb"
-          },
+          "DataSourceId": {},
+          "DataLocationS3": {},
           "DataRearrangement": {},
-          "CreatedByIamUser": {
-            "shape": "S29"
-          },
+          "CreatedByIamUser": {},
           "CreatedAt": {
             "type": "timestamp"
           },
@@ -1130,25 +766,17 @@
           "NumberOfFiles": {
             "type": "long"
           },
-          "Name": {
-            "shape": "Sa"
-          },
-          "Status": {
-            "shape": "S2a"
-          },
+          "Name": {},
+          "Status": {},
           "LogUri": {},
-          "Message": {
-            "shape": "S2b"
-          },
+          "Message": {},
           "RedshiftMetadata": {
             "shape": "S2i"
           },
           "RDSMetadata": {
             "shape": "S2j"
           },
-          "RoleARN": {
-            "shape": "St"
-          },
+          "RoleARN": {},
           "ComputeStatistics": {
             "type": "boolean"
           },
@@ -1161,9 +789,7 @@
           "StartedAt": {
             "type": "timestamp"
           },
-          "DataSourceSchema": {
-            "shape": "Sn"
-          }
+          "DataSourceSchema": {}
         }
       }
     },
@@ -1174,48 +800,30 @@
           "EvaluationId"
         ],
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          },
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "EvaluationDataSourceId": {
-            "shape": "S6"
-          },
-          "InputDataLocationS3": {
-            "shape": "Sb"
-          },
-          "CreatedByIamUser": {
-            "shape": "S29"
-          },
+          "EvaluationId": {},
+          "MLModelId": {},
+          "EvaluationDataSourceId": {},
+          "InputDataLocationS3": {},
+          "CreatedByIamUser": {},
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {
-            "shape": "Sa"
-          },
-          "Status": {
-            "shape": "S2a"
-          },
+          "Name": {},
+          "Status": {},
           "PerformanceMetrics": {
             "shape": "S2q"
           },
           "LogUri": {},
-          "Message": {
-            "shape": "S2b"
-          },
+          "Message": {},
           "ComputeTime": {
             "type": "long"
           },
@@ -1235,9 +843,7 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
+          "MLModelId": {},
           "Verbose": {
             "type": "boolean"
           }
@@ -1246,27 +852,17 @@
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "TrainingDataSourceId": {
-            "shape": "S6"
-          },
-          "CreatedByIamUser": {
-            "shape": "S29"
-          },
+          "MLModelId": {},
+          "TrainingDataSourceId": {},
+          "CreatedByIamUser": {},
           "CreatedAt": {
             "type": "timestamp"
           },
           "LastUpdatedAt": {
             "type": "timestamp"
           },
-          "Name": {
-            "shape": "S2z"
-          },
-          "Status": {
-            "shape": "S2a"
-          },
+          "Name": {},
+          "Status": {},
           "SizeInBytes": {
             "type": "long"
           },
@@ -1276,12 +872,8 @@
           "TrainingParameters": {
             "shape": "S1d"
           },
-          "InputDataLocationS3": {
-            "shape": "Sb"
-          },
-          "MLModelType": {
-            "shape": "S1c"
-          },
+          "InputDataLocationS3": {},
+          "MLModelType": {},
           "ScoreThreshold": {
             "type": "float"
           },
@@ -1289,9 +881,7 @@
             "type": "timestamp"
           },
           "LogUri": {},
-          "Message": {
-            "shape": "S2b"
-          },
+          "Message": {},
           "ComputeTime": {
             "type": "long"
           },
@@ -1301,12 +891,8 @@
           "StartedAt": {
             "type": "timestamp"
           },
-          "Recipe": {
-            "shape": "S1f"
-          },
-          "Schema": {
-            "shape": "Sn"
-          }
+          "Recipe": {},
+          "Schema": {}
         }
       }
     },
@@ -1319,17 +905,13 @@
           "PredictEndpoint"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
+          "MLModelId": {},
           "Record": {
             "type": "map",
             "key": {},
             "value": {}
           },
-          "PredictEndpoint": {
-            "shape": "S1m"
-          }
+          "PredictEndpoint": {}
         }
       },
       "output": {
@@ -1338,34 +920,21 @@
           "Prediction": {
             "type": "structure",
             "members": {
-              "predictedLabel": {
-                "shape": "S3k"
-              },
+              "predictedLabel": {},
               "predictedValue": {
                 "type": "float"
               },
               "predictedScores": {
                 "type": "map",
-                "key": {
-                  "shape": "S3k"
-                },
+                "key": {},
                 "value": {
                   "type": "float"
                 }
               },
               "details": {
                 "type": "map",
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "PredictiveModelType",
-                    "Algorithm"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "min": 1
-                }
+                "key": {},
+                "value": {}
               }
             }
           }
@@ -1380,20 +949,14 @@
           "BatchPredictionName"
         ],
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          },
-          "BatchPredictionName": {
-            "shape": "Sa"
-          }
+          "BatchPredictionId": {},
+          "BatchPredictionName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BatchPredictionId": {
-            "shape": "S6"
-          }
+          "BatchPredictionId": {}
         }
       }
     },
@@ -1405,20 +968,14 @@
           "DataSourceName"
         ],
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          },
-          "DataSourceName": {
-            "shape": "Sa"
-          }
+          "DataSourceId": {},
+          "DataSourceName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "DataSourceId": {
-            "shape": "S6"
-          }
+          "DataSourceId": {}
         }
       }
     },
@@ -1430,20 +987,14 @@
           "EvaluationName"
         ],
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          },
-          "EvaluationName": {
-            "shape": "Sa"
-          }
+          "EvaluationId": {},
+          "EvaluationName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "EvaluationId": {
-            "shape": "S6"
-          }
+          "EvaluationId": {}
         }
       }
     },
@@ -1454,12 +1005,8 @@
           "MLModelId"
         ],
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          },
-          "MLModelName": {
-            "shape": "Sa"
-          },
+          "MLModelId": {},
+          "MLModelName": {},
           "ScoreThreshold": {
             "type": "float"
           }
@@ -1468,9 +1015,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "MLModelId": {
-            "shape": "S6"
-          }
+          "MLModelId": {}
         }
       }
     }
@@ -1481,49 +1026,10 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S4"
-          },
-          "Value": {
-            "type": "string",
-            "min": 0,
-            "max": 256,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 100
-    },
-    "S4": {
-      "type": "string",
-      "min": 1,
-      "max": 128,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "S6": {
-      "type": "string",
-      "min": 1,
-      "max": 64,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "BatchPrediction",
-        "DataSource",
-        "Evaluation",
-        "MLModel"
-      ]
-    },
-    "Sa": {
-      "type": "string",
-      "max": 1024,
-      "pattern": ".*\\S.*|^$"
-    },
-    "Sb": {
-      "type": "string",
-      "max": 2048,
-      "pattern": "s3://([^/]+)(/.*)?"
+      }
     },
     "Sf": {
       "type": "structure",
@@ -1532,47 +1038,9 @@
         "DatabaseName"
       ],
       "members": {
-        "InstanceIdentifier": {
-          "type": "string",
-          "min": 1,
-          "max": 63,
-          "pattern": "[a-z0-9-]+"
-        },
-        "DatabaseName": {
-          "type": "string",
-          "min": 1,
-          "max": 64
-        }
+        "InstanceIdentifier": {},
+        "DatabaseName": {}
       }
-    },
-    "Si": {
-      "type": "string",
-      "min": 1,
-      "max": 16777216
-    },
-    "Sk": {
-      "type": "string",
-      "min": 1,
-      "max": 128
-    },
-    "Sn": {
-      "type": "string",
-      "max": 131071
-    },
-    "So": {
-      "type": "string",
-      "min": 1,
-      "max": 64
-    },
-    "Sp": {
-      "type": "string",
-      "min": 1,
-      "max": 64
-    },
-    "St": {
-      "type": "string",
-      "min": 1,
-      "max": 110
     },
     "Sy": {
       "type": "structure",
@@ -1581,46 +1049,14 @@
         "ClusterIdentifier"
       ],
       "members": {
-        "DatabaseName": {
-          "type": "string",
-          "min": 1,
-          "max": 64,
-          "pattern": "[a-z0-9]+"
-        },
-        "ClusterIdentifier": {
-          "type": "string",
-          "min": 1,
-          "max": 63,
-          "pattern": "[a-z0-9-]+"
-        }
+        "DatabaseName": {},
+        "ClusterIdentifier": {}
       }
-    },
-    "S11": {
-      "type": "string",
-      "min": 1,
-      "max": 16777216
-    },
-    "S13": {
-      "type": "string",
-      "min": 1,
-      "max": 128
-    },
-    "S1c": {
-      "type": "string",
-      "enum": [
-        "REGRESSION",
-        "BINARY",
-        "MULTICLASS"
-      ]
     },
     "S1d": {
       "type": "map",
       "key": {},
       "value": {}
-    },
-    "S1f": {
-      "type": "string",
-      "max": 131071
     },
     "S1j": {
       "type": "structure",
@@ -1631,59 +1067,9 @@
         "CreatedAt": {
           "type": "timestamp"
         },
-        "EndpointUrl": {
-          "shape": "S1m"
-        },
-        "EndpointStatus": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "READY",
-            "UPDATING",
-            "FAILED"
-          ]
-        }
+        "EndpointUrl": {},
+        "EndpointStatus": {}
       }
-    },
-    "S1m": {
-      "type": "string",
-      "max": 2048,
-      "pattern": "https://[a-zA-Z0-9-.]*\\.amazon(aws)?\\.com[/]?"
-    },
-    "S23": {
-      "type": "string",
-      "max": 1024,
-      "pattern": ".*\\S.*|^$"
-    },
-    "S24": {
-      "type": "string",
-      "enum": [
-        "asc",
-        "dsc"
-      ]
-    },
-    "S25": {
-      "type": "integer",
-      "min": 1,
-      "max": 100
-    },
-    "S29": {
-      "type": "string",
-      "pattern": "arn:aws:iam::[0-9]+:((user/.+)|(root))"
-    },
-    "S2a": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "INPROGRESS",
-        "FAILED",
-        "COMPLETED",
-        "DELETED"
-      ]
-    },
-    "S2b": {
-      "type": "string",
-      "max": 10240
     },
     "S2i": {
       "type": "structure",
@@ -1691,12 +1077,8 @@
         "RedshiftDatabase": {
           "shape": "Sy"
         },
-        "DatabaseUserName": {
-          "shape": "S13"
-        },
-        "SelectSqlQuery": {
-          "shape": "S11"
-        }
+        "DatabaseUserName": {},
+        "SelectSqlQuery": {}
       }
     },
     "S2j": {
@@ -1705,23 +1087,11 @@
         "Database": {
           "shape": "Sf"
         },
-        "DatabaseUserName": {
-          "shape": "Sk"
-        },
-        "SelectSqlQuery": {
-          "shape": "Si"
-        },
-        "ResourceRole": {
-          "shape": "So"
-        },
-        "ServiceRole": {
-          "shape": "Sp"
-        },
-        "DataPipelineId": {
-          "type": "string",
-          "min": 1,
-          "max": 1024
-        }
+        "DatabaseUserName": {},
+        "SelectSqlQuery": {},
+        "ResourceRole": {},
+        "ServiceRole": {},
+        "DataPipelineId": {}
       }
     },
     "S2q": {
@@ -1733,14 +1103,6 @@
           "value": {}
         }
       }
-    },
-    "S2z": {
-      "type": "string",
-      "max": 1024
-    },
-    "S3k": {
-      "type": "string",
-      "min": 1
     }
   },
   "examples": {}

--- a/apis/macie-2017-12-19.min.json
+++ b/apis/macie-2017-12-19.min.json
@@ -19,9 +19,7 @@
           "memberAccountId"
         ],
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          }
+          "memberAccountId": {}
         }
       }
     },
@@ -32,9 +30,7 @@
           "s3Resources"
         ],
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          },
+          "memberAccountId": {},
           "s3Resources": {
             "shape": "S4"
           }
@@ -56,9 +52,7 @@
           "memberAccountId"
         ],
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          }
+          "memberAccountId": {}
         }
       }
     },
@@ -69,9 +63,7 @@
           "associatedS3Resources"
         ],
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          },
+          "memberAccountId": {},
           "associatedS3Resources": {
             "type": "list",
             "member": {
@@ -93,11 +85,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "nextToken": {
-            "shape": "Sm"
-          },
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sn"
+            "type": "integer"
           }
         }
       },
@@ -109,15 +99,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "accountId": {
-                  "shape": "S2"
-                }
+                "accountId": {}
               }
             }
           },
-          "nextToken": {
-            "shape": "Sm"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -125,14 +111,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          },
-          "nextToken": {
-            "shape": "Sm"
-          },
+          "memberAccountId": {},
+          "nextToken": {},
           "maxResults": {
-            "shape": "Sn"
+            "type": "integer"
           }
         }
       },
@@ -142,9 +124,7 @@
           "s3Resources": {
             "shape": "S4"
           },
-          "nextToken": {
-            "shape": "Sm"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -155,9 +135,7 @@
           "s3ResourcesUpdate"
         ],
         "members": {
-          "memberAccountId": {
-            "shape": "S2"
-          },
+          "memberAccountId": {},
           "s3ResourcesUpdate": {
             "type": "list",
             "member": {
@@ -167,21 +145,13 @@
                 "classificationTypeUpdate"
               ],
               "members": {
-                "bucketName": {
-                  "shape": "S6"
-                },
-                "prefix": {
-                  "shape": "S7"
-                },
+                "bucketName": {},
+                "prefix": {},
                 "classificationTypeUpdate": {
                   "type": "structure",
                   "members": {
-                    "oneTime": {
-                      "shape": "S9"
-                    },
-                    "continuous": {
-                      "shape": "Sa"
-                    }
+                    "oneTime": {},
+                    "continuous": {}
                   }
                 }
               }
@@ -200,10 +170,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "[0-9]{12}"
-    },
     "S4": {
       "type": "list",
       "member": {
@@ -213,12 +179,8 @@
           "classificationType"
         ],
         "members": {
-          "bucketName": {
-            "shape": "S6"
-          },
-          "prefix": {
-            "shape": "S7"
-          },
+          "bucketName": {},
+          "prefix": {},
           "classificationType": {
             "type": "structure",
             "required": [
@@ -226,37 +188,12 @@
               "continuous"
             ],
             "members": {
-              "oneTime": {
-                "shape": "S9"
-              },
-              "continuous": {
-                "shape": "Sa"
-              }
+              "oneTime": {},
+              "continuous": {}
             }
           }
         }
       }
-    },
-    "S6": {
-      "type": "string",
-      "max": 500
-    },
-    "S7": {
-      "type": "string",
-      "max": 10000
-    },
-    "S9": {
-      "type": "string",
-      "enum": [
-        "FULL",
-        "NONE"
-      ]
-    },
-    "Sa": {
-      "type": "string",
-      "enum": [
-        "FULL"
-      ]
     },
     "Sc": {
       "type": "list",
@@ -266,14 +203,8 @@
           "failedItem": {
             "shape": "Se"
           },
-          "errorCode": {
-            "type": "string",
-            "max": 10
-          },
-          "errorMessage": {
-            "type": "string",
-            "max": 10000
-          }
+          "errorCode": {},
+          "errorMessage": {}
         }
       }
     },
@@ -283,21 +214,9 @@
         "bucketName"
       ],
       "members": {
-        "bucketName": {
-          "shape": "S6"
-        },
-        "prefix": {
-          "shape": "S7"
-        }
+        "bucketName": {},
+        "prefix": {}
       }
-    },
-    "Sm": {
-      "type": "string",
-      "max": 500
-    },
-    "Sn": {
-      "type": "integer",
-      "max": 250
     }
   }
 }

--- a/apis/marketplacecommerceanalytics-2015-07-01.min.json
+++ b/apis/marketplacecommerceanalytics-2015-07-01.min.json
@@ -24,47 +24,14 @@
           "snsTopicArn"
         ],
         "members": {
-          "dataSetType": {
-            "type": "string",
-            "enum": [
-              "customer_subscriber_hourly_monthly_subscriptions",
-              "customer_subscriber_annual_subscriptions",
-              "daily_business_usage_by_instance_type",
-              "daily_business_fees",
-              "daily_business_free_trial_conversions",
-              "daily_business_new_instances",
-              "daily_business_new_product_subscribers",
-              "daily_business_canceled_product_subscribers",
-              "monthly_revenue_billing_and_revenue_data",
-              "monthly_revenue_annual_subscriptions",
-              "disbursed_amount_by_product",
-              "disbursed_amount_by_product_with_uncollected_funds",
-              "disbursed_amount_by_instance_hours",
-              "disbursed_amount_by_customer_geo",
-              "disbursed_amount_by_age_of_uncollected_funds",
-              "disbursed_amount_by_age_of_disbursed_funds",
-              "customer_profile_by_industry",
-              "customer_profile_by_revenue",
-              "customer_profile_by_geography",
-              "sales_compensation_billed_revenue",
-              "us_sales_and_use_tax_records"
-            ],
-            "max": 255,
-            "min": 1
-          },
+          "dataSetType": {},
           "dataSetPublicationDate": {
             "type": "timestamp"
           },
-          "roleNameArn": {
-            "shape": "S4"
-          },
-          "destinationS3BucketName": {
-            "shape": "S5"
-          },
+          "roleNameArn": {},
+          "destinationS3BucketName": {},
           "destinationS3Prefix": {},
-          "snsTopicArn": {
-            "shape": "S7"
-          },
+          "snsTopicArn": {},
           "customerDefinedValues": {
             "shape": "S8"
           }
@@ -88,28 +55,14 @@
           "snsTopicArn"
         ],
         "members": {
-          "dataSetType": {
-            "type": "string",
-            "enum": [
-              "customer_support_contacts_data",
-              "test_customer_support_contacts_data"
-            ],
-            "max": 255,
-            "min": 1
-          },
+          "dataSetType": {},
           "fromDate": {
             "type": "timestamp"
           },
-          "roleNameArn": {
-            "shape": "S4"
-          },
-          "destinationS3BucketName": {
-            "shape": "S5"
-          },
+          "roleNameArn": {},
+          "destinationS3BucketName": {},
           "destinationS3Prefix": {},
-          "snsTopicArn": {
-            "shape": "S7"
-          },
+          "snsTopicArn": {},
           "customerDefinedValues": {
             "shape": "S8"
           }
@@ -124,32 +77,10 @@
     }
   },
   "shapes": {
-    "S4": {
-      "type": "string",
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "min": 1
-    },
     "S8": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      },
-      "value": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      },
-      "max": 5,
-      "min": 1
+      "key": {},
+      "value": {}
     }
   }
 }

--- a/apis/mediaconvert-2017-08-29.min.json
+++ b/apis/mediaconvert-2017-08-29.min.json
@@ -44,7 +44,6 @@
         "type": "structure",
         "members": {
           "BillingTagsSource": {
-            "shape": "S5",
             "locationName": "billingTagsSource"
           },
           "ClientRequestToken": {
@@ -184,7 +183,6 @@
             "locationName": "name"
           },
           "PricingPlan": {
-            "shape": "Sc4",
             "locationName": "pricingPlan"
           },
           "ReservationPlanSettings": {
@@ -292,12 +290,7 @@
             "type": "integer"
           },
           "Mode": {
-            "locationName": "mode",
-            "type": "string",
-            "enum": [
-              "DEFAULT",
-              "GET_ONLY"
-            ]
+            "locationName": "mode"
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -452,25 +445,18 @@
           },
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring",
-            "type": "string",
-            "enum": [
-              "NAME",
-              "CREATION_DATE",
-              "SYSTEM"
-            ]
+            "location": "querystring"
           },
           "MaxResults": {
-            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
-            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -502,16 +488,15 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
-            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           },
@@ -520,7 +505,6 @@
             "location": "querystring"
           },
           "Status": {
-            "shape": "Sbo",
             "locationName": "status",
             "location": "querystring"
           }
@@ -557,25 +541,18 @@
           },
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring",
-            "type": "string",
-            "enum": [
-              "NAME",
-              "CREATION_DATE",
-              "SYSTEM"
-            ]
+            "location": "querystring"
           },
           "MaxResults": {
-            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
-            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -608,24 +585,18 @@
         "members": {
           "ListBy": {
             "locationName": "listBy",
-            "location": "querystring",
-            "type": "string",
-            "enum": [
-              "NAME",
-              "CREATION_DATE"
-            ]
+            "location": "querystring"
           },
           "MaxResults": {
-            "shape": "Scy",
             "locationName": "maxResults",
-            "location": "querystring"
+            "location": "querystring",
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken",
             "location": "querystring"
           },
           "Order": {
-            "shape": "Scz",
             "locationName": "order",
             "location": "querystring"
           }
@@ -838,7 +809,6 @@
             "locationName": "reservationPlanSettings"
           },
           "Status": {
-            "shape": "Scc",
             "locationName": "status"
           }
         },
@@ -858,20 +828,12 @@
     }
   },
   "shapes": {
-    "S5": {
-      "type": "string",
-      "enum": [
-        "QUEUE",
-        "PRESET",
-        "JOB_TEMPLATE"
-      ]
-    },
     "S6": {
       "type": "structure",
       "members": {
         "AdAvailOffset": {
-          "shape": "S7",
-          "locationName": "adAvailOffset"
+          "locationName": "adAvailOffset",
+          "type": "integer"
         },
         "AvailBlanking": {
           "shape": "S8",
@@ -896,40 +858,33 @@
                 "locationName": "captionSelectors"
               },
               "DeblockFilter": {
-                "shape": "S1e",
                 "locationName": "deblockFilter"
               },
               "DenoiseFilter": {
-                "shape": "S1f",
                 "locationName": "denoiseFilter"
               },
               "FileInput": {
-                "locationName": "fileInput",
-                "type": "string",
-                "pattern": "^(s3:\\/\\/)([^\\/]+\\/)+([^\\/\\.]+|(([^\\/]*)\\.([mM]2[vV]|[mM][pP][eE][gG]|[aA][vV][iI]|[mM][pP]4|[fF][lL][vV]|[mM][pP][tT]|[mM][pP][gG]|[mM]4[vV]|[tT][rR][pP]|[fF]4[vV]|[mM]2[tT][sS]|[tT][sS]|264|[hH]264|[mM][kK][vV]|[mM][oO][vV]|[mM][tT][sS]|[mM]2[tT]|[wW][mM][vV]|[aA][sS][fF]|[vV][oO][bB]|3[gG][pP]|3[gG][pP][pP]|[mM][xX][fF]|[dD][iI][vV][xX]|[xX][vV][iI][dD]|[rR][aA][wW]|[dD][vV]|[gG][xX][fF]|[mM]1[vV]|3[gG]2|[vV][mM][fF]|[mM]3[uU]8|[lL][cC][hH]|[gG][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF][hH][dD]|[wW][aA][vV]|[yY]4[mM])))$"
+                "locationName": "fileInput"
               },
               "FilterEnable": {
-                "shape": "S1h",
                 "locationName": "filterEnable"
               },
               "FilterStrength": {
-                "shape": "S1i",
-                "locationName": "filterStrength"
+                "locationName": "filterStrength",
+                "type": "integer"
               },
               "InputClippings": {
                 "shape": "S1j",
                 "locationName": "inputClippings"
               },
               "ProgramNumber": {
-                "shape": "So",
-                "locationName": "programNumber"
+                "locationName": "programNumber",
+                "type": "integer"
               },
               "PsiControl": {
-                "shape": "S1m",
                 "locationName": "psiControl"
               },
               "TimecodeSource": {
-                "shape": "S1n",
                 "locationName": "timecodeSource"
               },
               "VideoSelector": {
@@ -957,19 +912,11 @@
         }
       }
     },
-    "S7": {
-      "type": "integer",
-      "min": -1000,
-      "max": 1000
-    },
     "S8": {
       "type": "structure",
       "members": {
         "AvailBlankingImage": {
-          "locationName": "availBlankingImage",
-          "type": "string",
-          "min": 14,
-          "pattern": "^(s3:\\/\\/)(.*?)\\.(bmp|BMP|png|PNG)$"
+          "locationName": "availBlankingImage"
         }
       }
     },
@@ -982,16 +929,10 @@
           "AudioSelectorNames": {
             "locationName": "audioSelectorNames",
             "type": "list",
-            "member": {
-              "shape": "Sf"
-            }
+            "member": {}
           }
         }
       }
-    },
-    "Sf": {
-      "type": "string",
-      "min": 1
     },
     "Sg": {
       "type": "map",
@@ -1000,29 +941,20 @@
         "type": "structure",
         "members": {
           "CustomLanguageCode": {
-            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "DefaultSelection": {
-            "locationName": "defaultSelection",
-            "type": "string",
-            "enum": [
-              "DEFAULT",
-              "NOT_DEFAULT"
-            ]
+            "locationName": "defaultSelection"
           },
           "ExternalAudioFileInput": {
-            "locationName": "externalAudioFileInput",
-            "type": "string",
-            "pattern": "^(s3:\\/\\/)([^\\/]+\\/)+([^\\/\\.]+|(([^\\/]*)\\.([mM]2[vV]|[mM][pP][eE][gG]|[aA][vV][iI]|[mM][pP]4|[fF][lL][vV]|[mM][pP][tT]|[mM][pP][gG]|[mM]4[vV]|[tT][rR][pP]|[fF]4[vV]|[mM]2[tT][sS]|[tT][sS]|264|[hH]264|[mM][kK][vV]|[mM][oO][vV]|[mM][tT][sS]|[mM]2[tT]|[wW][mM][vV]|[aA][sS][fF]|[vV][oO][bB]|3[gG][pP]|3[gG][pP][pP]|[mM][xX][fF]|[dD][iI][vV][xX]|[xX][vV][iI][dD]|[rR][aA][wW]|[dD][vV]|[gG][xX][fF]|[mM]1[vV]|3[gG]2|[vV][mM][fF]|[mM]3[uU]8|[lL][cC][hH]|[gG][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF]_[mM][pP][eE][gG]2|[mM][xX][fF][hH][dD]|[wW][aA][vV]|[yY]4[mM]|[aA][aA][cC]|[aA][iI][fF][fF]|[mM][pP]2|[aA][cC]3|[eE][cC]3|[dD][tT][sS][eE])))$"
+            "locationName": "externalAudioFileInput"
           },
           "LanguageCode": {
-            "shape": "Sl",
             "locationName": "languageCode"
           },
           "Offset": {
-            "shape": "Sm",
-            "locationName": "offset"
+            "locationName": "offset",
+            "type": "integer"
           },
           "Pids": {
             "shape": "Sn",
@@ -1030,22 +962,14 @@
           },
           "ProgramSelection": {
             "locationName": "programSelection",
-            "type": "integer",
-            "min": 0,
-            "max": 8
+            "type": "integer"
           },
           "RemixSettings": {
             "shape": "Sq",
             "locationName": "remixSettings"
           },
           "SelectorType": {
-            "locationName": "selectorType",
-            "type": "string",
-            "enum": [
-              "PID",
-              "TRACK",
-              "LANGUAGE_CODE"
-            ]
+            "locationName": "selectorType"
           },
           "Tracks": {
             "shape": "Sn",
@@ -1054,223 +978,11 @@
         }
       }
     },
-    "Si": {
-      "type": "string",
-      "min": 3,
-      "max": 3,
-      "pattern": "^[A-Za-z]{3}$"
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "ENG",
-        "SPA",
-        "FRA",
-        "DEU",
-        "GER",
-        "ZHO",
-        "ARA",
-        "HIN",
-        "JPN",
-        "RUS",
-        "POR",
-        "ITA",
-        "URD",
-        "VIE",
-        "KOR",
-        "PAN",
-        "ABK",
-        "AAR",
-        "AFR",
-        "AKA",
-        "SQI",
-        "AMH",
-        "ARG",
-        "HYE",
-        "ASM",
-        "AVA",
-        "AVE",
-        "AYM",
-        "AZE",
-        "BAM",
-        "BAK",
-        "EUS",
-        "BEL",
-        "BEN",
-        "BIH",
-        "BIS",
-        "BOS",
-        "BRE",
-        "BUL",
-        "MYA",
-        "CAT",
-        "KHM",
-        "CHA",
-        "CHE",
-        "NYA",
-        "CHU",
-        "CHV",
-        "COR",
-        "COS",
-        "CRE",
-        "HRV",
-        "CES",
-        "DAN",
-        "DIV",
-        "NLD",
-        "DZO",
-        "ENM",
-        "EPO",
-        "EST",
-        "EWE",
-        "FAO",
-        "FIJ",
-        "FIN",
-        "FRM",
-        "FUL",
-        "GLA",
-        "GLG",
-        "LUG",
-        "KAT",
-        "ELL",
-        "GRN",
-        "GUJ",
-        "HAT",
-        "HAU",
-        "HEB",
-        "HER",
-        "HMO",
-        "HUN",
-        "ISL",
-        "IDO",
-        "IBO",
-        "IND",
-        "INA",
-        "ILE",
-        "IKU",
-        "IPK",
-        "GLE",
-        "JAV",
-        "KAL",
-        "KAN",
-        "KAU",
-        "KAS",
-        "KAZ",
-        "KIK",
-        "KIN",
-        "KIR",
-        "KOM",
-        "KON",
-        "KUA",
-        "KUR",
-        "LAO",
-        "LAT",
-        "LAV",
-        "LIM",
-        "LIN",
-        "LIT",
-        "LUB",
-        "LTZ",
-        "MKD",
-        "MLG",
-        "MSA",
-        "MAL",
-        "MLT",
-        "GLV",
-        "MRI",
-        "MAR",
-        "MAH",
-        "MON",
-        "NAU",
-        "NAV",
-        "NDE",
-        "NBL",
-        "NDO",
-        "NEP",
-        "SME",
-        "NOR",
-        "NOB",
-        "NNO",
-        "OCI",
-        "OJI",
-        "ORI",
-        "ORM",
-        "OSS",
-        "PLI",
-        "FAS",
-        "POL",
-        "PUS",
-        "QUE",
-        "QAA",
-        "RON",
-        "ROH",
-        "RUN",
-        "SMO",
-        "SAG",
-        "SAN",
-        "SRD",
-        "SRB",
-        "SNA",
-        "III",
-        "SND",
-        "SIN",
-        "SLK",
-        "SLV",
-        "SOM",
-        "SOT",
-        "SUN",
-        "SWA",
-        "SSW",
-        "SWE",
-        "TGL",
-        "TAH",
-        "TGK",
-        "TAM",
-        "TAT",
-        "TEL",
-        "THA",
-        "BOD",
-        "TIR",
-        "TON",
-        "TSO",
-        "TSN",
-        "TUR",
-        "TUK",
-        "TWI",
-        "UIG",
-        "UKR",
-        "UZB",
-        "VEN",
-        "VOL",
-        "WLN",
-        "CYM",
-        "FRY",
-        "WOL",
-        "XHO",
-        "YID",
-        "YOR",
-        "ZHA",
-        "ZUL",
-        "ORJ",
-        "QPC",
-        "TNG"
-      ]
-    },
-    "Sm": {
-      "type": "integer",
-      "min": -2147483648,
-      "max": 2147483647
-    },
     "Sn": {
       "type": "list",
       "member": {
-        "shape": "So"
+        "type": "integer"
       }
-    },
-    "So": {
-      "type": "integer",
-      "min": 1,
-      "max": 2147483647
     },
     "Sq": {
       "type": "structure",
@@ -1289,9 +1001,7 @@
                     "locationName": "inputChannels",
                     "type": "list",
                     "member": {
-                      "type": "integer",
-                      "min": -60,
-                      "max": 6
+                      "type": "integer"
                     }
                   }
                 }
@@ -1301,20 +1011,13 @@
         },
         "ChannelsIn": {
           "locationName": "channelsIn",
-          "type": "integer",
-          "min": 1,
-          "max": 16
+          "type": "integer"
         },
         "ChannelsOut": {
-          "shape": "Sx",
-          "locationName": "channelsOut"
+          "locationName": "channelsOut",
+          "type": "integer"
         }
       }
-    },
-    "Sx": {
-      "type": "integer",
-      "min": 1,
-      "max": 8
     },
     "Sz": {
       "type": "map",
@@ -1323,11 +1026,9 @@
         "type": "structure",
         "members": {
           "CustomLanguageCode": {
-            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "LanguageCode": {
-            "shape": "Sl",
             "locationName": "languageCode"
           },
           "SourceSettings": {
@@ -1339,8 +1040,8 @@
                 "type": "structure",
                 "members": {
                   "SourceAncillaryChannelNumber": {
-                    "shape": "S13",
-                    "locationName": "sourceAncillaryChannelNumber"
+                    "locationName": "sourceAncillaryChannelNumber",
+                    "type": "integer"
                   }
                 }
               },
@@ -1349,8 +1050,8 @@
                 "type": "structure",
                 "members": {
                   "Pid": {
-                    "shape": "So",
-                    "locationName": "pid"
+                    "locationName": "pid",
+                    "type": "integer"
                   }
                 }
               },
@@ -1359,22 +1060,15 @@
                 "type": "structure",
                 "members": {
                   "Convert608To708": {
-                    "locationName": "convert608To708",
-                    "type": "string",
-                    "enum": [
-                      "UPCONVERT",
-                      "DISABLED"
-                    ]
+                    "locationName": "convert608To708"
                   },
                   "Source608ChannelNumber": {
-                    "shape": "S13",
-                    "locationName": "source608ChannelNumber"
+                    "locationName": "source608ChannelNumber",
+                    "type": "integer"
                   },
                   "Source608TrackNumber": {
                     "locationName": "source608TrackNumber",
-                    "type": "integer",
-                    "min": 1,
-                    "max": 1
+                    "type": "integer"
                   }
                 }
               },
@@ -1383,46 +1077,25 @@
                 "type": "structure",
                 "members": {
                   "Convert608To708": {
-                    "locationName": "convert608To708",
-                    "type": "string",
-                    "enum": [
-                      "UPCONVERT",
-                      "DISABLED"
-                    ]
+                    "locationName": "convert608To708"
                   },
                   "SourceFile": {
-                    "locationName": "sourceFile",
-                    "type": "string",
-                    "min": 14,
-                    "pattern": "^(s3:\\/\\/)(.*?)\\.(scc|SCC|ttml|TTML|dfxp|DFXP|stl|STL|srt|SRT|smi|SMI)$"
+                    "locationName": "sourceFile"
                   },
                   "TimeDelta": {
-                    "shape": "Sm",
-                    "locationName": "timeDelta"
+                    "locationName": "timeDelta",
+                    "type": "integer"
                   }
                 }
               },
               "SourceType": {
-                "locationName": "sourceType",
-                "type": "string",
-                "enum": [
-                  "ANCILLARY",
-                  "DVB_SUB",
-                  "EMBEDDED",
-                  "SCC",
-                  "TTML",
-                  "STL",
-                  "SRT",
-                  "TELETEXT",
-                  "NULL_SOURCE"
-                ]
+                "locationName": "sourceType"
               },
               "TeletextSourceSettings": {
                 "locationName": "teletextSourceSettings",
                 "type": "structure",
                 "members": {
                   "PageNumber": {
-                    "shape": "S1d",
                     "locationName": "pageNumber"
                   }
                 }
@@ -1432,112 +1105,40 @@
         }
       }
     },
-    "S13": {
-      "type": "integer",
-      "min": 1,
-      "max": 4
-    },
-    "S1d": {
-      "type": "string",
-      "min": 3,
-      "max": 3,
-      "pattern": "^[1-8][0-9a-fA-F][0-9a-eA-E]$"
-    },
-    "S1e": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
-    },
-    "S1f": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
-    },
-    "S1h": {
-      "type": "string",
-      "enum": [
-        "AUTO",
-        "DISABLE",
-        "FORCE"
-      ]
-    },
-    "S1i": {
-      "type": "integer",
-      "min": -5,
-      "max": 5
-    },
     "S1j": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "EndTimecode": {
-            "shape": "S1l",
             "locationName": "endTimecode"
           },
           "StartTimecode": {
-            "shape": "S1l",
             "locationName": "startTimecode"
           }
         }
       }
     },
-    "S1l": {
-      "type": "string",
-      "pattern": "^([01][0-9]|2[0-4]):[0-5][0-9]:[0-5][0-9][:;][0-9]{2}$"
-    },
-    "S1m": {
-      "type": "string",
-      "enum": [
-        "IGNORE_PSI",
-        "USE_PSI"
-      ]
-    },
-    "S1n": {
-      "type": "string",
-      "enum": [
-        "EMBEDDED",
-        "ZEROBASED",
-        "SPECIFIEDSTART"
-      ]
-    },
     "S1o": {
       "type": "structure",
       "members": {
         "ColorSpace": {
-          "locationName": "colorSpace",
-          "type": "string",
-          "enum": [
-            "FOLLOW",
-            "REC_601",
-            "REC_709",
-            "HDR10",
-            "HLG_2020"
-          ]
+          "locationName": "colorSpace"
         },
         "ColorSpaceUsage": {
-          "locationName": "colorSpaceUsage",
-          "type": "string",
-          "enum": [
-            "FORCE",
-            "FALLBACK"
-          ]
+          "locationName": "colorSpaceUsage"
         },
         "Hdr10Metadata": {
           "shape": "S1r",
           "locationName": "hdr10Metadata"
         },
         "Pid": {
-          "shape": "So",
-          "locationName": "pid"
+          "locationName": "pid",
+          "type": "integer"
         },
         "ProgramNumber": {
-          "shape": "Sm",
-          "locationName": "programNumber"
+          "locationName": "programNumber",
+          "type": "integer"
         }
       }
     },
@@ -1545,78 +1146,61 @@
       "type": "structure",
       "members": {
         "BluePrimaryX": {
-          "shape": "S1s",
-          "locationName": "bluePrimaryX"
+          "locationName": "bluePrimaryX",
+          "type": "integer"
         },
         "BluePrimaryY": {
-          "shape": "S1s",
-          "locationName": "bluePrimaryY"
+          "locationName": "bluePrimaryY",
+          "type": "integer"
         },
         "GreenPrimaryX": {
-          "shape": "S1s",
-          "locationName": "greenPrimaryX"
+          "locationName": "greenPrimaryX",
+          "type": "integer"
         },
         "GreenPrimaryY": {
-          "shape": "S1s",
-          "locationName": "greenPrimaryY"
+          "locationName": "greenPrimaryY",
+          "type": "integer"
         },
         "MaxContentLightLevel": {
-          "shape": "S1t",
-          "locationName": "maxContentLightLevel"
+          "locationName": "maxContentLightLevel",
+          "type": "integer"
         },
         "MaxFrameAverageLightLevel": {
-          "shape": "S1t",
-          "locationName": "maxFrameAverageLightLevel"
+          "locationName": "maxFrameAverageLightLevel",
+          "type": "integer"
         },
         "MaxLuminance": {
-          "shape": "S1u",
-          "locationName": "maxLuminance"
+          "locationName": "maxLuminance",
+          "type": "integer"
         },
         "MinLuminance": {
-          "shape": "S1u",
-          "locationName": "minLuminance"
+          "locationName": "minLuminance",
+          "type": "integer"
         },
         "RedPrimaryX": {
-          "shape": "S1s",
-          "locationName": "redPrimaryX"
+          "locationName": "redPrimaryX",
+          "type": "integer"
         },
         "RedPrimaryY": {
-          "shape": "S1s",
-          "locationName": "redPrimaryY"
+          "locationName": "redPrimaryY",
+          "type": "integer"
         },
         "WhitePointX": {
-          "shape": "S1s",
-          "locationName": "whitePointX"
+          "locationName": "whitePointX",
+          "type": "integer"
         },
         "WhitePointY": {
-          "shape": "S1s",
-          "locationName": "whitePointY"
+          "locationName": "whitePointY",
+          "type": "integer"
         }
       }
-    },
-    "S1s": {
-      "type": "integer",
-      "min": 0,
-      "max": 50000
-    },
-    "S1t": {
-      "type": "integer",
-      "min": 0,
-      "max": 65535
-    },
-    "S1u": {
-      "type": "integer",
-      "min": 0,
-      "max": 2147483647
     },
     "S1v": {
       "type": "structure",
       "members": {
         "BreakoutCode": {
           "locationName": "breakoutCode",
-          "type": "integer",
-          "min": 0,
-          "max": 9
+          "type": "integer"
         },
         "DistributorId": {
           "locationName": "distributorId"
@@ -1646,23 +1230,12 @@
                     "locationName": "baseUrl"
                   },
                   "ClientCache": {
-                    "locationName": "clientCache",
-                    "type": "string",
-                    "enum": [
-                      "DISABLED",
-                      "ENABLED"
-                    ]
+                    "locationName": "clientCache"
                   },
                   "CodecSpecification": {
-                    "locationName": "codecSpecification",
-                    "type": "string",
-                    "enum": [
-                      "RFC_6381",
-                      "RFC_4281"
-                    ]
+                    "locationName": "codecSpecification"
                   },
                   "Destination": {
-                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -1670,100 +1243,56 @@
                     "type": "structure",
                     "members": {
                       "ConstantInitializationVector": {
-                        "shape": "S25",
                         "locationName": "constantInitializationVector"
                       },
                       "EncryptionMethod": {
-                        "locationName": "encryptionMethod",
-                        "type": "string",
-                        "enum": [
-                          "SAMPLE_AES"
-                        ]
+                        "locationName": "encryptionMethod"
                       },
                       "InitializationVectorInManifest": {
-                        "locationName": "initializationVectorInManifest",
-                        "type": "string",
-                        "enum": [
-                          "INCLUDE",
-                          "EXCLUDE"
-                        ]
+                        "locationName": "initializationVectorInManifest"
                       },
                       "StaticKeyProvider": {
                         "shape": "S28",
                         "locationName": "staticKeyProvider"
                       },
                       "Type": {
-                        "locationName": "type",
-                        "type": "string",
-                        "enum": [
-                          "STATIC_KEY"
-                        ]
+                        "locationName": "type"
                       }
                     }
                   },
                   "FragmentLength": {
-                    "shape": "So",
-                    "locationName": "fragmentLength"
+                    "locationName": "fragmentLength",
+                    "type": "integer"
                   },
                   "ManifestCompression": {
-                    "locationName": "manifestCompression",
-                    "type": "string",
-                    "enum": [
-                      "GZIP",
-                      "NONE"
-                    ]
+                    "locationName": "manifestCompression"
                   },
                   "ManifestDurationFormat": {
-                    "locationName": "manifestDurationFormat",
-                    "type": "string",
-                    "enum": [
-                      "FLOATING_POINT",
-                      "INTEGER"
-                    ]
+                    "locationName": "manifestDurationFormat"
                   },
                   "MinBufferTime": {
-                    "shape": "S1u",
-                    "locationName": "minBufferTime"
+                    "locationName": "minBufferTime",
+                    "type": "integer"
                   },
                   "MinFinalSegmentLength": {
                     "locationName": "minFinalSegmentLength",
                     "type": "double"
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl",
-                    "type": "string",
-                    "enum": [
-                      "SINGLE_FILE",
-                      "SEGMENTED_FILES"
-                    ]
+                    "locationName": "segmentControl"
                   },
                   "SegmentLength": {
-                    "shape": "So",
-                    "locationName": "segmentLength"
+                    "locationName": "segmentLength",
+                    "type": "integer"
                   },
                   "StreamInfResolution": {
-                    "locationName": "streamInfResolution",
-                    "type": "string",
-                    "enum": [
-                      "INCLUDE",
-                      "EXCLUDE"
-                    ]
+                    "locationName": "streamInfResolution"
                   },
                   "WriteDashManifest": {
-                    "locationName": "writeDashManifest",
-                    "type": "string",
-                    "enum": [
-                      "DISABLED",
-                      "ENABLED"
-                    ]
+                    "locationName": "writeDashManifest"
                   },
                   "WriteHlsManifest": {
-                    "locationName": "writeHlsManifest",
-                    "type": "string",
-                    "enum": [
-                      "DISABLED",
-                      "ENABLED"
-                    ]
+                    "locationName": "writeHlsManifest"
                   }
                 }
               },
@@ -1775,7 +1304,6 @@
                     "locationName": "baseUrl"
                   },
                   "Destination": {
-                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -1789,40 +1317,25 @@
                     }
                   },
                   "FragmentLength": {
-                    "shape": "So",
-                    "locationName": "fragmentLength"
+                    "locationName": "fragmentLength",
+                    "type": "integer"
                   },
                   "HbbtvCompliance": {
-                    "locationName": "hbbtvCompliance",
-                    "type": "string",
-                    "enum": [
-                      "HBBTV_1_5",
-                      "NONE"
-                    ]
+                    "locationName": "hbbtvCompliance"
                   },
                   "MinBufferTime": {
-                    "shape": "S1u",
-                    "locationName": "minBufferTime"
+                    "locationName": "minBufferTime",
+                    "type": "integer"
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl",
-                    "type": "string",
-                    "enum": [
-                      "SINGLE_FILE",
-                      "SEGMENTED_FILES"
-                    ]
+                    "locationName": "segmentControl"
                   },
                   "SegmentLength": {
-                    "shape": "So",
-                    "locationName": "segmentLength"
+                    "locationName": "segmentLength",
+                    "type": "integer"
                   },
                   "WriteSegmentTimelineInRepresentation": {
-                    "locationName": "writeSegmentTimelineInRepresentation",
-                    "type": "string",
-                    "enum": [
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "writeSegmentTimelineInRepresentation"
                   }
                 }
               },
@@ -1831,7 +1344,6 @@
                 "type": "structure",
                 "members": {
                   "Destination": {
-                    "shape": "S23",
                     "locationName": "destination"
                   }
                 }
@@ -1843,13 +1355,7 @@
                   "AdMarkers": {
                     "locationName": "adMarkers",
                     "type": "list",
-                    "member": {
-                      "type": "string",
-                      "enum": [
-                        "ELEMENTAL",
-                        "ELEMENTAL_SCTE35"
-                      ]
-                    }
+                    "member": {}
                   },
                   "BaseUrl": {
                     "locationName": "baseUrl"
@@ -1861,15 +1367,13 @@
                       "type": "structure",
                       "members": {
                         "CaptionChannel": {
-                          "shape": "Sm",
-                          "locationName": "captionChannel"
+                          "locationName": "captionChannel",
+                          "type": "integer"
                         },
                         "CustomLanguageCode": {
-                          "shape": "Si",
                           "locationName": "customLanguageCode"
                         },
                         "LanguageCode": {
-                          "shape": "Sl",
                           "locationName": "languageCode"
                         },
                         "LanguageDescription": {
@@ -1879,65 +1383,32 @@
                     }
                   },
                   "CaptionLanguageSetting": {
-                    "locationName": "captionLanguageSetting",
-                    "type": "string",
-                    "enum": [
-                      "INSERT",
-                      "OMIT",
-                      "NONE"
-                    ]
+                    "locationName": "captionLanguageSetting"
                   },
                   "ClientCache": {
-                    "locationName": "clientCache",
-                    "type": "string",
-                    "enum": [
-                      "DISABLED",
-                      "ENABLED"
-                    ]
+                    "locationName": "clientCache"
                   },
                   "CodecSpecification": {
-                    "locationName": "codecSpecification",
-                    "type": "string",
-                    "enum": [
-                      "RFC_6381",
-                      "RFC_4281"
-                    ]
+                    "locationName": "codecSpecification"
                   },
                   "Destination": {
-                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "DirectoryStructure": {
-                    "locationName": "directoryStructure",
-                    "type": "string",
-                    "enum": [
-                      "SINGLE_DIRECTORY",
-                      "SUBDIRECTORY_PER_STREAM"
-                    ]
+                    "locationName": "directoryStructure"
                   },
                   "Encryption": {
                     "locationName": "encryption",
                     "type": "structure",
                     "members": {
                       "ConstantInitializationVector": {
-                        "shape": "S25",
                         "locationName": "constantInitializationVector"
                       },
                       "EncryptionMethod": {
-                        "locationName": "encryptionMethod",
-                        "type": "string",
-                        "enum": [
-                          "AES128",
-                          "SAMPLE_AES"
-                        ]
+                        "locationName": "encryptionMethod"
                       },
                       "InitializationVectorInManifest": {
-                        "locationName": "initializationVectorInManifest",
-                        "type": "string",
-                        "enum": [
-                          "INCLUDE",
-                          "EXCLUDE"
-                        ]
+                        "locationName": "initializationVectorInManifest"
                       },
                       "SpekeKeyProvider": {
                         "shape": "S2m",
@@ -1948,101 +1419,58 @@
                         "locationName": "staticKeyProvider"
                       },
                       "Type": {
-                        "locationName": "type",
-                        "type": "string",
-                        "enum": [
-                          "SPEKE",
-                          "STATIC_KEY"
-                        ]
+                        "locationName": "type"
                       }
                     }
                   },
                   "ManifestCompression": {
-                    "locationName": "manifestCompression",
-                    "type": "string",
-                    "enum": [
-                      "GZIP",
-                      "NONE"
-                    ]
+                    "locationName": "manifestCompression"
                   },
                   "ManifestDurationFormat": {
-                    "locationName": "manifestDurationFormat",
-                    "type": "string",
-                    "enum": [
-                      "FLOATING_POINT",
-                      "INTEGER"
-                    ]
+                    "locationName": "manifestDurationFormat"
                   },
                   "MinFinalSegmentLength": {
                     "locationName": "minFinalSegmentLength",
                     "type": "double"
                   },
                   "MinSegmentLength": {
-                    "shape": "S1u",
-                    "locationName": "minSegmentLength"
+                    "locationName": "minSegmentLength",
+                    "type": "integer"
                   },
                   "OutputSelection": {
-                    "locationName": "outputSelection",
-                    "type": "string",
-                    "enum": [
-                      "MANIFESTS_AND_SEGMENTS",
-                      "SEGMENTS_ONLY"
-                    ]
+                    "locationName": "outputSelection"
                   },
                   "ProgramDateTime": {
-                    "locationName": "programDateTime",
-                    "type": "string",
-                    "enum": [
-                      "INCLUDE",
-                      "EXCLUDE"
-                    ]
+                    "locationName": "programDateTime"
                   },
                   "ProgramDateTimePeriod": {
                     "locationName": "programDateTimePeriod",
-                    "type": "integer",
-                    "min": 0,
-                    "max": 3600
+                    "type": "integer"
                   },
                   "SegmentControl": {
-                    "locationName": "segmentControl",
-                    "type": "string",
-                    "enum": [
-                      "SINGLE_FILE",
-                      "SEGMENTED_FILES"
-                    ]
+                    "locationName": "segmentControl"
                   },
                   "SegmentLength": {
-                    "shape": "So",
-                    "locationName": "segmentLength"
+                    "locationName": "segmentLength",
+                    "type": "integer"
                   },
                   "SegmentsPerSubdirectory": {
-                    "shape": "So",
-                    "locationName": "segmentsPerSubdirectory"
+                    "locationName": "segmentsPerSubdirectory",
+                    "type": "integer"
                   },
                   "StreamInfResolution": {
-                    "locationName": "streamInfResolution",
-                    "type": "string",
-                    "enum": [
-                      "INCLUDE",
-                      "EXCLUDE"
-                    ]
+                    "locationName": "streamInfResolution"
                   },
                   "TimedMetadataId3Frame": {
-                    "locationName": "timedMetadataId3Frame",
-                    "type": "string",
-                    "enum": [
-                      "NONE",
-                      "PRIV",
-                      "TDRL"
-                    ]
+                    "locationName": "timedMetadataId3Frame"
                   },
                   "TimedMetadataId3Period": {
-                    "shape": "Sm",
-                    "locationName": "timedMetadataId3Period"
+                    "locationName": "timedMetadataId3Period",
+                    "type": "integer"
                   },
                   "TimestampDeltaMilliseconds": {
-                    "shape": "Sm",
-                    "locationName": "timestampDeltaMilliseconds"
+                    "locationName": "timestampDeltaMilliseconds",
+                    "type": "integer"
                   }
                 }
               },
@@ -2051,15 +1479,9 @@
                 "type": "structure",
                 "members": {
                   "AudioDeduplication": {
-                    "locationName": "audioDeduplication",
-                    "type": "string",
-                    "enum": [
-                      "COMBINE_DUPLICATE_STREAMS",
-                      "NONE"
-                    ]
+                    "locationName": "audioDeduplication"
                   },
                   "Destination": {
-                    "shape": "S23",
                     "locationName": "destination"
                   },
                   "Encryption": {
@@ -2073,29 +1495,16 @@
                     }
                   },
                   "FragmentLength": {
-                    "shape": "So",
-                    "locationName": "fragmentLength"
+                    "locationName": "fragmentLength",
+                    "type": "integer"
                   },
                   "ManifestEncoding": {
-                    "locationName": "manifestEncoding",
-                    "type": "string",
-                    "enum": [
-                      "UTF8",
-                      "UTF16"
-                    ]
+                    "locationName": "manifestEncoding"
                   }
                 }
               },
               "Type": {
-                "locationName": "type",
-                "type": "string",
-                "enum": [
-                  "HLS_GROUP_SETTINGS",
-                  "DASH_ISO_GROUP_SETTINGS",
-                  "FILE_GROUP_SETTINGS",
-                  "MS_SMOOTH_GROUP_SETTINGS",
-                  "CMAF_GROUP_SETTINGS"
-                ]
+                "locationName": "type"
               }
             }
           },
@@ -2116,11 +1525,9 @@
                     "type": "structure",
                     "members": {
                       "CaptionSelectorName": {
-                        "shape": "Sf",
                         "locationName": "captionSelectorName"
                       },
                       "CustomLanguageCode": {
-                        "shape": "Si",
                         "locationName": "customLanguageCode"
                       },
                       "DestinationSettings": {
@@ -2128,7 +1535,6 @@
                         "locationName": "destinationSettings"
                       },
                       "LanguageCode": {
-                        "shape": "Sl",
                         "locationName": "languageCode"
                       },
                       "LanguageDescription": {
@@ -2145,7 +1551,6 @@
                   "locationName": "extension"
                 },
                 "NameModifier": {
-                  "shape": "Sf",
                   "locationName": "nameModifier"
                 },
                 "OutputSettings": {
@@ -2163,22 +1568,10 @@
                           "locationName": "audioRenditionSets"
                         },
                         "AudioTrackType": {
-                          "locationName": "audioTrackType",
-                          "type": "string",
-                          "enum": [
-                            "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT",
-                            "ALTERNATE_AUDIO_AUTO_SELECT",
-                            "ALTERNATE_AUDIO_NOT_AUTO_SELECT",
-                            "AUDIO_ONLY_VARIANT_STREAM"
-                          ]
+                          "locationName": "audioTrackType"
                         },
                         "IFrameOnlyManifest": {
-                          "locationName": "iFrameOnlyManifest",
-                          "type": "string",
-                          "enum": [
-                            "INCLUDE",
-                            "EXCLUDE"
-                          ]
+                          "locationName": "iFrameOnlyManifest"
                         },
                         "SegmentModifier": {
                           "locationName": "segmentModifier"
@@ -2188,9 +1581,7 @@
                   }
                 },
                 "Preset": {
-                  "locationName": "preset",
-                  "type": "string",
-                  "min": 0
+                  "locationName": "preset"
                 },
                 "VideoDescription": {
                   "shape": "S7e",
@@ -2202,33 +1593,17 @@
         }
       }
     },
-    "S23": {
-      "type": "string",
-      "pattern": "^s3:\\/\\/"
-    },
-    "S25": {
-      "type": "string",
-      "min": 32,
-      "max": 32,
-      "pattern": "^[0-9a-fA-F]{32}$"
-    },
     "S28": {
       "type": "structure",
       "members": {
         "KeyFormat": {
-          "locationName": "keyFormat",
-          "type": "string",
-          "pattern": "^(identity|[A-Za-z]{2,6}(\\.[A-Za-z0-9-]{1,63})+)$"
+          "locationName": "keyFormat"
         },
         "KeyFormatVersions": {
-          "locationName": "keyFormatVersions",
-          "type": "string",
-          "pattern": "^(\\d+(\\/\\d+)*)$"
+          "locationName": "keyFormatVersions"
         },
         "StaticKeyValue": {
-          "locationName": "staticKeyValue",
-          "type": "string",
-          "pattern": "^[A-Za-z0-9]{32}$"
+          "locationName": "staticKeyValue"
         },
         "Url": {
           "locationName": "url"
@@ -2244,15 +1619,10 @@
         "SystemIds": {
           "locationName": "systemIds",
           "type": "list",
-          "member": {
-            "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-          }
+          "member": {}
         },
         "Url": {
-          "locationName": "url",
-          "type": "string",
-          "pattern": "^https:\\/\\/"
+          "locationName": "url"
         }
       }
     },
@@ -2266,42 +1636,20 @@
             "type": "structure",
             "members": {
               "Algorithm": {
-                "locationName": "algorithm",
-                "type": "string",
-                "enum": [
-                  "ITU_BS_1770_1",
-                  "ITU_BS_1770_2"
-                ]
+                "locationName": "algorithm"
               },
               "AlgorithmControl": {
-                "locationName": "algorithmControl",
-                "type": "string",
-                "enum": [
-                  "CORRECT_AUDIO",
-                  "MEASURE_ONLY"
-                ]
+                "locationName": "algorithmControl"
               },
               "CorrectionGateLevel": {
                 "locationName": "correctionGateLevel",
-                "type": "integer",
-                "min": -70,
-                "max": 0
+                "type": "integer"
               },
               "LoudnessLogging": {
-                "locationName": "loudnessLogging",
-                "type": "string",
-                "enum": [
-                  "LOG",
-                  "DONT_LOG"
-                ]
+                "locationName": "loudnessLogging"
               },
               "PeakCalculation": {
-                "locationName": "peakCalculation",
-                "type": "string",
-                "enum": [
-                  "TRUE_PEAK",
-                  "NONE"
-                ]
+                "locationName": "peakCalculation"
               },
               "TargetLkfs": {
                 "locationName": "targetLkfs",
@@ -2313,16 +1661,11 @@
             "locationName": "audioSourceName"
           },
           "AudioType": {
-            "shape": "S3v",
-            "locationName": "audioType"
+            "locationName": "audioType",
+            "type": "integer"
           },
           "AudioTypeControl": {
-            "locationName": "audioTypeControl",
-            "type": "string",
-            "enum": [
-              "FOLLOW_INPUT",
-              "USE_CONFIGURED"
-            ]
+            "locationName": "audioTypeControl"
           },
           "CodecSettings": {
             "locationName": "codecSettings",
@@ -2333,78 +1676,33 @@
                 "type": "structure",
                 "members": {
                   "AudioDescriptionBroadcasterMix": {
-                    "locationName": "audioDescriptionBroadcasterMix",
-                    "type": "string",
-                    "enum": [
-                      "BROADCASTER_MIXED_AD",
-                      "NORMAL"
-                    ]
+                    "locationName": "audioDescriptionBroadcasterMix"
                   },
                   "Bitrate": {
                     "locationName": "bitrate",
-                    "type": "integer",
-                    "min": 6000,
-                    "max": 1024000
+                    "type": "integer"
                   },
                   "CodecProfile": {
-                    "locationName": "codecProfile",
-                    "type": "string",
-                    "enum": [
-                      "LC",
-                      "HEV1",
-                      "HEV2"
-                    ]
+                    "locationName": "codecProfile"
                   },
                   "CodingMode": {
-                    "locationName": "codingMode",
-                    "type": "string",
-                    "enum": [
-                      "AD_RECEIVER_MIX",
-                      "CODING_MODE_1_0",
-                      "CODING_MODE_1_1",
-                      "CODING_MODE_2_0",
-                      "CODING_MODE_5_1"
-                    ]
+                    "locationName": "codingMode"
                   },
                   "RateControlMode": {
-                    "locationName": "rateControlMode",
-                    "type": "string",
-                    "enum": [
-                      "CBR",
-                      "VBR"
-                    ]
+                    "locationName": "rateControlMode"
                   },
                   "RawFormat": {
-                    "locationName": "rawFormat",
-                    "type": "string",
-                    "enum": [
-                      "LATM_LOAS",
-                      "NONE"
-                    ]
+                    "locationName": "rawFormat"
                   },
                   "SampleRate": {
                     "locationName": "sampleRate",
-                    "type": "integer",
-                    "min": 8000,
-                    "max": 96000
+                    "type": "integer"
                   },
                   "Specification": {
-                    "locationName": "specification",
-                    "type": "string",
-                    "enum": [
-                      "MPEG2",
-                      "MPEG4"
-                    ]
+                    "locationName": "specification"
                   },
                   "VbrQuality": {
-                    "locationName": "vbrQuality",
-                    "type": "string",
-                    "enum": [
-                      "LOW",
-                      "MEDIUM_LOW",
-                      "MEDIUM_HIGH",
-                      "HIGH"
-                    ]
+                    "locationName": "vbrQuality"
                   }
                 }
               },
@@ -2413,64 +1711,31 @@
                 "type": "structure",
                 "members": {
                   "Bitrate": {
-                    "shape": "S49",
-                    "locationName": "bitrate"
+                    "locationName": "bitrate",
+                    "type": "integer"
                   },
                   "BitstreamMode": {
-                    "locationName": "bitstreamMode",
-                    "type": "string",
-                    "enum": [
-                      "COMPLETE_MAIN",
-                      "COMMENTARY",
-                      "DIALOGUE",
-                      "EMERGENCY",
-                      "HEARING_IMPAIRED",
-                      "MUSIC_AND_EFFECTS",
-                      "VISUALLY_IMPAIRED",
-                      "VOICE_OVER"
-                    ]
+                    "locationName": "bitstreamMode"
                   },
                   "CodingMode": {
-                    "locationName": "codingMode",
-                    "type": "string",
-                    "enum": [
-                      "CODING_MODE_1_0",
-                      "CODING_MODE_1_1",
-                      "CODING_MODE_2_0",
-                      "CODING_MODE_3_2_LFE"
-                    ]
+                    "locationName": "codingMode"
                   },
                   "Dialnorm": {
-                    "shape": "S4c",
-                    "locationName": "dialnorm"
+                    "locationName": "dialnorm",
+                    "type": "integer"
                   },
                   "DynamicRangeCompressionProfile": {
-                    "locationName": "dynamicRangeCompressionProfile",
-                    "type": "string",
-                    "enum": [
-                      "FILM_STANDARD",
-                      "NONE"
-                    ]
+                    "locationName": "dynamicRangeCompressionProfile"
                   },
                   "LfeFilter": {
-                    "locationName": "lfeFilter",
-                    "type": "string",
-                    "enum": [
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "lfeFilter"
                   },
                   "MetadataControl": {
-                    "locationName": "metadataControl",
-                    "type": "string",
-                    "enum": [
-                      "FOLLOW_INPUT",
-                      "USE_CONFIGURED"
-                    ]
+                    "locationName": "metadataControl"
                   },
                   "SampleRate": {
-                    "shape": "S4g",
-                    "locationName": "sampleRate"
+                    "locationName": "sampleRate",
+                    "type": "integer"
                   }
                 }
               },
@@ -2479,119 +1744,57 @@
                 "type": "structure",
                 "members": {
                   "BitDepth": {
-                    "shape": "S4i",
-                    "locationName": "bitDepth"
+                    "locationName": "bitDepth",
+                    "type": "integer"
                   },
                   "Channels": {
-                    "shape": "S4j",
-                    "locationName": "channels"
+                    "locationName": "channels",
+                    "type": "integer"
                   },
                   "SampleRate": {
-                    "shape": "S4k",
-                    "locationName": "sampleRate"
+                    "locationName": "sampleRate",
+                    "type": "integer"
                   }
                 }
               },
               "Codec": {
-                "locationName": "codec",
-                "type": "string",
-                "enum": [
-                  "AAC",
-                  "MP2",
-                  "WAV",
-                  "AIFF",
-                  "AC3",
-                  "EAC3",
-                  "PASSTHROUGH"
-                ]
+                "locationName": "codec"
               },
               "Eac3Settings": {
                 "locationName": "eac3Settings",
                 "type": "structure",
                 "members": {
                   "AttenuationControl": {
-                    "locationName": "attenuationControl",
-                    "type": "string",
-                    "enum": [
-                      "ATTENUATE_3_DB",
-                      "NONE"
-                    ]
+                    "locationName": "attenuationControl"
                   },
                   "Bitrate": {
-                    "shape": "S49",
-                    "locationName": "bitrate"
+                    "locationName": "bitrate",
+                    "type": "integer"
                   },
                   "BitstreamMode": {
-                    "locationName": "bitstreamMode",
-                    "type": "string",
-                    "enum": [
-                      "COMPLETE_MAIN",
-                      "COMMENTARY",
-                      "EMERGENCY",
-                      "HEARING_IMPAIRED",
-                      "VISUALLY_IMPAIRED"
-                    ]
+                    "locationName": "bitstreamMode"
                   },
                   "CodingMode": {
-                    "locationName": "codingMode",
-                    "type": "string",
-                    "enum": [
-                      "CODING_MODE_1_0",
-                      "CODING_MODE_2_0",
-                      "CODING_MODE_3_2"
-                    ]
+                    "locationName": "codingMode"
                   },
                   "DcFilter": {
-                    "locationName": "dcFilter",
-                    "type": "string",
-                    "enum": [
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "dcFilter"
                   },
                   "Dialnorm": {
-                    "shape": "S4c",
-                    "locationName": "dialnorm"
+                    "locationName": "dialnorm",
+                    "type": "integer"
                   },
                   "DynamicRangeCompressionLine": {
-                    "locationName": "dynamicRangeCompressionLine",
-                    "type": "string",
-                    "enum": [
-                      "NONE",
-                      "FILM_STANDARD",
-                      "FILM_LIGHT",
-                      "MUSIC_STANDARD",
-                      "MUSIC_LIGHT",
-                      "SPEECH"
-                    ]
+                    "locationName": "dynamicRangeCompressionLine"
                   },
                   "DynamicRangeCompressionRf": {
-                    "locationName": "dynamicRangeCompressionRf",
-                    "type": "string",
-                    "enum": [
-                      "NONE",
-                      "FILM_STANDARD",
-                      "FILM_LIGHT",
-                      "MUSIC_STANDARD",
-                      "MUSIC_LIGHT",
-                      "SPEECH"
-                    ]
+                    "locationName": "dynamicRangeCompressionRf"
                   },
                   "LfeControl": {
-                    "locationName": "lfeControl",
-                    "type": "string",
-                    "enum": [
-                      "LFE",
-                      "NO_LFE"
-                    ]
+                    "locationName": "lfeControl"
                   },
                   "LfeFilter": {
-                    "locationName": "lfeFilter",
-                    "type": "string",
-                    "enum": [
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "lfeFilter"
                   },
                   "LoRoCenterMixLevel": {
                     "locationName": "loRoCenterMixLevel",
@@ -2610,60 +1813,26 @@
                     "type": "double"
                   },
                   "MetadataControl": {
-                    "locationName": "metadataControl",
-                    "type": "string",
-                    "enum": [
-                      "FOLLOW_INPUT",
-                      "USE_CONFIGURED"
-                    ]
+                    "locationName": "metadataControl"
                   },
                   "PassthroughControl": {
-                    "locationName": "passthroughControl",
-                    "type": "string",
-                    "enum": [
-                      "WHEN_POSSIBLE",
-                      "NO_PASSTHROUGH"
-                    ]
+                    "locationName": "passthroughControl"
                   },
                   "PhaseControl": {
-                    "locationName": "phaseControl",
-                    "type": "string",
-                    "enum": [
-                      "SHIFT_90_DEGREES",
-                      "NO_SHIFT"
-                    ]
+                    "locationName": "phaseControl"
                   },
                   "SampleRate": {
-                    "shape": "S4g",
-                    "locationName": "sampleRate"
+                    "locationName": "sampleRate",
+                    "type": "integer"
                   },
                   "StereoDownmix": {
-                    "locationName": "stereoDownmix",
-                    "type": "string",
-                    "enum": [
-                      "NOT_INDICATED",
-                      "LO_RO",
-                      "LT_RT",
-                      "DPL2"
-                    ]
+                    "locationName": "stereoDownmix"
                   },
                   "SurroundExMode": {
-                    "locationName": "surroundExMode",
-                    "type": "string",
-                    "enum": [
-                      "NOT_INDICATED",
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "surroundExMode"
                   },
                   "SurroundMode": {
-                    "locationName": "surroundMode",
-                    "type": "string",
-                    "enum": [
-                      "NOT_INDICATED",
-                      "ENABLED",
-                      "DISABLED"
-                    ]
+                    "locationName": "surroundMode"
                   }
                 }
               },
@@ -2673,19 +1842,15 @@
                 "members": {
                   "Bitrate": {
                     "locationName": "bitrate",
-                    "type": "integer",
-                    "min": 32000,
-                    "max": 384000
+                    "type": "integer"
                   },
                   "Channels": {
-                    "shape": "S4j",
-                    "locationName": "channels"
+                    "locationName": "channels",
+                    "type": "integer"
                   },
                   "SampleRate": {
                     "locationName": "sampleRate",
-                    "type": "integer",
-                    "min": 32000,
-                    "max": 48000
+                    "type": "integer"
                   }
                 }
               },
@@ -2694,91 +1859,42 @@
                 "type": "structure",
                 "members": {
                   "BitDepth": {
-                    "shape": "S4i",
-                    "locationName": "bitDepth"
+                    "locationName": "bitDepth",
+                    "type": "integer"
                   },
                   "Channels": {
-                    "shape": "Sx",
-                    "locationName": "channels"
+                    "locationName": "channels",
+                    "type": "integer"
                   },
                   "Format": {
-                    "locationName": "format",
-                    "type": "string",
-                    "enum": [
-                      "RIFF",
-                      "RF64"
-                    ]
+                    "locationName": "format"
                   },
                   "SampleRate": {
-                    "shape": "S4k",
-                    "locationName": "sampleRate"
+                    "locationName": "sampleRate",
+                    "type": "integer"
                   }
                 }
               }
             }
           },
           "CustomLanguageCode": {
-            "shape": "Si",
             "locationName": "customLanguageCode"
           },
           "LanguageCode": {
-            "shape": "Sl",
             "locationName": "languageCode"
           },
           "LanguageCodeControl": {
-            "locationName": "languageCodeControl",
-            "type": "string",
-            "enum": [
-              "FOLLOW_INPUT",
-              "USE_CONFIGURED"
-            ]
+            "locationName": "languageCodeControl"
           },
           "RemixSettings": {
             "shape": "Sq",
             "locationName": "remixSettings"
           },
           "StreamName": {
-            "locationName": "streamName",
-            "type": "string",
-            "pattern": "^[\\w\\s]*$"
+            "locationName": "streamName"
           }
         }
       }
-    },
-    "S3v": {
-      "type": "integer",
-      "min": 0,
-      "max": 255
-    },
-    "S49": {
-      "type": "integer",
-      "min": 64000,
-      "max": 640000
-    },
-    "S4c": {
-      "type": "integer",
-      "min": 1,
-      "max": 31
-    },
-    "S4g": {
-      "type": "integer",
-      "min": 48000,
-      "max": 48000
-    },
-    "S4i": {
-      "type": "integer",
-      "min": 16,
-      "max": 24
-    },
-    "S4j": {
-      "type": "integer",
-      "min": 1,
-      "max": 2
-    },
-    "S4k": {
-      "type": "integer",
-      "min": 8000,
-      "max": 192000
     },
     "S5c": {
       "type": "structure",
@@ -2788,220 +1904,129 @@
           "type": "structure",
           "members": {
             "Alignment": {
-              "locationName": "alignment",
-              "type": "string",
-              "enum": [
-                "CENTERED",
-                "LEFT"
-              ]
+              "locationName": "alignment"
             },
             "BackgroundColor": {
-              "locationName": "backgroundColor",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "BLACK",
-                "WHITE"
-              ]
+              "locationName": "backgroundColor"
             },
             "BackgroundOpacity": {
-              "shape": "S3v",
-              "locationName": "backgroundOpacity"
+              "locationName": "backgroundOpacity",
+              "type": "integer"
             },
             "FontColor": {
-              "locationName": "fontColor",
-              "type": "string",
-              "enum": [
-                "WHITE",
-                "BLACK",
-                "YELLOW",
-                "RED",
-                "GREEN",
-                "BLUE"
-              ]
+              "locationName": "fontColor"
             },
             "FontOpacity": {
-              "shape": "S3v",
-              "locationName": "fontOpacity"
+              "locationName": "fontOpacity",
+              "type": "integer"
             },
             "FontResolution": {
-              "shape": "S5h",
-              "locationName": "fontResolution"
+              "locationName": "fontResolution",
+              "type": "integer"
             },
             "FontSize": {
-              "shape": "S5i",
-              "locationName": "fontSize"
+              "locationName": "fontSize",
+              "type": "integer"
             },
             "OutlineColor": {
-              "locationName": "outlineColor",
-              "type": "string",
-              "enum": [
-                "BLACK",
-                "WHITE",
-                "YELLOW",
-                "RED",
-                "GREEN",
-                "BLUE"
-              ]
+              "locationName": "outlineColor"
             },
             "OutlineSize": {
-              "shape": "S5k",
-              "locationName": "outlineSize"
+              "locationName": "outlineSize",
+              "type": "integer"
             },
             "ShadowColor": {
-              "locationName": "shadowColor",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "BLACK",
-                "WHITE"
-              ]
+              "locationName": "shadowColor"
             },
             "ShadowOpacity": {
-              "shape": "S3v",
-              "locationName": "shadowOpacity"
+              "locationName": "shadowOpacity",
+              "type": "integer"
             },
             "ShadowXOffset": {
-              "shape": "Sm",
-              "locationName": "shadowXOffset"
+              "locationName": "shadowXOffset",
+              "type": "integer"
             },
             "ShadowYOffset": {
-              "shape": "Sm",
-              "locationName": "shadowYOffset"
+              "locationName": "shadowYOffset",
+              "type": "integer"
             },
             "TeletextSpacing": {
-              "locationName": "teletextSpacing",
-              "type": "string",
-              "enum": [
-                "FIXED_GRID",
-                "PROPORTIONAL"
-              ]
+              "locationName": "teletextSpacing"
             },
             "XPosition": {
-              "shape": "S1u",
-              "locationName": "xPosition"
+              "locationName": "xPosition",
+              "type": "integer"
             },
             "YPosition": {
-              "shape": "S1u",
-              "locationName": "yPosition"
+              "locationName": "yPosition",
+              "type": "integer"
             }
           }
         },
         "DestinationType": {
-          "locationName": "destinationType",
-          "type": "string",
-          "enum": [
-            "BURN_IN",
-            "DVB_SUB",
-            "EMBEDDED",
-            "SCC",
-            "SRT",
-            "TELETEXT",
-            "TTML",
-            "WEBVTT"
-          ]
+          "locationName": "destinationType"
         },
         "DvbSubDestinationSettings": {
           "locationName": "dvbSubDestinationSettings",
           "type": "structure",
           "members": {
             "Alignment": {
-              "locationName": "alignment",
-              "type": "string",
-              "enum": [
-                "CENTERED",
-                "LEFT"
-              ]
+              "locationName": "alignment"
             },
             "BackgroundColor": {
-              "locationName": "backgroundColor",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "BLACK",
-                "WHITE"
-              ]
+              "locationName": "backgroundColor"
             },
             "BackgroundOpacity": {
-              "shape": "S3v",
-              "locationName": "backgroundOpacity"
+              "locationName": "backgroundOpacity",
+              "type": "integer"
             },
             "FontColor": {
-              "locationName": "fontColor",
-              "type": "string",
-              "enum": [
-                "WHITE",
-                "BLACK",
-                "YELLOW",
-                "RED",
-                "GREEN",
-                "BLUE"
-              ]
+              "locationName": "fontColor"
             },
             "FontOpacity": {
-              "shape": "S3v",
-              "locationName": "fontOpacity"
+              "locationName": "fontOpacity",
+              "type": "integer"
             },
             "FontResolution": {
-              "shape": "S5h",
-              "locationName": "fontResolution"
+              "locationName": "fontResolution",
+              "type": "integer"
             },
             "FontSize": {
-              "shape": "S5i",
-              "locationName": "fontSize"
+              "locationName": "fontSize",
+              "type": "integer"
             },
             "OutlineColor": {
-              "locationName": "outlineColor",
-              "type": "string",
-              "enum": [
-                "BLACK",
-                "WHITE",
-                "YELLOW",
-                "RED",
-                "GREEN",
-                "BLUE"
-              ]
+              "locationName": "outlineColor"
             },
             "OutlineSize": {
-              "shape": "S5k",
-              "locationName": "outlineSize"
+              "locationName": "outlineSize",
+              "type": "integer"
             },
             "ShadowColor": {
-              "locationName": "shadowColor",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "BLACK",
-                "WHITE"
-              ]
+              "locationName": "shadowColor"
             },
             "ShadowOpacity": {
-              "shape": "S3v",
-              "locationName": "shadowOpacity"
+              "locationName": "shadowOpacity",
+              "type": "integer"
             },
             "ShadowXOffset": {
-              "shape": "Sm",
-              "locationName": "shadowXOffset"
+              "locationName": "shadowXOffset",
+              "type": "integer"
             },
             "ShadowYOffset": {
-              "shape": "Sm",
-              "locationName": "shadowYOffset"
+              "locationName": "shadowYOffset",
+              "type": "integer"
             },
             "TeletextSpacing": {
-              "locationName": "teletextSpacing",
-              "type": "string",
-              "enum": [
-                "FIXED_GRID",
-                "PROPORTIONAL"
-              ]
+              "locationName": "teletextSpacing"
             },
             "XPosition": {
-              "shape": "S1u",
-              "locationName": "xPosition"
+              "locationName": "xPosition",
+              "type": "integer"
             },
             "YPosition": {
-              "shape": "S1u",
-              "locationName": "yPosition"
+              "locationName": "yPosition",
+              "type": "integer"
             }
           }
         },
@@ -3010,14 +2035,7 @@
           "type": "structure",
           "members": {
             "Framerate": {
-              "locationName": "framerate",
-              "type": "string",
-              "enum": [
-                "FRAMERATE_23_97",
-                "FRAMERATE_24",
-                "FRAMERATE_29_97_DROPFRAME",
-                "FRAMERATE_29_97_NON_DROPFRAME"
-              ]
+              "locationName": "framerate"
             }
           }
         },
@@ -3026,7 +2044,6 @@
           "type": "structure",
           "members": {
             "PageNumber": {
-              "shape": "S1d",
               "locationName": "pageNumber"
             }
           }
@@ -3036,62 +2053,24 @@
           "type": "structure",
           "members": {
             "StylePassthrough": {
-              "locationName": "stylePassthrough",
-              "type": "string",
-              "enum": [
-                "ENABLED",
-                "DISABLED"
-              ]
+              "locationName": "stylePassthrough"
             }
           }
         }
       }
     },
-    "S5h": {
-      "type": "integer",
-      "min": 96,
-      "max": 600
-    },
-    "S5i": {
-      "type": "integer",
-      "min": 0,
-      "max": 96
-    },
-    "S5k": {
-      "type": "integer",
-      "min": 0,
-      "max": 10
-    },
     "S60": {
       "type": "structure",
       "members": {
         "Container": {
-          "locationName": "container",
-          "type": "string",
-          "enum": [
-            "F4V",
-            "ISMV",
-            "M2TS",
-            "M3U8",
-            "CMFC",
-            "MOV",
-            "MP4",
-            "MPD",
-            "MXF",
-            "RAW"
-          ]
+          "locationName": "container"
         },
         "F4vSettings": {
           "locationName": "f4vSettings",
           "type": "structure",
           "members": {
             "MoovPlacement": {
-              "locationName": "moovPlacement",
-              "type": "string",
-              "enum": [
-                "PROGRESSIVE_DOWNLOAD",
-                "NORMAL"
-              ]
+              "locationName": "moovPlacement"
             }
           }
         },
@@ -3100,50 +2079,37 @@
           "type": "structure",
           "members": {
             "AudioBufferModel": {
-              "locationName": "audioBufferModel",
-              "type": "string",
-              "enum": [
-                "DVB",
-                "ATSC"
-              ]
+              "locationName": "audioBufferModel"
             },
             "AudioFramesPerPes": {
-              "shape": "S1u",
-              "locationName": "audioFramesPerPes"
+              "locationName": "audioFramesPerPes",
+              "type": "integer"
             },
             "AudioPids": {
               "shape": "S66",
               "locationName": "audioPids"
             },
             "Bitrate": {
-              "shape": "S1u",
-              "locationName": "bitrate"
+              "locationName": "bitrate",
+              "type": "integer"
             },
             "BufferModel": {
-              "locationName": "bufferModel",
-              "type": "string",
-              "enum": [
-                "MULTIPLEX",
-                "NONE"
-              ]
+              "locationName": "bufferModel"
             },
             "DvbNitSettings": {
               "locationName": "dvbNitSettings",
               "type": "structure",
               "members": {
                 "NetworkId": {
-                  "shape": "S1t",
-                  "locationName": "networkId"
+                  "locationName": "networkId",
+                  "type": "integer"
                 },
                 "NetworkName": {
-                  "shape": "S6a",
                   "locationName": "networkName"
                 },
                 "NitInterval": {
                   "locationName": "nitInterval",
-                  "type": "integer",
-                  "min": 25,
-                  "max": 10000
+                  "type": "integer"
                 }
               }
             },
@@ -3152,27 +2118,16 @@
               "type": "structure",
               "members": {
                 "OutputSdt": {
-                  "locationName": "outputSdt",
-                  "type": "string",
-                  "enum": [
-                    "SDT_FOLLOW",
-                    "SDT_FOLLOW_IF_PRESENT",
-                    "SDT_MANUAL",
-                    "SDT_NONE"
-                  ]
+                  "locationName": "outputSdt"
                 },
                 "SdtInterval": {
                   "locationName": "sdtInterval",
-                  "type": "integer",
-                  "min": 25,
-                  "max": 2000
+                  "type": "integer"
                 },
                 "ServiceName": {
-                  "shape": "S6a",
                   "locationName": "serviceName"
                 },
                 "ServiceProviderName": {
-                  "shape": "S6a",
                   "locationName": "serviceProviderName"
                 }
               }
@@ -3187,39 +2142,22 @@
               "members": {
                 "TdtInterval": {
                   "locationName": "tdtInterval",
-                  "type": "integer",
-                  "min": 1000,
-                  "max": 30000
+                  "type": "integer"
                 }
               }
             },
             "DvbTeletextPid": {
-              "shape": "S67",
-              "locationName": "dvbTeletextPid"
+              "locationName": "dvbTeletextPid",
+              "type": "integer"
             },
             "EbpAudioInterval": {
-              "locationName": "ebpAudioInterval",
-              "type": "string",
-              "enum": [
-                "VIDEO_AND_FIXED_INTERVALS",
-                "VIDEO_INTERVAL"
-              ]
+              "locationName": "ebpAudioInterval"
             },
             "EbpPlacement": {
-              "locationName": "ebpPlacement",
-              "type": "string",
-              "enum": [
-                "VIDEO_AND_AUDIO_PIDS",
-                "VIDEO_PID"
-              ]
+              "locationName": "ebpPlacement"
             },
             "EsRateInPes": {
-              "locationName": "esRateInPes",
-              "type": "string",
-              "enum": [
-                "INCLUDE",
-                "EXCLUDE"
-              ]
+              "locationName": "esRateInPes"
             },
             "FragmentTime": {
               "locationName": "fragmentTime",
@@ -3227,115 +2165,77 @@
             },
             "MaxPcrInterval": {
               "locationName": "maxPcrInterval",
-              "type": "integer",
-              "min": 0,
-              "max": 500
+              "type": "integer"
             },
             "MinEbpInterval": {
               "locationName": "minEbpInterval",
-              "type": "integer",
-              "min": 0,
-              "max": 10000
+              "type": "integer"
             },
             "NielsenId3": {
-              "locationName": "nielsenId3",
-              "type": "string",
-              "enum": [
-                "INSERT",
-                "NONE"
-              ]
+              "locationName": "nielsenId3"
             },
             "NullPacketBitrate": {
               "locationName": "nullPacketBitrate",
               "type": "double"
             },
             "PatInterval": {
-              "shape": "S6o",
-              "locationName": "patInterval"
+              "locationName": "patInterval",
+              "type": "integer"
             },
             "PcrControl": {
-              "locationName": "pcrControl",
-              "type": "string",
-              "enum": [
-                "PCR_EVERY_PES_PACKET",
-                "CONFIGURED_PCR_PERIOD"
-              ]
+              "locationName": "pcrControl"
             },
             "PcrPid": {
-              "shape": "S67",
-              "locationName": "pcrPid"
+              "locationName": "pcrPid",
+              "type": "integer"
             },
             "PmtInterval": {
-              "shape": "S6o",
-              "locationName": "pmtInterval"
+              "locationName": "pmtInterval",
+              "type": "integer"
             },
             "PmtPid": {
-              "shape": "S67",
-              "locationName": "pmtPid"
+              "locationName": "pmtPid",
+              "type": "integer"
             },
             "PrivateMetadataPid": {
-              "shape": "S67",
-              "locationName": "privateMetadataPid"
+              "locationName": "privateMetadataPid",
+              "type": "integer"
             },
             "ProgramNumber": {
-              "shape": "S1t",
-              "locationName": "programNumber"
+              "locationName": "programNumber",
+              "type": "integer"
             },
             "RateMode": {
-              "locationName": "rateMode",
-              "type": "string",
-              "enum": [
-                "VBR",
-                "CBR"
-              ]
+              "locationName": "rateMode"
             },
             "Scte35Pid": {
-              "shape": "S67",
-              "locationName": "scte35Pid"
+              "locationName": "scte35Pid",
+              "type": "integer"
             },
             "Scte35Source": {
-              "locationName": "scte35Source",
-              "type": "string",
-              "enum": [
-                "PASSTHROUGH",
-                "NONE"
-              ]
+              "locationName": "scte35Source"
             },
             "SegmentationMarkers": {
-              "locationName": "segmentationMarkers",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "RAI_SEGSTART",
-                "RAI_ADAPT",
-                "PSI_SEGSTART",
-                "EBP",
-                "EBP_LEGACY"
-              ]
+              "locationName": "segmentationMarkers"
             },
             "SegmentationStyle": {
-              "locationName": "segmentationStyle",
-              "type": "string",
-              "enum": [
-                "MAINTAIN_CADENCE",
-                "RESET_CADENCE"
-              ]
+              "locationName": "segmentationStyle"
             },
             "SegmentationTime": {
               "locationName": "segmentationTime",
               "type": "double"
             },
             "TimedMetadataPid": {
-              "shape": "S67",
-              "locationName": "timedMetadataPid"
+              "locationName": "timedMetadataPid",
+              "type": "integer"
             },
             "TransportStreamId": {
-              "shape": "S1t",
-              "locationName": "transportStreamId"
+              "locationName": "transportStreamId",
+              "type": "integer"
             },
             "VideoPid": {
-              "shape": "S67",
-              "locationName": "videoPid"
+              "locationName": "videoPid",
+              "type": "integer"
             }
           }
         },
@@ -3344,84 +2244,64 @@
           "type": "structure",
           "members": {
             "AudioFramesPerPes": {
-              "shape": "S1u",
-              "locationName": "audioFramesPerPes"
+              "locationName": "audioFramesPerPes",
+              "type": "integer"
             },
             "AudioPids": {
               "shape": "S66",
               "locationName": "audioPids"
             },
             "NielsenId3": {
-              "locationName": "nielsenId3",
-              "type": "string",
-              "enum": [
-                "INSERT",
-                "NONE"
-              ]
+              "locationName": "nielsenId3"
             },
             "PatInterval": {
-              "shape": "S6o",
-              "locationName": "patInterval"
+              "locationName": "patInterval",
+              "type": "integer"
             },
             "PcrControl": {
-              "locationName": "pcrControl",
-              "type": "string",
-              "enum": [
-                "PCR_EVERY_PES_PACKET",
-                "CONFIGURED_PCR_PERIOD"
-              ]
+              "locationName": "pcrControl"
             },
             "PcrPid": {
-              "shape": "S67",
-              "locationName": "pcrPid"
+              "locationName": "pcrPid",
+              "type": "integer"
             },
             "PmtInterval": {
-              "shape": "S6o",
-              "locationName": "pmtInterval"
+              "locationName": "pmtInterval",
+              "type": "integer"
             },
             "PmtPid": {
-              "shape": "S67",
-              "locationName": "pmtPid"
+              "locationName": "pmtPid",
+              "type": "integer"
             },
             "PrivateMetadataPid": {
-              "shape": "S67",
-              "locationName": "privateMetadataPid"
+              "locationName": "privateMetadataPid",
+              "type": "integer"
             },
             "ProgramNumber": {
-              "shape": "S1t",
-              "locationName": "programNumber"
+              "locationName": "programNumber",
+              "type": "integer"
             },
             "Scte35Pid": {
-              "shape": "S67",
-              "locationName": "scte35Pid"
+              "locationName": "scte35Pid",
+              "type": "integer"
             },
             "Scte35Source": {
-              "locationName": "scte35Source",
-              "type": "string",
-              "enum": [
-                "PASSTHROUGH",
-                "NONE"
-              ]
+              "locationName": "scte35Source"
             },
             "TimedMetadata": {
-              "locationName": "timedMetadata",
-              "type": "string",
-              "enum": [
-                "PASSTHROUGH",
-                "NONE"
-              ]
+              "locationName": "timedMetadata"
             },
             "TimedMetadataPid": {
-              "shape": "S67",
-              "locationName": "timedMetadataPid"
+              "locationName": "timedMetadataPid",
+              "type": "integer"
             },
             "TransportStreamId": {
-              "shape": "S1t",
-              "locationName": "transportStreamId"
+              "locationName": "transportStreamId",
+              "type": "integer"
             },
             "VideoPid": {
-              "shape": "S67",
-              "locationName": "videoPid"
+              "locationName": "videoPid",
+              "type": "integer"
             }
           }
         },
@@ -3430,44 +2310,19 @@
           "type": "structure",
           "members": {
             "ClapAtom": {
-              "locationName": "clapAtom",
-              "type": "string",
-              "enum": [
-                "INCLUDE",
-                "EXCLUDE"
-              ]
+              "locationName": "clapAtom"
             },
             "CslgAtom": {
-              "locationName": "cslgAtom",
-              "type": "string",
-              "enum": [
-                "INCLUDE",
-                "EXCLUDE"
-              ]
+              "locationName": "cslgAtom"
             },
             "Mpeg2FourCCControl": {
-              "locationName": "mpeg2FourCCControl",
-              "type": "string",
-              "enum": [
-                "XDCAM",
-                "MPEG"
-              ]
+              "locationName": "mpeg2FourCCControl"
             },
             "PaddingControl": {
-              "locationName": "paddingControl",
-              "type": "string",
-              "enum": [
-                "OMNEON",
-                "NONE"
-              ]
+              "locationName": "paddingControl"
             },
             "Reference": {
-              "locationName": "reference",
-              "type": "string",
-              "enum": [
-                "SELF_CONTAINED",
-                "EXTERNAL"
-              ]
+              "locationName": "reference"
             }
           }
         },
@@ -3476,28 +2331,13 @@
           "type": "structure",
           "members": {
             "CslgAtom": {
-              "locationName": "cslgAtom",
-              "type": "string",
-              "enum": [
-                "INCLUDE",
-                "EXCLUDE"
-              ]
+              "locationName": "cslgAtom"
             },
             "FreeSpaceBox": {
-              "locationName": "freeSpaceBox",
-              "type": "string",
-              "enum": [
-                "INCLUDE",
-                "EXCLUDE"
-              ]
+              "locationName": "freeSpaceBox"
             },
             "MoovPlacement": {
-              "locationName": "moovPlacement",
-              "type": "string",
-              "enum": [
-                "PROGRESSIVE_DOWNLOAD",
-                "NORMAL"
-              ]
+              "locationName": "moovPlacement"
             },
             "Mp4MajorBrand": {
               "locationName": "mp4MajorBrand"
@@ -3509,80 +2349,44 @@
     "S66": {
       "type": "list",
       "member": {
-        "shape": "S67"
+        "type": "integer"
       }
-    },
-    "S67": {
-      "type": "integer",
-      "min": 32,
-      "max": 8182
-    },
-    "S6a": {
-      "type": "string",
-      "min": 1,
-      "max": 256
-    },
-    "S6o": {
-      "type": "integer",
-      "min": 0,
-      "max": 1000
     },
     "S7e": {
       "type": "structure",
       "members": {
         "AfdSignaling": {
-          "locationName": "afdSignaling",
-          "type": "string",
-          "enum": [
-            "NONE",
-            "AUTO",
-            "FIXED"
-          ]
+          "locationName": "afdSignaling"
         },
         "AntiAlias": {
-          "locationName": "antiAlias",
-          "type": "string",
-          "enum": [
-            "DISABLED",
-            "ENABLED"
-          ]
+          "locationName": "antiAlias"
         },
         "CodecSettings": {
           "locationName": "codecSettings",
           "type": "structure",
           "members": {
             "Codec": {
-              "locationName": "codec",
-              "type": "string",
-              "enum": [
-                "FRAME_CAPTURE",
-                "H_264",
-                "H_265",
-                "MPEG2",
-                "PRORES"
-              ]
+              "locationName": "codec"
             },
             "FrameCaptureSettings": {
               "locationName": "frameCaptureSettings",
               "type": "structure",
               "members": {
                 "FramerateDenominator": {
-                  "shape": "So",
-                  "locationName": "framerateDenominator"
+                  "locationName": "framerateDenominator",
+                  "type": "integer"
                 },
                 "FramerateNumerator": {
-                  "shape": "So",
-                  "locationName": "framerateNumerator"
+                  "locationName": "framerateNumerator",
+                  "type": "integer"
                 },
                 "MaxCaptures": {
                   "locationName": "maxCaptures",
-                  "type": "integer",
-                  "min": 1,
-                  "max": 10000000
+                  "type": "integer"
                 },
                 "Quality": {
-                  "shape": "S7l",
-                  "locationName": "quality"
+                  "locationName": "quality",
+                  "type": "integer"
                 }
               }
             },
@@ -3591,293 +2395,147 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "OFF",
-                    "LOW",
-                    "MEDIUM",
-                    "HIGH",
-                    "HIGHER",
-                    "MAX"
-                  ]
+                  "locationName": "adaptiveQuantization"
                 },
                 "Bitrate": {
-                  "shape": "S7o",
-                  "locationName": "bitrate"
+                  "locationName": "bitrate",
+                  "type": "integer"
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel",
-                  "type": "string",
-                  "enum": [
-                    "AUTO",
-                    "LEVEL_1",
-                    "LEVEL_1_1",
-                    "LEVEL_1_2",
-                    "LEVEL_1_3",
-                    "LEVEL_2",
-                    "LEVEL_2_1",
-                    "LEVEL_2_2",
-                    "LEVEL_3",
-                    "LEVEL_3_1",
-                    "LEVEL_3_2",
-                    "LEVEL_4",
-                    "LEVEL_4_1",
-                    "LEVEL_4_2",
-                    "LEVEL_5",
-                    "LEVEL_5_1",
-                    "LEVEL_5_2"
-                  ]
+                  "locationName": "codecLevel"
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile",
-                  "type": "string",
-                  "enum": [
-                    "BASELINE",
-                    "HIGH",
-                    "HIGH_10BIT",
-                    "HIGH_422",
-                    "HIGH_422_10BIT",
-                    "MAIN"
-                  ]
+                  "locationName": "codecProfile"
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop",
-                  "type": "string",
-                  "enum": [
-                    "ADAPTIVE",
-                    "STATIC"
-                  ]
+                  "locationName": "dynamicSubGop"
                 },
                 "EntropyEncoding": {
-                  "locationName": "entropyEncoding",
-                  "type": "string",
-                  "enum": [
-                    "CABAC",
-                    "CAVLC"
-                  ]
+                  "locationName": "entropyEncoding"
                 },
                 "FieldEncoding": {
-                  "locationName": "fieldEncoding",
-                  "type": "string",
-                  "enum": [
-                    "PAFF",
-                    "FORCE_FIELD"
-                  ]
+                  "locationName": "fieldEncoding"
                 },
                 "FlickerAdaptiveQuantization": {
-                  "locationName": "flickerAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "flickerAdaptiveQuantization"
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "framerateControl"
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm",
-                  "type": "string",
-                  "enum": [
-                    "DUPLICATE_DROP",
-                    "INTERPOLATE"
-                  ]
+                  "locationName": "framerateConversionAlgorithm"
                 },
                 "FramerateDenominator": {
-                  "shape": "So",
-                  "locationName": "framerateDenominator"
+                  "locationName": "framerateDenominator",
+                  "type": "integer"
                 },
                 "FramerateNumerator": {
-                  "shape": "So",
-                  "locationName": "framerateNumerator"
+                  "locationName": "framerateNumerator",
+                  "type": "integer"
                 },
                 "GopBReference": {
-                  "locationName": "gopBReference",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "gopBReference"
                 },
                 "GopClosedCadence": {
-                  "shape": "S1u",
-                  "locationName": "gopClosedCadence"
+                  "locationName": "gopClosedCadence",
+                  "type": "integer"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits",
-                  "type": "string",
-                  "enum": [
-                    "FRAMES",
-                    "SECONDS"
-                  ]
+                  "locationName": "gopSizeUnits"
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "shape": "S7z",
-                  "locationName": "hrdBufferInitialFillPercentage"
+                  "locationName": "hrdBufferInitialFillPercentage",
+                  "type": "integer"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer",
-                  "min": 0,
-                  "max": 1152000000
+                  "type": "integer"
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode",
-                  "type": "string",
-                  "enum": [
-                    "PROGRESSIVE",
-                    "TOP_FIELD",
-                    "BOTTOM_FIELD",
-                    "FOLLOW_TOP_FIELD",
-                    "FOLLOW_BOTTOM_FIELD"
-                  ]
+                  "locationName": "interlaceMode"
                 },
                 "MaxBitrate": {
-                  "shape": "S7o",
-                  "locationName": "maxBitrate"
+                  "locationName": "maxBitrate",
+                  "type": "integer"
                 },
                 "MinIInterval": {
-                  "shape": "S82",
-                  "locationName": "minIInterval"
+                  "locationName": "minIInterval",
+                  "type": "integer"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "shape": "S83",
-                  "locationName": "numberBFramesBetweenReferenceFrames"
+                  "locationName": "numberBFramesBetweenReferenceFrames",
+                  "type": "integer"
                 },
                 "NumberReferenceFrames": {
-                  "shape": "S84",
-                  "locationName": "numberReferenceFrames"
+                  "locationName": "numberReferenceFrames",
+                  "type": "integer"
                 },
                 "ParControl": {
-                  "locationName": "parControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "parControl"
                 },
                 "ParDenominator": {
-                  "shape": "So",
-                  "locationName": "parDenominator"
+                  "locationName": "parDenominator",
+                  "type": "integer"
                 },
                 "ParNumerator": {
-                  "shape": "So",
-                  "locationName": "parNumerator"
+                  "locationName": "parNumerator",
+                  "type": "integer"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel",
-                  "type": "string",
-                  "enum": [
-                    "SINGLE_PASS",
-                    "SINGLE_PASS_HQ",
-                    "MULTI_PASS_HQ"
-                  ]
+                  "locationName": "qualityTuningLevel"
                 },
                 "QvbrSettings": {
                   "locationName": "qvbrSettings",
                   "type": "structure",
                   "members": {
                     "MaxAverageBitrate": {
-                      "shape": "S7o",
-                      "locationName": "maxAverageBitrate"
+                      "locationName": "maxAverageBitrate",
+                      "type": "integer"
                     },
                     "QvbrQualityLevel": {
-                      "shape": "S88",
-                      "locationName": "qvbrQualityLevel"
+                      "locationName": "qvbrQualityLevel",
+                      "type": "integer"
                     }
                   }
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode",
-                  "type": "string",
-                  "enum": [
-                    "VBR",
-                    "CBR",
-                    "QVBR"
-                  ]
+                  "locationName": "rateControlMode"
                 },
                 "RepeatPps": {
-                  "locationName": "repeatPps",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "repeatPps"
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "sceneChangeDetect"
                 },
                 "Slices": {
-                  "shape": "S8c",
-                  "locationName": "slices"
+                  "locationName": "slices",
+                  "type": "integer"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "slowPal"
                 },
                 "Softness": {
-                  "shape": "S8e",
-                  "locationName": "softness"
+                  "locationName": "softness",
+                  "type": "integer"
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "spatialAdaptiveQuantization"
                 },
                 "Syntax": {
-                  "locationName": "syntax",
-                  "type": "string",
-                  "enum": [
-                    "DEFAULT",
-                    "RP2027"
-                  ]
+                  "locationName": "syntax"
                 },
                 "Telecine": {
-                  "locationName": "telecine",
-                  "type": "string",
-                  "enum": [
-                    "NONE",
-                    "SOFT",
-                    "HARD"
-                  ]
+                  "locationName": "telecine"
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "temporalAdaptiveQuantization"
                 },
                 "UnregisteredSeiTimecode": {
-                  "locationName": "unregisteredSeiTimecode",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "unregisteredSeiTimecode"
                 }
               }
             },
@@ -3886,297 +2544,146 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "OFF",
-                    "LOW",
-                    "MEDIUM",
-                    "HIGH",
-                    "HIGHER",
-                    "MAX"
-                  ]
+                  "locationName": "adaptiveQuantization"
                 },
                 "AlternateTransferFunctionSei": {
-                  "locationName": "alternateTransferFunctionSei",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "alternateTransferFunctionSei"
                 },
                 "Bitrate": {
-                  "shape": "S8n",
-                  "locationName": "bitrate"
+                  "locationName": "bitrate",
+                  "type": "integer"
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel",
-                  "type": "string",
-                  "enum": [
-                    "AUTO",
-                    "LEVEL_1",
-                    "LEVEL_2",
-                    "LEVEL_2_1",
-                    "LEVEL_3",
-                    "LEVEL_3_1",
-                    "LEVEL_4",
-                    "LEVEL_4_1",
-                    "LEVEL_5",
-                    "LEVEL_5_1",
-                    "LEVEL_5_2",
-                    "LEVEL_6",
-                    "LEVEL_6_1",
-                    "LEVEL_6_2"
-                  ]
+                  "locationName": "codecLevel"
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile",
-                  "type": "string",
-                  "enum": [
-                    "MAIN_MAIN",
-                    "MAIN_HIGH",
-                    "MAIN10_MAIN",
-                    "MAIN10_HIGH",
-                    "MAIN_422_8BIT_MAIN",
-                    "MAIN_422_8BIT_HIGH",
-                    "MAIN_422_10BIT_MAIN",
-                    "MAIN_422_10BIT_HIGH"
-                  ]
+                  "locationName": "codecProfile"
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop",
-                  "type": "string",
-                  "enum": [
-                    "ADAPTIVE",
-                    "STATIC"
-                  ]
+                  "locationName": "dynamicSubGop"
                 },
                 "FlickerAdaptiveQuantization": {
-                  "locationName": "flickerAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "flickerAdaptiveQuantization"
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "framerateControl"
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm",
-                  "type": "string",
-                  "enum": [
-                    "DUPLICATE_DROP",
-                    "INTERPOLATE"
-                  ]
+                  "locationName": "framerateConversionAlgorithm"
                 },
                 "FramerateDenominator": {
-                  "shape": "So",
-                  "locationName": "framerateDenominator"
+                  "locationName": "framerateDenominator",
+                  "type": "integer"
                 },
                 "FramerateNumerator": {
-                  "shape": "So",
-                  "locationName": "framerateNumerator"
+                  "locationName": "framerateNumerator",
+                  "type": "integer"
                 },
                 "GopBReference": {
-                  "locationName": "gopBReference",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "gopBReference"
                 },
                 "GopClosedCadence": {
-                  "shape": "S1u",
-                  "locationName": "gopClosedCadence"
+                  "locationName": "gopClosedCadence",
+                  "type": "integer"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits",
-                  "type": "string",
-                  "enum": [
-                    "FRAMES",
-                    "SECONDS"
-                  ]
+                  "locationName": "gopSizeUnits"
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "shape": "S7z",
-                  "locationName": "hrdBufferInitialFillPercentage"
+                  "locationName": "hrdBufferInitialFillPercentage",
+                  "type": "integer"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer",
-                  "min": 0,
-                  "max": 1466400000
+                  "type": "integer"
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode",
-                  "type": "string",
-                  "enum": [
-                    "PROGRESSIVE",
-                    "TOP_FIELD",
-                    "BOTTOM_FIELD",
-                    "FOLLOW_TOP_FIELD",
-                    "FOLLOW_BOTTOM_FIELD"
-                  ]
+                  "locationName": "interlaceMode"
                 },
                 "MaxBitrate": {
-                  "shape": "S8n",
-                  "locationName": "maxBitrate"
+                  "locationName": "maxBitrate",
+                  "type": "integer"
                 },
                 "MinIInterval": {
-                  "shape": "S82",
-                  "locationName": "minIInterval"
+                  "locationName": "minIInterval",
+                  "type": "integer"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "shape": "S83",
-                  "locationName": "numberBFramesBetweenReferenceFrames"
+                  "locationName": "numberBFramesBetweenReferenceFrames",
+                  "type": "integer"
                 },
                 "NumberReferenceFrames": {
-                  "shape": "S84",
-                  "locationName": "numberReferenceFrames"
+                  "locationName": "numberReferenceFrames",
+                  "type": "integer"
                 },
                 "ParControl": {
-                  "locationName": "parControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "parControl"
                 },
                 "ParDenominator": {
-                  "shape": "So",
-                  "locationName": "parDenominator"
+                  "locationName": "parDenominator",
+                  "type": "integer"
                 },
                 "ParNumerator": {
-                  "shape": "So",
-                  "locationName": "parNumerator"
+                  "locationName": "parNumerator",
+                  "type": "integer"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel",
-                  "type": "string",
-                  "enum": [
-                    "SINGLE_PASS",
-                    "SINGLE_PASS_HQ",
-                    "MULTI_PASS_HQ"
-                  ]
+                  "locationName": "qualityTuningLevel"
                 },
                 "QvbrSettings": {
                   "locationName": "qvbrSettings",
                   "type": "structure",
                   "members": {
                     "MaxAverageBitrate": {
-                      "shape": "S8n",
-                      "locationName": "maxAverageBitrate"
+                      "locationName": "maxAverageBitrate",
+                      "type": "integer"
                     },
                     "QvbrQualityLevel": {
-                      "shape": "S88",
-                      "locationName": "qvbrQualityLevel"
+                      "locationName": "qvbrQualityLevel",
+                      "type": "integer"
                     }
                   }
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode",
-                  "type": "string",
-                  "enum": [
-                    "VBR",
-                    "CBR",
-                    "QVBR"
-                  ]
+                  "locationName": "rateControlMode"
                 },
                 "SampleAdaptiveOffsetFilterMode": {
-                  "locationName": "sampleAdaptiveOffsetFilterMode",
-                  "type": "string",
-                  "enum": [
-                    "DEFAULT",
-                    "ADAPTIVE",
-                    "OFF"
-                  ]
+                  "locationName": "sampleAdaptiveOffsetFilterMode"
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "sceneChangeDetect"
                 },
                 "Slices": {
-                  "shape": "S8c",
-                  "locationName": "slices"
+                  "locationName": "slices",
+                  "type": "integer"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "slowPal"
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "spatialAdaptiveQuantization"
                 },
                 "Telecine": {
-                  "locationName": "telecine",
-                  "type": "string",
-                  "enum": [
-                    "NONE",
-                    "SOFT",
-                    "HARD"
-                  ]
+                  "locationName": "telecine"
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "temporalAdaptiveQuantization"
                 },
                 "TemporalIds": {
-                  "locationName": "temporalIds",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "temporalIds"
                 },
                 "Tiles": {
-                  "locationName": "tiles",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "tiles"
                 },
                 "UnregisteredSeiTimecode": {
-                  "locationName": "unregisteredSeiTimecode",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "unregisteredSeiTimecode"
                 },
                 "WriteMp4PackagingType": {
-                  "locationName": "writeMp4PackagingType",
-                  "type": "string",
-                  "enum": [
-                    "HVC1",
-                    "HEV1"
-                  ]
+                  "locationName": "writeMp4PackagingType"
                 }
               }
             },
@@ -4185,222 +2692,110 @@
               "type": "structure",
               "members": {
                 "AdaptiveQuantization": {
-                  "locationName": "adaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "OFF",
-                    "LOW",
-                    "MEDIUM",
-                    "HIGH"
-                  ]
+                  "locationName": "adaptiveQuantization"
                 },
                 "Bitrate": {
                   "locationName": "bitrate",
-                  "type": "integer",
-                  "min": 1000,
-                  "max": 288000000
+                  "type": "integer"
                 },
                 "CodecLevel": {
-                  "locationName": "codecLevel",
-                  "type": "string",
-                  "enum": [
-                    "AUTO",
-                    "LOW",
-                    "MAIN",
-                    "HIGH1440",
-                    "HIGH"
-                  ]
+                  "locationName": "codecLevel"
                 },
                 "CodecProfile": {
-                  "locationName": "codecProfile",
-                  "type": "string",
-                  "enum": [
-                    "MAIN",
-                    "PROFILE_422"
-                  ]
+                  "locationName": "codecProfile"
                 },
                 "DynamicSubGop": {
-                  "locationName": "dynamicSubGop",
-                  "type": "string",
-                  "enum": [
-                    "ADAPTIVE",
-                    "STATIC"
-                  ]
+                  "locationName": "dynamicSubGop"
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "framerateControl"
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm",
-                  "type": "string",
-                  "enum": [
-                    "DUPLICATE_DROP",
-                    "INTERPOLATE"
-                  ]
+                  "locationName": "framerateConversionAlgorithm"
                 },
                 "FramerateDenominator": {
                   "locationName": "framerateDenominator",
-                  "type": "integer",
-                  "min": 1,
-                  "max": 1001
+                  "type": "integer"
                 },
                 "FramerateNumerator": {
                   "locationName": "framerateNumerator",
-                  "type": "integer",
-                  "min": 24,
-                  "max": 60000
+                  "type": "integer"
                 },
                 "GopClosedCadence": {
-                  "shape": "S1u",
-                  "locationName": "gopClosedCadence"
+                  "locationName": "gopClosedCadence",
+                  "type": "integer"
                 },
                 "GopSize": {
                   "locationName": "gopSize",
                   "type": "double"
                 },
                 "GopSizeUnits": {
-                  "locationName": "gopSizeUnits",
-                  "type": "string",
-                  "enum": [
-                    "FRAMES",
-                    "SECONDS"
-                  ]
+                  "locationName": "gopSizeUnits"
                 },
                 "HrdBufferInitialFillPercentage": {
-                  "shape": "S7z",
-                  "locationName": "hrdBufferInitialFillPercentage"
+                  "locationName": "hrdBufferInitialFillPercentage",
+                  "type": "integer"
                 },
                 "HrdBufferSize": {
                   "locationName": "hrdBufferSize",
-                  "type": "integer",
-                  "min": 0,
-                  "max": 47185920
+                  "type": "integer"
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode",
-                  "type": "string",
-                  "enum": [
-                    "PROGRESSIVE",
-                    "TOP_FIELD",
-                    "BOTTOM_FIELD",
-                    "FOLLOW_TOP_FIELD",
-                    "FOLLOW_BOTTOM_FIELD"
-                  ]
+                  "locationName": "interlaceMode"
                 },
                 "IntraDcPrecision": {
-                  "locationName": "intraDcPrecision",
-                  "type": "string",
-                  "enum": [
-                    "AUTO",
-                    "INTRA_DC_PRECISION_8",
-                    "INTRA_DC_PRECISION_9",
-                    "INTRA_DC_PRECISION_10",
-                    "INTRA_DC_PRECISION_11"
-                  ]
+                  "locationName": "intraDcPrecision"
                 },
                 "MaxBitrate": {
                   "locationName": "maxBitrate",
-                  "type": "integer",
-                  "min": 1000,
-                  "max": 300000000
+                  "type": "integer"
                 },
                 "MinIInterval": {
-                  "shape": "S82",
-                  "locationName": "minIInterval"
+                  "locationName": "minIInterval",
+                  "type": "integer"
                 },
                 "NumberBFramesBetweenReferenceFrames": {
-                  "shape": "S83",
-                  "locationName": "numberBFramesBetweenReferenceFrames"
+                  "locationName": "numberBFramesBetweenReferenceFrames",
+                  "type": "integer"
                 },
                 "ParControl": {
-                  "locationName": "parControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "parControl"
                 },
                 "ParDenominator": {
-                  "shape": "So",
-                  "locationName": "parDenominator"
+                  "locationName": "parDenominator",
+                  "type": "integer"
                 },
                 "ParNumerator": {
-                  "shape": "So",
-                  "locationName": "parNumerator"
+                  "locationName": "parNumerator",
+                  "type": "integer"
                 },
                 "QualityTuningLevel": {
-                  "locationName": "qualityTuningLevel",
-                  "type": "string",
-                  "enum": [
-                    "SINGLE_PASS",
-                    "MULTI_PASS"
-                  ]
+                  "locationName": "qualityTuningLevel"
                 },
                 "RateControlMode": {
-                  "locationName": "rateControlMode",
-                  "type": "string",
-                  "enum": [
-                    "VBR",
-                    "CBR"
-                  ]
+                  "locationName": "rateControlMode"
                 },
                 "SceneChangeDetect": {
-                  "locationName": "sceneChangeDetect",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "sceneChangeDetect"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "slowPal"
                 },
                 "Softness": {
-                  "shape": "S8e",
-                  "locationName": "softness"
+                  "locationName": "softness",
+                  "type": "integer"
                 },
                 "SpatialAdaptiveQuantization": {
-                  "locationName": "spatialAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "spatialAdaptiveQuantization"
                 },
                 "Syntax": {
-                  "locationName": "syntax",
-                  "type": "string",
-                  "enum": [
-                    "DEFAULT",
-                    "D_10"
-                  ]
+                  "locationName": "syntax"
                 },
                 "Telecine": {
-                  "locationName": "telecine",
-                  "type": "string",
-                  "enum": [
-                    "NONE",
-                    "SOFT",
-                    "HARD"
-                  ]
+                  "locationName": "telecine"
                 },
                 "TemporalAdaptiveQuantization": {
-                  "locationName": "temporalAdaptiveQuantization",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "temporalAdaptiveQuantization"
                 }
               }
             },
@@ -4409,150 +2804,80 @@
               "type": "structure",
               "members": {
                 "CodecProfile": {
-                  "locationName": "codecProfile",
-                  "type": "string",
-                  "enum": [
-                    "APPLE_PRORES_422",
-                    "APPLE_PRORES_422_HQ",
-                    "APPLE_PRORES_422_LT",
-                    "APPLE_PRORES_422_PROXY"
-                  ]
+                  "locationName": "codecProfile"
                 },
                 "FramerateControl": {
-                  "locationName": "framerateControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "framerateControl"
                 },
                 "FramerateConversionAlgorithm": {
-                  "locationName": "framerateConversionAlgorithm",
-                  "type": "string",
-                  "enum": [
-                    "DUPLICATE_DROP",
-                    "INTERPOLATE"
-                  ]
+                  "locationName": "framerateConversionAlgorithm"
                 },
                 "FramerateDenominator": {
-                  "shape": "So",
-                  "locationName": "framerateDenominator"
+                  "locationName": "framerateDenominator",
+                  "type": "integer"
                 },
                 "FramerateNumerator": {
-                  "shape": "So",
-                  "locationName": "framerateNumerator"
+                  "locationName": "framerateNumerator",
+                  "type": "integer"
                 },
                 "InterlaceMode": {
-                  "locationName": "interlaceMode",
-                  "type": "string",
-                  "enum": [
-                    "PROGRESSIVE",
-                    "TOP_FIELD",
-                    "BOTTOM_FIELD",
-                    "FOLLOW_TOP_FIELD",
-                    "FOLLOW_BOTTOM_FIELD"
-                  ]
+                  "locationName": "interlaceMode"
                 },
                 "ParControl": {
-                  "locationName": "parControl",
-                  "type": "string",
-                  "enum": [
-                    "INITIALIZE_FROM_SOURCE",
-                    "SPECIFIED"
-                  ]
+                  "locationName": "parControl"
                 },
                 "ParDenominator": {
-                  "shape": "So",
-                  "locationName": "parDenominator"
+                  "locationName": "parDenominator",
+                  "type": "integer"
                 },
                 "ParNumerator": {
-                  "shape": "So",
-                  "locationName": "parNumerator"
+                  "locationName": "parNumerator",
+                  "type": "integer"
                 },
                 "SlowPal": {
-                  "locationName": "slowPal",
-                  "type": "string",
-                  "enum": [
-                    "DISABLED",
-                    "ENABLED"
-                  ]
+                  "locationName": "slowPal"
                 },
                 "Telecine": {
-                  "locationName": "telecine",
-                  "type": "string",
-                  "enum": [
-                    "NONE",
-                    "HARD"
-                  ]
+                  "locationName": "telecine"
                 }
               }
             }
           }
         },
         "ColorMetadata": {
-          "locationName": "colorMetadata",
-          "type": "string",
-          "enum": [
-            "IGNORE",
-            "INSERT"
-          ]
+          "locationName": "colorMetadata"
         },
         "Crop": {
           "shape": "Sa9",
           "locationName": "crop"
         },
         "DropFrameTimecode": {
-          "locationName": "dropFrameTimecode",
-          "type": "string",
-          "enum": [
-            "DISABLED",
-            "ENABLED"
-          ]
+          "locationName": "dropFrameTimecode"
         },
         "FixedAfd": {
           "locationName": "fixedAfd",
-          "type": "integer",
-          "min": 0,
-          "max": 15
+          "type": "integer"
         },
         "Height": {
           "locationName": "height",
-          "type": "integer",
-          "min": 32,
-          "max": 2160
+          "type": "integer"
         },
         "Position": {
           "shape": "Sa9",
           "locationName": "position"
         },
         "RespondToAfd": {
-          "locationName": "respondToAfd",
-          "type": "string",
-          "enum": [
-            "NONE",
-            "RESPOND",
-            "PASSTHROUGH"
-          ]
+          "locationName": "respondToAfd"
         },
         "ScalingBehavior": {
-          "locationName": "scalingBehavior",
-          "type": "string",
-          "enum": [
-            "DEFAULT",
-            "STRETCH_TO_OUTPUT"
-          ]
+          "locationName": "scalingBehavior"
         },
         "Sharpness": {
-          "shape": "S7z",
-          "locationName": "sharpness"
+          "locationName": "sharpness",
+          "type": "integer"
         },
         "TimecodeInsertion": {
-          "locationName": "timecodeInsertion",
-          "type": "string",
-          "enum": [
-            "DISABLED",
-            "PIC_TIMING_SEI"
-          ]
+          "locationName": "timecodeInsertion"
         },
         "VideoPreprocessors": {
           "locationName": "videoPreprocessors",
@@ -4563,23 +2888,15 @@
               "type": "structure",
               "members": {
                 "Brightness": {
-                  "shape": "S7l",
-                  "locationName": "brightness"
+                  "locationName": "brightness",
+                  "type": "integer"
                 },
                 "ColorSpaceConversion": {
-                  "locationName": "colorSpaceConversion",
-                  "type": "string",
-                  "enum": [
-                    "NONE",
-                    "FORCE_601",
-                    "FORCE_709",
-                    "FORCE_HDR10",
-                    "FORCE_HLG_2020"
-                  ]
+                  "locationName": "colorSpaceConversion"
                 },
                 "Contrast": {
-                  "shape": "S7l",
-                  "locationName": "contrast"
+                  "locationName": "contrast",
+                  "type": "integer"
                 },
                 "Hdr10Metadata": {
                   "shape": "S1r",
@@ -4587,13 +2904,11 @@
                 },
                 "Hue": {
                   "locationName": "hue",
-                  "type": "integer",
-                  "min": -180,
-                  "max": 180
+                  "type": "integer"
                 },
                 "Saturation": {
-                  "shape": "S7l",
-                  "locationName": "saturation"
+                  "locationName": "saturation",
+                  "type": "integer"
                 }
               }
             },
@@ -4602,31 +2917,13 @@
               "type": "structure",
               "members": {
                 "Algorithm": {
-                  "locationName": "algorithm",
-                  "type": "string",
-                  "enum": [
-                    "INTERPOLATE",
-                    "INTERPOLATE_TICKER",
-                    "BLEND",
-                    "BLEND_TICKER"
-                  ]
+                  "locationName": "algorithm"
                 },
                 "Control": {
-                  "locationName": "control",
-                  "type": "string",
-                  "enum": [
-                    "FORCE_ALL_FRAMES",
-                    "NORMAL"
-                  ]
+                  "locationName": "control"
                 },
                 "Mode": {
-                  "locationName": "mode",
-                  "type": "string",
-                  "enum": [
-                    "DEINTERLACE",
-                    "INVERSE_TELECINE",
-                    "ADAPTIVE"
-                  ]
+                  "locationName": "mode"
                 }
               }
             },
@@ -4641,53 +2938,46 @@
                     "type": "structure",
                     "members": {
                       "Duration": {
-                        "shape": "Sm",
-                        "locationName": "duration"
+                        "locationName": "duration",
+                        "type": "integer"
                       },
                       "FadeIn": {
-                        "shape": "Sm",
-                        "locationName": "fadeIn"
+                        "locationName": "fadeIn",
+                        "type": "integer"
                       },
                       "FadeOut": {
-                        "shape": "Sm",
-                        "locationName": "fadeOut"
+                        "locationName": "fadeOut",
+                        "type": "integer"
                       },
                       "Height": {
-                        "shape": "Sm",
-                        "locationName": "height"
+                        "locationName": "height",
+                        "type": "integer"
                       },
                       "ImageInserterInput": {
-                        "locationName": "imageInserterInput",
-                        "type": "string",
-                        "min": 14,
-                        "pattern": "^(s3:\\/\\/)(.*?)\\.(bmp|BMP|png|PNG|tga|TGA)$"
+                        "locationName": "imageInserterInput"
                       },
                       "ImageX": {
-                        "shape": "Sm",
-                        "locationName": "imageX"
+                        "locationName": "imageX",
+                        "type": "integer"
                       },
                       "ImageY": {
-                        "shape": "Sm",
-                        "locationName": "imageY"
+                        "locationName": "imageY",
+                        "type": "integer"
                       },
                       "Layer": {
                         "locationName": "layer",
-                        "type": "integer",
-                        "min": 0,
-                        "max": 99
+                        "type": "integer"
                       },
                       "Opacity": {
-                        "shape": "S7z",
-                        "locationName": "opacity"
+                        "locationName": "opacity",
+                        "type": "integer"
                       },
                       "StartTime": {
-                        "locationName": "startTime",
-                        "type": "string",
-                        "pattern": "^((([0-1]\\d)|(2[0-3]))(:[0-5]\\d){2}([:;][0-5]\\d))$"
+                        "locationName": "startTime"
                       },
                       "Width": {
-                        "shape": "Sm",
-                        "locationName": "width"
+                        "locationName": "width",
+                        "type": "integer"
                       }
                     }
                   }
@@ -4699,25 +2989,15 @@
               "type": "structure",
               "members": {
                 "Filter": {
-                  "locationName": "filter",
-                  "type": "string",
-                  "enum": [
-                    "BILATERAL",
-                    "MEAN",
-                    "GAUSSIAN",
-                    "LANCZOS",
-                    "SHARPEN",
-                    "CONSERVE",
-                    "SPATIAL"
-                  ]
+                  "locationName": "filter"
                 },
                 "FilterSettings": {
                   "locationName": "filterSettings",
                   "type": "structure",
                   "members": {
                     "Strength": {
-                      "shape": "Say",
-                      "locationName": "strength"
+                      "locationName": "strength",
+                      "type": "integer"
                     }
                   }
                 },
@@ -4726,20 +3006,16 @@
                   "type": "structure",
                   "members": {
                     "PostFilterSharpenStrength": {
-                      "shape": "Say",
-                      "locationName": "postFilterSharpenStrength"
+                      "locationName": "postFilterSharpenStrength",
+                      "type": "integer"
                     },
                     "Speed": {
                       "locationName": "speed",
-                      "type": "integer",
-                      "min": -2,
-                      "max": 3
+                      "type": "integer"
                     },
                     "Strength": {
                       "locationName": "strength",
-                      "type": "integer",
-                      "min": 0,
-                      "max": 16
+                      "type": "integer"
                     }
                   }
                 }
@@ -4751,29 +3027,13 @@
               "members": {
                 "FontSize": {
                   "locationName": "fontSize",
-                  "type": "integer",
-                  "min": 10,
-                  "max": 48
+                  "type": "integer"
                 },
                 "Position": {
-                  "locationName": "position",
-                  "type": "string",
-                  "enum": [
-                    "TOP_CENTER",
-                    "TOP_LEFT",
-                    "TOP_RIGHT",
-                    "MIDDLE_LEFT",
-                    "MIDDLE_CENTER",
-                    "MIDDLE_RIGHT",
-                    "BOTTOM_LEFT",
-                    "BOTTOM_CENTER",
-                    "BOTTOM_RIGHT"
-                  ]
+                  "locationName": "position"
                 },
                 "Prefix": {
-                  "locationName": "prefix",
-                  "type": "string",
-                  "pattern": "^[ -~]+$"
+                  "locationName": "prefix"
                 }
               }
             }
@@ -4781,117 +3041,45 @@
         },
         "Width": {
           "locationName": "width",
-          "type": "integer",
-          "min": 32,
-          "max": 4096
+          "type": "integer"
         }
       }
-    },
-    "S7l": {
-      "type": "integer",
-      "min": 1,
-      "max": 100
-    },
-    "S7o": {
-      "type": "integer",
-      "min": 1000,
-      "max": 1152000000
-    },
-    "S7z": {
-      "type": "integer",
-      "min": 0,
-      "max": 100
-    },
-    "S82": {
-      "type": "integer",
-      "min": 0,
-      "max": 30
-    },
-    "S83": {
-      "type": "integer",
-      "min": 0,
-      "max": 7
-    },
-    "S84": {
-      "type": "integer",
-      "min": 1,
-      "max": 6
-    },
-    "S88": {
-      "type": "integer",
-      "min": 1,
-      "max": 10
-    },
-    "S8c": {
-      "type": "integer",
-      "min": 1,
-      "max": 32
-    },
-    "S8e": {
-      "type": "integer",
-      "min": 0,
-      "max": 128
-    },
-    "S8n": {
-      "type": "integer",
-      "min": 1000,
-      "max": 1466400000
     },
     "Sa9": {
       "type": "structure",
       "members": {
         "Height": {
-          "shape": "Saa",
-          "locationName": "height"
+          "locationName": "height",
+          "type": "integer"
         },
         "Width": {
-          "shape": "Saa",
-          "locationName": "width"
+          "locationName": "width",
+          "type": "integer"
         },
         "X": {
-          "shape": "S1u",
-          "locationName": "x"
+          "locationName": "x",
+          "type": "integer"
         },
         "Y": {
-          "shape": "S1u",
-          "locationName": "y"
+          "locationName": "y",
+          "type": "integer"
         }
       }
-    },
-    "Saa": {
-      "type": "integer",
-      "min": 2,
-      "max": 2147483647
-    },
-    "Say": {
-      "type": "integer",
-      "min": 0,
-      "max": 3
     },
     "Sb7": {
       "type": "structure",
       "members": {
         "Anchor": {
-          "shape": "S1l",
           "locationName": "anchor"
         },
         "Source": {
-          "locationName": "source",
-          "type": "string",
-          "enum": [
-            "EMBEDDED",
-            "ZEROBASED",
-            "SPECIFIEDSTART"
-          ]
+          "locationName": "source"
         },
         "Start": {
-          "shape": "S1l",
           "locationName": "start"
         },
         "TimestampOffset": {
-          "locationName": "timestampOffset",
-          "type": "string",
-          "pattern": "^([0-9]{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
+          "locationName": "timestampOffset"
         }
       }
     },
@@ -4905,12 +3093,9 @@
             "type": "structure",
             "members": {
               "Id3": {
-                "locationName": "id3",
-                "type": "string",
-                "pattern": "^[A-Za-z0-9+\\/]+={0,2}$"
+                "locationName": "id3"
               },
               "Timecode": {
-                "shape": "S1l",
                 "locationName": "timecode"
               }
             }
@@ -4930,7 +3115,6 @@
           "locationName": "arn"
         },
         "BillingTagsSource": {
-          "shape": "S5",
           "locationName": "billingTagsSource"
         },
         "CreatedAt": {
@@ -4997,7 +3181,6 @@
           "locationName": "settings"
         },
         "Status": {
-          "shape": "Sbo",
           "locationName": "status"
         },
         "Timing": {
@@ -5032,22 +3215,12 @@
       "type": "timestamp",
       "timestampFormat": "unixTimestamp"
     },
-    "Sbo": {
-      "type": "string",
-      "enum": [
-        "SUBMITTED",
-        "PROGRESSING",
-        "COMPLETE",
-        "CANCELED",
-        "ERROR"
-      ]
-    },
     "Sbr": {
       "type": "structure",
       "members": {
         "AdAvailOffset": {
-          "shape": "S7",
-          "locationName": "adAvailOffset"
+          "locationName": "adAvailOffset",
+          "type": "integer"
         },
         "AvailBlanking": {
           "shape": "S8",
@@ -5072,35 +3245,30 @@
                 "locationName": "captionSelectors"
               },
               "DeblockFilter": {
-                "shape": "S1e",
                 "locationName": "deblockFilter"
               },
               "DenoiseFilter": {
-                "shape": "S1f",
                 "locationName": "denoiseFilter"
               },
               "FilterEnable": {
-                "shape": "S1h",
                 "locationName": "filterEnable"
               },
               "FilterStrength": {
-                "shape": "S1i",
-                "locationName": "filterStrength"
+                "locationName": "filterStrength",
+                "type": "integer"
               },
               "InputClippings": {
                 "shape": "S1j",
                 "locationName": "inputClippings"
               },
               "ProgramNumber": {
-                "shape": "So",
-                "locationName": "programNumber"
+                "locationName": "programNumber",
+                "type": "integer"
               },
               "PsiControl": {
-                "shape": "S1m",
                 "locationName": "psiControl"
               },
               "TimecodeSource": {
-                "shape": "S1n",
                 "locationName": "timecodeSource"
               },
               "VideoSelector": {
@@ -5159,20 +3327,12 @@
           "locationName": "settings"
         },
         "Type": {
-          "shape": "Sbw",
           "locationName": "type"
         }
       },
       "required": [
         "Settings",
         "Name"
-      ]
-    },
-    "Sbw": {
-      "type": "string",
-      "enum": [
-        "SYSTEM",
-        "CUSTOM"
       ]
     },
     "Sby": {
@@ -5189,7 +3349,6 @@
             "type": "structure",
             "members": {
               "CustomLanguageCode": {
-                "shape": "Si",
                 "locationName": "customLanguageCode"
               },
               "DestinationSettings": {
@@ -5197,7 +3356,6 @@
                 "locationName": "destinationSettings"
               },
               "LanguageCode": {
-                "shape": "Sl",
                 "locationName": "languageCode"
               },
               "LanguageDescription": {
@@ -5244,7 +3402,6 @@
           "locationName": "settings"
         },
         "Type": {
-          "shape": "Sbw",
           "locationName": "type"
         }
       },
@@ -5253,22 +3410,13 @@
         "Name"
       ]
     },
-    "Sc4": {
-      "type": "string",
-      "enum": [
-        "ON_DEMAND",
-        "RESERVED"
-      ]
-    },
     "Sc5": {
       "type": "structure",
       "members": {
         "Commitment": {
-          "shape": "Sc6",
           "locationName": "commitment"
         },
         "RenewalType": {
-          "shape": "Sc7",
           "locationName": "renewalType"
         },
         "ReservedSlots": {
@@ -5280,19 +3428,6 @@
         "ReservedSlots",
         "Commitment",
         "RenewalType"
-      ]
-    },
-    "Sc6": {
-      "type": "string",
-      "enum": [
-        "ONE_YEAR"
-      ]
-    },
-    "Sc7": {
-      "type": "string",
-      "enum": [
-        "AUTO_RENEW",
-        "EXPIRE"
       ]
     },
     "Sc9": {
@@ -5316,7 +3451,6 @@
           "locationName": "name"
         },
         "PricingPlan": {
-          "shape": "Sc4",
           "locationName": "pricingPlan"
         },
         "ProgressingJobsCount": {
@@ -5328,7 +3462,6 @@
           "type": "structure",
           "members": {
             "Commitment": {
-              "shape": "Sc6",
               "locationName": "commitment"
             },
             "ExpiresAt": {
@@ -5340,7 +3473,6 @@
               "locationName": "purchasedAt"
             },
             "RenewalType": {
-              "shape": "Sc7",
               "locationName": "renewalType"
             },
             "ReservedSlots": {
@@ -5348,17 +3480,11 @@
               "type": "integer"
             },
             "Status": {
-              "locationName": "status",
-              "type": "string",
-              "enum": [
-                "ACTIVE",
-                "EXPIRED"
-              ]
+              "locationName": "status"
             }
           }
         },
         "Status": {
-          "shape": "Scc",
           "locationName": "status"
         },
         "SubmittedJobsCount": {
@@ -5366,31 +3492,11 @@
           "type": "integer"
         },
         "Type": {
-          "shape": "Sbw",
           "locationName": "type"
         }
       },
       "required": [
         "Name"
-      ]
-    },
-    "Scc": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "PAUSED"
-      ]
-    },
-    "Scy": {
-      "type": "integer",
-      "min": 1,
-      "max": 20
-    },
-    "Scz": {
-      "type": "string",
-      "enum": [
-        "ASCENDING",
-        "DESCENDING"
       ]
     }
   }

--- a/apis/medialive-2017-10-14.min.json
+++ b/apis/medialive-2017-10-14.min.json
@@ -113,7 +113,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -170,7 +169,6 @@
             "locationName": "sources"
           },
           "Type": {
-            "shape": "S9y",
             "locationName": "type"
           }
         }
@@ -257,7 +255,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -271,7 +268,6 @@
             "locationName": "roleArn"
           },
           "State": {
-            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -359,7 +355,6 @@
             "type": "integer"
           },
           "DurationUnits": {
-            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "End": {
@@ -379,7 +374,6 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
-            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -396,7 +390,6 @@
             "locationName": "start"
           },
           "State": {
-            "shape": "Saw",
             "locationName": "state"
           },
           "UsagePrice": {
@@ -454,7 +447,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -468,7 +460,6 @@
             "locationName": "roleArn"
           },
           "State": {
-            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -521,11 +512,9 @@
             "locationName": "sources"
           },
           "State": {
-            "shape": "Sa5",
             "locationName": "state"
           },
           "Type": {
-            "shape": "S9y",
             "locationName": "type"
           }
         }
@@ -563,7 +552,6 @@
             "locationName": "inputs"
           },
           "State": {
-            "shape": "Sab",
             "locationName": "state"
           },
           "WhitelistRules": {
@@ -605,7 +593,6 @@
             "type": "integer"
           },
           "DurationUnits": {
-            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "FixedPrice": {
@@ -619,7 +606,6 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
-            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -672,7 +658,6 @@
             "type": "integer"
           },
           "DurationUnits": {
-            "shape": "Sam",
             "locationName": "durationUnits"
           },
           "End": {
@@ -692,7 +677,6 @@
             "locationName": "offeringId"
           },
           "OfferingType": {
-            "shape": "San",
             "locationName": "offeringType"
           },
           "Region": {
@@ -709,7 +693,6 @@
             "locationName": "start"
           },
           "State": {
-            "shape": "Saw",
             "locationName": "state"
           },
           "UsagePrice": {
@@ -733,9 +716,9 @@
             "locationName": "channelId"
           },
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -769,9 +752,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -811,7 +794,6 @@
                   "locationName": "inputSpecification"
                 },
                 "LogLevel": {
-                  "shape": "S9n",
                   "locationName": "logLevel"
                 },
                 "Name": {
@@ -825,7 +807,6 @@
                   "locationName": "roleArn"
                 },
                 "State": {
-                  "shape": "S9s",
                   "locationName": "state"
                 }
               }
@@ -847,9 +828,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -883,9 +864,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -927,9 +908,9 @@
             "locationName": "codec"
           },
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "MaximumBitrate": {
             "location": "querystring",
@@ -984,7 +965,6 @@
                   "type": "integer"
                 },
                 "DurationUnits": {
-                  "shape": "Sam",
                   "locationName": "durationUnits"
                 },
                 "FixedPrice": {
@@ -998,7 +978,6 @@
                   "locationName": "offeringId"
                 },
                 "OfferingType": {
-                  "shape": "San",
                   "locationName": "offeringType"
                 },
                 "Region": {
@@ -1032,9 +1011,9 @@
             "locationName": "codec"
           },
           "MaxResults": {
-            "shape": "Sb8",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "MaximumBitrate": {
             "location": "querystring",
@@ -1091,8 +1070,8 @@
         "type": "structure",
         "members": {
           "Count": {
-            "shape": "Sq",
-            "locationName": "count"
+            "locationName": "count",
+            "type": "integer"
           },
           "Name": {
             "locationName": "name"
@@ -1167,7 +1146,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1181,7 +1159,6 @@
             "locationName": "roleArn"
           },
           "State": {
-            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -1234,7 +1211,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1248,7 +1224,6 @@
             "locationName": "roleArn"
           },
           "State": {
-            "shape": "S9s",
             "locationName": "state"
           }
         }
@@ -1284,7 +1259,6 @@
             "locationName": "inputSpecification"
           },
           "LogLevel": {
-            "shape": "S9n",
             "locationName": "logLevel"
           },
           "Name": {
@@ -1402,8 +1376,8 @@
                 "type": "structure",
                 "members": {
                   "SpliceEventId": {
-                    "shape": "S8",
-                    "locationName": "spliceEventId"
+                    "locationName": "spliceEventId",
+                    "type": "long"
                   }
                 },
                 "required": [
@@ -1416,13 +1390,11 @@
                 "members": {
                   "Duration": {
                     "locationName": "duration",
-                    "type": "long",
-                    "min": 0,
-                    "max": 8589934591
+                    "type": "long"
                   },
                   "SpliceEventId": {
-                    "shape": "S8",
-                    "locationName": "spliceEventId"
+                    "locationName": "spliceEventId",
+                    "type": "long"
                   }
                 },
                 "required": [
@@ -1452,38 +1424,16 @@
                                   "type": "structure",
                                   "members": {
                                     "ArchiveAllowedFlag": {
-                                      "locationName": "archiveAllowedFlag",
-                                      "type": "string",
-                                      "enum": [
-                                        "ARCHIVE_NOT_ALLOWED",
-                                        "ARCHIVE_ALLOWED"
-                                      ]
+                                      "locationName": "archiveAllowedFlag"
                                     },
                                     "DeviceRestrictions": {
-                                      "locationName": "deviceRestrictions",
-                                      "type": "string",
-                                      "enum": [
-                                        "NONE",
-                                        "RESTRICT_GROUP0",
-                                        "RESTRICT_GROUP1",
-                                        "RESTRICT_GROUP2"
-                                      ]
+                                      "locationName": "deviceRestrictions"
                                     },
                                     "NoRegionalBlackoutFlag": {
-                                      "locationName": "noRegionalBlackoutFlag",
-                                      "type": "string",
-                                      "enum": [
-                                        "REGIONAL_BLACKOUT",
-                                        "NO_REGIONAL_BLACKOUT"
-                                      ]
+                                      "locationName": "noRegionalBlackoutFlag"
                                     },
                                     "WebDeliveryAllowedFlag": {
-                                      "locationName": "webDeliveryAllowedFlag",
-                                      "type": "string",
-                                      "enum": [
-                                        "WEB_DELIVERY_NOT_ALLOWED",
-                                        "WEB_DELIVERY_ALLOWED"
-                                      ]
+                                      "locationName": "webDeliveryAllowedFlag"
                                     }
                                   },
                                   "required": [
@@ -1494,49 +1444,42 @@
                                   ]
                                 },
                                 "SegmentNum": {
-                                  "shape": "Sl",
-                                  "locationName": "segmentNum"
+                                  "locationName": "segmentNum",
+                                  "type": "integer"
                                 },
                                 "SegmentationCancelIndicator": {
-                                  "locationName": "segmentationCancelIndicator",
-                                  "type": "string",
-                                  "enum": [
-                                    "SEGMENTATION_EVENT_NOT_CANCELED",
-                                    "SEGMENTATION_EVENT_CANCELED"
-                                  ]
+                                  "locationName": "segmentationCancelIndicator"
                                 },
                                 "SegmentationDuration": {
                                   "locationName": "segmentationDuration",
-                                  "type": "long",
-                                  "min": 0,
-                                  "max": 1099511627775
+                                  "type": "long"
                                 },
                                 "SegmentationEventId": {
-                                  "shape": "S8",
-                                  "locationName": "segmentationEventId"
+                                  "locationName": "segmentationEventId",
+                                  "type": "long"
                                 },
                                 "SegmentationTypeId": {
-                                  "shape": "Sl",
-                                  "locationName": "segmentationTypeId"
+                                  "locationName": "segmentationTypeId",
+                                  "type": "integer"
                                 },
                                 "SegmentationUpid": {
                                   "locationName": "segmentationUpid"
                                 },
                                 "SegmentationUpidType": {
-                                  "shape": "Sl",
-                                  "locationName": "segmentationUpidType"
+                                  "locationName": "segmentationUpidType",
+                                  "type": "integer"
                                 },
                                 "SegmentsExpected": {
-                                  "shape": "Sl",
-                                  "locationName": "segmentsExpected"
+                                  "locationName": "segmentsExpected",
+                                  "type": "integer"
                                 },
                                 "SubSegmentNum": {
-                                  "shape": "Sl",
-                                  "locationName": "subSegmentNum"
+                                  "locationName": "subSegmentNum",
+                                  "type": "integer"
                                 },
                                 "SubSegmentsExpected": {
-                                  "shape": "Sl",
-                                  "locationName": "subSegmentsExpected"
+                                  "locationName": "subSegmentsExpected",
+                                  "type": "integer"
                                 }
                               },
                               "required": [
@@ -1565,44 +1508,44 @@
                 "type": "structure",
                 "members": {
                   "Duration": {
-                    "shape": "Sp",
-                    "locationName": "duration"
+                    "locationName": "duration",
+                    "type": "integer"
                   },
                   "FadeIn": {
-                    "shape": "Sp",
-                    "locationName": "fadeIn"
+                    "locationName": "fadeIn",
+                    "type": "integer"
                   },
                   "FadeOut": {
-                    "shape": "Sp",
-                    "locationName": "fadeOut"
+                    "locationName": "fadeOut",
+                    "type": "integer"
                   },
                   "Height": {
-                    "shape": "Sq",
-                    "locationName": "height"
+                    "locationName": "height",
+                    "type": "integer"
                   },
                   "Image": {
                     "shape": "Sr",
                     "locationName": "image"
                   },
                   "ImageX": {
-                    "shape": "Sp",
-                    "locationName": "imageX"
+                    "locationName": "imageX",
+                    "type": "integer"
                   },
                   "ImageY": {
-                    "shape": "Sp",
-                    "locationName": "imageY"
+                    "locationName": "imageY",
+                    "type": "integer"
                   },
                   "Layer": {
-                    "shape": "Ss",
-                    "locationName": "layer"
+                    "locationName": "layer",
+                    "type": "integer"
                   },
                   "Opacity": {
-                    "shape": "St",
-                    "locationName": "opacity"
+                    "locationName": "opacity",
+                    "type": "integer"
                   },
                   "Width": {
-                    "shape": "Sq",
-                    "locationName": "width"
+                    "locationName": "width",
+                    "type": "integer"
                   }
                 },
                 "required": [
@@ -1614,12 +1557,12 @@
                 "type": "structure",
                 "members": {
                   "FadeOut": {
-                    "shape": "Sp",
-                    "locationName": "fadeOut"
+                    "locationName": "fadeOut",
+                    "type": "integer"
                   },
                   "Layer": {
-                    "shape": "Ss",
-                    "locationName": "layer"
+                    "locationName": "layer",
+                    "type": "integer"
                   }
                 }
               }
@@ -1648,24 +1591,6 @@
         ]
       }
     },
-    "S8": {
-      "type": "long",
-      "min": 0,
-      "max": 4294967295
-    },
-    "Sl": {
-      "type": "integer",
-      "min": 0,
-      "max": 255
-    },
-    "Sp": {
-      "type": "integer",
-      "min": 0
-    },
-    "Sq": {
-      "type": "integer",
-      "min": 1
-    },
     "Sr": {
       "type": "structure",
       "members": {
@@ -1682,16 +1607,6 @@
       "required": [
         "Uri"
       ]
-    },
-    "Ss": {
-      "type": "integer",
-      "min": 0,
-      "max": 7
-    },
-    "St": {
-      "type": "integer",
-      "min": 0,
-      "max": 100
     },
     "Sy": {
       "type": "list",
@@ -1743,19 +1658,10 @@
                 "type": "structure",
                 "members": {
                   "Algorithm": {
-                    "locationName": "algorithm",
-                    "type": "string",
-                    "enum": [
-                      "ITU_1770_1",
-                      "ITU_1770_2"
-                    ]
+                    "locationName": "algorithm"
                   },
                   "AlgorithmControl": {
-                    "locationName": "algorithmControl",
-                    "type": "string",
-                    "enum": [
-                      "CORRECT_AUDIO"
-                    ]
+                    "locationName": "algorithmControl"
                   },
                   "TargetLkfs": {
                     "locationName": "targetLkfs",
@@ -1767,22 +1673,10 @@
                 "locationName": "audioSelectorName"
               },
               "AudioType": {
-                "locationName": "audioType",
-                "type": "string",
-                "enum": [
-                  "CLEAN_EFFECTS",
-                  "HEARING_IMPAIRED",
-                  "UNDEFINED",
-                  "VISUAL_IMPAIRED_COMMENTARY"
-                ]
+                "locationName": "audioType"
               },
               "AudioTypeControl": {
-                "locationName": "audioTypeControl",
-                "type": "string",
-                "enum": [
-                  "FOLLOW_INPUT",
-                  "USE_CONFIGURED"
-                ]
+                "locationName": "audioTypeControl"
               },
               "CodecSettings": {
                 "locationName": "codecSettings",
@@ -1797,70 +1691,29 @@
                         "type": "double"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode",
-                        "type": "string",
-                        "enum": [
-                          "AD_RECEIVER_MIX",
-                          "CODING_MODE_1_0",
-                          "CODING_MODE_1_1",
-                          "CODING_MODE_2_0",
-                          "CODING_MODE_5_1"
-                        ]
+                        "locationName": "codingMode"
                       },
                       "InputType": {
-                        "locationName": "inputType",
-                        "type": "string",
-                        "enum": [
-                          "BROADCASTER_MIXED_AD",
-                          "NORMAL"
-                        ]
+                        "locationName": "inputType"
                       },
                       "Profile": {
-                        "locationName": "profile",
-                        "type": "string",
-                        "enum": [
-                          "HEV1",
-                          "HEV2",
-                          "LC"
-                        ]
+                        "locationName": "profile"
                       },
                       "RateControlMode": {
-                        "locationName": "rateControlMode",
-                        "type": "string",
-                        "enum": [
-                          "CBR",
-                          "VBR"
-                        ]
+                        "locationName": "rateControlMode"
                       },
                       "RawFormat": {
-                        "locationName": "rawFormat",
-                        "type": "string",
-                        "enum": [
-                          "LATM_LOAS",
-                          "NONE"
-                        ]
+                        "locationName": "rawFormat"
                       },
                       "SampleRate": {
                         "locationName": "sampleRate",
                         "type": "double"
                       },
                       "Spec": {
-                        "locationName": "spec",
-                        "type": "string",
-                        "enum": [
-                          "MPEG2",
-                          "MPEG4"
-                        ]
+                        "locationName": "spec"
                       },
                       "VbrQuality": {
-                        "locationName": "vbrQuality",
-                        "type": "string",
-                        "enum": [
-                          "HIGH",
-                          "LOW",
-                          "MEDIUM_HIGH",
-                          "MEDIUM_LOW"
-                        ]
+                        "locationName": "vbrQuality"
                       }
                     }
                   },
@@ -1873,56 +1726,23 @@
                         "type": "double"
                       },
                       "BitstreamMode": {
-                        "locationName": "bitstreamMode",
-                        "type": "string",
-                        "enum": [
-                          "COMMENTARY",
-                          "COMPLETE_MAIN",
-                          "DIALOGUE",
-                          "EMERGENCY",
-                          "HEARING_IMPAIRED",
-                          "MUSIC_AND_EFFECTS",
-                          "VISUALLY_IMPAIRED",
-                          "VOICE_OVER"
-                        ]
+                        "locationName": "bitstreamMode"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode",
-                        "type": "string",
-                        "enum": [
-                          "CODING_MODE_1_0",
-                          "CODING_MODE_1_1",
-                          "CODING_MODE_2_0",
-                          "CODING_MODE_3_2_LFE"
-                        ]
+                        "locationName": "codingMode"
                       },
                       "Dialnorm": {
-                        "shape": "S1t",
-                        "locationName": "dialnorm"
+                        "locationName": "dialnorm",
+                        "type": "integer"
                       },
                       "DrcProfile": {
-                        "locationName": "drcProfile",
-                        "type": "string",
-                        "enum": [
-                          "FILM_STANDARD",
-                          "NONE"
-                        ]
+                        "locationName": "drcProfile"
                       },
                       "LfeFilter": {
-                        "locationName": "lfeFilter",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "lfeFilter"
                       },
                       "MetadataControl": {
-                        "locationName": "metadataControl",
-                        "type": "string",
-                        "enum": [
-                          "FOLLOW_INPUT",
-                          "USE_CONFIGURED"
-                        ]
+                        "locationName": "metadataControl"
                       }
                     }
                   },
@@ -1931,88 +1751,36 @@
                     "type": "structure",
                     "members": {
                       "AttenuationControl": {
-                        "locationName": "attenuationControl",
-                        "type": "string",
-                        "enum": [
-                          "ATTENUATE_3_DB",
-                          "NONE"
-                        ]
+                        "locationName": "attenuationControl"
                       },
                       "Bitrate": {
                         "locationName": "bitrate",
                         "type": "double"
                       },
                       "BitstreamMode": {
-                        "locationName": "bitstreamMode",
-                        "type": "string",
-                        "enum": [
-                          "COMMENTARY",
-                          "COMPLETE_MAIN",
-                          "EMERGENCY",
-                          "HEARING_IMPAIRED",
-                          "VISUALLY_IMPAIRED"
-                        ]
+                        "locationName": "bitstreamMode"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode",
-                        "type": "string",
-                        "enum": [
-                          "CODING_MODE_1_0",
-                          "CODING_MODE_2_0",
-                          "CODING_MODE_3_2"
-                        ]
+                        "locationName": "codingMode"
                       },
                       "DcFilter": {
-                        "locationName": "dcFilter",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "dcFilter"
                       },
                       "Dialnorm": {
-                        "shape": "S1t",
-                        "locationName": "dialnorm"
+                        "locationName": "dialnorm",
+                        "type": "integer"
                       },
                       "DrcLine": {
-                        "locationName": "drcLine",
-                        "type": "string",
-                        "enum": [
-                          "FILM_LIGHT",
-                          "FILM_STANDARD",
-                          "MUSIC_LIGHT",
-                          "MUSIC_STANDARD",
-                          "NONE",
-                          "SPEECH"
-                        ]
+                        "locationName": "drcLine"
                       },
                       "DrcRf": {
-                        "locationName": "drcRf",
-                        "type": "string",
-                        "enum": [
-                          "FILM_LIGHT",
-                          "FILM_STANDARD",
-                          "MUSIC_LIGHT",
-                          "MUSIC_STANDARD",
-                          "NONE",
-                          "SPEECH"
-                        ]
+                        "locationName": "drcRf"
                       },
                       "LfeControl": {
-                        "locationName": "lfeControl",
-                        "type": "string",
-                        "enum": [
-                          "LFE",
-                          "NO_LFE"
-                        ]
+                        "locationName": "lfeControl"
                       },
                       "LfeFilter": {
-                        "locationName": "lfeFilter",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "lfeFilter"
                       },
                       "LoRoCenterMixLevel": {
                         "locationName": "loRoCenterMixLevel",
@@ -2031,56 +1799,22 @@
                         "type": "double"
                       },
                       "MetadataControl": {
-                        "locationName": "metadataControl",
-                        "type": "string",
-                        "enum": [
-                          "FOLLOW_INPUT",
-                          "USE_CONFIGURED"
-                        ]
+                        "locationName": "metadataControl"
                       },
                       "PassthroughControl": {
-                        "locationName": "passthroughControl",
-                        "type": "string",
-                        "enum": [
-                          "NO_PASSTHROUGH",
-                          "WHEN_POSSIBLE"
-                        ]
+                        "locationName": "passthroughControl"
                       },
                       "PhaseControl": {
-                        "locationName": "phaseControl",
-                        "type": "string",
-                        "enum": [
-                          "NO_SHIFT",
-                          "SHIFT_90_DEGREES"
-                        ]
+                        "locationName": "phaseControl"
                       },
                       "StereoDownmix": {
-                        "locationName": "stereoDownmix",
-                        "type": "string",
-                        "enum": [
-                          "DPL2",
-                          "LO_RO",
-                          "LT_RT",
-                          "NOT_INDICATED"
-                        ]
+                        "locationName": "stereoDownmix"
                       },
                       "SurroundExMode": {
-                        "locationName": "surroundExMode",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED",
-                          "NOT_INDICATED"
-                        ]
+                        "locationName": "surroundExMode"
                       },
                       "SurroundMode": {
-                        "locationName": "surroundMode",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED",
-                          "NOT_INDICATED"
-                        ]
+                        "locationName": "surroundMode"
                       }
                     }
                   },
@@ -2093,12 +1827,7 @@
                         "type": "double"
                       },
                       "CodingMode": {
-                        "locationName": "codingMode",
-                        "type": "string",
-                        "enum": [
-                          "CODING_MODE_1_0",
-                          "CODING_MODE_2_0"
-                        ]
+                        "locationName": "codingMode"
                       },
                       "SampleRate": {
                         "locationName": "sampleRate",
@@ -2114,16 +1843,10 @@
                 }
               },
               "LanguageCode": {
-                "shape": "S2f",
                 "locationName": "languageCode"
               },
               "LanguageCodeControl": {
-                "locationName": "languageCodeControl",
-                "type": "string",
-                "enum": [
-                  "FOLLOW_INPUT",
-                  "USE_CONFIGURED"
-                ]
+                "locationName": "languageCodeControl"
               },
               "Name": {
                 "locationName": "name"
@@ -2146,13 +1869,11 @@
                             "members": {
                               "Gain": {
                                 "locationName": "gain",
-                                "type": "integer",
-                                "min": -60,
-                                "max": 6
+                                "type": "integer"
                               },
                               "InputChannel": {
-                                "shape": "S2n",
-                                "locationName": "inputChannel"
+                                "locationName": "inputChannel",
+                                "type": "integer"
                               }
                             },
                             "required": [
@@ -2162,8 +1883,8 @@
                           }
                         },
                         "OutputChannel": {
-                          "shape": "Ss",
-                          "locationName": "outputChannel"
+                          "locationName": "outputChannel",
+                          "type": "integer"
                         }
                       },
                       "required": [
@@ -2174,15 +1895,11 @@
                   },
                   "ChannelsIn": {
                     "locationName": "channelsIn",
-                    "type": "integer",
-                    "min": 1,
-                    "max": 16
+                    "type": "integer"
                   },
                   "ChannelsOut": {
                     "locationName": "channelsOut",
-                    "type": "integer",
-                    "min": 1,
-                    "max": 8
+                    "type": "integer"
                   }
                 },
                 "required": [
@@ -2208,12 +1925,7 @@
               "locationName": "availBlankingImage"
             },
             "State": {
-              "locationName": "state",
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "ENABLED"
-              ]
+              "locationName": "state"
             }
           }
         },
@@ -2230,24 +1942,14 @@
                   "type": "structure",
                   "members": {
                     "AdAvailOffset": {
-                      "shape": "S2v",
-                      "locationName": "adAvailOffset"
+                      "locationName": "adAvailOffset",
+                      "type": "integer"
                     },
                     "NoRegionalBlackoutFlag": {
-                      "locationName": "noRegionalBlackoutFlag",
-                      "type": "string",
-                      "enum": [
-                        "FOLLOW",
-                        "IGNORE"
-                      ]
+                      "locationName": "noRegionalBlackoutFlag"
                     },
                     "WebDeliveryAllowedFlag": {
-                      "locationName": "webDeliveryAllowedFlag",
-                      "type": "string",
-                      "enum": [
-                        "FOLLOW",
-                        "IGNORE"
-                      ]
+                      "locationName": "webDeliveryAllowedFlag"
                     }
                   }
                 },
@@ -2256,24 +1958,14 @@
                   "type": "structure",
                   "members": {
                     "AdAvailOffset": {
-                      "shape": "S2v",
-                      "locationName": "adAvailOffset"
+                      "locationName": "adAvailOffset",
+                      "type": "integer"
                     },
                     "NoRegionalBlackoutFlag": {
-                      "locationName": "noRegionalBlackoutFlag",
-                      "type": "string",
-                      "enum": [
-                        "FOLLOW",
-                        "IGNORE"
-                      ]
+                      "locationName": "noRegionalBlackoutFlag"
                     },
                     "WebDeliveryAllowedFlag": {
-                      "locationName": "webDeliveryAllowedFlag",
-                      "type": "string",
-                      "enum": [
-                        "FOLLOW",
-                        "IGNORE"
-                      ]
+                      "locationName": "webDeliveryAllowedFlag"
                     }
                   }
                 }
@@ -2290,30 +1982,17 @@
               "locationName": "blackoutSlateImage"
             },
             "NetworkEndBlackout": {
-              "locationName": "networkEndBlackout",
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "ENABLED"
-              ]
+              "locationName": "networkEndBlackout"
             },
             "NetworkEndBlackoutImage": {
               "shape": "Sr",
               "locationName": "networkEndBlackoutImage"
             },
             "NetworkId": {
-              "locationName": "networkId",
-              "type": "string",
-              "min": 34,
-              "max": 34
+              "locationName": "networkId"
             },
             "State": {
-              "locationName": "state",
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "ENABLED"
-              ]
+              "locationName": "state"
             }
           }
         },
@@ -2340,82 +2019,46 @@
                     "type": "structure",
                     "members": {
                       "Alignment": {
-                        "locationName": "alignment",
-                        "type": "string",
-                        "enum": [
-                          "CENTERED",
-                          "LEFT",
-                          "SMART"
-                        ]
+                        "locationName": "alignment"
                       },
                       "BackgroundColor": {
-                        "locationName": "backgroundColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "NONE",
-                          "WHITE"
-                        ]
+                        "locationName": "backgroundColor"
                       },
                       "BackgroundOpacity": {
-                        "shape": "Sl",
-                        "locationName": "backgroundOpacity"
+                        "locationName": "backgroundOpacity",
+                        "type": "integer"
                       },
                       "Font": {
                         "shape": "Sr",
                         "locationName": "font"
                       },
                       "FontColor": {
-                        "locationName": "fontColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "BLUE",
-                          "GREEN",
-                          "RED",
-                          "WHITE",
-                          "YELLOW"
-                        ]
+                        "locationName": "fontColor"
                       },
                       "FontOpacity": {
-                        "shape": "Sl",
-                        "locationName": "fontOpacity"
+                        "locationName": "fontOpacity",
+                        "type": "integer"
                       },
                       "FontResolution": {
-                        "shape": "S3d",
-                        "locationName": "fontResolution"
+                        "locationName": "fontResolution",
+                        "type": "integer"
                       },
                       "FontSize": {
                         "locationName": "fontSize"
                       },
                       "OutlineColor": {
-                        "locationName": "outlineColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "BLUE",
-                          "GREEN",
-                          "RED",
-                          "WHITE",
-                          "YELLOW"
-                        ]
+                        "locationName": "outlineColor"
                       },
                       "OutlineSize": {
-                        "shape": "S3f",
-                        "locationName": "outlineSize"
+                        "locationName": "outlineSize",
+                        "type": "integer"
                       },
                       "ShadowColor": {
-                        "locationName": "shadowColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "NONE",
-                          "WHITE"
-                        ]
+                        "locationName": "shadowColor"
                       },
                       "ShadowOpacity": {
-                        "shape": "Sl",
-                        "locationName": "shadowOpacity"
+                        "locationName": "shadowOpacity",
+                        "type": "integer"
                       },
                       "ShadowXOffset": {
                         "locationName": "shadowXOffset",
@@ -2426,20 +2069,15 @@
                         "type": "integer"
                       },
                       "TeletextGridControl": {
-                        "locationName": "teletextGridControl",
-                        "type": "string",
-                        "enum": [
-                          "FIXED",
-                          "SCALED"
-                        ]
+                        "locationName": "teletextGridControl"
                       },
                       "XPosition": {
-                        "shape": "Sp",
-                        "locationName": "xPosition"
+                        "locationName": "xPosition",
+                        "type": "integer"
                       },
                       "YPosition": {
-                        "shape": "Sp",
-                        "locationName": "yPosition"
+                        "locationName": "yPosition",
+                        "type": "integer"
                       }
                     }
                   },
@@ -2448,82 +2086,46 @@
                     "type": "structure",
                     "members": {
                       "Alignment": {
-                        "locationName": "alignment",
-                        "type": "string",
-                        "enum": [
-                          "CENTERED",
-                          "LEFT",
-                          "SMART"
-                        ]
+                        "locationName": "alignment"
                       },
                       "BackgroundColor": {
-                        "locationName": "backgroundColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "NONE",
-                          "WHITE"
-                        ]
+                        "locationName": "backgroundColor"
                       },
                       "BackgroundOpacity": {
-                        "shape": "Sl",
-                        "locationName": "backgroundOpacity"
+                        "locationName": "backgroundOpacity",
+                        "type": "integer"
                       },
                       "Font": {
                         "shape": "Sr",
                         "locationName": "font"
                       },
                       "FontColor": {
-                        "locationName": "fontColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "BLUE",
-                          "GREEN",
-                          "RED",
-                          "WHITE",
-                          "YELLOW"
-                        ]
+                        "locationName": "fontColor"
                       },
                       "FontOpacity": {
-                        "shape": "Sl",
-                        "locationName": "fontOpacity"
+                        "locationName": "fontOpacity",
+                        "type": "integer"
                       },
                       "FontResolution": {
-                        "shape": "S3d",
-                        "locationName": "fontResolution"
+                        "locationName": "fontResolution",
+                        "type": "integer"
                       },
                       "FontSize": {
                         "locationName": "fontSize"
                       },
                       "OutlineColor": {
-                        "locationName": "outlineColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "BLUE",
-                          "GREEN",
-                          "RED",
-                          "WHITE",
-                          "YELLOW"
-                        ]
+                        "locationName": "outlineColor"
                       },
                       "OutlineSize": {
-                        "shape": "S3f",
-                        "locationName": "outlineSize"
+                        "locationName": "outlineSize",
+                        "type": "integer"
                       },
                       "ShadowColor": {
-                        "locationName": "shadowColor",
-                        "type": "string",
-                        "enum": [
-                          "BLACK",
-                          "NONE",
-                          "WHITE"
-                        ]
+                        "locationName": "shadowColor"
                       },
                       "ShadowOpacity": {
-                        "shape": "Sl",
-                        "locationName": "shadowOpacity"
+                        "locationName": "shadowOpacity",
+                        "type": "integer"
                       },
                       "ShadowXOffset": {
                         "locationName": "shadowXOffset",
@@ -2534,20 +2136,15 @@
                         "type": "integer"
                       },
                       "TeletextGridControl": {
-                        "locationName": "teletextGridControl",
-                        "type": "string",
-                        "enum": [
-                          "FIXED",
-                          "SCALED"
-                        ]
+                        "locationName": "teletextGridControl"
                       },
                       "XPosition": {
-                        "shape": "Sp",
-                        "locationName": "xPosition"
+                        "locationName": "xPosition",
+                        "type": "integer"
                       },
                       "YPosition": {
-                        "shape": "Sp",
-                        "locationName": "yPosition"
+                        "locationName": "yPosition",
+                        "type": "integer"
                       }
                     }
                   },
@@ -2591,12 +2188,7 @@
                     "type": "structure",
                     "members": {
                       "StyleControl": {
-                        "locationName": "styleControl",
-                        "type": "string",
-                        "enum": [
-                          "PASSTHROUGH",
-                          "USE_CONFIGURED"
-                        ]
+                        "locationName": "styleControl"
                       }
                     }
                   },
@@ -2629,65 +2221,40 @@
           "members": {
             "InitialAudioGain": {
               "locationName": "initialAudioGain",
-              "type": "integer",
-              "min": -60,
-              "max": 60
+              "type": "integer"
             },
             "InputEndAction": {
-              "locationName": "inputEndAction",
-              "type": "string",
-              "enum": [
-                "NONE",
-                "SWITCH_AND_LOOP_INPUTS"
-              ]
+              "locationName": "inputEndAction"
             },
             "InputLossBehavior": {
               "locationName": "inputLossBehavior",
               "type": "structure",
               "members": {
                 "BlackFrameMsec": {
-                  "shape": "S44",
-                  "locationName": "blackFrameMsec"
+                  "locationName": "blackFrameMsec",
+                  "type": "integer"
                 },
                 "InputLossImageColor": {
-                  "locationName": "inputLossImageColor",
-                  "type": "string",
-                  "min": 6,
-                  "max": 6
+                  "locationName": "inputLossImageColor"
                 },
                 "InputLossImageSlate": {
                   "shape": "Sr",
                   "locationName": "inputLossImageSlate"
                 },
                 "InputLossImageType": {
-                  "locationName": "inputLossImageType",
-                  "type": "string",
-                  "enum": [
-                    "COLOR",
-                    "SLATE"
-                  ]
+                  "locationName": "inputLossImageType"
                 },
                 "RepeatFrameMsec": {
-                  "shape": "S44",
-                  "locationName": "repeatFrameMsec"
+                  "locationName": "repeatFrameMsec",
+                  "type": "integer"
                 }
               }
             },
             "OutputTimingSource": {
-              "locationName": "outputTimingSource",
-              "type": "string",
-              "enum": [
-                "INPUT_CLOCK",
-                "SYSTEM_CLOCK"
-              ]
+              "locationName": "outputTimingSource"
             },
             "SupportLowFramerateInputs": {
-              "locationName": "supportLowFramerateInputs",
-              "type": "string",
-              "enum": [
-                "DISABLED",
-                "ENABLED"
-              ]
+              "locationName": "supportLowFramerateInputs"
             }
           }
         },
@@ -2698,9 +2265,7 @@
             "type": "structure",
             "members": {
               "Name": {
-                "locationName": "name",
-                "type": "string",
-                "max": 32
+                "locationName": "name"
               },
               "OutputGroupSettings": {
                 "locationName": "outputGroupSettings",
@@ -2715,8 +2280,8 @@
                         "locationName": "destination"
                       },
                       "RolloverInterval": {
-                        "shape": "Sq",
-                        "locationName": "rolloverInterval"
+                        "locationName": "rolloverInterval",
+                        "type": "integer"
                       }
                     },
                     "required": [
@@ -2730,14 +2295,7 @@
                       "AdMarkers": {
                         "locationName": "adMarkers",
                         "type": "list",
-                        "member": {
-                          "type": "string",
-                          "enum": [
-                            "ADOBE",
-                            "ELEMENTAL",
-                            "ELEMENTAL_SCTE35"
-                          ]
-                        }
+                        "member": {}
                       },
                       "BaseUrlContent": {
                         "locationName": "baseUrlContent"
@@ -2752,15 +2310,13 @@
                           "type": "structure",
                           "members": {
                             "CaptionChannel": {
-                              "shape": "S4k",
-                              "locationName": "captionChannel"
+                              "locationName": "captionChannel",
+                              "type": "integer"
                             },
                             "LanguageCode": {
-                              "shape": "S2f",
                               "locationName": "languageCode"
                             },
                             "LanguageDescription": {
-                              "shape": "S4l",
                               "locationName": "languageDescription"
                             }
                           },
@@ -2772,32 +2328,15 @@
                         }
                       },
                       "CaptionLanguageSetting": {
-                        "locationName": "captionLanguageSetting",
-                        "type": "string",
-                        "enum": [
-                          "INSERT",
-                          "NONE",
-                          "OMIT"
-                        ]
+                        "locationName": "captionLanguageSetting"
                       },
                       "ClientCache": {
-                        "locationName": "clientCache",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "clientCache"
                       },
                       "CodecSpecification": {
-                        "locationName": "codecSpecification",
-                        "type": "string",
-                        "enum": [
-                          "RFC_4281",
-                          "RFC_6381"
-                        ]
+                        "locationName": "codecSpecification"
                       },
                       "ConstantIv": {
-                        "shape": "S4p",
                         "locationName": "constantIv"
                       },
                       "Destination": {
@@ -2805,20 +2344,10 @@
                         "locationName": "destination"
                       },
                       "DirectoryStructure": {
-                        "locationName": "directoryStructure",
-                        "type": "string",
-                        "enum": [
-                          "SINGLE_DIRECTORY",
-                          "SUBDIRECTORY_PER_STREAM"
-                        ]
+                        "locationName": "directoryStructure"
                       },
                       "EncryptionType": {
-                        "locationName": "encryptionType",
-                        "type": "string",
-                        "enum": [
-                          "AES128",
-                          "SAMPLE_AES"
-                        ]
+                        "locationName": "encryptionType"
                       },
                       "HlsCdnSettings": {
                         "locationName": "hlsCdnSettings",
@@ -2829,28 +2358,23 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "shape": "Sp",
-                                "locationName": "connectionRetryInterval"
+                                "locationName": "connectionRetryInterval",
+                                "type": "integer"
                               },
                               "FilecacheDuration": {
-                                "shape": "S4u",
-                                "locationName": "filecacheDuration"
+                                "locationName": "filecacheDuration",
+                                "type": "integer"
                               },
                               "HttpTransferMode": {
-                                "locationName": "httpTransferMode",
-                                "type": "string",
-                                "enum": [
-                                  "CHUNKED",
-                                  "NON_CHUNKED"
-                                ]
+                                "locationName": "httpTransferMode"
                               },
                               "NumRetries": {
-                                "shape": "Sp",
-                                "locationName": "numRetries"
+                                "locationName": "numRetries",
+                                "type": "integer"
                               },
                               "RestartDelay": {
-                                "shape": "S2n",
-                                "locationName": "restartDelay"
+                                "locationName": "restartDelay",
+                                "type": "integer"
                               },
                               "Salt": {
                                 "locationName": "salt"
@@ -2865,20 +2389,20 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "shape": "Sp",
-                                "locationName": "connectionRetryInterval"
+                                "locationName": "connectionRetryInterval",
+                                "type": "integer"
                               },
                               "FilecacheDuration": {
-                                "shape": "S4u",
-                                "locationName": "filecacheDuration"
+                                "locationName": "filecacheDuration",
+                                "type": "integer"
                               },
                               "NumRetries": {
-                                "shape": "Sp",
-                                "locationName": "numRetries"
+                                "locationName": "numRetries",
+                                "type": "integer"
                               },
                               "RestartDelay": {
-                                "shape": "S2n",
-                                "locationName": "restartDelay"
+                                "locationName": "restartDelay",
+                                "type": "integer"
                               }
                             }
                           },
@@ -2887,27 +2411,23 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "shape": "Sp",
-                                "locationName": "connectionRetryInterval"
+                                "locationName": "connectionRetryInterval",
+                                "type": "integer"
                               },
                               "FilecacheDuration": {
-                                "shape": "S4u",
-                                "locationName": "filecacheDuration"
+                                "locationName": "filecacheDuration",
+                                "type": "integer"
                               },
                               "MediaStoreStorageClass": {
-                                "locationName": "mediaStoreStorageClass",
-                                "type": "string",
-                                "enum": [
-                                  "TEMPORAL"
-                                ]
+                                "locationName": "mediaStoreStorageClass"
                               },
                               "NumRetries": {
-                                "shape": "Sp",
-                                "locationName": "numRetries"
+                                "locationName": "numRetries",
+                                "type": "integer"
                               },
                               "RestartDelay": {
-                                "shape": "S2n",
-                                "locationName": "restartDelay"
+                                "locationName": "restartDelay",
+                                "type": "integer"
                               }
                             }
                           },
@@ -2916,28 +2436,23 @@
                             "type": "structure",
                             "members": {
                               "ConnectionRetryInterval": {
-                                "shape": "Sp",
-                                "locationName": "connectionRetryInterval"
+                                "locationName": "connectionRetryInterval",
+                                "type": "integer"
                               },
                               "FilecacheDuration": {
-                                "shape": "S4u",
-                                "locationName": "filecacheDuration"
+                                "locationName": "filecacheDuration",
+                                "type": "integer"
                               },
                               "HttpTransferMode": {
-                                "locationName": "httpTransferMode",
-                                "type": "string",
-                                "enum": [
-                                  "CHUNKED",
-                                  "NON_CHUNKED"
-                                ]
+                                "locationName": "httpTransferMode"
                               },
                               "NumRetries": {
-                                "shape": "Sp",
-                                "locationName": "numRetries"
+                                "locationName": "numRetries",
+                                "type": "integer"
                               },
                               "RestartDelay": {
-                                "shape": "S2n",
-                                "locationName": "restartDelay"
+                                "locationName": "restartDelay",
+                                "type": "integer"
                               }
                             }
                           }
@@ -2945,36 +2460,20 @@
                       },
                       "IndexNSegments": {
                         "locationName": "indexNSegments",
-                        "type": "integer",
-                        "min": 3
+                        "type": "integer"
                       },
                       "InputLossAction": {
-                        "locationName": "inputLossAction",
-                        "type": "string",
-                        "enum": [
-                          "EMIT_OUTPUT",
-                          "PAUSE_OUTPUT"
-                        ]
+                        "locationName": "inputLossAction"
                       },
                       "IvInManifest": {
-                        "locationName": "ivInManifest",
-                        "type": "string",
-                        "enum": [
-                          "EXCLUDE",
-                          "INCLUDE"
-                        ]
+                        "locationName": "ivInManifest"
                       },
                       "IvSource": {
-                        "locationName": "ivSource",
-                        "type": "string",
-                        "enum": [
-                          "EXPLICIT",
-                          "FOLLOWS_SEGMENT_NUMBER"
-                        ]
+                        "locationName": "ivSource"
                       },
                       "KeepSegments": {
-                        "shape": "Sq",
-                        "locationName": "keepSegments"
+                        "locationName": "keepSegments",
+                        "type": "integer"
                       },
                       "KeyFormat": {
                         "locationName": "keyFormat"
@@ -2995,7 +2494,6 @@
                                 "locationName": "keyProviderServer"
                               },
                               "StaticKeyValue": {
-                                "shape": "S4p",
                                 "locationName": "staticKeyValue"
                               }
                             },
@@ -3006,103 +2504,55 @@
                         }
                       },
                       "ManifestCompression": {
-                        "locationName": "manifestCompression",
-                        "type": "string",
-                        "enum": [
-                          "GZIP",
-                          "NONE"
-                        ]
+                        "locationName": "manifestCompression"
                       },
                       "ManifestDurationFormat": {
-                        "locationName": "manifestDurationFormat",
-                        "type": "string",
-                        "enum": [
-                          "FLOATING_POINT",
-                          "INTEGER"
-                        ]
+                        "locationName": "manifestDurationFormat"
                       },
                       "MinSegmentLength": {
-                        "shape": "Sp",
-                        "locationName": "minSegmentLength"
+                        "locationName": "minSegmentLength",
+                        "type": "integer"
                       },
                       "Mode": {
-                        "locationName": "mode",
-                        "type": "string",
-                        "enum": [
-                          "LIVE",
-                          "VOD"
-                        ]
+                        "locationName": "mode"
                       },
                       "OutputSelection": {
-                        "locationName": "outputSelection",
-                        "type": "string",
-                        "enum": [
-                          "MANIFESTS_AND_SEGMENTS",
-                          "SEGMENTS_ONLY"
-                        ]
+                        "locationName": "outputSelection"
                       },
                       "ProgramDateTime": {
-                        "locationName": "programDateTime",
-                        "type": "string",
-                        "enum": [
-                          "EXCLUDE",
-                          "INCLUDE"
-                        ]
+                        "locationName": "programDateTime"
                       },
                       "ProgramDateTimePeriod": {
                         "locationName": "programDateTimePeriod",
-                        "type": "integer",
-                        "min": 0,
-                        "max": 3600
+                        "type": "integer"
                       },
                       "SegmentLength": {
-                        "shape": "Sq",
-                        "locationName": "segmentLength"
+                        "locationName": "segmentLength",
+                        "type": "integer"
                       },
                       "SegmentationMode": {
-                        "locationName": "segmentationMode",
-                        "type": "string",
-                        "enum": [
-                          "USE_INPUT_SEGMENTATION",
-                          "USE_SEGMENT_DURATION"
-                        ]
+                        "locationName": "segmentationMode"
                       },
                       "SegmentsPerSubdirectory": {
-                        "shape": "Sq",
-                        "locationName": "segmentsPerSubdirectory"
+                        "locationName": "segmentsPerSubdirectory",
+                        "type": "integer"
                       },
                       "StreamInfResolution": {
-                        "locationName": "streamInfResolution",
-                        "type": "string",
-                        "enum": [
-                          "EXCLUDE",
-                          "INCLUDE"
-                        ]
+                        "locationName": "streamInfResolution"
                       },
                       "TimedMetadataId3Frame": {
-                        "locationName": "timedMetadataId3Frame",
-                        "type": "string",
-                        "enum": [
-                          "NONE",
-                          "PRIV",
-                          "TDRL"
-                        ]
+                        "locationName": "timedMetadataId3Frame"
                       },
                       "TimedMetadataId3Period": {
-                        "shape": "Sp",
-                        "locationName": "timedMetadataId3Period"
+                        "locationName": "timedMetadataId3Period",
+                        "type": "integer"
                       },
                       "TimestampDeltaMilliseconds": {
-                        "shape": "Sp",
-                        "locationName": "timestampDeltaMilliseconds"
+                        "locationName": "timestampDeltaMilliseconds",
+                        "type": "integer"
                       },
                       "TsFileMode": {
-                        "locationName": "tsFileMode",
-                        "type": "string",
-                        "enum": [
-                          "SEGMENTED_FILES",
-                          "SINGLE_FILE"
-                        ]
+                        "locationName": "tsFileMode"
                       }
                     },
                     "required": [
@@ -3117,24 +2567,14 @@
                         "locationName": "acquisitionPointId"
                       },
                       "AudioOnlyTimecodeControl": {
-                        "locationName": "audioOnlyTimecodeControl",
-                        "type": "string",
-                        "enum": [
-                          "PASSTHROUGH",
-                          "USE_CONFIGURED_CLOCK"
-                        ]
+                        "locationName": "audioOnlyTimecodeControl"
                       },
                       "CertificateMode": {
-                        "locationName": "certificateMode",
-                        "type": "string",
-                        "enum": [
-                          "SELF_SIGNED",
-                          "VERIFY_AUTHENTICITY"
-                        ]
+                        "locationName": "certificateMode"
                       },
                       "ConnectionRetryInterval": {
-                        "shape": "Sp",
-                        "locationName": "connectionRetryInterval"
+                        "locationName": "connectionRetryInterval",
+                        "type": "integer"
                       },
                       "Destination": {
                         "shape": "S4e",
@@ -3144,84 +2584,48 @@
                         "locationName": "eventId"
                       },
                       "EventIdMode": {
-                        "locationName": "eventIdMode",
-                        "type": "string",
-                        "enum": [
-                          "NO_EVENT_ID",
-                          "USE_CONFIGURED",
-                          "USE_TIMESTAMP"
-                        ]
+                        "locationName": "eventIdMode"
                       },
                       "EventStopBehavior": {
-                        "locationName": "eventStopBehavior",
-                        "type": "string",
-                        "enum": [
-                          "NONE",
-                          "SEND_EOS"
-                        ]
+                        "locationName": "eventStopBehavior"
                       },
                       "FilecacheDuration": {
-                        "shape": "Sp",
-                        "locationName": "filecacheDuration"
+                        "locationName": "filecacheDuration",
+                        "type": "integer"
                       },
                       "FragmentLength": {
-                        "shape": "Sq",
-                        "locationName": "fragmentLength"
+                        "locationName": "fragmentLength",
+                        "type": "integer"
                       },
                       "InputLossAction": {
-                        "locationName": "inputLossAction",
-                        "type": "string",
-                        "enum": [
-                          "EMIT_OUTPUT",
-                          "PAUSE_OUTPUT"
-                        ]
+                        "locationName": "inputLossAction"
                       },
                       "NumRetries": {
-                        "shape": "Sp",
-                        "locationName": "numRetries"
+                        "locationName": "numRetries",
+                        "type": "integer"
                       },
                       "RestartDelay": {
-                        "shape": "Sp",
-                        "locationName": "restartDelay"
+                        "locationName": "restartDelay",
+                        "type": "integer"
                       },
                       "SegmentationMode": {
-                        "locationName": "segmentationMode",
-                        "type": "string",
-                        "enum": [
-                          "USE_INPUT_SEGMENTATION",
-                          "USE_SEGMENT_DURATION"
-                        ]
+                        "locationName": "segmentationMode"
                       },
                       "SendDelayMs": {
-                        "shape": "S5o",
-                        "locationName": "sendDelayMs"
+                        "locationName": "sendDelayMs",
+                        "type": "integer"
                       },
                       "SparseTrackType": {
-                        "locationName": "sparseTrackType",
-                        "type": "string",
-                        "enum": [
-                          "NONE",
-                          "SCTE_35"
-                        ]
+                        "locationName": "sparseTrackType"
                       },
                       "StreamManifestBehavior": {
-                        "locationName": "streamManifestBehavior",
-                        "type": "string",
-                        "enum": [
-                          "DO_NOT_SEND",
-                          "SEND"
-                        ]
+                        "locationName": "streamManifestBehavior"
                       },
                       "TimestampOffset": {
                         "locationName": "timestampOffset"
                       },
                       "TimestampOffsetMode": {
-                        "locationName": "timestampOffsetMode",
-                        "type": "string",
-                        "enum": [
-                          "USE_CONFIGURED_OFFSET",
-                          "USE_EVENT_START_DATE"
-                        ]
+                        "locationName": "timestampOffsetMode"
                       }
                     },
                     "required": [
@@ -3233,38 +2637,21 @@
                     "type": "structure",
                     "members": {
                       "AuthenticationScheme": {
-                        "locationName": "authenticationScheme",
-                        "type": "string",
-                        "enum": [
-                          "AKAMAI",
-                          "COMMON"
-                        ]
+                        "locationName": "authenticationScheme"
                       },
                       "CacheFullBehavior": {
-                        "locationName": "cacheFullBehavior",
-                        "type": "string",
-                        "enum": [
-                          "DISCONNECT_IMMEDIATELY",
-                          "WAIT_FOR_SERVER"
-                        ]
+                        "locationName": "cacheFullBehavior"
                       },
                       "CacheLength": {
                         "locationName": "cacheLength",
-                        "type": "integer",
-                        "min": 30
+                        "type": "integer"
                       },
                       "CaptionData": {
-                        "locationName": "captionData",
-                        "type": "string",
-                        "enum": [
-                          "ALL",
-                          "FIELD1_608",
-                          "FIELD1_AND_FIELD2_608"
-                        ]
+                        "locationName": "captionData"
                       },
                       "RestartDelay": {
-                        "shape": "Sp",
-                        "locationName": "restartDelay"
+                        "locationName": "restartDelay",
+                        "type": "integer"
                       }
                     }
                   },
@@ -3273,26 +2660,14 @@
                     "type": "structure",
                     "members": {
                       "InputLossAction": {
-                        "locationName": "inputLossAction",
-                        "type": "string",
-                        "enum": [
-                          "DROP_PROGRAM",
-                          "DROP_TS",
-                          "EMIT_PROGRAM"
-                        ]
+                        "locationName": "inputLossAction"
                       },
                       "TimedMetadataId3Frame": {
-                        "locationName": "timedMetadataId3Frame",
-                        "type": "string",
-                        "enum": [
-                          "NONE",
-                          "PRIV",
-                          "TDRL"
-                        ]
+                        "locationName": "timedMetadataId3Frame"
                       },
                       "TimedMetadataId3Period": {
-                        "shape": "Sp",
-                        "locationName": "timedMetadataId3Period"
+                        "locationName": "timedMetadataId3Period",
+                        "type": "integer"
                       }
                     }
                   }
@@ -3313,10 +2688,7 @@
                       "locationName": "captionDescriptionNames"
                     },
                     "OutputName": {
-                      "locationName": "outputName",
-                      "type": "string",
-                      "min": 1,
-                      "max": 255
+                      "locationName": "outputName"
                     },
                     "OutputSettings": {
                       "locationName": "outputSettings",
@@ -3367,14 +2739,7 @@
                                       "locationName": "audioOnlyImage"
                                     },
                                     "AudioTrackType": {
-                                      "locationName": "audioTrackType",
-                                      "type": "string",
-                                      "enum": [
-                                        "ALTERNATE_AUDIO_AUTO_SELECT",
-                                        "ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT",
-                                        "ALTERNATE_AUDIO_NOT_AUTO_SELECT",
-                                        "AUDIO_ONLY_VARIANT_STREAM"
-                                      ]
+                                      "locationName": "audioTrackType"
                                     }
                                   }
                                 },
@@ -3390,8 +2755,8 @@
                                       "type": "structure",
                                       "members": {
                                         "AudioFramesPerPes": {
-                                          "shape": "Sp",
-                                          "locationName": "audioFramesPerPes"
+                                          "locationName": "audioFramesPerPes",
+                                          "type": "integer"
                                         },
                                         "AudioPids": {
                                           "locationName": "audioPids"
@@ -3400,60 +2765,45 @@
                                           "locationName": "ecmPid"
                                         },
                                         "PatInterval": {
-                                          "shape": "S6t",
-                                          "locationName": "patInterval"
+                                          "locationName": "patInterval",
+                                          "type": "integer"
                                         },
                                         "PcrControl": {
-                                          "locationName": "pcrControl",
-                                          "type": "string",
-                                          "enum": [
-                                            "CONFIGURED_PCR_PERIOD",
-                                            "PCR_EVERY_PES_PACKET"
-                                          ]
+                                          "locationName": "pcrControl"
                                         },
                                         "PcrPeriod": {
-                                          "shape": "S6v",
-                                          "locationName": "pcrPeriod"
+                                          "locationName": "pcrPeriod",
+                                          "type": "integer"
                                         },
                                         "PcrPid": {
                                           "locationName": "pcrPid"
                                         },
                                         "PmtInterval": {
-                                          "shape": "S6t",
-                                          "locationName": "pmtInterval"
+                                          "locationName": "pmtInterval",
+                                          "type": "integer"
                                         },
                                         "PmtPid": {
                                           "locationName": "pmtPid"
                                         },
                                         "ProgramNum": {
-                                          "shape": "S6w",
-                                          "locationName": "programNum"
+                                          "locationName": "programNum",
+                                          "type": "integer"
                                         },
                                         "Scte35Behavior": {
-                                          "locationName": "scte35Behavior",
-                                          "type": "string",
-                                          "enum": [
-                                            "NO_PASSTHROUGH",
-                                            "PASSTHROUGH"
-                                          ]
+                                          "locationName": "scte35Behavior"
                                         },
                                         "Scte35Pid": {
                                           "locationName": "scte35Pid"
                                         },
                                         "TimedMetadataBehavior": {
-                                          "locationName": "timedMetadataBehavior",
-                                          "type": "string",
-                                          "enum": [
-                                            "NO_PASSTHROUGH",
-                                            "PASSTHROUGH"
-                                          ]
+                                          "locationName": "timedMetadataBehavior"
                                         },
                                         "TimedMetadataPid": {
                                           "locationName": "timedMetadataPid"
                                         },
                                         "TransportStreamId": {
-                                          "shape": "S6w",
-                                          "locationName": "transportStreamId"
+                                          "locationName": "transportStreamId",
+                                          "type": "integer"
                                         },
                                         "VideoPid": {
                                           "locationName": "videoPid"
@@ -3468,7 +2818,6 @@
                               }
                             },
                             "NameModifier": {
-                              "shape": "S4l",
                               "locationName": "nameModifier"
                             },
                             "SegmentModifier": {
@@ -3493,24 +2842,19 @@
                           "type": "structure",
                           "members": {
                             "CertificateMode": {
-                              "locationName": "certificateMode",
-                              "type": "string",
-                              "enum": [
-                                "SELF_SIGNED",
-                                "VERIFY_AUTHENTICITY"
-                              ]
+                              "locationName": "certificateMode"
                             },
                             "ConnectionRetryInterval": {
-                              "shape": "Sq",
-                              "locationName": "connectionRetryInterval"
+                              "locationName": "connectionRetryInterval",
+                              "type": "integer"
                             },
                             "Destination": {
                               "shape": "S4e",
                               "locationName": "destination"
                             },
                             "NumRetries": {
-                              "shape": "Sp",
-                              "locationName": "numRetries"
+                              "locationName": "numRetries",
+                              "type": "integer"
                             }
                           },
                           "required": [
@@ -3522,8 +2866,8 @@
                           "type": "structure",
                           "members": {
                             "BufferMsec": {
-                              "shape": "S5o",
-                              "locationName": "bufferMsec"
+                              "locationName": "bufferMsec",
+                              "type": "integer"
                             },
                             "ContainerSettings": {
                               "locationName": "containerSettings",
@@ -3545,23 +2889,14 @@
                               "members": {
                                 "ColumnDepth": {
                                   "locationName": "columnDepth",
-                                  "type": "integer",
-                                  "min": 4,
-                                  "max": 20
+                                  "type": "integer"
                                 },
                                 "IncludeFec": {
-                                  "locationName": "includeFec",
-                                  "type": "string",
-                                  "enum": [
-                                    "COLUMN",
-                                    "COLUMN_AND_ROW"
-                                  ]
+                                  "locationName": "includeFec"
                                 },
                                 "RowLength": {
                                   "locationName": "rowLength",
-                                  "type": "integer",
-                                  "min": 1,
-                                  "max": 20
+                                  "type": "integer"
                                 }
                               }
                             }
@@ -3594,19 +2929,11 @@
           "type": "structure",
           "members": {
             "Source": {
-              "locationName": "source",
-              "type": "string",
-              "enum": [
-                "EMBEDDED",
-                "SYSTEMCLOCK",
-                "ZEROBASED"
-              ]
+              "locationName": "source"
             },
             "SyncThreshold": {
               "locationName": "syncThreshold",
-              "type": "integer",
-              "min": 1,
-              "max": 1000000
+              "type": "integer"
             }
           },
           "required": [
@@ -3628,86 +2955,37 @@
                     "type": "structure",
                     "members": {
                       "AdaptiveQuantization": {
-                        "locationName": "adaptiveQuantization",
-                        "type": "string",
-                        "enum": [
-                          "HIGH",
-                          "HIGHER",
-                          "LOW",
-                          "MAX",
-                          "MEDIUM",
-                          "OFF"
-                        ]
+                        "locationName": "adaptiveQuantization"
                       },
                       "AfdSignaling": {
-                        "locationName": "afdSignaling",
-                        "type": "string",
-                        "enum": [
-                          "AUTO",
-                          "FIXED",
-                          "NONE"
-                        ]
+                        "locationName": "afdSignaling"
                       },
                       "Bitrate": {
-                        "shape": "S7u",
-                        "locationName": "bitrate"
+                        "locationName": "bitrate",
+                        "type": "integer"
                       },
                       "BufFillPct": {
-                        "shape": "St",
-                        "locationName": "bufFillPct"
+                        "locationName": "bufFillPct",
+                        "type": "integer"
                       },
                       "BufSize": {
-                        "shape": "Sp",
-                        "locationName": "bufSize"
+                        "locationName": "bufSize",
+                        "type": "integer"
                       },
                       "ColorMetadata": {
-                        "locationName": "colorMetadata",
-                        "type": "string",
-                        "enum": [
-                          "IGNORE",
-                          "INSERT"
-                        ]
+                        "locationName": "colorMetadata"
                       },
                       "EntropyEncoding": {
-                        "locationName": "entropyEncoding",
-                        "type": "string",
-                        "enum": [
-                          "CABAC",
-                          "CAVLC"
-                        ]
+                        "locationName": "entropyEncoding"
                       },
                       "FixedAfd": {
-                        "locationName": "fixedAfd",
-                        "type": "string",
-                        "enum": [
-                          "AFD_0000",
-                          "AFD_0010",
-                          "AFD_0011",
-                          "AFD_0100",
-                          "AFD_1000",
-                          "AFD_1001",
-                          "AFD_1010",
-                          "AFD_1011",
-                          "AFD_1101",
-                          "AFD_1110",
-                          "AFD_1111"
-                        ]
+                        "locationName": "fixedAfd"
                       },
                       "FlickerAq": {
-                        "locationName": "flickerAq",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "flickerAq"
                       },
                       "FramerateControl": {
-                        "locationName": "framerateControl",
-                        "type": "string",
-                        "enum": [
-                          "INITIALIZE_FROM_SOURCE",
-                          "SPECIFIED"
-                        ]
+                        "locationName": "framerateControl"
                       },
                       "FramerateDenominator": {
                         "locationName": "framerateDenominator",
@@ -3718,176 +2996,83 @@
                         "type": "integer"
                       },
                       "GopBReference": {
-                        "locationName": "gopBReference",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "gopBReference"
                       },
                       "GopClosedCadence": {
-                        "shape": "Sp",
-                        "locationName": "gopClosedCadence"
+                        "locationName": "gopClosedCadence",
+                        "type": "integer"
                       },
                       "GopNumBFrames": {
-                        "shape": "Ss",
-                        "locationName": "gopNumBFrames"
+                        "locationName": "gopNumBFrames",
+                        "type": "integer"
                       },
                       "GopSize": {
                         "locationName": "gopSize",
                         "type": "double"
                       },
                       "GopSizeUnits": {
-                        "locationName": "gopSizeUnits",
-                        "type": "string",
-                        "enum": [
-                          "FRAMES",
-                          "SECONDS"
-                        ]
+                        "locationName": "gopSizeUnits"
                       },
                       "Level": {
-                        "locationName": "level",
-                        "type": "string",
-                        "enum": [
-                          "H264_LEVEL_1",
-                          "H264_LEVEL_1_1",
-                          "H264_LEVEL_1_2",
-                          "H264_LEVEL_1_3",
-                          "H264_LEVEL_2",
-                          "H264_LEVEL_2_1",
-                          "H264_LEVEL_2_2",
-                          "H264_LEVEL_3",
-                          "H264_LEVEL_3_1",
-                          "H264_LEVEL_3_2",
-                          "H264_LEVEL_4",
-                          "H264_LEVEL_4_1",
-                          "H264_LEVEL_4_2",
-                          "H264_LEVEL_5",
-                          "H264_LEVEL_5_1",
-                          "H264_LEVEL_5_2",
-                          "H264_LEVEL_AUTO"
-                        ]
+                        "locationName": "level"
                       },
                       "LookAheadRateControl": {
-                        "locationName": "lookAheadRateControl",
-                        "type": "string",
-                        "enum": [
-                          "HIGH",
-                          "LOW",
-                          "MEDIUM"
-                        ]
+                        "locationName": "lookAheadRateControl"
                       },
                       "MaxBitrate": {
-                        "shape": "S7u",
-                        "locationName": "maxBitrate"
+                        "locationName": "maxBitrate",
+                        "type": "integer"
                       },
                       "MinIInterval": {
                         "locationName": "minIInterval",
-                        "type": "integer",
-                        "min": 0,
-                        "max": 30
+                        "type": "integer"
                       },
                       "NumRefFrames": {
                         "locationName": "numRefFrames",
-                        "type": "integer",
-                        "min": 1,
-                        "max": 6
+                        "type": "integer"
                       },
                       "ParControl": {
-                        "locationName": "parControl",
-                        "type": "string",
-                        "enum": [
-                          "INITIALIZE_FROM_SOURCE",
-                          "SPECIFIED"
-                        ]
+                        "locationName": "parControl"
                       },
                       "ParDenominator": {
-                        "shape": "Sq",
-                        "locationName": "parDenominator"
+                        "locationName": "parDenominator",
+                        "type": "integer"
                       },
                       "ParNumerator": {
                         "locationName": "parNumerator",
                         "type": "integer"
                       },
                       "Profile": {
-                        "locationName": "profile",
-                        "type": "string",
-                        "enum": [
-                          "BASELINE",
-                          "HIGH",
-                          "HIGH_10BIT",
-                          "HIGH_422",
-                          "HIGH_422_10BIT",
-                          "MAIN"
-                        ]
+                        "locationName": "profile"
                       },
                       "RateControlMode": {
-                        "locationName": "rateControlMode",
-                        "type": "string",
-                        "enum": [
-                          "CBR",
-                          "VBR"
-                        ]
+                        "locationName": "rateControlMode"
                       },
                       "ScanType": {
-                        "locationName": "scanType",
-                        "type": "string",
-                        "enum": [
-                          "INTERLACED",
-                          "PROGRESSIVE"
-                        ]
+                        "locationName": "scanType"
                       },
                       "SceneChangeDetect": {
-                        "locationName": "sceneChangeDetect",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "sceneChangeDetect"
                       },
                       "Slices": {
                         "locationName": "slices",
-                        "type": "integer",
-                        "min": 1,
-                        "max": 32
+                        "type": "integer"
                       },
                       "Softness": {
                         "locationName": "softness",
-                        "type": "integer",
-                        "min": 0,
-                        "max": 128
+                        "type": "integer"
                       },
                       "SpatialAq": {
-                        "locationName": "spatialAq",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "spatialAq"
                       },
                       "Syntax": {
-                        "locationName": "syntax",
-                        "type": "string",
-                        "enum": [
-                          "DEFAULT",
-                          "RP2027"
-                        ]
+                        "locationName": "syntax"
                       },
                       "TemporalAq": {
-                        "locationName": "temporalAq",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "ENABLED"
-                        ]
+                        "locationName": "temporalAq"
                       },
                       "TimecodeInsertion": {
-                        "locationName": "timecodeInsertion",
-                        "type": "string",
-                        "enum": [
-                          "DISABLED",
-                          "PIC_TIMING_SEI"
-                        ]
+                        "locationName": "timecodeInsertion"
                       }
                     }
                   }
@@ -3901,25 +3086,14 @@
                 "locationName": "name"
               },
               "RespondToAfd": {
-                "locationName": "respondToAfd",
-                "type": "string",
-                "enum": [
-                  "NONE",
-                  "PASSTHROUGH",
-                  "RESPOND"
-                ]
+                "locationName": "respondToAfd"
               },
               "ScalingBehavior": {
-                "locationName": "scalingBehavior",
-                "type": "string",
-                "enum": [
-                  "DEFAULT",
-                  "STRETCH_TO_OUTPUT"
-                ]
+                "locationName": "scalingBehavior"
               },
               "Sharpness": {
-                "shape": "St",
-                "locationName": "sharpness"
+                "locationName": "sharpness",
+                "type": "integer"
               },
               "Width": {
                 "locationName": "width",
@@ -3939,41 +3113,6 @@
         "TimecodeConfig"
       ]
     },
-    "S1t": {
-      "type": "integer",
-      "min": 1,
-      "max": 31
-    },
-    "S2f": {
-      "type": "string",
-      "min": 3,
-      "max": 3
-    },
-    "S2n": {
-      "type": "integer",
-      "min": 0,
-      "max": 15
-    },
-    "S2v": {
-      "type": "integer",
-      "min": -1000,
-      "max": 1000
-    },
-    "S3d": {
-      "type": "integer",
-      "min": 96,
-      "max": 600
-    },
-    "S3f": {
-      "type": "integer",
-      "min": 0,
-      "max": 10
-    },
-    "S44": {
-      "type": "integer",
-      "min": 0,
-      "max": 1000000
-    },
     "S4e": {
       "type": "structure",
       "members": {
@@ -3982,120 +3121,58 @@
         }
       }
     },
-    "S4k": {
-      "type": "integer",
-      "min": 1,
-      "max": 4
-    },
-    "S4l": {
-      "type": "string",
-      "min": 1
-    },
-    "S4p": {
-      "type": "string",
-      "min": 32,
-      "max": 32
-    },
-    "S4u": {
-      "type": "integer",
-      "min": 0,
-      "max": 600
-    },
-    "S5o": {
-      "type": "integer",
-      "min": 0,
-      "max": 10000
-    },
     "S66": {
       "type": "structure",
       "members": {
         "AbsentInputAudioBehavior": {
-          "locationName": "absentInputAudioBehavior",
-          "type": "string",
-          "enum": [
-            "DROP",
-            "ENCODE_SILENCE"
-          ]
+          "locationName": "absentInputAudioBehavior"
         },
         "Arib": {
-          "locationName": "arib",
-          "type": "string",
-          "enum": [
-            "DISABLED",
-            "ENABLED"
-          ]
+          "locationName": "arib"
         },
         "AribCaptionsPid": {
           "locationName": "aribCaptionsPid"
         },
         "AribCaptionsPidControl": {
-          "locationName": "aribCaptionsPidControl",
-          "type": "string",
-          "enum": [
-            "AUTO",
-            "USE_CONFIGURED"
-          ]
+          "locationName": "aribCaptionsPidControl"
         },
         "AudioBufferModel": {
-          "locationName": "audioBufferModel",
-          "type": "string",
-          "enum": [
-            "ATSC",
-            "DVB"
-          ]
+          "locationName": "audioBufferModel"
         },
         "AudioFramesPerPes": {
-          "shape": "Sp",
-          "locationName": "audioFramesPerPes"
+          "locationName": "audioFramesPerPes",
+          "type": "integer"
         },
         "AudioPids": {
           "locationName": "audioPids"
         },
         "AudioStreamType": {
-          "locationName": "audioStreamType",
-          "type": "string",
-          "enum": [
-            "ATSC",
-            "DVB"
-          ]
+          "locationName": "audioStreamType"
         },
         "Bitrate": {
-          "shape": "Sp",
-          "locationName": "bitrate"
+          "locationName": "bitrate",
+          "type": "integer"
         },
         "BufferModel": {
-          "locationName": "bufferModel",
-          "type": "string",
-          "enum": [
-            "MULTIPLEX",
-            "NONE"
-          ]
+          "locationName": "bufferModel"
         },
         "CcDescriptor": {
-          "locationName": "ccDescriptor",
-          "type": "string",
-          "enum": [
-            "DISABLED",
-            "ENABLED"
-          ]
+          "locationName": "ccDescriptor"
         },
         "DvbNitSettings": {
           "locationName": "dvbNitSettings",
           "type": "structure",
           "members": {
             "NetworkId": {
-              "shape": "S6f",
-              "locationName": "networkId"
+              "locationName": "networkId",
+              "type": "integer"
             },
             "NetworkName": {
-              "shape": "S6g",
               "locationName": "networkName"
             },
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer",
-              "min": 25,
-              "max": 10000
+              "type": "integer"
             }
           },
           "required": [
@@ -4108,27 +3185,16 @@
           "type": "structure",
           "members": {
             "OutputSdt": {
-              "locationName": "outputSdt",
-              "type": "string",
-              "enum": [
-                "SDT_FOLLOW",
-                "SDT_FOLLOW_IF_PRESENT",
-                "SDT_MANUAL",
-                "SDT_NONE"
-              ]
+              "locationName": "outputSdt"
             },
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer",
-              "min": 25,
-              "max": 2000
+              "type": "integer"
             },
             "ServiceName": {
-              "shape": "S6g",
               "locationName": "serviceName"
             },
             "ServiceProviderName": {
-              "shape": "S6g",
               "locationName": "serviceProviderName"
             }
           }
@@ -4142,9 +3208,7 @@
           "members": {
             "RepInterval": {
               "locationName": "repInterval",
-              "type": "integer",
-              "min": 1000,
-              "max": 30000
+              "type": "integer"
             }
           }
         },
@@ -4152,43 +3216,23 @@
           "locationName": "dvbTeletextPid"
         },
         "Ebif": {
-          "locationName": "ebif",
-          "type": "string",
-          "enum": [
-            "NONE",
-            "PASSTHROUGH"
-          ]
+          "locationName": "ebif"
         },
         "EbpAudioInterval": {
-          "locationName": "ebpAudioInterval",
-          "type": "string",
-          "enum": [
-            "VIDEO_AND_FIXED_INTERVALS",
-            "VIDEO_INTERVAL"
-          ]
+          "locationName": "ebpAudioInterval"
         },
         "EbpLookaheadMs": {
-          "shape": "S5o",
-          "locationName": "ebpLookaheadMs"
+          "locationName": "ebpLookaheadMs",
+          "type": "integer"
         },
         "EbpPlacement": {
-          "locationName": "ebpPlacement",
-          "type": "string",
-          "enum": [
-            "VIDEO_AND_AUDIO_PIDS",
-            "VIDEO_PID"
-          ]
+          "locationName": "ebpPlacement"
         },
         "EcmPid": {
           "locationName": "ecmPid"
         },
         "EsRateInPes": {
-          "locationName": "esRateInPes",
-          "type": "string",
-          "enum": [
-            "EXCLUDE",
-            "INCLUDE"
-          ]
+          "locationName": "esRateInPes"
         },
         "EtvPlatformPid": {
           "locationName": "etvPlatformPid"
@@ -4201,12 +3245,7 @@
           "type": "double"
         },
         "Klv": {
-          "locationName": "klv",
-          "type": "string",
-          "enum": [
-            "NONE",
-            "PASSTHROUGH"
-          ]
+          "locationName": "klv"
         },
         "KlvDataPids": {
           "locationName": "klvDataPids"
@@ -4216,129 +3255,66 @@
           "type": "double"
         },
         "PatInterval": {
-          "shape": "S6t",
-          "locationName": "patInterval"
+          "locationName": "patInterval",
+          "type": "integer"
         },
         "PcrControl": {
-          "locationName": "pcrControl",
-          "type": "string",
-          "enum": [
-            "CONFIGURED_PCR_PERIOD",
-            "PCR_EVERY_PES_PACKET"
-          ]
+          "locationName": "pcrControl"
         },
         "PcrPeriod": {
-          "shape": "S6v",
-          "locationName": "pcrPeriod"
+          "locationName": "pcrPeriod",
+          "type": "integer"
         },
         "PcrPid": {
           "locationName": "pcrPid"
         },
         "PmtInterval": {
-          "shape": "S6t",
-          "locationName": "pmtInterval"
+          "locationName": "pmtInterval",
+          "type": "integer"
         },
         "PmtPid": {
           "locationName": "pmtPid"
         },
         "ProgramNum": {
-          "shape": "S6w",
-          "locationName": "programNum"
+          "locationName": "programNum",
+          "type": "integer"
         },
         "RateMode": {
-          "locationName": "rateMode",
-          "type": "string",
-          "enum": [
-            "CBR",
-            "VBR"
-          ]
+          "locationName": "rateMode"
         },
         "Scte27Pids": {
           "locationName": "scte27Pids"
         },
         "Scte35Control": {
-          "locationName": "scte35Control",
-          "type": "string",
-          "enum": [
-            "NONE",
-            "PASSTHROUGH"
-          ]
+          "locationName": "scte35Control"
         },
         "Scte35Pid": {
           "locationName": "scte35Pid"
         },
         "SegmentationMarkers": {
-          "locationName": "segmentationMarkers",
-          "type": "string",
-          "enum": [
-            "EBP",
-            "EBP_LEGACY",
-            "NONE",
-            "PSI_SEGSTART",
-            "RAI_ADAPT",
-            "RAI_SEGSTART"
-          ]
+          "locationName": "segmentationMarkers"
         },
         "SegmentationStyle": {
-          "locationName": "segmentationStyle",
-          "type": "string",
-          "enum": [
-            "MAINTAIN_CADENCE",
-            "RESET_CADENCE"
-          ]
+          "locationName": "segmentationStyle"
         },
         "SegmentationTime": {
           "locationName": "segmentationTime",
           "type": "double"
         },
         "TimedMetadataBehavior": {
-          "locationName": "timedMetadataBehavior",
-          "type": "string",
-          "enum": [
-            "NO_PASSTHROUGH",
-            "PASSTHROUGH"
-          ]
+          "locationName": "timedMetadataBehavior"
         },
         "TimedMetadataPid": {
           "locationName": "timedMetadataPid"
         },
         "TransportStreamId": {
-          "shape": "S6w",
-          "locationName": "transportStreamId"
+          "locationName": "transportStreamId",
+          "type": "integer"
         },
         "VideoPid": {
           "locationName": "videoPid"
         }
       }
-    },
-    "S6f": {
-      "type": "integer",
-      "min": 0,
-      "max": 65536
-    },
-    "S6g": {
-      "type": "string",
-      "min": 1,
-      "max": 256
-    },
-    "S6t": {
-      "type": "integer",
-      "min": 0,
-      "max": 1000
-    },
-    "S6v": {
-      "type": "integer",
-      "min": 0,
-      "max": 500
-    },
-    "S6w": {
-      "type": "integer",
-      "min": 0,
-      "max": 65535
-    },
-    "S7u": {
-      "type": "integer",
-      "min": 1000
     },
     "S8j": {
       "type": "list",
@@ -4373,12 +3349,7 @@
                               "locationName": "languageCode"
                             },
                             "LanguageSelectionPolicy": {
-                              "locationName": "languageSelectionPolicy",
-                              "type": "string",
-                              "enum": [
-                                "LOOSE",
-                                "STRICT"
-                              ]
+                              "locationName": "languageSelectionPolicy"
                             }
                           },
                           "required": [
@@ -4390,8 +3361,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "shape": "S8s",
-                              "locationName": "pid"
+                              "locationName": "pid",
+                              "type": "integer"
                             }
                           },
                           "required": [
@@ -4432,8 +3403,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "shape": "Sq",
-                              "locationName": "pid"
+                              "locationName": "pid",
+                              "type": "integer"
                             }
                           }
                         },
@@ -4442,28 +3413,18 @@
                           "type": "structure",
                           "members": {
                             "Convert608To708": {
-                              "locationName": "convert608To708",
-                              "type": "string",
-                              "enum": [
-                                "DISABLED",
-                                "UPCONVERT"
-                              ]
+                              "locationName": "convert608To708"
                             },
                             "Scte20Detection": {
-                              "locationName": "scte20Detection",
-                              "type": "string",
-                              "enum": [
-                                "AUTO",
-                                "OFF"
-                              ]
+                              "locationName": "scte20Detection"
                             },
                             "Source608ChannelNumber": {
-                              "shape": "S4k",
-                              "locationName": "source608ChannelNumber"
+                              "locationName": "source608ChannelNumber",
+                              "type": "integer"
                             },
                             "Source608TrackNumber": {
-                              "shape": "S91",
-                              "locationName": "source608TrackNumber"
+                              "locationName": "source608TrackNumber",
+                              "type": "integer"
                             }
                           }
                         },
@@ -4472,16 +3433,11 @@
                           "type": "structure",
                           "members": {
                             "Convert608To708": {
-                              "locationName": "convert608To708",
-                              "type": "string",
-                              "enum": [
-                                "DISABLED",
-                                "UPCONVERT"
-                              ]
+                              "locationName": "convert608To708"
                             },
                             "Source608ChannelNumber": {
-                              "shape": "S4k",
-                              "locationName": "source608ChannelNumber"
+                              "locationName": "source608ChannelNumber",
+                              "type": "integer"
                             }
                           }
                         },
@@ -4490,8 +3446,8 @@
                           "type": "structure",
                           "members": {
                             "Pid": {
-                              "shape": "Sq",
-                              "locationName": "pid"
+                              "locationName": "pid",
+                              "type": "integer"
                             }
                           }
                         },
@@ -4513,33 +3469,17 @@
                 }
               },
               "DeblockFilter": {
-                "locationName": "deblockFilter",
-                "type": "string",
-                "enum": [
-                  "DISABLED",
-                  "ENABLED"
-                ]
+                "locationName": "deblockFilter"
               },
               "DenoiseFilter": {
-                "locationName": "denoiseFilter",
-                "type": "string",
-                "enum": [
-                  "DISABLED",
-                  "ENABLED"
-                ]
+                "locationName": "denoiseFilter"
               },
               "FilterStrength": {
-                "shape": "S91",
-                "locationName": "filterStrength"
+                "locationName": "filterStrength",
+                "type": "integer"
               },
               "InputFilter": {
-                "locationName": "inputFilter",
-                "type": "string",
-                "enum": [
-                  "AUTO",
-                  "DISABLED",
-                  "FORCED"
-                ]
+                "locationName": "inputFilter"
               },
               "NetworkInputSettings": {
                 "locationName": "networkInputSettings",
@@ -4550,61 +3490,40 @@
                     "type": "structure",
                     "members": {
                       "Bandwidth": {
-                        "shape": "Sp",
-                        "locationName": "bandwidth"
+                        "locationName": "bandwidth",
+                        "type": "integer"
                       },
                       "BufferSegments": {
-                        "shape": "Sp",
-                        "locationName": "bufferSegments"
+                        "locationName": "bufferSegments",
+                        "type": "integer"
                       },
                       "Retries": {
-                        "shape": "Sp",
-                        "locationName": "retries"
+                        "locationName": "retries",
+                        "type": "integer"
                       },
                       "RetryInterval": {
-                        "shape": "Sp",
-                        "locationName": "retryInterval"
+                        "locationName": "retryInterval",
+                        "type": "integer"
                       }
                     }
                   },
                   "ServerValidation": {
-                    "locationName": "serverValidation",
-                    "type": "string",
-                    "enum": [
-                      "CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME",
-                      "CHECK_CRYPTOGRAPHY_ONLY"
-                    ]
+                    "locationName": "serverValidation"
                   }
                 }
               },
               "SourceEndBehavior": {
-                "locationName": "sourceEndBehavior",
-                "type": "string",
-                "enum": [
-                  "CONTINUE",
-                  "LOOP"
-                ]
+                "locationName": "sourceEndBehavior"
               },
               "VideoSelector": {
                 "locationName": "videoSelector",
                 "type": "structure",
                 "members": {
                   "ColorSpace": {
-                    "locationName": "colorSpace",
-                    "type": "string",
-                    "enum": [
-                      "FOLLOW",
-                      "REC_601",
-                      "REC_709"
-                    ]
+                    "locationName": "colorSpace"
                   },
                   "ColorSpaceUsage": {
-                    "locationName": "colorSpaceUsage",
-                    "type": "string",
-                    "enum": [
-                      "FALLBACK",
-                      "FORCE"
-                    ]
+                    "locationName": "colorSpaceUsage"
                   },
                   "SelectorSettings": {
                     "locationName": "selectorSettings",
@@ -4615,8 +3534,8 @@
                         "type": "structure",
                         "members": {
                           "Pid": {
-                            "shape": "S8s",
-                            "locationName": "pid"
+                            "locationName": "pid",
+                            "type": "integer"
                           }
                         }
                       },
@@ -4625,8 +3544,8 @@
                         "type": "structure",
                         "members": {
                           "ProgramId": {
-                            "shape": "S6f",
-                            "locationName": "programId"
+                            "locationName": "programId",
+                            "type": "integer"
                           }
                         }
                       }
@@ -4639,57 +3558,19 @@
         }
       }
     },
-    "S8s": {
-      "type": "integer",
-      "min": 0,
-      "max": 8191
-    },
-    "S91": {
-      "type": "integer",
-      "min": 1,
-      "max": 5
-    },
     "S9j": {
       "type": "structure",
       "members": {
         "Codec": {
-          "locationName": "codec",
-          "type": "string",
-          "enum": [
-            "MPEG2",
-            "AVC",
-            "HEVC"
-          ]
+          "locationName": "codec"
         },
         "MaximumBitrate": {
-          "locationName": "maximumBitrate",
-          "type": "string",
-          "enum": [
-            "MAX_10_MBPS",
-            "MAX_20_MBPS",
-            "MAX_50_MBPS"
-          ]
+          "locationName": "maximumBitrate"
         },
         "Resolution": {
-          "locationName": "resolution",
-          "type": "string",
-          "enum": [
-            "SD",
-            "HD",
-            "UHD"
-          ]
+          "locationName": "resolution"
         }
       }
-    },
-    "S9n": {
-      "type": "string",
-      "enum": [
-        "ERROR",
-        "WARNING",
-        "INFO",
-        "DEBUG",
-        "DISABLED"
-      ]
     },
     "S9p": {
       "type": "structure",
@@ -4721,7 +3602,6 @@
           "locationName": "inputSpecification"
         },
         "LogLevel": {
-          "shape": "S9n",
           "locationName": "logLevel"
         },
         "Name": {
@@ -4735,7 +3615,6 @@
           "locationName": "roleArn"
         },
         "State": {
-          "shape": "S9s",
           "locationName": "state"
         }
       }
@@ -4750,20 +3629,6 @@
           }
         }
       }
-    },
-    "S9s": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "CREATE_FAILED",
-        "IDLE",
-        "STARTING",
-        "RUNNING",
-        "RECOVERING",
-        "STOPPING",
-        "DELETING",
-        "DELETED"
-      ]
     },
     "S9u": {
       "type": "list",
@@ -4792,16 +3657,6 @@
           }
         }
       }
-    },
-    "S9y": {
-      "type": "string",
-      "enum": [
-        "UDP_PUSH",
-        "RTP_PUSH",
-        "RTMP_PUSH",
-        "RTMP_PULL",
-        "URL_PULL"
-      ]
     },
     "Sa0": {
       "type": "structure",
@@ -4832,11 +3687,9 @@
           "locationName": "sources"
         },
         "State": {
-          "shape": "Sa5",
           "locationName": "state"
         },
         "Type": {
-          "shape": "S9y",
           "locationName": "type"
         }
       }
@@ -4875,16 +3728,6 @@
         }
       }
     },
-    "Sa5": {
-      "type": "string",
-      "enum": [
-        "CREATING",
-        "DETACHED",
-        "ATTACHED",
-        "DELETING",
-        "DELETED"
-      ]
-    },
     "Sa7": {
       "type": "list",
       "member": {
@@ -4910,7 +3753,6 @@
           "locationName": "inputs"
         },
         "State": {
-          "shape": "Sab",
           "locationName": "state"
         },
         "WhitelistRules": {
@@ -4918,15 +3760,6 @@
           "locationName": "whitelistRules"
         }
       }
-    },
-    "Sab": {
-      "type": "string",
-      "enum": [
-        "IDLE",
-        "IN_USE",
-        "UPDATING",
-        "DELETED"
-      ]
     },
     "Sac": {
       "type": "list",
@@ -4939,98 +3772,31 @@
         }
       }
     },
-    "Sam": {
-      "type": "string",
-      "enum": [
-        "MONTHS"
-      ]
-    },
-    "San": {
-      "type": "string",
-      "enum": [
-        "NO_UPFRONT"
-      ]
-    },
     "Sao": {
       "type": "structure",
       "members": {
         "Codec": {
-          "locationName": "codec",
-          "type": "string",
-          "enum": [
-            "MPEG2",
-            "AVC",
-            "HEVC",
-            "AUDIO"
-          ]
+          "locationName": "codec"
         },
         "MaximumBitrate": {
-          "locationName": "maximumBitrate",
-          "type": "string",
-          "enum": [
-            "MAX_10_MBPS",
-            "MAX_20_MBPS",
-            "MAX_50_MBPS"
-          ]
+          "locationName": "maximumBitrate"
         },
         "MaximumFramerate": {
-          "locationName": "maximumFramerate",
-          "type": "string",
-          "enum": [
-            "MAX_30_FPS",
-            "MAX_60_FPS"
-          ]
+          "locationName": "maximumFramerate"
         },
         "Resolution": {
-          "locationName": "resolution",
-          "type": "string",
-          "enum": [
-            "SD",
-            "HD",
-            "UHD"
-          ]
+          "locationName": "resolution"
         },
         "ResourceType": {
-          "locationName": "resourceType",
-          "type": "string",
-          "enum": [
-            "INPUT",
-            "OUTPUT",
-            "CHANNEL"
-          ]
+          "locationName": "resourceType"
         },
         "SpecialFeature": {
-          "locationName": "specialFeature",
-          "type": "string",
-          "enum": [
-            "ADVANCED_AUDIO",
-            "AUDIO_NORMALIZATION"
-          ]
+          "locationName": "specialFeature"
         },
         "VideoQuality": {
-          "locationName": "videoQuality",
-          "type": "string",
-          "enum": [
-            "STANDARD",
-            "ENHANCED",
-            "PREMIUM"
-          ]
+          "locationName": "videoQuality"
         }
       }
-    },
-    "Saw": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "EXPIRED",
-        "CANCELED",
-        "DELETED"
-      ]
-    },
-    "Sb8": {
-      "type": "integer",
-      "min": 1,
-      "max": 1000
     },
     "Sbr": {
       "type": "structure",
@@ -5050,7 +3816,6 @@
           "type": "integer"
         },
         "DurationUnits": {
-          "shape": "Sam",
           "locationName": "durationUnits"
         },
         "End": {
@@ -5070,7 +3835,6 @@
           "locationName": "offeringId"
         },
         "OfferingType": {
-          "shape": "San",
           "locationName": "offeringType"
         },
         "Region": {
@@ -5087,7 +3851,6 @@
           "locationName": "start"
         },
         "State": {
-          "shape": "Saw",
           "locationName": "state"
         },
         "UsagePrice": {

--- a/apis/mediapackage-2017-10-12.min.json
+++ b/apis/mediapackage-2017-10-12.min.json
@@ -320,7 +320,7 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "shape": "S17"
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -375,7 +375,7 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "maxResults",
-            "shape": "S17"
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -714,8 +714,7 @@
           "member": {
             "members": {
               "AdMarkers": {
-                "locationName": "adMarkers",
-                "shape": "Sf"
+                "locationName": "adMarkers"
               },
               "Id": {
                 "locationName": "id"
@@ -728,8 +727,7 @@
                 "locationName": "manifestName"
               },
               "PlaylistType": {
-                "locationName": "playlistType",
-                "shape": "Sh"
+                "locationName": "playlistType"
               },
               "PlaylistWindowSeconds": {
                 "locationName": "playlistWindowSeconds",
@@ -805,22 +803,6 @@
       "member": {},
       "type": "list"
     },
-    "Sf": {
-      "enum": [
-        "NONE",
-        "SCTE35_ENHANCED",
-        "PASSTHROUGH"
-      ],
-      "type": "string"
-    },
-    "Sh": {
-      "enum": [
-        "NONE",
-        "EVENT",
-        "VOD"
-      ],
-      "type": "string"
-    },
     "Si": {
       "members": {
         "MaxVideoBitsPerSecond": {
@@ -832,13 +814,7 @@
           "type": "integer"
         },
         "StreamOrder": {
-          "locationName": "streamOrder",
-          "enum": [
-            "ORIGINAL",
-            "VIDEO_BITRATE_ASCENDING",
-            "VIDEO_BITRATE_DESCENDING"
-          ],
-          "type": "string"
+          "locationName": "streamOrder"
         }
       },
       "type": "structure"
@@ -876,21 +852,11 @@
         },
         "PeriodTriggers": {
           "locationName": "periodTriggers",
-          "member": {
-            "enum": [
-              "ADS"
-            ],
-            "type": "string"
-          },
+          "member": {},
           "type": "list"
         },
         "Profile": {
-          "locationName": "profile",
-          "enum": [
-            "NONE",
-            "HBBTV_1_5"
-          ],
-          "type": "string"
+          "locationName": "profile"
         },
         "SegmentDurationSeconds": {
           "locationName": "segmentDurationSeconds",
@@ -910,8 +876,7 @@
     "Sp": {
       "members": {
         "AdMarkers": {
-          "locationName": "adMarkers",
-          "shape": "Sf"
+          "locationName": "adMarkers"
         },
         "Encryption": {
           "locationName": "encryption",
@@ -920,12 +885,7 @@
               "locationName": "constantInitializationVector"
             },
             "EncryptionMethod": {
-              "locationName": "encryptionMethod",
-              "enum": [
-                "AES_128",
-                "SAMPLE_AES"
-              ],
-              "type": "string"
+              "locationName": "encryptionMethod"
             },
             "KeyRotationIntervalSeconds": {
               "locationName": "keyRotationIntervalSeconds",
@@ -950,8 +910,7 @@
           "type": "boolean"
         },
         "PlaylistType": {
-          "locationName": "playlistType",
-          "shape": "Sh"
+          "locationName": "playlistType"
         },
         "PlaylistWindowSeconds": {
           "locationName": "playlistWindowSeconds",
@@ -1017,8 +976,7 @@
           "member": {
             "members": {
               "AdMarkers": {
-                "locationName": "adMarkers",
-                "shape": "Sf"
+                "locationName": "adMarkers"
               },
               "Id": {
                 "locationName": "id"
@@ -1031,8 +989,7 @@
                 "locationName": "manifestName"
               },
               "PlaylistType": {
-                "locationName": "playlistType",
-                "shape": "Sh"
+                "locationName": "playlistType"
               },
               "PlaylistWindowSeconds": {
                 "locationName": "playlistWindowSeconds",
@@ -1066,11 +1023,6 @@
         }
       },
       "type": "structure"
-    },
-    "S17": {
-      "max": 1000,
-      "min": 1,
-      "type": "integer"
     }
   }
 }

--- a/apis/mediastore-2017-09-01.min.json
+++ b/apis/mediastore-2017-09-01.min.json
@@ -21,9 +21,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -45,9 +43,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -62,9 +58,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -79,9 +73,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -93,9 +85,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -114,9 +104,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -125,9 +113,7 @@
           "Policy"
         ],
         "members": {
-          "Policy": {
-            "shape": "Sj"
-          }
+          "Policy": {}
         }
       }
     },
@@ -138,9 +124,7 @@
           "ContainerName"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          }
+          "ContainerName": {}
         }
       },
       "output": {
@@ -159,13 +143,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "Sx"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -181,9 +161,7 @@
               "shape": "S4"
             }
           },
-          "NextToken": {
-            "shape": "Sx"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -195,12 +173,8 @@
           "Policy"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          },
-          "Policy": {
-            "shape": "Sj"
-          }
+          "ContainerName": {},
+          "Policy": {}
         }
       },
       "output": {
@@ -216,9 +190,7 @@
           "CorsPolicy"
         ],
         "members": {
-          "ContainerName": {
-            "shape": "S2"
-          },
+          "ContainerName": {},
           "CorsPolicy": {
             "shape": "Sm"
           }
@@ -231,49 +203,17 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "\\w+"
-    },
     "S4": {
       "type": "structure",
       "members": {
-        "Endpoint": {
-          "type": "string",
-          "max": 255,
-          "min": 1
-        },
+        "Endpoint": {},
         "CreationTime": {
           "type": "timestamp"
         },
-        "ARN": {
-          "type": "string",
-          "max": 1024,
-          "min": 1,
-          "pattern": "arn:aws:mediastore:[a-z]+-[a-z]+-\\d:\\d{12}:container/\\w{1,255}"
-        },
-        "Name": {
-          "shape": "S2"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "ACTIVE",
-            "CREATING",
-            "DELETING"
-          ],
-          "max": 16,
-          "min": 1
-        }
+        "ARN": {},
+        "Name": {},
+        "Status": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "max": 8192,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
     },
     "Sm": {
       "type": "list",
@@ -282,60 +222,25 @@
         "members": {
           "AllowedOrigins": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-            }
+            "member": {}
           },
           "AllowedMethods": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "PUT",
-                "GET",
-                "DELETE",
-                "HEAD"
-              ]
-            }
+            "member": {}
           },
           "AllowedHeaders": {
             "type": "list",
-            "member": {
-              "shape": "St"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           },
           "MaxAgeSeconds": {
-            "type": "integer",
-            "max": 2147483647,
-            "min": 0
+            "type": "integer"
           },
           "ExposeHeaders": {
             "type": "list",
-            "member": {
-              "shape": "St"
-            },
-            "max": 100,
-            "min": 0
+            "member": {}
           }
         }
-      },
-      "max": 100,
-      "min": 1
-    },
-    "St": {
-      "type": "string",
-      "max": 8192,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "Sx": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[0-9A-Za-z=/+]+"
+      }
     }
   }
 }

--- a/apis/mediastore-data-2017-09-01.min.json
+++ b/apis/mediastore-data-2017-09-01.min.json
@@ -24,7 +24,6 @@
         ],
         "members": {
           "Path": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           }
@@ -47,7 +46,6 @@
         ],
         "members": {
           "Path": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           }
@@ -57,19 +55,17 @@
         "type": "structure",
         "members": {
           "ETag": {
-            "shape": "S6",
             "location": "header",
             "locationName": "ETag"
           },
           "ContentType": {
-            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
           "ContentLength": {
-            "shape": "S8",
             "location": "header",
-            "locationName": "Content-Length"
+            "locationName": "Content-Length",
+            "type": "long"
           },
           "CacheControl": {
             "location": "header",
@@ -95,15 +91,12 @@
         ],
         "members": {
           "Path": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           },
           "Range": {
             "location": "header",
-            "locationName": "Range",
-            "type": "string",
-            "pattern": "^bytes=(?:\\d+\\-\\d*|\\d*\\-\\d+)$"
+            "locationName": "Range"
           }
         }
       },
@@ -122,22 +115,18 @@
           },
           "ContentRange": {
             "location": "header",
-            "locationName": "Content-Range",
-            "type": "string",
-            "pattern": "^bytes=\\d+\\-\\d+/\\d+$"
+            "locationName": "Content-Range"
           },
           "ContentLength": {
-            "shape": "S8",
             "location": "header",
-            "locationName": "Content-Length"
+            "locationName": "Content-Length",
+            "type": "long"
           },
           "ContentType": {
-            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
           "ETag": {
-            "shape": "S6",
             "location": "header",
             "locationName": "ETag"
           },
@@ -163,18 +152,12 @@
         "members": {
           "Path": {
             "location": "querystring",
-            "locationName": "Path",
-            "type": "string",
-            "max": 900,
-            "min": 0,
-            "pattern": "/?(?:[A-Za-z0-9_\\.\\-\\~]+/){0,10}(?:[A-Za-z0-9_\\.\\-\\~]+)?/?"
+            "locationName": "Path"
           },
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer",
-            "max": 1000,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -190,28 +173,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "type": "string",
-                  "pattern": "[A-Za-z0-9_\\.\\-\\~]+"
-                },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "OBJECT",
-                    "FOLDER"
-                  ]
-                },
-                "ETag": {
-                  "shape": "S6"
-                },
+                "Name": {},
+                "Type": {},
+                "ETag": {},
                 "LastModified": {
                   "type": "timestamp"
                 },
-                "ContentType": {
-                  "shape": "S7"
-                },
+                "ContentType": {},
                 "ContentLength": {
-                  "shape": "S8"
+                  "type": "long"
                 }
               }
             }
@@ -236,12 +206,10 @@
             "shape": "Se"
           },
           "Path": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Path"
           },
           "ContentType": {
-            "shape": "S7",
             "location": "header",
             "locationName": "Content-Type"
           },
@@ -250,7 +218,6 @@
             "locationName": "Cache-Control"
           },
           "StorageClass": {
-            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-storage-class"
           }
@@ -260,55 +227,18 @@
       "output": {
         "type": "structure",
         "members": {
-          "ContentSHA256": {
-            "type": "string",
-            "max": 64,
-            "min": 64,
-            "pattern": "[0-9A-Fa-f]{64}"
-          },
-          "ETag": {
-            "shape": "S6"
-          },
-          "StorageClass": {
-            "shape": "Sr"
-          }
+          "ContentSHA256": {},
+          "ETag": {},
+          "StorageClass": {}
         }
       },
       "authtype": "v4-unsigned-body"
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 900,
-      "min": 1,
-      "pattern": "(?:[A-Za-z0-9_\\.\\-\\~]+/){0,10}[A-Za-z0-9_\\.\\-\\~]+"
-    },
-    "S6": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[0-9A-Fa-f]+"
-    },
-    "S7": {
-      "type": "string",
-      "pattern": "^[\\w\\-\\/\\.]{1,255}$"
-    },
-    "S8": {
-      "type": "long",
-      "min": 0
-    },
     "Se": {
       "type": "blob",
       "streaming": true
-    },
-    "Sr": {
-      "type": "string",
-      "enum": [
-        "TEMPORAL"
-      ],
-      "max": 16,
-      "min": 1
     }
   }
 }

--- a/apis/mediatailor-2018-04-23.min.json
+++ b/apis/mediatailor-2018-04-23.min.json
@@ -83,9 +83,7 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer",
-            "min": 1,
-            "max": 100
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",

--- a/apis/meteringmarketplace-2016-01-14.min.json
+++ b/apis/meteringmarketplace-2016-01-14.min.json
@@ -24,9 +24,7 @@
           "UsageRecords": {
             "shape": "S2"
           },
-          "ProductCode": {
-            "shape": "S8"
-          }
+          "ProductCode": {}
         }
       },
       "output": {
@@ -41,14 +39,7 @@
                   "shape": "S3"
                 },
                 "MeteringRecordId": {},
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Success",
-                    "CustomerNotSubscribed",
-                    "DuplicateRecord"
-                  ]
-                }
+                "Status": {}
               }
             }
           },
@@ -69,17 +60,13 @@
           "DryRun"
         ],
         "members": {
-          "ProductCode": {
-            "shape": "S8"
-          },
+          "ProductCode": {},
           "Timestamp": {
             "type": "timestamp"
           },
-          "UsageDimension": {
-            "shape": "S6"
-          },
+          "UsageDimension": {},
           "UsageQuantity": {
-            "shape": "S7"
+            "type": "integer"
           },
           "DryRun": {
             "type": "boolean"
@@ -100,21 +87,14 @@
           "RegistrationToken"
         ],
         "members": {
-          "RegistrationToken": {
-            "type": "string",
-            "pattern": "\\S+"
-          }
+          "RegistrationToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CustomerIdentifier": {
-            "shape": "S5"
-          },
-          "ProductCode": {
-            "shape": "S8"
-          }
+          "CustomerIdentifier": {},
+          "ProductCode": {}
         }
       }
     }
@@ -124,9 +104,7 @@
       "type": "list",
       "member": {
         "shape": "S3"
-      },
-      "max": 25,
-      "min": 0
+      }
     },
     "S3": {
       "type": "structure",
@@ -140,36 +118,12 @@
         "Timestamp": {
           "type": "timestamp"
         },
-        "CustomerIdentifier": {
-          "shape": "S5"
-        },
-        "Dimension": {
-          "shape": "S6"
-        },
+        "CustomerIdentifier": {},
+        "Dimension": {},
         "Quantity": {
-          "shape": "S7"
+          "type": "integer"
         }
       }
-    },
-    "S5": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S7": {
-      "type": "integer",
-      "max": 1000000,
-      "min": 0
-    },
-    "S8": {
-      "type": "string",
-      "max": 255,
-      "min": 1
     }
   }
 }

--- a/apis/mobile-2017-07-01.min.json
+++ b/apis/mobile-2017-07-01.min.json
@@ -151,7 +151,6 @@
             "locationName": "projectId"
           },
           "platform": {
-            "shape": "Sw",
             "location": "querystring",
             "locationName": "platform"
           }
@@ -294,14 +293,7 @@
         "name": {},
         "projectId": {},
         "region": {},
-        "state": {
-          "type": "string",
-          "enum": [
-            "NORMAL",
-            "SYNCING",
-            "IMPORTING"
-          ]
-        },
+        "state": {},
         "createdDate": {
           "type": "timestamp"
         },
@@ -341,23 +333,9 @@
         "iconUrl": {},
         "availablePlatforms": {
           "type": "list",
-          "member": {
-            "shape": "Sw"
-          }
+          "member": {}
         }
       }
-    },
-    "Sw": {
-      "type": "string",
-      "enum": [
-        "OSX",
-        "WINDOWS",
-        "LINUX",
-        "OBJC",
-        "SWIFT",
-        "ANDROID",
-        "JAVASCRIPT"
-      ]
     }
   }
 }

--- a/apis/mobileanalytics-2014-06-05.min.json
+++ b/apis/mobileanalytics-2014-06-05.min.json
@@ -30,16 +30,12 @@
                 "timestamp"
               ],
               "members": {
-                "eventType": {
-                  "shape": "S4"
-                },
+                "eventType": {},
                 "timestamp": {},
                 "session": {
                   "type": "structure",
                   "members": {
-                    "id": {
-                      "shape": "S4"
-                    },
+                    "id": {},
                     "duration": {
                       "type": "long"
                     },
@@ -47,34 +43,18 @@
                     "stopTimestamp": {}
                   }
                 },
-                "version": {
-                  "type": "string",
-                  "min": 1,
-                  "max": 10
-                },
+                "version": {},
                 "attributes": {
                   "type": "map",
-                  "key": {
-                    "shape": "S4"
-                  },
-                  "value": {
-                    "type": "string",
-                    "min": 0,
-                    "max": 1000
-                  },
-                  "min": 0,
-                  "max": 50
+                  "key": {},
+                  "value": {}
                 },
                 "metrics": {
                   "type": "map",
-                  "key": {
-                    "shape": "S4"
-                  },
+                  "key": {},
                   "value": {
                     "type": "double"
-                  },
-                  "min": 0,
-                  "max": 50
+                  }
                 }
               }
             }
@@ -91,11 +71,5 @@
       }
     }
   },
-  "shapes": {
-    "S4": {
-      "type": "string",
-      "min": 1,
-      "max": 50
-    }
-  }
+  "shapes": {}
 }

--- a/apis/monitoring-2010-08-01.min.json
+++ b/apis/monitoring-2010-08-01.min.json
@@ -48,12 +48,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "AlarmName": {
-            "shape": "S3"
-          },
-          "HistoryItemType": {
-            "shape": "S9"
-          },
+          "AlarmName": {},
+          "HistoryItemType": {},
           "StartDate": {
             "type": "timestamp"
           },
@@ -61,11 +57,9 @@
             "type": "timestamp"
           },
           "MaxRecords": {
-            "shape": "Sb"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -77,31 +71,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "AlarmName": {
-                  "shape": "S3"
-                },
+                "AlarmName": {},
                 "Timestamp": {
                   "type": "timestamp"
                 },
-                "HistoryItemType": {
-                  "shape": "S9"
-                },
-                "HistorySummary": {
-                  "type": "string",
-                  "max": 255,
-                  "min": 1
-                },
-                "HistoryData": {
-                  "type": "string",
-                  "max": 4095,
-                  "min": 1
-                }
+                "HistoryItemType": {},
+                "HistorySummary": {},
+                "HistoryData": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -112,25 +92,13 @@
           "AlarmNames": {
             "shape": "S2"
           },
-          "AlarmNamePrefix": {
-            "type": "string",
-            "max": 255,
-            "min": 1
-          },
-          "StateValue": {
-            "shape": "Sk"
-          },
-          "ActionPrefix": {
-            "type": "string",
-            "max": 1024,
-            "min": 1
-          },
+          "AlarmNamePrefix": {},
+          "StateValue": {},
+          "ActionPrefix": {},
           "MaxRecords": {
-            "shape": "Sb"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -140,9 +108,7 @@
           "MetricAlarms": {
             "shape": "Sn"
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -154,27 +120,17 @@
           "Namespace"
         ],
         "members": {
-          "MetricName": {
-            "shape": "Sw"
-          },
-          "Namespace": {
-            "shape": "Sx"
-          },
-          "Statistic": {
-            "shape": "Sy"
-          },
-          "ExtendedStatistic": {
-            "shape": "Sz"
-          },
+          "MetricName": {},
+          "Namespace": {},
+          "Statistic": {},
+          "ExtendedStatistic": {},
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "Unit": {
-            "shape": "S15"
-          }
+          "Unit": {}
         }
       },
       "output": {
@@ -250,9 +206,7 @@
                 "Id"
               ],
               "members": {
-                "Id": {
-                  "shape": "S1n"
-                },
+                "Id": {},
                 "MetricStat": {
                   "type": "structure",
                   "required": [
@@ -265,19 +219,13 @@
                       "shape": "S1p"
                     },
                     "Period": {
-                      "shape": "S14"
+                      "type": "integer"
                     },
                     "Stat": {},
-                    "Unit": {
-                      "shape": "S15"
-                    }
+                    "Unit": {}
                   }
                 },
-                "Expression": {
-                  "type": "string",
-                  "max": 1024,
-                  "min": 1
-                },
+                "Expression": {},
                 "Label": {},
                 "ReturnData": {
                   "type": "boolean"
@@ -291,16 +239,8 @@
           "EndTime": {
             "type": "timestamp"
           },
-          "NextToken": {
-            "shape": "Sc"
-          },
-          "ScanBy": {
-            "type": "string",
-            "enum": [
-              "TimestampDescending",
-              "TimestampAscending"
-            ]
-          },
+          "NextToken": {},
+          "ScanBy": {},
           "MaxDatapoints": {
             "type": "integer"
           }
@@ -315,9 +255,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S1n"
-                },
+                "Id": {},
                 "Label": {},
                 "Timestamps": {
                   "type": "list",
@@ -331,14 +269,7 @@
                     "type": "double"
                   }
                 },
-                "StatusCode": {
-                  "type": "string",
-                  "enum": [
-                    "Complete",
-                    "InternalError",
-                    "PartialData"
-                  ]
-                },
+                "StatusCode": {},
                 "Messages": {
                   "type": "list",
                   "member": {
@@ -352,9 +283,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -369,12 +298,8 @@
           "Period"
         ],
         "members": {
-          "Namespace": {
-            "shape": "Sx"
-          },
-          "MetricName": {
-            "shape": "Sw"
-          },
+          "Namespace": {},
+          "MetricName": {},
           "Dimensions": {
             "shape": "S10"
           },
@@ -385,27 +310,17 @@
             "type": "timestamp"
           },
           "Period": {
-            "shape": "S14"
+            "type": "integer"
           },
           "Statistics": {
             "type": "list",
-            "member": {
-              "shape": "Sy"
-            },
-            "max": 5,
-            "min": 1
+            "member": {}
           },
           "ExtendedStatistics": {
             "type": "list",
-            "member": {
-              "shape": "Sz"
-            },
-            "max": 10,
-            "min": 1
+            "member": {}
           },
-          "Unit": {
-            "shape": "S15"
-          }
+          "Unit": {}
         }
       },
       "output": {
@@ -436,14 +351,10 @@
                 "Maximum": {
                   "type": "double"
                 },
-                "Unit": {
-                  "shape": "S15"
-                },
+                "Unit": {},
                 "ExtendedStatistics": {
                   "type": "map",
-                  "key": {
-                    "shape": "Sz"
-                  },
+                  "key": {},
                   "value": {
                     "type": "double"
                   }
@@ -490,9 +401,7 @@
         "type": "structure",
         "members": {
           "DashboardNamePrefix": {},
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -515,9 +424,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -525,12 +432,8 @@
       "input": {
         "type": "structure",
         "members": {
-          "Namespace": {
-            "shape": "Sx"
-          },
-          "MetricName": {
-            "shape": "Sw"
-          },
+          "Namespace": {},
+          "MetricName": {},
           "Dimensions": {
             "type": "list",
             "member": {
@@ -539,19 +442,12 @@
                 "Name"
               ],
               "members": {
-                "Name": {
-                  "shape": "S12"
-                },
-                "Value": {
-                  "shape": "S13"
-                }
+                "Name": {},
+                "Value": {}
               }
-            },
-            "max": 10
+            }
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -564,9 +460,7 @@
               "shape": "S1p"
             }
           },
-          "NextToken": {
-            "shape": "Sc"
-          }
+          "NextToken": {}
         },
         "xmlOrder": [
           "Metrics",
@@ -616,12 +510,8 @@
           "ComparisonOperator"
         ],
         "members": {
-          "AlarmName": {
-            "shape": "S3"
-          },
-          "AlarmDescription": {
-            "shape": "Sq"
-          },
+          "AlarmName": {},
+          "AlarmDescription": {},
           "ActionsEnabled": {
             "type": "boolean"
           },
@@ -634,45 +524,29 @@
           "InsufficientDataActions": {
             "shape": "Ss"
           },
-          "MetricName": {
-            "shape": "Sw"
-          },
-          "Namespace": {
-            "shape": "Sx"
-          },
-          "Statistic": {
-            "shape": "Sy"
-          },
-          "ExtendedStatistic": {
-            "shape": "Sz"
-          },
+          "MetricName": {},
+          "Namespace": {},
+          "Statistic": {},
+          "ExtendedStatistic": {},
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "Unit": {
-            "shape": "S15"
-          },
+          "Unit": {},
           "EvaluationPeriods": {
-            "shape": "S16"
+            "type": "integer"
           },
           "DatapointsToAlarm": {
-            "shape": "S17"
+            "type": "integer"
           },
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {
-            "shape": "S19"
-          },
-          "TreatMissingData": {
-            "shape": "S1a"
-          },
-          "EvaluateLowSampleCountPercentile": {
-            "shape": "S1b"
-          }
+          "ComparisonOperator": {},
+          "TreatMissingData": {},
+          "EvaluateLowSampleCountPercentile": {}
         }
       }
     },
@@ -684,9 +558,7 @@
           "MetricData"
         ],
         "members": {
-          "Namespace": {
-            "shape": "Sx"
-          },
+          "Namespace": {},
           "MetricData": {
             "type": "list",
             "member": {
@@ -695,9 +567,7 @@
                 "MetricName"
               ],
               "members": {
-                "MetricName": {
-                  "shape": "Sw"
-                },
+                "MetricName": {},
                 "Dimensions": {
                   "shape": "S10"
                 },
@@ -742,12 +612,9 @@
                     "type": "double"
                   }
                 },
-                "Unit": {
-                  "shape": "S15"
-                },
+                "Unit": {},
                 "StorageResolution": {
-                  "type": "integer",
-                  "min": 1
+                  "type": "integer"
                 }
               }
             }
@@ -764,18 +631,10 @@
           "StateReason"
         ],
         "members": {
-          "AlarmName": {
-            "shape": "S3"
-          },
-          "StateValue": {
-            "shape": "Sk"
-          },
-          "StateReason": {
-            "shape": "Su"
-          },
-          "StateReasonData": {
-            "shape": "Sv"
-          }
+          "AlarmName": {},
+          "StateValue": {},
+          "StateReason": {},
+          "StateReasonData": {}
         }
       }
     }
@@ -783,58 +642,16 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      },
-      "max": 100
-    },
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S9": {
-      "type": "string",
-      "enum": [
-        "ConfigurationUpdate",
-        "StateUpdate",
-        "Action"
-      ]
-    },
-    "Sb": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "Sc": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "OK",
-        "ALARM",
-        "INSUFFICIENT_DATA"
-      ]
+      "member": {}
     },
     "Sn": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "AlarmName": {
-            "shape": "S3"
-          },
-          "AlarmArn": {
-            "type": "string",
-            "max": 1600,
-            "min": 1
-          },
-          "AlarmDescription": {
-            "shape": "Sq"
-          },
+          "AlarmName": {},
+          "AlarmArn": {},
+          "AlarmDescription": {},
           "AlarmConfigurationUpdatedTimestamp": {
             "type": "timestamp"
           },
@@ -850,57 +667,35 @@
           "InsufficientDataActions": {
             "shape": "Ss"
           },
-          "StateValue": {
-            "shape": "Sk"
-          },
-          "StateReason": {
-            "shape": "Su"
-          },
-          "StateReasonData": {
-            "shape": "Sv"
-          },
+          "StateValue": {},
+          "StateReason": {},
+          "StateReasonData": {},
           "StateUpdatedTimestamp": {
             "type": "timestamp"
           },
-          "MetricName": {
-            "shape": "Sw"
-          },
-          "Namespace": {
-            "shape": "Sx"
-          },
-          "Statistic": {
-            "shape": "Sy"
-          },
-          "ExtendedStatistic": {
-            "shape": "Sz"
-          },
+          "MetricName": {},
+          "Namespace": {},
+          "Statistic": {},
+          "ExtendedStatistic": {},
           "Dimensions": {
             "shape": "S10"
           },
           "Period": {
-            "shape": "S14"
+            "type": "integer"
           },
-          "Unit": {
-            "shape": "S15"
-          },
+          "Unit": {},
           "EvaluationPeriods": {
-            "shape": "S16"
+            "type": "integer"
           },
           "DatapointsToAlarm": {
-            "shape": "S17"
+            "type": "integer"
           },
           "Threshold": {
             "type": "double"
           },
-          "ComparisonOperator": {
-            "shape": "S19"
-          },
-          "TreatMissingData": {
-            "shape": "S1a"
-          },
-          "EvaluateLowSampleCountPercentile": {
-            "shape": "S1b"
-          }
+          "ComparisonOperator": {},
+          "TreatMissingData": {},
+          "EvaluateLowSampleCountPercentile": {}
         },
         "xmlOrder": [
           "AlarmName",
@@ -931,54 +726,9 @@
         ]
       }
     },
-    "Sq": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
     "Ss": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 1024,
-        "min": 1
-      },
-      "max": 5
-    },
-    "Su": {
-      "type": "string",
-      "max": 1023,
-      "min": 0
-    },
-    "Sv": {
-      "type": "string",
-      "max": 4000,
-      "min": 0
-    },
-    "Sw": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "Sx": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[^:].*"
-    },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "SampleCount",
-        "Average",
-        "Sum",
-        "Minimum",
-        "Maximum"
-      ]
-    },
-    "Sz": {
-      "type": "string",
-      "pattern": "p(\\d{1,2}(\\.\\d{0,2})?|100)"
+      "member": {}
     },
     "S10": {
       "type": "list",
@@ -989,107 +739,20 @@
           "Value"
         ],
         "members": {
-          "Name": {
-            "shape": "S12"
-          },
-          "Value": {
-            "shape": "S13"
-          }
+          "Name": {},
+          "Value": {}
         },
         "xmlOrder": [
           "Name",
           "Value"
         ]
-      },
-      "max": 10
-    },
-    "S12": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S13": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S14": {
-      "type": "integer",
-      "min": 1
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "Seconds",
-        "Microseconds",
-        "Milliseconds",
-        "Bytes",
-        "Kilobytes",
-        "Megabytes",
-        "Gigabytes",
-        "Terabytes",
-        "Bits",
-        "Kilobits",
-        "Megabits",
-        "Gigabits",
-        "Terabits",
-        "Percent",
-        "Count",
-        "Bytes/Second",
-        "Kilobytes/Second",
-        "Megabytes/Second",
-        "Gigabytes/Second",
-        "Terabytes/Second",
-        "Bits/Second",
-        "Kilobits/Second",
-        "Megabits/Second",
-        "Gigabits/Second",
-        "Terabits/Second",
-        "Count/Second",
-        "None"
-      ]
-    },
-    "S16": {
-      "type": "integer",
-      "min": 1
-    },
-    "S17": {
-      "type": "integer",
-      "min": 1
-    },
-    "S19": {
-      "type": "string",
-      "enum": [
-        "GreaterThanOrEqualToThreshold",
-        "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold"
-      ]
-    },
-    "S1a": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S1b": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S1n": {
-      "type": "string",
-      "max": 255,
-      "min": 1
+      }
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "Namespace": {
-          "shape": "Sx"
-        },
-        "MetricName": {
-          "shape": "Sw"
-        },
+        "Namespace": {},
+        "MetricName": {},
         "Dimensions": {
           "shape": "S10"
         }

--- a/apis/mq-2017-11-27.min.json
+++ b/apis/mq-2017-11-27.min.json
@@ -35,11 +35,9 @@
             "idempotencyToken": true
           },
           "DeploymentMode": {
-            "shape": "S6",
             "locationName": "deploymentMode"
           },
           "EngineType": {
-            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -114,7 +112,6 @@
         "type": "structure",
         "members": {
           "EngineType": {
-            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -295,7 +292,6 @@
             "locationName": "brokerName"
           },
           "BrokerState": {
-            "shape": "St",
             "locationName": "brokerState"
           },
           "Configurations": {
@@ -324,11 +320,9 @@
             "locationName": "created"
           },
           "DeploymentMode": {
-            "shape": "S6",
             "locationName": "deploymentMode"
           },
           "EngineType": {
-            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -426,7 +420,6 @@
             "locationName": "description"
           },
           "EngineType": {
-            "shape": "S7",
             "locationName": "engineType"
           },
           "EngineVersion": {
@@ -537,7 +530,6 @@
                 "locationName": "groups"
               },
               "PendingChange": {
-                "shape": "S10",
                 "locationName": "pendingChange"
               }
             }
@@ -558,9 +550,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -587,7 +579,6 @@
                   "locationName": "brokerName"
                 },
                 "BrokerState": {
-                  "shape": "St",
                   "locationName": "brokerState"
                 },
                 "Created": {
@@ -595,7 +586,6 @@
                   "locationName": "created"
                 },
                 "DeploymentMode": {
-                  "shape": "S6",
                   "locationName": "deploymentMode"
                 },
                 "HostInstanceType": {
@@ -624,9 +614,9 @@
             "locationName": "configuration-id"
           },
           "MaxResults": {
-            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -670,9 +660,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -700,7 +690,6 @@
                   "locationName": "description"
                 },
                 "EngineType": {
-                  "shape": "S7",
                   "locationName": "engineType"
                 },
                 "EngineVersion": {
@@ -743,9 +732,9 @@
             "locationName": "broker-id"
           },
           "MaxResults": {
-            "shape": "S19",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -764,9 +753,7 @@
           },
           "MaxResults": {
             "locationName": "maxResults",
-            "type": "integer",
-            "min": 5,
-            "max": 100
+            "type": "integer"
           },
           "NextToken": {
             "locationName": "nextToken"
@@ -900,13 +887,7 @@
                   "locationName": "elementName"
                 },
                 "Reason": {
-                  "locationName": "reason",
-                  "type": "string",
-                  "enum": [
-                    "DISALLOWED_ELEMENT_REMOVED",
-                    "DISALLOWED_ATTRIBUTE_REMOVED",
-                    "INVALID_ATTRIBUTE_VALUE_REMOVED"
-                  ]
+                  "locationName": "reason"
                 }
               }
             }
@@ -967,19 +948,6 @@
         }
       }
     },
-    "S6": {
-      "type": "string",
-      "enum": [
-        "SINGLE_INSTANCE",
-        "ACTIVE_STANDBY_MULTI_AZ"
-      ]
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "ACTIVEMQ"
-      ]
-    },
     "S8": {
       "type": "structure",
       "members": {
@@ -997,17 +965,7 @@
       "type": "structure",
       "members": {
         "DayOfWeek": {
-          "locationName": "dayOfWeek",
-          "type": "string",
-          "enum": [
-            "MONDAY",
-            "TUESDAY",
-            "WEDNESDAY",
-            "THURSDAY",
-            "FRIDAY",
-            "SATURDAY",
-            "SUNDAY"
-          ]
+          "locationName": "dayOfWeek"
         },
         "TimeOfDay": {
           "locationName": "timeOfDay"
@@ -1041,23 +999,12 @@
         }
       }
     },
-    "St": {
-      "type": "string",
-      "enum": [
-        "CREATION_IN_PROGRESS",
-        "CREATION_FAILED",
-        "DELETION_IN_PROGRESS",
-        "RUNNING",
-        "REBOOT_IN_PROGRESS"
-      ]
-    },
     "Sy": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "PendingChange": {
-            "shape": "S10",
             "locationName": "pendingChange"
           },
           "Username": {
@@ -1065,19 +1012,6 @@
           }
         }
       }
-    },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "CREATE",
-        "UPDATE",
-        "DELETE"
-      ]
-    },
-    "S19": {
-      "type": "integer",
-      "min": 1,
-      "max": 100
     }
   }
 }

--- a/apis/mturk-requester-2017-01-17.min.json
+++ b/apis/mturk-requester-2017-01-17.min.json
@@ -38,9 +38,7 @@
           "AssignmentId"
         ],
         "members": {
-          "AssignmentId": {
-            "shape": "S6"
-          },
+          "AssignmentId": {},
           "RequesterFeedback": {},
           "OverrideRejection": {
             "type": "boolean"
@@ -61,12 +59,8 @@
           "WorkerId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
-          "WorkerId": {
-            "shape": "Sa"
-          },
+          "QualificationTypeId": {},
+          "WorkerId": {},
           "IntegerValue": {
             "type": "integer"
           },
@@ -88,15 +82,11 @@
           "NumberOfAdditionalAssignments"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
+          "HITId": {},
           "NumberOfAdditionalAssignments": {
             "type": "integer"
           },
-          "UniqueRequestToken": {
-            "shape": "Sd"
-          }
+          "UniqueRequestToken": {}
         }
       },
       "output": {
@@ -127,9 +117,7 @@
           "AssignmentDurationInSeconds": {
             "type": "long"
           },
-          "Reward": {
-            "shape": "Sh"
-          },
+          "Reward": {},
           "Title": {},
           "Keywords": {},
           "Description": {},
@@ -138,18 +126,14 @@
           "QualificationRequirements": {
             "shape": "Si"
           },
-          "UniqueRequestToken": {
-            "shape": "Sd"
-          },
+          "UniqueRequestToken": {},
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
           "HITReviewPolicy": {
             "shape": "Sq"
           },
-          "HITLayoutId": {
-            "shape": "S6"
-          },
+          "HITLayoutId": {},
           "HITLayoutParameters": {
             "shape": "Sw"
           }
@@ -180,9 +164,7 @@
           "AssignmentDurationInSeconds": {
             "type": "long"
           },
-          "Reward": {
-            "shape": "Sh"
-          },
+          "Reward": {},
           "Title": {},
           "Keywords": {},
           "Description": {},
@@ -194,9 +176,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "HITTypeId": {
-            "shape": "S6"
-          }
+          "HITTypeId": {}
         }
       },
       "idempotent": true
@@ -209,9 +189,7 @@
           "LifetimeInSeconds"
         ],
         "members": {
-          "HITTypeId": {
-            "shape": "S6"
-          },
+          "HITTypeId": {},
           "MaxAssignments": {
             "type": "integer"
           },
@@ -220,18 +198,14 @@
           },
           "Question": {},
           "RequesterAnnotation": {},
-          "UniqueRequestToken": {
-            "shape": "Sd"
-          },
+          "UniqueRequestToken": {},
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
           "HITReviewPolicy": {
             "shape": "Sq"
           },
-          "HITLayoutId": {
-            "shape": "S6"
-          },
+          "HITLayoutId": {},
           "HITLayoutParameters": {
             "shape": "Sw"
           }
@@ -258,9 +232,7 @@
           "Name": {},
           "Keywords": {},
           "Description": {},
-          "QualificationTypeStatus": {
-            "shape": "S18"
-          },
+          "QualificationTypeStatus": {},
           "RetryDelayInSeconds": {
             "type": "long"
           },
@@ -294,9 +266,7 @@
           "Reason"
         ],
         "members": {
-          "WorkerId": {
-            "shape": "Sa"
-          },
+          "WorkerId": {},
           "Reason": {}
         }
       },
@@ -312,9 +282,7 @@
           "HITId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          }
+          "HITId": {}
         }
       },
       "output": {
@@ -330,9 +298,7 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          }
+          "QualificationTypeId": {}
         }
       },
       "output": {
@@ -348,9 +314,7 @@
           "WorkerId"
         ],
         "members": {
-          "WorkerId": {
-            "shape": "Sa"
-          },
+          "WorkerId": {},
           "Reason": {}
         }
       },
@@ -368,12 +332,8 @@
           "QualificationTypeId"
         ],
         "members": {
-          "WorkerId": {
-            "shape": "Sa"
-          },
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
+          "WorkerId": {},
+          "QualificationTypeId": {},
           "Reason": {}
         }
       },
@@ -390,12 +350,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "AvailableBalance": {
-            "shape": "Sh"
-          },
-          "OnHoldBalance": {
-            "shape": "Sh"
-          }
+          "AvailableBalance": {},
+          "OnHoldBalance": {}
         }
       },
       "idempotent": true
@@ -407,9 +363,7 @@
           "AssignmentId"
         ],
         "members": {
-          "AssignmentId": {
-            "shape": "S6"
-          }
+          "AssignmentId": {}
         }
       },
       "output": {
@@ -433,9 +387,7 @@
           "QuestionIdentifier"
         ],
         "members": {
-          "AssignmentId": {
-            "shape": "S6"
-          },
+          "AssignmentId": {},
           "QuestionIdentifier": {}
         }
       },
@@ -454,9 +406,7 @@
           "HITId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          }
+          "HITId": {}
         }
       },
       "output": {
@@ -477,12 +427,8 @@
           "WorkerId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
-          "WorkerId": {
-            "shape": "Sa"
-          }
+          "QualificationTypeId": {},
+          "WorkerId": {}
         }
       },
       "output": {
@@ -502,9 +448,7 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          }
+          "QualificationTypeId": {}
         }
       },
       "output": {
@@ -524,29 +468,21 @@
           "HITId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "HITId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           },
           "AssignmentStatuses": {
             "type": "list",
-            "member": {
-              "shape": "S1q"
-            }
+            "member": {}
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -564,17 +500,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
-          "AssignmentId": {
-            "shape": "S6"
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "HITId": {},
+          "AssignmentId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
@@ -584,23 +514,15 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "BonusPayments": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "WorkerId": {
-                  "shape": "Sa"
-                },
-                "BonusAmount": {
-                  "shape": "Sh"
-                },
-                "AssignmentId": {
-                  "shape": "S6"
-                },
+                "WorkerId": {},
+                "BonusAmount": {},
+                "AssignmentId": {},
                 "Reason": {},
                 "GrantTime": {
                   "type": "timestamp"
@@ -616,20 +538,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -647,23 +565,17 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "QualificationTypeId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -678,14 +590,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "QualificationTypeId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
@@ -695,21 +603,15 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "QualificationRequests": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
                 "QualificationRequestId": {},
-                "QualificationTypeId": {
-                  "shape": "S6"
-                },
-                "WorkerId": {
-                  "shape": "Sa"
-                },
+                "QualificationTypeId": {},
+                "WorkerId": {},
                 "Test": {},
                 "Answer": {},
                 "SubmitTime": {
@@ -736,11 +638,9 @@
           "MustBeOwnedByCaller": {
             "type": "boolean"
           },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
@@ -750,9 +650,7 @@
           "NumResults": {
             "type": "integer"
           },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "QualificationTypes": {
             "type": "list",
             "member": {
@@ -770,18 +668,10 @@
           "HITId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
+          "HITId": {},
           "PolicyLevels": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "Assignment",
-                "HIT"
-              ]
-            }
+            "member": {}
           },
           "RetrieveActions": {
             "type": "boolean"
@@ -789,20 +679,16 @@
           "RetrieveResults": {
             "type": "boolean"
           },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
+          "HITId": {},
           "AssignmentReviewPolicy": {
             "shape": "Sq"
           },
@@ -815,9 +701,7 @@
           "HITReviewReport": {
             "shape": "S2r"
           },
-          "NextToken": {
-            "shape": "S22"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -826,30 +710,18 @@
       "input": {
         "type": "structure",
         "members": {
-          "HITTypeId": {
-            "shape": "S6"
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "Reviewable",
-              "Reviewing"
-            ]
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "HITTypeId": {},
+          "Status": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -864,20 +736,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -886,9 +754,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkerId": {
-                  "shape": "Sa"
-                },
+                "WorkerId": {},
                 "Reason": {}
               }
             }
@@ -904,26 +770,18 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
-          "Status": {
-            "shape": "S1y"
-          },
-          "NextToken": {
-            "shape": "S22"
-          },
+          "QualificationTypeId": {},
+          "Status": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S23"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S22"
-          },
+          "NextToken": {},
           "NumResults": {
             "type": "integer"
           },
@@ -950,9 +808,7 @@
           "MessageText": {},
           "WorkerIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa"
-            }
+            "member": {}
           }
         }
       },
@@ -964,17 +820,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "NotifyWorkersFailureCode": {
-                  "type": "string",
-                  "enum": [
-                    "SoftFailure",
-                    "HardFailure"
-                  ]
-                },
+                "NotifyWorkersFailureCode": {},
                 "NotifyWorkersFailureMessage": {},
-                "WorkerId": {
-                  "shape": "Sa"
-                }
+                "WorkerId": {}
               }
             }
           }
@@ -989,9 +837,7 @@
           "RequesterFeedback"
         ],
         "members": {
-          "AssignmentId": {
-            "shape": "S6"
-          },
+          "AssignmentId": {},
           "RequesterFeedback": {}
         }
       },
@@ -1027,19 +873,11 @@
           "Reason"
         ],
         "members": {
-          "WorkerId": {
-            "shape": "Sa"
-          },
-          "BonusAmount": {
-            "shape": "Sh"
-          },
-          "AssignmentId": {
-            "shape": "S6"
-          },
+          "WorkerId": {},
+          "BonusAmount": {},
+          "AssignmentId": {},
           "Reason": {},
-          "UniqueRequestToken": {
-            "shape": "Sd"
-          }
+          "UniqueRequestToken": {}
         }
       },
       "output": {
@@ -1058,9 +896,7 @@
           "Notification": {
             "shape": "S3k"
           },
-          "TestEventType": {
-            "shape": "S3n"
-          }
+          "TestEventType": {}
         }
       },
       "output": {
@@ -1076,9 +912,7 @@
           "ExpireAt"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
+          "HITId": {},
           "ExpireAt": {
             "type": "timestamp"
           }
@@ -1097,9 +931,7 @@
           "HITId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
+          "HITId": {},
           "Revert": {
             "type": "boolean"
           }
@@ -1119,12 +951,8 @@
           "HITTypeId"
         ],
         "members": {
-          "HITId": {
-            "shape": "S6"
-          },
-          "HITTypeId": {
-            "shape": "S6"
-          }
+          "HITId": {},
+          "HITTypeId": {}
         }
       },
       "output": {
@@ -1140,9 +968,7 @@
           "HITTypeId"
         ],
         "members": {
-          "HITTypeId": {
-            "shape": "S6"
-          },
+          "HITTypeId": {},
           "Notification": {
             "shape": "S3k"
           },
@@ -1164,13 +990,9 @@
           "QualificationTypeId"
         ],
         "members": {
-          "QualificationTypeId": {
-            "shape": "S6"
-          },
+          "QualificationTypeId": {},
           "Description": {},
-          "QualificationTypeStatus": {
-            "shape": "S18"
-          },
+          "QualificationTypeStatus": {},
           "Test": {},
           "AnswerKey": {},
           "TestDurationInSeconds": {
@@ -1198,27 +1020,6 @@
     }
   },
   "shapes": {
-    "S6": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[A-Z0-9]+$"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^A[A-Z0-9]+$"
-    },
-    "Sd": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "^[0-9]+(\\.)?[0-9]{0,2}$"
-    },
     "Si": {
       "type": "list",
       "member": {
@@ -1229,21 +1030,7 @@
         ],
         "members": {
           "QualificationTypeId": {},
-          "Comparator": {
-            "type": "string",
-            "enum": [
-              "LessThan",
-              "LessThanOrEqualTo",
-              "GreaterThan",
-              "GreaterThanOrEqualTo",
-              "EqualTo",
-              "NotEqualTo",
-              "Exists",
-              "DoesNotExist",
-              "In",
-              "NotIn"
-            ]
-          },
+          "Comparator": {},
           "IntegerValues": {
             "type": "list",
             "member": {
@@ -1260,14 +1047,7 @@
             "deprecated": true,
             "type": "boolean"
           },
-          "ActionsGuarded": {
-            "type": "string",
-            "enum": [
-              "Accept",
-              "PreviewAndAccept",
-              "DiscoverPreviewAndAccept"
-            ]
-          }
+          "ActionsGuarded": {}
         }
       }
     },
@@ -1277,18 +1057,9 @@
         "Country"
       ],
       "members": {
-        "Country": {
-          "shape": "So"
-        },
-        "Subdivision": {
-          "shape": "So"
-        }
+        "Country": {},
+        "Subdivision": {}
       }
-    },
-    "So": {
-      "type": "string",
-      "max": 2,
-      "min": 2
     },
     "Sq": {
       "type": "structure",
@@ -1344,18 +1115,10 @@
     "Sz": {
       "type": "structure",
       "members": {
-        "HITId": {
-          "shape": "S6"
-        },
-        "HITTypeId": {
-          "shape": "S6"
-        },
-        "HITGroupId": {
-          "shape": "S6"
-        },
-        "HITLayoutId": {
-          "shape": "S6"
-        },
+        "HITId": {},
+        "HITTypeId": {},
+        "HITGroupId": {},
+        "HITLayoutId": {},
         "CreationTime": {
           "type": "timestamp"
         },
@@ -1363,22 +1126,11 @@
         "Description": {},
         "Question": {},
         "Keywords": {},
-        "HITStatus": {
-          "type": "string",
-          "enum": [
-            "Assignable",
-            "Unassignable",
-            "Reviewable",
-            "Reviewing",
-            "Disposed"
-          ]
-        },
+        "HITStatus": {},
         "MaxAssignments": {
           "type": "integer"
         },
-        "Reward": {
-          "shape": "Sh"
-        },
+        "Reward": {},
         "AutoApprovalDelayInSeconds": {
           "type": "long"
         },
@@ -1392,15 +1144,7 @@
         "QualificationRequirements": {
           "shape": "Si"
         },
-        "HITReviewStatus": {
-          "type": "string",
-          "enum": [
-            "NotReviewed",
-            "MarkedForReview",
-            "ReviewedAppropriate",
-            "ReviewedInappropriate"
-          ]
-        },
+        "HITReviewStatus": {},
         "NumberOfAssignmentsPending": {
           "type": "integer"
         },
@@ -1412,28 +1156,17 @@
         }
       }
     },
-    "S18": {
-      "type": "string",
-      "enum": [
-        "Active",
-        "Inactive"
-      ]
-    },
     "S1a": {
       "type": "structure",
       "members": {
-        "QualificationTypeId": {
-          "shape": "S6"
-        },
+        "QualificationTypeId": {},
         "CreationTime": {
           "type": "timestamp"
         },
         "Name": {},
         "Description": {},
         "Keywords": {},
-        "QualificationTypeStatus": {
-          "shape": "S18"
-        },
+        "QualificationTypeStatus": {},
         "Test": {},
         "TestDurationInSeconds": {
           "type": "long"
@@ -1456,18 +1189,10 @@
     "S1p": {
       "type": "structure",
       "members": {
-        "AssignmentId": {
-          "shape": "S6"
-        },
-        "WorkerId": {
-          "shape": "Sa"
-        },
-        "HITId": {
-          "shape": "S6"
-        },
-        "AssignmentStatus": {
-          "shape": "S1q"
-        },
+        "AssignmentId": {},
+        "WorkerId": {},
+        "HITId": {},
+        "AssignmentStatus": {},
         "AutoApprovalTime": {
           "type": "timestamp"
         },
@@ -1490,23 +1215,11 @@
         "RequesterFeedback": {}
       }
     },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "Submitted",
-        "Approved",
-        "Rejected"
-      ]
-    },
     "S1x": {
       "type": "structure",
       "members": {
-        "QualificationTypeId": {
-          "shape": "S6"
-        },
-        "WorkerId": {
-          "shape": "Sa"
-        },
+        "QualificationTypeId": {},
+        "WorkerId": {},
         "GrantTime": {
           "type": "timestamp"
         },
@@ -1516,27 +1229,8 @@
         "LocaleValue": {
           "shape": "Sn"
         },
-        "Status": {
-          "shape": "S1y"
-        }
+        "Status": {}
       }
-    },
-    "S1y": {
-      "type": "string",
-      "enum": [
-        "Granted",
-        "Revoked"
-      ]
-    },
-    "S22": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S23": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     },
     "S2d": {
       "type": "list",
@@ -1552,16 +1246,10 @@
           "member": {
             "type": "structure",
             "members": {
-              "ActionId": {
-                "shape": "S6"
-              },
-              "SubjectId": {
-                "shape": "S6"
-              },
+              "ActionId": {},
+              "SubjectId": {},
               "SubjectType": {},
-              "QuestionId": {
-                "shape": "S6"
-              },
+              "QuestionId": {},
               "Key": {},
               "Value": {}
             }
@@ -1572,23 +1260,11 @@
           "member": {
             "type": "structure",
             "members": {
-              "ActionId": {
-                "shape": "S6"
-              },
+              "ActionId": {},
               "ActionName": {},
-              "TargetId": {
-                "shape": "S6"
-              },
+              "TargetId": {},
               "TargetType": {},
-              "Status": {
-                "type": "string",
-                "enum": [
-                  "Intended",
-                  "Succeeded",
-                  "Failed",
-                  "Cancelled"
-                ]
-              },
+              "Status": {},
               "CompleteTime": {
                 "type": "timestamp"
               },
@@ -1609,39 +1285,13 @@
       ],
       "members": {
         "Destination": {},
-        "Transport": {
-          "type": "string",
-          "enum": [
-            "Email",
-            "SQS",
-            "SNS"
-          ]
-        },
+        "Transport": {},
         "Version": {},
         "EventTypes": {
           "type": "list",
-          "member": {
-            "shape": "S3n"
-          }
+          "member": {}
         }
       }
-    },
-    "S3n": {
-      "type": "string",
-      "enum": [
-        "AssignmentAccepted",
-        "AssignmentAbandoned",
-        "AssignmentReturned",
-        "AssignmentSubmitted",
-        "AssignmentRejected",
-        "AssignmentApproved",
-        "HITCreated",
-        "HITExpired",
-        "HITReviewable",
-        "HITExtended",
-        "HITDisposed",
-        "Ping"
-      ]
     }
   }
 }

--- a/apis/neptune-2014-10-31.min.json
+++ b/apis/neptune-2014-10-31.min.json
@@ -1062,9 +1062,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S43"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -1098,9 +1096,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S43"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S7"
@@ -2375,13 +2371,7 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          }
+          "ApplyMethod": {}
         }
       }
     },
@@ -2428,17 +2418,6 @@
         }
       },
       "wrapper": true
-    },
-    "S43": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot",
-        "db-cluster",
-        "db-cluster-snapshot"
-      ]
     },
     "S4l": {
       "type": "list",

--- a/apis/opsworks-2013-02-18.min.json
+++ b/apis/opsworks-2013-02-18.min.json
@@ -108,9 +108,7 @@
           "CloneAppIds": {
             "shape": "S3"
           },
-          "DefaultRootDeviceType": {
-            "shape": "Sf"
-          },
+          "DefaultRootDeviceType": {},
           "AgentVersion": {}
         }
       },
@@ -137,9 +135,7 @@
           "DataSources": {
             "shape": "Si"
           },
-          "Type": {
-            "shape": "Sk"
-          },
+          "Type": {},
           "AppSource": {
             "shape": "Sd"
           },
@@ -211,9 +207,7 @@
             "shape": "S3"
           },
           "InstanceType": {},
-          "AutoScalingType": {
-            "shape": "Sx"
-          },
+          "AutoScalingType": {},
           "Hostname": {},
           "Os": {},
           "AmiId": {},
@@ -221,12 +215,8 @@
           "AvailabilityZone": {},
           "VirtualizationType": {},
           "SubnetId": {},
-          "Architecture": {
-            "shape": "Sy"
-          },
-          "RootDeviceType": {
-            "shape": "Sf"
-          },
+          "Architecture": {},
+          "RootDeviceType": {},
           "BlockDeviceMappings": {
             "shape": "Sz"
           },
@@ -258,9 +248,7 @@
         ],
         "members": {
           "StackId": {},
-          "Type": {
-            "shape": "S16"
-          },
+          "Type": {},
           "Name": {},
           "Shortname": {},
           "Attributes": {
@@ -349,9 +337,7 @@
             "shape": "Sd"
           },
           "DefaultSshKeyName": {},
-          "DefaultRootDeviceType": {
-            "shape": "Sf"
-          },
+          "DefaultRootDeviceType": {},
           "AgentVersion": {}
         }
       },
@@ -554,9 +540,7 @@
                 "DataSources": {
                   "shape": "Si"
                 },
-                "Type": {
-                  "shape": "Sk"
-                },
+                "Type": {},
                 "AppSource": {
                   "shape": "Sd"
                 },
@@ -785,13 +769,9 @@
               "members": {
                 "AgentVersion": {},
                 "AmiId": {},
-                "Architecture": {
-                  "shape": "Sy"
-                },
+                "Architecture": {},
                 "Arn": {},
-                "AutoScalingType": {
-                  "shape": "Sx"
-                },
+                "AutoScalingType": {},
                 "AvailabilityZone": {},
                 "BlockDeviceMappings": {
                   "shape": "Sz"
@@ -832,9 +812,7 @@
                     "Version": {}
                   }
                 },
-                "RootDeviceType": {
-                  "shape": "Sf"
-                },
+                "RootDeviceType": {},
                 "RootDeviceVolumeId": {},
                 "SecurityGroupIds": {
                   "shape": "S3"
@@ -846,13 +824,7 @@
                 "Status": {},
                 "SubnetId": {},
                 "Tenancy": {},
-                "VirtualizationType": {
-                  "type": "string",
-                  "enum": [
-                    "paravirtual",
-                    "hvm"
-                  ]
-                }
+                "VirtualizationType": {}
               }
             }
           }
@@ -880,9 +852,7 @@
                 "Arn": {},
                 "StackId": {},
                 "LayerId": {},
-                "Type": {
-                  "shape": "S16"
-                },
+                "Type": {},
                 "Name": {},
                 "Shortname": {},
                 "Attributes": {
@@ -1333,9 +1303,7 @@
                 },
                 "DefaultSshKeyName": {},
                 "CreatedAt": {},
-                "DefaultRootDeviceType": {
-                  "shape": "Sf"
-                },
+                "DefaultRootDeviceType": {},
                 "AgentVersion": {}
               }
             }
@@ -1500,9 +1468,7 @@
         "members": {
           "InstanceId": {},
           "ValidForInMinutes": {
-            "type": "integer",
-            "max": 1440,
-            "min": 60
+            "type": "integer"
           }
         }
       },
@@ -1827,9 +1793,7 @@
           "DataSources": {
             "shape": "Si"
           },
-          "Type": {
-            "shape": "Sk"
-          },
+          "Type": {},
           "AppSource": {
             "shape": "Sd"
           },
@@ -1875,16 +1839,12 @@
             "shape": "S3"
           },
           "InstanceType": {},
-          "AutoScalingType": {
-            "shape": "Sx"
-          },
+          "AutoScalingType": {},
           "Hostname": {},
           "Os": {},
           "AmiId": {},
           "SshKeyName": {},
-          "Architecture": {
-            "shape": "Sy"
-          },
+          "Architecture": {},
           "InstallUpdatesOnBoot": {
             "type": "boolean"
           },
@@ -1999,9 +1959,7 @@
             "shape": "Sd"
           },
           "DefaultSshKeyName": {},
-          "DefaultRootDeviceType": {
-            "shape": "Sf"
-          },
+          "DefaultRootDeviceType": {},
           "UseOpsworksSecurityGroups": {
             "type": "boolean"
           },
@@ -2046,12 +2004,7 @@
     },
     "S8": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "Color"
-        ]
-      },
+      "key": {},
       "value": {}
     },
     "Sa": {
@@ -2073,28 +2026,13 @@
     "Sd": {
       "type": "structure",
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "git",
-            "svn",
-            "archive",
-            "s3"
-          ]
-        },
+        "Type": {},
         "Url": {},
         "Username": {},
         "Password": {},
         "SshKey": {},
         "Revision": {}
       }
-    },
-    "Sf": {
-      "type": "string",
-      "enum": [
-        "ebs",
-        "instance-store"
-      ]
     },
     "Si": {
       "type": "list",
@@ -2106,18 +2044,6 @@
           "DatabaseName": {}
         }
       }
-    },
-    "Sk": {
-      "type": "string",
-      "enum": [
-        "aws-flow-ruby",
-        "java",
-        "rails",
-        "php",
-        "nodejs",
-        "static",
-        "other"
-      ]
     },
     "Sl": {
       "type": "structure",
@@ -2133,15 +2059,7 @@
     },
     "Sm": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "DocumentRoot",
-          "RailsEnv",
-          "AutoBundleOnDeploy",
-          "AwsFlowRubySettings"
-        ]
-      },
+      "key": {},
       "value": {}
     },
     "So": {
@@ -2167,23 +2085,7 @@
         "Name"
       ],
       "members": {
-        "Name": {
-          "type": "string",
-          "enum": [
-            "install_dependencies",
-            "update_dependencies",
-            "update_custom_cookbooks",
-            "execute_recipes",
-            "configure",
-            "setup",
-            "deploy",
-            "rollback",
-            "start",
-            "stop",
-            "restart",
-            "undeploy"
-          ]
-        },
+        "Name": {},
         "Args": {
           "type": "map",
           "key": {},
@@ -2192,20 +2094,6 @@
           }
         }
       }
-    },
-    "Sx": {
-      "type": "string",
-      "enum": [
-        "load",
-        "timer"
-      ]
-    },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "x86_64",
-        "i386"
-      ]
     },
     "Sz": {
       "type": "list",
@@ -2225,14 +2113,7 @@
               "VolumeSize": {
                 "type": "integer"
               },
-              "VolumeType": {
-                "type": "string",
-                "enum": [
-                  "gp2",
-                  "io1",
-                  "standard"
-                ]
-              },
+              "VolumeType": {},
               "DeleteOnTermination": {
                 "type": "boolean"
               }
@@ -2241,55 +2122,9 @@
         }
       }
     },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "aws-flow-ruby",
-        "ecs-cluster",
-        "java-app",
-        "lb",
-        "web",
-        "php-app",
-        "rails-app",
-        "nodejs-app",
-        "memcached",
-        "db-master",
-        "monitoring-master",
-        "custom"
-      ]
-    },
     "S17": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "EcsClusterArn",
-          "EnableHaproxyStats",
-          "HaproxyStatsUrl",
-          "HaproxyStatsUser",
-          "HaproxyStatsPassword",
-          "HaproxyHealthCheckUrl",
-          "HaproxyHealthCheckMethod",
-          "MysqlRootPassword",
-          "MysqlRootPasswordUbiquitous",
-          "GangliaUrl",
-          "GangliaUser",
-          "GangliaPassword",
-          "MemcachedMemory",
-          "NodejsVersion",
-          "RubyVersion",
-          "RubygemsVersion",
-          "ManageBundler",
-          "BundlerVersion",
-          "RailsStack",
-          "PassengerVersion",
-          "Jvm",
-          "JvmVersion",
-          "JvmOptions",
-          "JavaAppServer",
-          "JavaAppServerVersion"
-        ]
-      },
+      "key": {},
       "value": {}
     },
     "S19": {
@@ -2305,120 +2140,12 @@
             "members": {
               "LogGroupName": {},
               "DatetimeFormat": {},
-              "TimeZone": {
-                "type": "string",
-                "enum": [
-                  "LOCAL",
-                  "UTC"
-                ]
-              },
+              "TimeZone": {},
               "File": {},
               "FileFingerprintLines": {},
               "MultiLineStartPattern": {},
-              "InitialPosition": {
-                "type": "string",
-                "enum": [
-                  "start_of_file",
-                  "end_of_file"
-                ]
-              },
-              "Encoding": {
-                "type": "string",
-                "enum": [
-                  "ascii",
-                  "big5",
-                  "big5hkscs",
-                  "cp037",
-                  "cp424",
-                  "cp437",
-                  "cp500",
-                  "cp720",
-                  "cp737",
-                  "cp775",
-                  "cp850",
-                  "cp852",
-                  "cp855",
-                  "cp856",
-                  "cp857",
-                  "cp858",
-                  "cp860",
-                  "cp861",
-                  "cp862",
-                  "cp863",
-                  "cp864",
-                  "cp865",
-                  "cp866",
-                  "cp869",
-                  "cp874",
-                  "cp875",
-                  "cp932",
-                  "cp949",
-                  "cp950",
-                  "cp1006",
-                  "cp1026",
-                  "cp1140",
-                  "cp1250",
-                  "cp1251",
-                  "cp1252",
-                  "cp1253",
-                  "cp1254",
-                  "cp1255",
-                  "cp1256",
-                  "cp1257",
-                  "cp1258",
-                  "euc_jp",
-                  "euc_jis_2004",
-                  "euc_jisx0213",
-                  "euc_kr",
-                  "gb2312",
-                  "gbk",
-                  "gb18030",
-                  "hz",
-                  "iso2022_jp",
-                  "iso2022_jp_1",
-                  "iso2022_jp_2",
-                  "iso2022_jp_2004",
-                  "iso2022_jp_3",
-                  "iso2022_jp_ext",
-                  "iso2022_kr",
-                  "latin_1",
-                  "iso8859_2",
-                  "iso8859_3",
-                  "iso8859_4",
-                  "iso8859_5",
-                  "iso8859_6",
-                  "iso8859_7",
-                  "iso8859_8",
-                  "iso8859_9",
-                  "iso8859_10",
-                  "iso8859_13",
-                  "iso8859_14",
-                  "iso8859_15",
-                  "iso8859_16",
-                  "johab",
-                  "koi8_r",
-                  "koi8_u",
-                  "mac_cyrillic",
-                  "mac_greek",
-                  "mac_iceland",
-                  "mac_latin2",
-                  "mac_roman",
-                  "mac_turkish",
-                  "ptcp154",
-                  "shift_jis",
-                  "shift_jis_2004",
-                  "shift_jisx0213",
-                  "utf_32",
-                  "utf_32_be",
-                  "utf_32_le",
-                  "utf_16",
-                  "utf_16_be",
-                  "utf_16_le",
-                  "utf_7",
-                  "utf_8",
-                  "utf_8_sig"
-                ]
-              },
+              "InitialPosition": {},
+              "Encoding": {},
               "BufferDuration": {
                 "type": "integer"
               },
@@ -2506,10 +2233,10 @@
           "type": "integer"
         },
         "ThresholdsWaitTime": {
-          "shape": "S37"
+          "type": "integer"
         },
         "IgnoreMetricsTime": {
-          "shape": "S37"
+          "type": "integer"
         },
         "CpuThreshold": {
           "type": "double"
@@ -2524,11 +2251,6 @@
           "shape": "S3"
         }
       }
-    },
-    "S37": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     },
     "S4b": {
       "type": "structure",

--- a/apis/opsworkscm-2016-11-01.min.json
+++ b/apis/opsworkscm-2016-11-01.min.json
@@ -23,12 +23,8 @@
           "EngineAttributes"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
-          "NodeName": {
-            "shape": "S3"
-          },
+          "ServerName": {},
+          "NodeName": {},
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -48,9 +44,7 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
+          "ServerName": {},
           "Description": {}
         }
       },
@@ -86,37 +80,22 @@
             "shape": "S4"
           },
           "BackupRetentionCount": {
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           },
-          "ServerName": {
-            "shape": "S2"
-          },
-          "InstanceProfileArn": {
-            "type": "string",
-            "pattern": "arn:aws:iam::[0-9]{12}:instance-profile/.*"
-          },
+          "ServerName": {},
+          "InstanceProfileArn": {},
           "InstanceType": {},
           "KeyPair": {},
-          "PreferredMaintenanceWindow": {
-            "shape": "Sh"
-          },
-          "PreferredBackupWindow": {
-            "shape": "Sh"
-          },
+          "PreferredMaintenanceWindow": {},
+          "PreferredBackupWindow": {},
           "SecurityGroupIds": {
             "shape": "Sj"
           },
-          "ServiceRoleArn": {
-            "type": "string",
-            "pattern": "arn:aws:iam::[0-9]{12}:role/.*"
-          },
+          "ServiceRoleArn": {},
           "SubnetIds": {
             "shape": "Sj"
           },
-          "BackupId": {
-            "shape": "Se"
-          }
+          "BackupId": {}
         }
       },
       "output": {
@@ -135,9 +114,7 @@
           "BackupId"
         ],
         "members": {
-          "BackupId": {
-            "shape": "Se"
-          }
+          "BackupId": {}
         }
       },
       "output": {
@@ -152,9 +129,7 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          }
+          "ServerName": {}
         }
       },
       "output": {
@@ -192,15 +167,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "BackupId": {
-            "shape": "Se"
-          },
-          "ServerName": {
-            "shape": "S2"
-          },
+          "BackupId": {},
+          "ServerName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           }
         }
       },
@@ -224,12 +195,10 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
+          "ServerName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           }
         }
       },
@@ -263,22 +232,13 @@
         ],
         "members": {
           "NodeAssociationStatusToken": {},
-          "ServerName": {
-            "shape": "S2"
-          }
+          "ServerName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NodeAssociationStatus": {
-            "type": "string",
-            "enum": [
-              "SUCCESS",
-              "FAILED",
-              "IN_PROGRESS"
-            ]
-          },
+          "NodeAssociationStatus": {},
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -289,12 +249,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
+          "ServerName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           }
         }
       },
@@ -319,12 +277,8 @@
           "NodeName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
-          "NodeName": {
-            "shape": "S3"
-          },
+          "ServerName": {},
+          "NodeName": {},
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -345,12 +299,8 @@
           "ServerName"
         ],
         "members": {
-          "BackupId": {
-            "shape": "Se"
-          },
-          "ServerName": {
-            "shape": "S2"
-          },
+          "BackupId": {},
+          "ServerName": {},
           "InstanceType": {},
           "KeyPair": {}
         }
@@ -367,9 +317,7 @@
           "ServerName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
+          "ServerName": {},
           "EngineAttributes": {
             "shape": "S4"
           }
@@ -397,15 +345,9 @@
           "BackupRetentionCount": {
             "type": "integer"
           },
-          "ServerName": {
-            "shape": "S2"
-          },
-          "PreferredMaintenanceWindow": {
-            "shape": "Sh"
-          },
-          "PreferredBackupWindow": {
-            "shape": "Sh"
-          }
+          "ServerName": {},
+          "PreferredMaintenanceWindow": {},
+          "PreferredBackupWindow": {}
         }
       },
       "output": {
@@ -425,15 +367,8 @@
           "AttributeName"
         ],
         "members": {
-          "ServerName": {
-            "shape": "S2"
-          },
-          "AttributeName": {
-            "type": "string",
-            "max": 64,
-            "min": 1,
-            "pattern": "[A-Z][A-Z0-9_]*"
-          },
+          "ServerName": {},
+          "AttributeName": {},
           "AttributeValue": {}
         }
       },
@@ -448,16 +383,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 40,
-      "min": 1,
-      "pattern": "[a-zA-Z][a-zA-Z0-9\\-]*"
-    },
-    "S3": {
-      "type": "string",
-      "pattern": "^[\\-\\p{Alnum}_:.]+$"
-    },
     "S4": {
       "type": "list",
       "member": {
@@ -475,16 +400,8 @@
       "type": "structure",
       "members": {
         "BackupArn": {},
-        "BackupId": {
-          "shape": "Se"
-        },
-        "BackupType": {
-          "type": "string",
-          "enum": [
-            "AUTOMATED",
-            "MANUAL"
-          ]
-        },
+        "BackupId": {},
+        "BackupType": {},
         "CreatedAt": {
           "type": "timestamp"
         },
@@ -495,12 +412,8 @@
         "InstanceProfileArn": {},
         "InstanceType": {},
         "KeyPair": {},
-        "PreferredBackupWindow": {
-          "shape": "Sh"
-        },
-        "PreferredMaintenanceWindow": {
-          "shape": "Sh"
-        },
+        "PreferredBackupWindow": {},
+        "PreferredMaintenanceWindow": {},
         "S3DataSize": {
           "deprecated": true,
           "type": "integer"
@@ -512,19 +425,9 @@
         "SecurityGroupIds": {
           "shape": "Sj"
         },
-        "ServerName": {
-          "shape": "S2"
-        },
+        "ServerName": {},
         "ServiceRoleArn": {},
-        "Status": {
-          "type": "string",
-          "enum": [
-            "IN_PROGRESS",
-            "OK",
-            "FAILED",
-            "DELETING"
-          ]
-        },
+        "Status": {},
         "StatusDescription": {},
         "SubnetIds": {
           "shape": "Sj"
@@ -532,14 +435,6 @@
         "ToolsVersion": {},
         "UserArn": {}
       }
-    },
-    "Se": {
-      "type": "string",
-      "max": 79
-    },
-    "Sh": {
-      "type": "string",
-      "pattern": "^((Mon|Tue|Wed|Thu|Fri|Sat|Sun):)?([0-1][0-9]|2[0-3]):[0-5][0-9]$"
     },
     "Sj": {
       "type": "list",
@@ -572,51 +467,20 @@
         "InstanceProfileArn": {},
         "InstanceType": {},
         "KeyPair": {},
-        "MaintenanceStatus": {
-          "type": "string",
-          "enum": [
-            "SUCCESS",
-            "FAILED"
-          ]
-        },
-        "PreferredMaintenanceWindow": {
-          "shape": "Sh"
-        },
-        "PreferredBackupWindow": {
-          "shape": "Sh"
-        },
+        "MaintenanceStatus": {},
+        "PreferredMaintenanceWindow": {},
+        "PreferredBackupWindow": {},
         "SecurityGroupIds": {
           "shape": "Sj"
         },
         "ServiceRoleArn": {},
-        "Status": {
-          "type": "string",
-          "enum": [
-            "BACKING_UP",
-            "CONNECTION_LOST",
-            "CREATING",
-            "DELETING",
-            "MODIFYING",
-            "FAILED",
-            "HEALTHY",
-            "RUNNING",
-            "RESTORING",
-            "SETUP",
-            "UNDER_MAINTENANCE",
-            "UNHEALTHY",
-            "TERMINATED"
-          ]
-        },
+        "Status": {},
         "StatusReason": {},
         "SubnetIds": {
           "shape": "Sj"
         },
         "ServerArn": {}
       }
-    },
-    "S15": {
-      "type": "integer",
-      "min": 1
     }
   }
 }

--- a/apis/organizations-2016-11-28.min.json
+++ b/apis/organizations-2016-11-28.min.json
@@ -20,9 +20,7 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {
-            "shape": "S2"
-          }
+          "HandshakeId": {}
         }
       },
       "output": {
@@ -42,12 +40,8 @@
           "TargetId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          },
-          "TargetId": {
-            "shape": "Sj"
-          }
+          "PolicyId": {},
+          "TargetId": {}
         }
       }
     },
@@ -58,9 +52,7 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {
-            "shape": "S2"
-          }
+          "HandshakeId": {}
         }
       },
       "output": {
@@ -86,17 +78,8 @@
           "AccountName": {
             "shape": "So"
           },
-          "RoleName": {
-            "type": "string",
-            "pattern": "[\\w+=,.@-]{1,64}"
-          },
-          "IamUserAccessToBilling": {
-            "type": "string",
-            "enum": [
-              "ALLOW",
-              "DENY"
-            ]
-          }
+          "RoleName": {},
+          "IamUserAccessToBilling": {}
         }
       },
       "output": {
@@ -112,9 +95,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "FeatureSet": {
-            "shape": "Sy"
-          }
+          "FeatureSet": {}
         }
       },
       "output": {
@@ -134,12 +115,8 @@
           "Name"
         ],
         "members": {
-          "ParentId": {
-            "shape": "S19"
-          },
-          "Name": {
-            "shape": "S1a"
-          }
+          "ParentId": {},
+          "Name": {}
         }
       },
       "output": {
@@ -161,18 +138,10 @@
           "Type"
         ],
         "members": {
-          "Content": {
-            "shape": "S1g"
-          },
-          "Description": {
-            "shape": "S1h"
-          },
-          "Name": {
-            "shape": "S1i"
-          },
-          "Type": {
-            "shape": "S16"
-          }
+          "Content": {},
+          "Description": {},
+          "Name": {},
+          "Type": {}
         }
       },
       "output": {
@@ -191,9 +160,7 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {
-            "shape": "S2"
-          }
+          "HandshakeId": {}
         }
       },
       "output": {
@@ -213,9 +180,7 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {
-            "shape": "S1d"
-          }
+          "OrganizationalUnitId": {}
         }
       }
     },
@@ -226,9 +191,7 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          }
+          "PolicyId": {}
         }
       }
     },
@@ -239,9 +202,7 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {
-            "shape": "Sv"
-          }
+          "AccountId": {}
         }
       },
       "output": {
@@ -260,9 +221,7 @@
           "CreateAccountRequestId"
         ],
         "members": {
-          "CreateAccountRequestId": {
-            "shape": "St"
-          }
+          "CreateAccountRequestId": {}
         }
       },
       "output": {
@@ -281,9 +240,7 @@
           "HandshakeId"
         ],
         "members": {
-          "HandshakeId": {
-            "shape": "S2"
-          }
+          "HandshakeId": {}
         }
       },
       "output": {
@@ -312,9 +269,7 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {
-            "shape": "S1d"
-          }
+          "OrganizationalUnitId": {}
         }
       },
       "output": {
@@ -333,9 +288,7 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          }
+          "PolicyId": {}
         }
       },
       "output": {
@@ -355,12 +308,8 @@
           "TargetId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          },
-          "TargetId": {
-            "shape": "Sj"
-          }
+          "PolicyId": {},
+          "TargetId": {}
         }
       }
     },
@@ -371,9 +320,7 @@
           "ServicePrincipal"
         ],
         "members": {
-          "ServicePrincipal": {
-            "shape": "S28"
-          }
+          "ServicePrincipal": {}
         }
       }
     },
@@ -385,12 +332,8 @@
           "PolicyType"
         ],
         "members": {
-          "RootId": {
-            "shape": "S2a"
-          },
-          "PolicyType": {
-            "shape": "S16"
-          }
+          "RootId": {},
+          "PolicyType": {}
         }
       },
       "output": {
@@ -409,9 +352,7 @@
           "ServicePrincipal"
         ],
         "members": {
-          "ServicePrincipal": {
-            "shape": "S28"
-          }
+          "ServicePrincipal": {}
         }
       }
     },
@@ -437,12 +378,8 @@
           "PolicyType"
         ],
         "members": {
-          "RootId": {
-            "shape": "S2a"
-          },
-          "PolicyType": {
-            "shape": "S16"
-          }
+          "RootId": {},
+          "PolicyType": {}
         }
       },
       "output": {
@@ -466,7 +403,6 @@
           },
           "Notes": {
             "type": "string",
-            "max": 1024,
             "sensitive": true
           }
         }
@@ -487,7 +423,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -499,9 +435,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ServicePrincipal": {
-                  "shape": "S28"
-                },
+                "ServicePrincipal": {},
                 "DateEnabled": {
                   "type": "timestamp"
                 }
@@ -518,7 +452,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -539,12 +473,10 @@
           "ParentId"
         ],
         "members": {
-          "ParentId": {
-            "shape": "S19"
-          },
+          "ParentId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -566,15 +498,11 @@
           "ChildType"
         ],
         "members": {
-          "ParentId": {
-            "shape": "S19"
-          },
-          "ChildType": {
-            "shape": "S2z"
-          },
+          "ParentId": {},
+          "ChildType": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -586,12 +514,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S33"
-                },
-                "Type": {
-                  "shape": "S2z"
-                }
+                "Id": {},
+                "Type": {}
               }
             }
           },
@@ -605,13 +529,11 @@
         "members": {
           "States": {
             "type": "list",
-            "member": {
-              "shape": "Su"
-            }
+            "member": {}
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -637,7 +559,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -660,7 +582,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -681,12 +603,10 @@
           "ParentId"
         ],
         "members": {
-          "ParentId": {
-            "shape": "S19"
-          },
+          "ParentId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -710,12 +630,10 @@
           "ChildId"
         ],
         "members": {
-          "ChildId": {
-            "shape": "S33"
-          },
+          "ChildId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -727,16 +645,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S19"
-                },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "ROOT",
-                    "ORGANIZATIONAL_UNIT"
-                  ]
-                }
+                "Id": {},
+                "Type": {}
               }
             }
           },
@@ -751,12 +661,10 @@
           "Filter"
         ],
         "members": {
-          "Filter": {
-            "shape": "S16"
-          },
+          "Filter": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -778,15 +686,11 @@
           "Filter"
         ],
         "members": {
-          "TargetId": {
-            "shape": "Sj"
-          },
-          "Filter": {
-            "shape": "S16"
-          },
+          "TargetId": {},
+          "Filter": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -806,7 +710,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -830,12 +734,10 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          },
+          "PolicyId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S2p"
+            "type": "integer"
           }
         }
       },
@@ -847,26 +749,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetId": {
-                  "shape": "Sj"
-                },
-                "Arn": {
-                  "type": "string",
-                  "pattern": "^arn:aws:organizations::.+:.+"
-                },
-                "Name": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "ACCOUNT",
-                    "ORGANIZATIONAL_UNIT",
-                    "ROOT"
-                  ]
-                }
+                "TargetId": {},
+                "Arn": {},
+                "Name": {},
+                "Type": {}
               }
             }
           },
@@ -883,15 +769,9 @@
           "DestinationParentId"
         ],
         "members": {
-          "AccountId": {
-            "shape": "Sv"
-          },
-          "SourceParentId": {
-            "shape": "S19"
-          },
-          "DestinationParentId": {
-            "shape": "S19"
-          }
+          "AccountId": {},
+          "SourceParentId": {},
+          "DestinationParentId": {}
         }
       }
     },
@@ -902,9 +782,7 @@
           "AccountId"
         ],
         "members": {
-          "AccountId": {
-            "shape": "Sv"
-          }
+          "AccountId": {}
         }
       }
     },
@@ -915,12 +793,8 @@
           "OrganizationalUnitId"
         ],
         "members": {
-          "OrganizationalUnitId": {
-            "shape": "S1d"
-          },
-          "Name": {
-            "shape": "S1a"
-          }
+          "OrganizationalUnitId": {},
+          "Name": {}
         }
       },
       "output": {
@@ -939,18 +813,10 @@
           "PolicyId"
         ],
         "members": {
-          "PolicyId": {
-            "shape": "Si"
-          },
-          "Name": {
-            "shape": "S1i"
-          },
-          "Description": {
-            "shape": "S1h"
-          },
-          "Content": {
-            "shape": "S1g"
-          }
+          "PolicyId": {},
+          "Name": {},
+          "Description": {},
+          "Content": {}
         }
       },
       "output": {
@@ -964,46 +830,25 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "^h-[0-9a-z]{8,32}$"
-    },
     "S4": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
-        "Arn": {
-          "type": "string",
-          "pattern": "^arn:aws:organizations::\\d{12}:handshake\\/o-[a-z0-9]{10,32}\\/[a-z_]{1,32}\\/h-[0-9a-z]{8,32}"
-        },
+        "Id": {},
+        "Arn": {},
         "Parties": {
           "type": "list",
           "member": {
             "shape": "S7"
           }
         },
-        "State": {
-          "type": "string",
-          "enum": [
-            "REQUESTED",
-            "OPEN",
-            "CANCELED",
-            "ACCEPTED",
-            "DECLINED",
-            "EXPIRED"
-          ]
-        },
+        "State": {},
         "RequestedTimestamp": {
           "type": "timestamp"
         },
         "ExpirationTimestamp": {
           "type": "timestamp"
         },
-        "Action": {
-          "shape": "Sc"
-        },
+        "Action": {},
         "Resources": {
           "shape": "Sd"
         }
@@ -1018,28 +863,10 @@
       "members": {
         "Id": {
           "type": "string",
-          "max": 64,
-          "min": 1,
           "sensitive": true
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "ACCOUNT",
-            "ORGANIZATION",
-            "EMAIL"
-          ]
-        }
+        "Type": {}
       }
-    },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "INVITE",
-        "ENABLE_ALL_FEATURES",
-        "APPROVE_ALL_FEATURES",
-        "ADD_ORGANIZATIONS_SERVICE_LINKED_ROLE"
-      ]
     },
     "Sd": {
       "type": "list",
@@ -1050,124 +877,47 @@
             "type": "string",
             "sensitive": true
           },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "ACCOUNT",
-              "ORGANIZATION",
-              "ORGANIZATION_FEATURE_SET",
-              "EMAIL",
-              "MASTER_EMAIL",
-              "MASTER_NAME",
-              "NOTES",
-              "PARENT_HANDSHAKE"
-            ]
-          },
+          "Type": {},
           "Resources": {
             "shape": "Sd"
           }
         }
       }
     },
-    "Si": {
-      "type": "string",
-      "pattern": "^p-[0-9a-zA-Z_]{8,128}$"
-    },
-    "Sj": {
-      "type": "string",
-      "pattern": "^(r-[0-9a-z]{4,32})|(\\d{12})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
-    },
     "Sn": {
       "type": "string",
-      "max": 64,
-      "min": 6,
-      "pattern": "[^\\s@]+@[^\\s@]+\\.[^\\s@]+",
       "sensitive": true
     },
     "So": {
       "type": "string",
-      "max": 50,
-      "min": 1,
-      "pattern": "[\\u0020-\\u007E]+",
       "sensitive": true
     },
     "Ss": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "St"
-        },
+        "Id": {},
         "AccountName": {
           "shape": "So"
         },
-        "State": {
-          "shape": "Su"
-        },
+        "State": {},
         "RequestedTimestamp": {
           "type": "timestamp"
         },
         "CompletedTimestamp": {
           "type": "timestamp"
         },
-        "AccountId": {
-          "shape": "Sv"
-        },
-        "FailureReason": {
-          "type": "string",
-          "enum": [
-            "ACCOUNT_LIMIT_EXCEEDED",
-            "EMAIL_ALREADY_EXISTS",
-            "INVALID_ADDRESS",
-            "INVALID_EMAIL",
-            "CONCURRENT_ACCOUNT_MODIFICATION",
-            "INTERNAL_FAILURE"
-          ]
-        }
+        "AccountId": {},
+        "FailureReason": {}
       }
-    },
-    "St": {
-      "type": "string",
-      "pattern": "^car-[a-z0-9]{8,32}$"
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "SUCCEEDED",
-        "FAILED"
-      ]
-    },
-    "Sv": {
-      "type": "string",
-      "pattern": "^\\d{12}$"
-    },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "ALL",
-        "CONSOLIDATED_BILLING"
-      ]
     },
     "S10": {
       "type": "structure",
       "members": {
-        "Id": {
-          "type": "string",
-          "pattern": "^o-[a-z0-9]{10,32}$"
-        },
-        "Arn": {
-          "type": "string",
-          "pattern": "^arn:aws:organizations::\\d{12}:organization\\/o-[a-z0-9]{10,32}"
-        },
-        "FeatureSet": {
-          "shape": "Sy"
-        },
-        "MasterAccountArn": {
-          "shape": "S13"
-        },
-        "MasterAccountId": {
-          "shape": "Sv"
-        },
+        "Id": {},
+        "Arn": {},
+        "FeatureSet": {},
+        "MasterAccountArn": {},
+        "MasterAccountId": {},
         "MasterAccountEmail": {
           "shape": "Sn"
         },
@@ -1176,76 +926,23 @@
         }
       }
     },
-    "S13": {
-      "type": "string",
-      "pattern": "^arn:aws:organizations::\\d{12}:account\\/o-[a-z0-9]{10,32}\\/\\d{12}"
-    },
     "S14": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Type": {
-            "shape": "S16"
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "ENABLED",
-              "PENDING_ENABLE",
-              "PENDING_DISABLE"
-            ]
-          }
+          "Type": {},
+          "Status": {}
         }
       }
-    },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "SERVICE_CONTROL_POLICY"
-      ]
-    },
-    "S19": {
-      "type": "string",
-      "pattern": "^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
-    },
-    "S1a": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S1c": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S1d"
-        },
-        "Arn": {
-          "type": "string",
-          "pattern": "^arn:aws:organizations::\\d{12}:ou\\/o-[a-z0-9]{10,32}\\/ou-[0-9a-z]{4,32}-[0-9a-z]{8,32}"
-        },
-        "Name": {
-          "shape": "S1a"
-        }
+        "Id": {},
+        "Arn": {},
+        "Name": {}
       }
-    },
-    "S1d": {
-      "type": "string",
-      "pattern": "^ou-[0-9a-z]{4,32}-[a-z0-9]{8,32}$"
-    },
-    "S1g": {
-      "type": "string",
-      "max": 1000000,
-      "min": 1
-    },
-    "S1h": {
-      "type": "string",
-      "max": 512
-    },
-    "S1i": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S1k": {
       "type": "structure",
@@ -1253,30 +950,17 @@
         "PolicySummary": {
           "shape": "S1l"
         },
-        "Content": {
-          "shape": "S1g"
-        }
+        "Content": {}
       }
     },
     "S1l": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "Si"
-        },
-        "Arn": {
-          "type": "string",
-          "pattern": "^(arn:aws:organizations::\\d{12}:policy\\/o-[a-z0-9]{10,32}\\/[0-9a-z_]+\\/p-[0-9a-z]{10,32})|(arn:aws:organizations::aws:policy\\/[0-9a-z_]+\\/p-[0-9a-zA-Z_]{10,128})"
-        },
-        "Name": {
-          "shape": "S1i"
-        },
-        "Description": {
-          "shape": "S1h"
-        },
-        "Type": {
-          "shape": "S16"
-        },
+        "Id": {},
+        "Arn": {},
+        "Name": {},
+        "Description": {},
+        "Type": {},
         "AwsManaged": {
           "type": "boolean"
         }
@@ -1285,71 +969,31 @@
     "S1u": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "Sv"
-        },
-        "Arn": {
-          "shape": "S13"
-        },
+        "Id": {},
+        "Arn": {},
         "Email": {
           "shape": "Sn"
         },
         "Name": {
           "shape": "So"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "ACTIVE",
-            "SUSPENDED"
-          ]
-        },
-        "JoinedMethod": {
-          "type": "string",
-          "enum": [
-            "INVITED",
-            "CREATED"
-          ]
-        },
+        "Status": {},
+        "JoinedMethod": {},
         "JoinedTimestamp": {
           "type": "timestamp"
         }
       }
     },
-    "S28": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+=,.@-]*"
-    },
-    "S2a": {
-      "type": "string",
-      "pattern": "^r-[0-9a-z]{4,32}$"
-    },
     "S2c": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S2a"
-        },
-        "Arn": {
-          "type": "string",
-          "pattern": "^arn:aws:organizations::\\d{12}:root\\/o-[a-z0-9]{10,32}\\/r-[0-9a-z]{4,32}"
-        },
-        "Name": {
-          "type": "string",
-          "max": 128,
-          "min": 1
-        },
+        "Id": {},
+        "Arn": {},
+        "Name": {},
         "PolicyTypes": {
           "shape": "S14"
         }
       }
-    },
-    "S2p": {
-      "type": "integer",
-      "max": 20,
-      "min": 1
     },
     "S2v": {
       "type": "list",
@@ -1357,26 +1001,11 @@
         "shape": "S1u"
       }
     },
-    "S2z": {
-      "type": "string",
-      "enum": [
-        "ACCOUNT",
-        "ORGANIZATIONAL_UNIT"
-      ]
-    },
-    "S33": {
-      "type": "string",
-      "pattern": "^(\\d{12})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$"
-    },
     "S39": {
       "type": "structure",
       "members": {
-        "ActionType": {
-          "shape": "Sc"
-        },
-        "ParentHandshakeId": {
-          "shape": "S2"
-        }
+        "ActionType": {},
+        "ParentHandshakeId": {}
       }
     },
     "S3b": {

--- a/apis/pi-2018-02-27.min.json
+++ b/apis/pi-2018-02-27.min.json
@@ -26,9 +26,7 @@
           "GroupBy"
         ],
         "members": {
-          "ServiceType": {
-            "shape": "S2"
-          },
+          "ServiceType": {},
           "Identifier": {},
           "StartTime": {
             "type": "timestamp"
@@ -50,7 +48,7 @@
             "shape": "S9"
           },
           "MaxResults": {
-            "shape": "Sa"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -113,9 +111,7 @@
           "EndTime"
         ],
         "members": {
-          "ServiceType": {
-            "shape": "S2"
-          },
+          "ServiceType": {},
           "Identifier": {},
           "MetricQueries": {
             "type": "list",
@@ -133,9 +129,7 @@
                   "shape": "S9"
                 }
               }
-            },
-            "max": 15,
-            "min": 1
+            }
           },
           "StartTime": {
             "type": "timestamp"
@@ -147,7 +141,7 @@
             "type": "integer"
           },
           "MaxResults": {
-            "shape": "Sa"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -206,12 +200,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "enum": [
-        "RDS"
-      ]
-    },
     "S6": {
       "type": "structure",
       "required": [
@@ -221,14 +209,10 @@
         "Group": {},
         "Dimensions": {
           "type": "list",
-          "member": {},
-          "max": 10,
-          "min": 1
+          "member": {}
         },
         "Limit": {
-          "type": "integer",
-          "max": 10,
-          "min": 1
+          "type": "integer"
         }
       }
     },
@@ -236,11 +220,6 @@
       "type": "map",
       "key": {},
       "value": {}
-    },
-    "Sa": {
-      "type": "integer",
-      "max": 20,
-      "min": 0
     },
     "Se": {
       "type": "map",

--- a/apis/pinpoint-2016-12-01.min.json
+++ b/apis/pinpoint-2016-12-01.min.json
@@ -143,9 +143,7 @@
                 "type": "boolean"
               },
               "ExternalId": {},
-              "Format": {
-                "shape": "S13"
-              },
+              "Format": {},
               "RegisterEndpoints": {
                 "type": "boolean"
               },
@@ -1997,9 +1995,7 @@
                         "Attributes": {
                           "shape": "S2w"
                         },
-                        "ChannelType": {
-                          "shape": "S2x"
-                        },
+                        "ChannelType": {},
                         "Demographic": {
                           "shape": "S2y"
                         },
@@ -2185,9 +2181,7 @@
                   "type": "structure",
                   "members": {
                     "BodyOverride": {},
-                    "ChannelType": {
-                      "shape": "S2x"
-                    },
+                    "ChannelType": {},
                     "Context": {
                       "shape": "S62"
                     },
@@ -2236,9 +2230,7 @@
                 "value": {
                   "type": "structure",
                   "members": {
-                    "DeliveryStatus": {
-                      "shape": "S6x"
-                    },
+                    "DeliveryStatus": {},
                     "MessageId": {},
                     "StatusCode": {
                       "type": "integer"
@@ -2763,9 +2755,7 @@
               "Attributes": {
                 "shape": "S2w"
               },
-              "ChannelType": {
-                "shape": "S2x"
-              },
+              "ChannelType": {},
               "Demographic": {
                 "shape": "S2y"
               },
@@ -2830,9 +2820,7 @@
                     "Attributes": {
                       "shape": "S2w"
                     },
-                    "ChannelType": {
-                      "shape": "S2x"
-                    },
+                    "ChannelType": {},
                     "Demographic": {
                       "shape": "S2y"
                     },
@@ -3097,9 +3085,7 @@
           "type": "structure",
           "members": {
             "Body": {},
-            "MessageType": {
-              "shape": "Sh"
-            },
+            "MessageType": {},
             "SenderId": {}
           }
         }
@@ -3108,9 +3094,7 @@
     "Sb": {
       "type": "structure",
       "members": {
-        "Action": {
-          "shape": "Sc"
-        },
+        "Action": {},
         "Body": {},
         "ImageIconUrl": {},
         "ImageSmallIconUrl": {},
@@ -3129,35 +3113,11 @@
       },
       "required": []
     },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "OPEN_APP",
-        "DEEP_LINK",
-        "URL"
-      ]
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "TRANSACTIONAL",
-        "PROMOTIONAL"
-      ]
-    },
     "Si": {
       "type": "structure",
       "members": {
         "EndTime": {},
-        "Frequency": {
-          "type": "string",
-          "enum": [
-            "ONCE",
-            "HOURLY",
-            "DAILY",
-            "WEEKLY",
-            "MONTHLY"
-          ]
-        },
+        "Frequency": {},
         "IsLocalTime": {
           "type": "boolean"
         },
@@ -3180,13 +3140,7 @@
       "type": "structure",
       "members": {
         "LambdaFunctionName": {},
-        "Mode": {
-          "type": "string",
-          "enum": [
-            "DELIVERY",
-            "FILTER"
-          ]
-        },
+        "Mode": {},
         "WebUrl": {}
       }
     },
@@ -3279,17 +3233,7 @@
     "Ss": {
       "type": "structure",
       "members": {
-        "CampaignStatus": {
-          "type": "string",
-          "enum": [
-            "SCHEDULED",
-            "EXECUTING",
-            "PENDING_NEXT_RUN",
-            "COMPLETED",
-            "PAUSED",
-            "DELETED"
-          ]
-        }
+        "CampaignStatus": {}
       }
     },
     "Sx": {
@@ -3320,9 +3264,7 @@
           "shape": "Sz"
         },
         "Id": {},
-        "JobStatus": {
-          "shape": "S10"
-        },
+        "JobStatus": {},
         "TotalFailures": {
           "type": "integer"
         },
@@ -3340,25 +3282,6 @@
       "type": "list",
       "member": {}
     },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "CREATED",
-        "INITIALIZING",
-        "PROCESSING",
-        "COMPLETING",
-        "COMPLETED",
-        "FAILING",
-        "FAILED"
-      ]
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "CSV",
-        "JSON"
-      ]
-    },
     "S15": {
       "type": "structure",
       "members": {
@@ -3375,9 +3298,7 @@
               "type": "boolean"
             },
             "ExternalId": {},
-            "Format": {
-              "shape": "S13"
-            },
+            "Format": {},
             "RegisterEndpoints": {
               "type": "boolean"
             },
@@ -3395,9 +3316,7 @@
           "shape": "Sz"
         },
         "Id": {},
-        "JobStatus": {
-          "shape": "S10"
-        },
+        "JobStatus": {},
         "TotalFailures": {
           "type": "integer"
         },
@@ -3436,22 +3355,8 @@
             "Recency": {
               "type": "structure",
               "members": {
-                "Duration": {
-                  "type": "string",
-                  "enum": [
-                    "HR_24",
-                    "DAY_7",
-                    "DAY_14",
-                    "DAY_30"
-                  ]
-                },
-                "RecencyType": {
-                  "type": "string",
-                  "enum": [
-                    "ACTIVE",
-                    "INACTIVE"
-                  ]
-                }
+                "Duration": {},
+                "RecencyType": {}
               },
               "required": []
             }
@@ -3533,13 +3438,7 @@
       "value": {
         "type": "structure",
         "members": {
-          "AttributeType": {
-            "type": "string",
-            "enum": [
-              "INCLUSIVE",
-              "EXCLUSIVE"
-            ]
-          },
+          "AttributeType": {},
           "Values": {
             "shape": "Sz"
           }
@@ -3550,13 +3449,7 @@
     "S1i": {
       "type": "structure",
       "members": {
-        "DimensionType": {
-          "type": "string",
-          "enum": [
-            "INCLUSIVE",
-            "EXCLUSIVE"
-          ]
-        },
+        "DimensionType": {},
         "Values": {
           "shape": "Sz"
         }
@@ -3589,34 +3482,13 @@
                   }
                 }
               },
-              "SourceType": {
-                "type": "string",
-                "enum": [
-                  "ALL",
-                  "ANY",
-                  "NONE"
-                ]
-              },
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "ALL",
-                  "ANY",
-                  "NONE"
-                ]
-              }
+              "SourceType": {},
+              "Type": {}
             },
             "required": []
           }
         },
-        "Include": {
-          "type": "string",
-          "enum": [
-            "ALL",
-            "ANY",
-            "NONE"
-          ]
-        }
+        "Include": {}
       },
       "required": []
     },
@@ -3640,9 +3512,7 @@
               }
             },
             "ExternalId": {},
-            "Format": {
-              "shape": "S13"
-            },
+            "Format": {},
             "RoleArn": {},
             "S3Url": {},
             "Size": {
@@ -3656,13 +3526,7 @@
         "SegmentGroups": {
           "shape": "S1q"
         },
-        "SegmentType": {
-          "type": "string",
-          "enum": [
-            "DIMENSIONAL",
-            "IMPORT"
-          ]
-        },
+        "SegmentType": {},
         "Version": {
           "type": "integer"
         }
@@ -3868,9 +3732,7 @@
         "Attributes": {
           "shape": "S2w"
         },
-        "ChannelType": {
-          "shape": "S2x"
-        },
+        "ChannelType": {},
         "CohortId": {},
         "CreationDate": {},
         "Demographic": {
@@ -3898,21 +3760,6 @@
       "value": {
         "shape": "Sz"
       }
-    },
-    "S2x": {
-      "type": "string",
-      "enum": [
-        "GCM",
-        "APNS",
-        "APNS_SANDBOX",
-        "APNS_VOIP",
-        "APNS_VOIP_SANDBOX",
-        "ADM",
-        "SMS",
-        "EMAIL",
-        "BAIDU",
-        "CUSTOM"
-      ]
     },
     "S2y": {
       "type": "structure",
@@ -4137,9 +3984,7 @@
         "ADMMessage": {
           "type": "structure",
           "members": {
-            "Action": {
-              "shape": "Sc"
-            },
+            "Action": {},
             "Body": {},
             "ConsolidationKey": {},
             "Data": {
@@ -4166,9 +4011,7 @@
         "APNSMessage": {
           "type": "structure",
           "members": {
-            "Action": {
-              "shape": "Sc"
-            },
+            "Action": {},
             "Badge": {
               "type": "integer"
             },
@@ -4200,9 +4043,7 @@
         "BaiduMessage": {
           "type": "structure",
           "members": {
-            "Action": {
-              "shape": "Sc"
-            },
+            "Action": {},
             "Body": {},
             "Data": {
               "shape": "S62"
@@ -4238,9 +4079,7 @@
         "DefaultPushNotificationMessage": {
           "type": "structure",
           "members": {
-            "Action": {
-              "shape": "Sc"
-            },
+            "Action": {},
             "Body": {},
             "Data": {
               "shape": "S62"
@@ -4258,9 +4097,7 @@
         "GCMMessage": {
           "type": "structure",
           "members": {
-            "Action": {
-              "shape": "Sc"
-            },
+            "Action": {},
             "Body": {},
             "CollapseKey": {},
             "Data": {
@@ -4292,9 +4129,7 @@
           "members": {
             "Body": {},
             "Keyword": {},
-            "MessageType": {
-              "shape": "Sh"
-            },
+            "MessageType": {},
             "OriginationNumber": {},
             "SenderId": {},
             "Substitutions": {
@@ -4312,9 +4147,7 @@
         "type": "structure",
         "members": {
           "Address": {},
-          "DeliveryStatus": {
-            "shape": "S6x"
-          },
+          "DeliveryStatus": {},
           "MessageId": {},
           "StatusCode": {
             "type": "integer"
@@ -4324,18 +4157,6 @@
         },
         "required": []
       }
-    },
-    "S6x": {
-      "type": "string",
-      "enum": [
-        "SUCCESSFUL",
-        "THROTTLED",
-        "TEMPORARY_FAILURE",
-        "PERMANENT_FAILURE",
-        "UNKNOWN_FAILURE",
-        "OPT_OUT",
-        "DUPLICATE"
-      ]
     },
     "S7y": {
       "type": "structure",

--- a/apis/polly-2016-06-10.min.json
+++ b/apis/polly-2016-06-10.min.json
@@ -44,7 +44,6 @@
         "type": "structure",
         "members": {
           "LanguageCode": {
-            "shape": "S5",
             "location": "querystring",
             "locationName": "LanguageCode"
           },
@@ -67,26 +66,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Gender": {
-                  "type": "string",
-                  "enum": [
-                    "Female",
-                    "Male"
-                  ]
-                },
-                "Id": {
-                  "shape": "Sc"
-                },
-                "LanguageCode": {
-                  "shape": "S5"
-                },
+                "Gender": {},
+                "Id": {},
+                "LanguageCode": {},
                 "LanguageName": {},
                 "Name": {},
                 "AdditionalLanguageCodes": {
                   "type": "list",
-                  "member": {
-                    "shape": "S5"
-                  }
+                  "member": {}
                 }
               }
             }
@@ -145,7 +132,6 @@
         ],
         "members": {
           "TaskId": {
-            "shape": "Sr",
             "location": "uri",
             "locationName": "TaskId"
           }
@@ -208,16 +194,13 @@
           "MaxResults": {
             "location": "querystring",
             "locationName": "MaxResults",
-            "type": "integer",
-            "max": 100,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
             "locationName": "NextToken"
           },
           "Status": {
-            "shape": "Su",
             "location": "querystring",
             "locationName": "Status"
           }
@@ -279,34 +262,18 @@
           "LexiconNames": {
             "shape": "S10"
           },
-          "OutputFormat": {
-            "shape": "S11"
-          },
-          "OutputS3BucketName": {
-            "type": "string",
-            "pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
-          },
-          "OutputS3KeyPrefix": {
-            "type": "string",
-            "pattern": "^[0-9a-zA-Z\\/\\!\\-_\\.\\*\\'\\(\\)]{0,800}$"
-          },
+          "OutputFormat": {},
+          "OutputS3BucketName": {},
+          "OutputS3KeyPrefix": {},
           "SampleRate": {},
-          "SnsTopicArn": {
-            "shape": "Sz"
-          },
+          "SnsTopicArn": {},
           "SpeechMarkTypes": {
             "shape": "S13"
           },
           "Text": {},
-          "TextType": {
-            "shape": "S15"
-          },
-          "VoiceId": {
-            "shape": "Sc"
-          },
-          "LanguageCode": {
-            "shape": "S5"
-          }
+          "TextType": {},
+          "VoiceId": {},
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -334,23 +301,15 @@
           "LexiconNames": {
             "shape": "S10"
           },
-          "OutputFormat": {
-            "shape": "S11"
-          },
+          "OutputFormat": {},
           "SampleRate": {},
           "SpeechMarkTypes": {
             "shape": "S13"
           },
           "Text": {},
-          "TextType": {
-            "shape": "S15"
-          },
-          "VoiceId": {
-            "shape": "Sc"
-          },
-          "LanguageCode": {
-            "shape": "S5"
-          }
+          "TextType": {},
+          "VoiceId": {},
+          "LanguageCode": {}
         }
       },
       "output": {
@@ -377,107 +336,13 @@
   "shapes": {
     "S2": {
       "type": "string",
-      "pattern": "[0-9A-Za-z]{1,20}",
       "sensitive": true
-    },
-    "S5": {
-      "type": "string",
-      "enum": [
-        "cmn-CN",
-        "cy-GB",
-        "da-DK",
-        "de-DE",
-        "en-AU",
-        "en-GB",
-        "en-GB-WLS",
-        "en-IN",
-        "en-US",
-        "es-ES",
-        "es-US",
-        "fr-CA",
-        "fr-FR",
-        "is-IS",
-        "it-IT",
-        "ja-JP",
-        "hi-IN",
-        "ko-KR",
-        "nb-NO",
-        "nl-NL",
-        "pl-PL",
-        "pt-BR",
-        "pt-PT",
-        "ro-RO",
-        "ru-RU",
-        "sv-SE",
-        "tr-TR"
-      ]
-    },
-    "Sc": {
-      "type": "string",
-      "enum": [
-        "Geraint",
-        "Gwyneth",
-        "Mads",
-        "Naja",
-        "Hans",
-        "Marlene",
-        "Nicole",
-        "Russell",
-        "Amy",
-        "Brian",
-        "Emma",
-        "Raveena",
-        "Ivy",
-        "Joanna",
-        "Joey",
-        "Justin",
-        "Kendra",
-        "Kimberly",
-        "Matthew",
-        "Salli",
-        "Conchita",
-        "Enrique",
-        "Miguel",
-        "Penelope",
-        "Chantal",
-        "Celine",
-        "Lea",
-        "Mathieu",
-        "Dora",
-        "Karl",
-        "Carla",
-        "Giorgio",
-        "Mizuki",
-        "Liv",
-        "Lotte",
-        "Ruben",
-        "Ewa",
-        "Jacek",
-        "Jan",
-        "Maja",
-        "Ricardo",
-        "Vitoria",
-        "Cristiano",
-        "Ines",
-        "Carmen",
-        "Maxim",
-        "Tatyana",
-        "Astrid",
-        "Filiz",
-        "Vicki",
-        "Takumi",
-        "Seoyeon",
-        "Aditi",
-        "Zhiyu"
-      ]
     },
     "Sk": {
       "type": "structure",
       "members": {
         "Alphabet": {},
-        "LanguageCode": {
-          "shape": "S5"
-        },
+        "LanguageCode": {},
         "LastModified": {
           "type": "timestamp"
         },
@@ -490,20 +355,11 @@
         }
       }
     },
-    "Sr": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
     "St": {
       "type": "structure",
       "members": {
-        "TaskId": {
-          "shape": "Sr"
-        },
-        "TaskStatus": {
-          "shape": "Su"
-        },
+        "TaskId": {},
+        "TaskStatus": {},
         "TaskStatusReason": {},
         "OutputUri": {},
         "CreationTime": {
@@ -512,78 +368,29 @@
         "RequestCharacters": {
           "type": "integer"
         },
-        "SnsTopicArn": {
-          "shape": "Sz"
-        },
+        "SnsTopicArn": {},
         "LexiconNames": {
           "shape": "S10"
         },
-        "OutputFormat": {
-          "shape": "S11"
-        },
+        "OutputFormat": {},
         "SampleRate": {},
         "SpeechMarkTypes": {
           "shape": "S13"
         },
-        "TextType": {
-          "shape": "S15"
-        },
-        "VoiceId": {
-          "shape": "Sc"
-        },
-        "LanguageCode": {
-          "shape": "S5"
-        }
+        "TextType": {},
+        "VoiceId": {},
+        "LanguageCode": {}
       }
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "scheduled",
-        "inProgress",
-        "completed",
-        "failed"
-      ]
-    },
-    "Sz": {
-      "type": "string",
-      "pattern": "^arn:aws(-(cn|iso(-b)?|us-gov))?:sns:.*:\\w{12}:.+$"
     },
     "S10": {
       "type": "list",
       "member": {
         "shape": "S2"
-      },
-      "max": 5
-    },
-    "S11": {
-      "type": "string",
-      "enum": [
-        "json",
-        "mp3",
-        "ogg_vorbis",
-        "pcm"
-      ]
+      }
     },
     "S13": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "sentence",
-          "ssml",
-          "viseme",
-          "word"
-        ]
-      },
-      "max": 4
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "ssml",
-        "text"
-      ]
+      "member": {}
     }
   }
 }

--- a/apis/pricing-2017-10-15.min.json
+++ b/apis/pricing-2017-10-15.min.json
@@ -22,7 +22,7 @@
           "FormatVersion": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S3"
+            "type": "integer"
           }
         }
       },
@@ -59,7 +59,7 @@
           "AttributeName": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S3"
+            "type": "integer"
           }
         }
       },
@@ -94,12 +94,7 @@
                 "Value"
               ],
               "members": {
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "TERM_MATCH"
-                  ]
-                },
+                "Type": {},
                 "Field": {},
                 "Value": {}
               }
@@ -108,7 +103,7 @@
           "FormatVersion": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S3"
+            "type": "integer"
           }
         }
       },
@@ -127,11 +122,5 @@
       }
     }
   },
-  "shapes": {
-    "S3": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    }
-  }
+  "shapes": {}
 }

--- a/apis/rds-2013-01-10.min.json
+++ b/apis/rds-2013-01-10.min.json
@@ -758,9 +758,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S32"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -791,9 +789,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S32"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -1839,24 +1835,9 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          }
+          "ApplyMethod": {}
         }
       }
-    },
-    "S32": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot"
-      ]
     },
     "S3m": {
       "type": "structure",

--- a/apis/rds-2013-02-12.min.json
+++ b/apis/rds-2013-02-12.min.json
@@ -803,9 +803,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S3a"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -836,9 +834,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S3a"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -1971,24 +1967,9 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          }
+          "ApplyMethod": {}
         }
       }
-    },
-    "S3a": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot"
-      ]
     },
     "S3w": {
       "type": "structure",

--- a/apis/rds-2013-09-09.min.json
+++ b/apis/rds-2013-09-09.min.json
@@ -864,9 +864,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S3f"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -900,9 +898,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S3f"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -2107,24 +2103,9 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          }
+          "ApplyMethod": {}
         }
       }
-    },
-    "S3f": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot"
-      ]
     },
     "S41": {
       "type": "structure",

--- a/apis/rds-2014-09-01.min.json
+++ b/apis/rds-2014-09-01.min.json
@@ -922,9 +922,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S3j"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -958,9 +956,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S3j"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S6"
@@ -2180,24 +2176,9 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          }
+          "ApplyMethod": {}
         }
       }
-    },
-    "S3j": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot"
-      ]
     },
     "S45": {
       "type": "structure",

--- a/apis/rds-2014-10-31.min.json
+++ b/apis/rds-2014-10-31.min.json
@@ -1622,9 +1622,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S5v"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -1658,9 +1656,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S5v"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S7"
@@ -4132,13 +4128,7 @@
             "type": "boolean"
           },
           "MinimumEngineVersion": {},
-          "ApplyMethod": {
-            "type": "string",
-            "enum": [
-              "immediate",
-              "pending-reboot"
-            ]
-          },
+          "ApplyMethod": {},
           "SupportedEngineModes": {
             "shape": "S45"
           }
@@ -4213,17 +4203,6 @@
         }
       },
       "wrapper": true
-    },
-    "S5v": {
-      "type": "string",
-      "enum": [
-        "db-instance",
-        "db-parameter-group",
-        "db-security-group",
-        "db-snapshot",
-        "db-cluster",
-        "db-cluster-snapshot"
-      ]
     },
     "S6k": {
       "type": "list",

--- a/apis/redshift-2012-12-01.min.json
+++ b/apis/redshift-2012-12-01.min.json
@@ -976,9 +976,7 @@
         "type": "structure",
         "members": {
           "SourceIdentifier": {},
-          "SourceType": {
-            "shape": "S47"
-          },
+          "SourceType": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -1006,9 +1004,7 @@
               "type": "structure",
               "members": {
                 "SourceIdentifier": {},
-                "SourceType": {
-                  "shape": "S47"
-                },
+                "SourceType": {},
                 "Message": {},
                 "EventCategories": {
                   "shape": "S23"
@@ -1969,9 +1965,7 @@
         "RecurringCharges": {
           "shape": "S8"
         },
-        "ReservedNodeOfferingType": {
-          "shape": "Sa"
-        }
+        "ReservedNodeOfferingType": {}
       },
       "wrapper": true
     },
@@ -1988,13 +1982,6 @@
         },
         "wrapper": true
       }
-    },
-    "Sa": {
-      "type": "string",
-      "enum": [
-        "Regular",
-        "Upgradable"
-      ]
     },
     "Sd": {
       "type": "structure",
@@ -2503,28 +2490,13 @@
           "Source": {},
           "DataType": {},
           "AllowedValues": {},
-          "ApplyType": {
-            "type": "string",
-            "enum": [
-              "static",
-              "dynamic"
-            ]
-          },
+          "ApplyType": {},
           "IsModifiable": {
             "type": "boolean"
           },
           "MinimumEngineVersion": {}
         }
       }
-    },
-    "S47": {
-      "type": "string",
-      "enum": [
-        "cluster",
-        "cluster-parameter-group",
-        "cluster-security-group",
-        "cluster-snapshot"
-      ]
     },
     "S4i": {
       "type": "structure",
@@ -2565,9 +2537,7 @@
           "RecurringCharges": {
             "shape": "S8"
           },
-          "ReservedNodeOfferingType": {
-            "shape": "Sa"
-          }
+          "ReservedNodeOfferingType": {}
         },
         "wrapper": true
       }
@@ -2576,16 +2546,7 @@
       "type": "structure",
       "members": {
         "TableRestoreRequestId": {},
-        "Status": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "IN_PROGRESS",
-            "SUCCEEDED",
-            "FAILED",
-            "CANCELED"
-          ]
-        },
+        "Status": {},
         "Message": {},
         "RequestTime": {
           "type": "timestamp"

--- a/apis/rekognition-2016-06-27.min.json
+++ b/apis/rekognition-2016-06-27.min.json
@@ -27,7 +27,7 @@
             "shape": "S2"
           },
           "SimilarityThreshold": {
-            "shape": "S8"
+            "type": "float"
           }
         }
       },
@@ -41,7 +41,7 @@
                 "shape": "Sb"
               },
               "Confidence": {
-                "shape": "S8"
+                "type": "float"
               }
             }
           },
@@ -51,7 +51,7 @@
               "type": "structure",
               "members": {
                 "Similarity": {
-                  "shape": "S8"
+                  "type": "float"
                 },
                 "Face": {
                   "shape": "Sf"
@@ -65,12 +65,8 @@
               "shape": "Sf"
             }
           },
-          "SourceImageOrientationCorrection": {
-            "shape": "Sn"
-          },
-          "TargetImageOrientationCorrection": {
-            "shape": "Sn"
-          }
+          "SourceImageOrientationCorrection": {},
+          "TargetImageOrientationCorrection": {}
         }
       }
     },
@@ -81,16 +77,14 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          }
+          "CollectionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "StatusCode": {
-            "shape": "Sr"
+            "type": "integer"
           },
           "CollectionArn": {},
           "FaceModelVersion": {}
@@ -114,23 +108,17 @@
           "Output": {
             "shape": "Sx"
           },
-          "Name": {
-            "shape": "S10"
-          },
+          "Name": {},
           "Settings": {
             "shape": "S11"
           },
-          "RoleArn": {
-            "shape": "S13"
-          }
+          "RoleArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "StreamProcessorArn": {
-            "shape": "S15"
-          }
+          "StreamProcessorArn": {}
         }
       }
     },
@@ -141,16 +129,14 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          }
+          "CollectionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "StatusCode": {
-            "shape": "Sr"
+            "type": "integer"
           }
         }
       }
@@ -163,9 +149,7 @@
           "FaceIds"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          },
+          "CollectionId": {},
           "FaceIds": {
             "shape": "S19"
           }
@@ -187,9 +171,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S10"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -204,16 +186,14 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          }
+          "CollectionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
           "FaceCount": {
-            "shape": "S1g"
+            "type": "long"
           },
           "FaceModelVersion": {},
           "CollectionARN": {},
@@ -230,23 +210,15 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S10"
-          }
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S10"
-          },
-          "StreamProcessorArn": {
-            "shape": "S15"
-          },
-          "Status": {
-            "shape": "S1k"
-          },
+          "Name": {},
+          "StreamProcessorArn": {},
+          "Status": {},
           "StatusMessage": {},
           "CreationTimestamp": {
             "type": "timestamp"
@@ -260,9 +232,7 @@
           "Output": {
             "shape": "Sx"
           },
-          "RoleArn": {
-            "shape": "S13"
-          },
+          "RoleArn": {},
           "Settings": {
             "shape": "S11"
           }
@@ -293,9 +263,7 @@
               "shape": "S1q"
             }
           },
-          "OrientationCorrection": {
-            "shape": "Sn"
-          }
+          "OrientationCorrection": {}
         }
       }
     },
@@ -310,10 +278,10 @@
             "shape": "S2"
           },
           "MaxLabels": {
-            "shape": "Sr"
+            "type": "integer"
           },
           "MinConfidence": {
-            "shape": "S8"
+            "type": "float"
           }
         }
       },
@@ -326,9 +294,7 @@
               "shape": "S28"
             }
           },
-          "OrientationCorrection": {
-            "shape": "Sn"
-          }
+          "OrientationCorrection": {}
         }
       }
     },
@@ -343,7 +309,7 @@
             "shape": "S2"
           },
           "MinConfidence": {
-            "shape": "S8"
+            "type": "float"
           }
         }
       },
@@ -380,21 +346,15 @@
               "type": "structure",
               "members": {
                 "DetectedText": {},
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "LINE",
-                    "WORD"
-                  ]
-                },
+                "Type": {},
                 "Id": {
-                  "shape": "Sr"
+                  "type": "integer"
                 },
                 "ParentId": {
-                  "shape": "Sr"
+                  "type": "integer"
                 },
                 "Confidence": {
-                  "shape": "S8"
+                  "type": "float"
                 },
                 "Geometry": {
                   "type": "structure",
@@ -431,9 +391,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "S2m"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -453,37 +411,23 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "ID",
-              "TIMESTAMP"
-            ]
-          }
+          "NextToken": {},
+          "SortBy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "Celebrities": {
             "type": "list",
             "member": {
@@ -499,11 +443,9 @@
                       "shape": "S2o"
                     },
                     "Name": {},
-                    "Id": {
-                      "shape": "S2m"
-                    },
+                    "Id": {},
                     "Confidence": {
-                      "shape": "S8"
+                      "type": "float"
                     },
                     "BoundingBox": {
                       "shape": "Sb"
@@ -526,30 +468,18 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "NAME",
-              "TIMESTAMP"
-            ]
-          }
+          "NextToken": {},
+          "SortBy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
@@ -568,9 +498,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S2t"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -581,30 +509,22 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          }
+          "NextToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "Faces": {
             "type": "list",
             "member": {
@@ -629,34 +549,20 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "INDEX",
-              "TIMESTAMP"
-            ]
-          }
+          "NextToken": {},
+          "SortBy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
@@ -687,37 +593,23 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "NAME",
-              "TIMESTAMP"
-            ]
-          }
+          "NextToken": {},
+          "SortBy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "Labels": {
             "type": "list",
             "member": {
@@ -742,37 +634,23 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          },
+          "JobId": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "INDEX",
-              "TIMESTAMP"
-            ]
-          }
+          "NextToken": {},
+          "SortBy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobStatus": {
-            "shape": "S2w"
-          },
+          "JobStatus": {},
           "StatusMessage": {},
           "VideoMetadata": {
             "shape": "S2y"
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "Persons": {
             "type": "list",
             "member": {
@@ -798,29 +676,18 @@
           "Image"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          },
+          "CollectionId": {},
           "Image": {
             "shape": "S2"
           },
-          "ExternalImageId": {
-            "shape": "S3n"
-          },
+          "ExternalImageId": {},
           "DetectionAttributes": {
             "shape": "S1m"
           },
           "MaxFaces": {
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           },
-          "QualityFilter": {
-            "type": "string",
-            "enum": [
-              "NONE",
-              "AUTO"
-            ]
-          }
+          "QualityFilter": {}
         }
       },
       "output": {
@@ -840,9 +707,7 @@
               }
             }
           },
-          "OrientationCorrection": {
-            "shape": "Sn"
-          },
+          "OrientationCorrection": {},
           "FaceModelVersion": {},
           "UnindexedFaces": {
             "type": "list",
@@ -851,17 +716,7 @@
               "members": {
                 "Reasons": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "enum": [
-                      "EXCEEDS_MAX_FACES",
-                      "EXTREME_POSE",
-                      "LOW_BRIGHTNESS",
-                      "LOW_SHARPNESS",
-                      "LOW_CONFIDENCE",
-                      "SMALL_BOUNDING_BOX"
-                    ]
-                  }
+                  "member": {}
                 },
                 "FaceDetail": {
                   "shape": "S1q"
@@ -876,11 +731,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S49"
+            "type": "integer"
           }
         }
       },
@@ -889,13 +742,9 @@
         "members": {
           "CollectionIds": {
             "type": "list",
-            "member": {
-              "shape": "Sp"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "FaceModelVersions": {
             "type": "list",
             "member": {}
@@ -910,14 +759,10 @@
           "CollectionId"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          },
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "CollectionId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S49"
+            "type": "integer"
           }
         }
       },
@@ -939,31 +784,23 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S2s"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S2t"
-          },
+          "NextToken": {},
           "StreamProcessors": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S10"
-                },
-                "Status": {
-                  "shape": "S1k"
-                }
+                "Name": {},
+                "Status": {}
               }
             }
           }
@@ -994,14 +831,12 @@
                   "shape": "S2o"
                 },
                 "Name": {},
-                "Id": {
-                  "shape": "S2m"
-                },
+                "Id": {},
                 "Face": {
                   "shape": "Sf"
                 },
                 "MatchConfidence": {
-                  "shape": "S8"
+                  "type": "float"
                 }
               }
             }
@@ -1012,9 +847,7 @@
               "shape": "Sf"
             }
           },
-          "OrientationCorrection": {
-            "shape": "Sn"
-          }
+          "OrientationCorrection": {}
         }
       }
     },
@@ -1026,26 +859,20 @@
           "FaceId"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          },
-          "FaceId": {
-            "shape": "S1a"
-          },
+          "CollectionId": {},
+          "FaceId": {},
           "MaxFaces": {
-            "shape": "S4q"
+            "type": "integer"
           },
           "FaceMatchThreshold": {
-            "shape": "S8"
+            "type": "float"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SearchedFaceId": {
-            "shape": "S1a"
-          },
+          "SearchedFaceId": {},
           "FaceMatches": {
             "shape": "S3j"
           },
@@ -1061,17 +888,15 @@
           "Image"
         ],
         "members": {
-          "CollectionId": {
-            "shape": "Sp"
-          },
+          "CollectionId": {},
           "Image": {
             "shape": "S2"
           },
           "MaxFaces": {
-            "shape": "S4q"
+            "type": "integer"
           },
           "FaceMatchThreshold": {
-            "shape": "S8"
+            "type": "float"
           }
         }
       },
@@ -1082,7 +907,7 @@
             "shape": "Sb"
           },
           "SearchedFaceConfidence": {
-            "shape": "S8"
+            "type": "float"
           },
           "FaceMatches": {
             "shape": "S3j"
@@ -1101,23 +926,17 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1133,25 +952,19 @@
             "shape": "S4v"
           },
           "MinConfidence": {
-            "shape": "S8"
+            "type": "float"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1166,30 +979,18 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "FaceAttributes": {
-            "type": "string",
-            "enum": [
-              "DEFAULT",
-              "ALL"
-            ]
-          },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "FaceAttributes": {},
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1205,29 +1006,21 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "FaceMatchThreshold": {
-            "shape": "S8"
+            "type": "float"
           },
-          "CollectionId": {
-            "shape": "Sp"
-          },
+          "CollectionId": {},
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1242,26 +1035,20 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "MinConfidence": {
-            "shape": "S8"
+            "type": "float"
           },
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1276,23 +1063,17 @@
           "Video": {
             "shape": "S4v"
           },
-          "ClientRequestToken": {
-            "shape": "S4w"
-          },
+          "ClientRequestToken": {},
           "NotificationChannel": {
             "shape": "S4x"
           },
-          "JobTag": {
-            "shape": "S4z"
-          }
+          "JobTag": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S2r"
-          }
+          "JobId": {}
         }
       },
       "idempotent": true
@@ -1304,9 +1085,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S10"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1321,9 +1100,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S10"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -1337,9 +1114,7 @@
       "type": "structure",
       "members": {
         "Bytes": {
-          "type": "blob",
-          "max": 5242880,
-          "min": 1
+          "type": "blob"
         },
         "S3Object": {
           "shape": "S4"
@@ -1349,28 +1124,10 @@
     "S4": {
       "type": "structure",
       "members": {
-        "Bucket": {
-          "type": "string",
-          "max": 255,
-          "min": 3,
-          "pattern": "[0-9A-Za-z\\.\\-_]*"
-        },
-        "Name": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        },
-        "Version": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        }
+        "Bucket": {},
+        "Name": {},
+        "Version": {}
       }
-    },
-    "S8": {
-      "type": "float",
-      "max": 100,
-      "min": 0
     },
     "Sb": {
       "type": "structure",
@@ -1396,7 +1153,7 @@
           "shape": "Sb"
         },
         "Confidence": {
-          "shape": "S8"
+          "type": "float"
         },
         "Landmarks": {
           "shape": "Sg"
@@ -1414,36 +1171,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "eyeLeft",
-              "eyeRight",
-              "nose",
-              "mouthLeft",
-              "mouthRight",
-              "leftEyeBrowLeft",
-              "leftEyeBrowRight",
-              "leftEyeBrowUp",
-              "rightEyeBrowLeft",
-              "rightEyeBrowRight",
-              "rightEyeBrowUp",
-              "leftEyeLeft",
-              "leftEyeRight",
-              "leftEyeUp",
-              "leftEyeDown",
-              "rightEyeLeft",
-              "rightEyeRight",
-              "rightEyeUp",
-              "rightEyeDown",
-              "noseLeft",
-              "noseRight",
-              "mouthUp",
-              "mouthDown",
-              "leftPupil",
-              "rightPupil"
-            ]
-          },
+          "Type": {},
           "X": {
             "type": "float"
           },
@@ -1457,20 +1185,15 @@
       "type": "structure",
       "members": {
         "Roll": {
-          "shape": "Sk"
+          "type": "float"
         },
         "Yaw": {
-          "shape": "Sk"
+          "type": "float"
         },
         "Pitch": {
-          "shape": "Sk"
+          "type": "float"
         }
       }
-    },
-    "Sk": {
-      "type": "float",
-      "max": 180,
-      "min": -180
     },
     "Sl": {
       "type": "structure",
@@ -1483,35 +1206,13 @@
         }
       }
     },
-    "Sn": {
-      "type": "string",
-      "enum": [
-        "ROTATE_0",
-        "ROTATE_90",
-        "ROTATE_180",
-        "ROTATE_270"
-      ]
-    },
-    "Sp": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.\\-]+"
-    },
-    "Sr": {
-      "type": "integer",
-      "min": 0
-    },
     "Su": {
       "type": "structure",
       "members": {
         "KinesisVideoStream": {
           "type": "structure",
           "members": {
-            "Arn": {
-              "type": "string",
-              "pattern": "(^arn:([a-z\\d-]+):kinesisvideo:([a-z\\d-]+):\\d{12}:.+$)"
-            }
+            "Arn": {}
           }
         }
       }
@@ -1522,19 +1223,10 @@
         "KinesisDataStream": {
           "type": "structure",
           "members": {
-            "Arn": {
-              "type": "string",
-              "pattern": "(^arn:([a-z\\d-]+):kinesis:([a-z\\d-]+):\\d{12}:.+$)"
-            }
+            "Arn": {}
           }
         }
       }
-    },
-    "S10": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.\\-]+"
     },
     "S11": {
       "type": "structure",
@@ -1542,59 +1234,21 @@
         "FaceSearch": {
           "type": "structure",
           "members": {
-            "CollectionId": {
-              "shape": "Sp"
-            },
+            "CollectionId": {},
             "FaceMatchThreshold": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         }
       }
     },
-    "S13": {
-      "type": "string",
-      "pattern": "arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
-    },
-    "S15": {
-      "type": "string",
-      "pattern": "(^arn:[a-z\\d-]+:rekognition:[a-z\\d-]+:\\d{12}:streamprocessor\\/.+$)"
-    },
     "S19": {
       "type": "list",
-      "member": {
-        "shape": "S1a"
-      },
-      "max": 4096,
-      "min": 1
-    },
-    "S1a": {
-      "type": "string",
-      "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "S1g": {
-      "type": "long",
-      "min": 0
-    },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "STOPPED",
-        "STARTING",
-        "RUNNING",
-        "FAILED",
-        "STOPPING"
-      ]
+      "member": {}
     },
     "S1m": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "DEFAULT",
-          "ALL"
-        ]
-      }
+      "member": {}
     },
     "S1q": {
       "type": "structure",
@@ -1606,10 +1260,10 @@
           "type": "structure",
           "members": {
             "Low": {
-              "shape": "Sr"
+              "type": "integer"
             },
             "High": {
-              "shape": "Sr"
+              "type": "integer"
             }
           }
         },
@@ -1620,7 +1274,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1631,7 +1285,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1642,22 +1296,16 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
         "Gender": {
           "type": "structure",
           "members": {
-            "Value": {
-              "type": "string",
-              "enum": [
-                "Male",
-                "Female"
-              ]
-            },
+            "Value": {},
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1668,7 +1316,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1679,7 +1327,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1690,7 +1338,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1701,7 +1349,7 @@
               "type": "boolean"
             },
             "Confidence": {
-              "shape": "S8"
+              "type": "float"
             }
           }
         },
@@ -1710,21 +1358,9 @@
           "member": {
             "type": "structure",
             "members": {
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "HAPPY",
-                  "SAD",
-                  "ANGRY",
-                  "CONFUSED",
-                  "DISGUSTED",
-                  "SURPRISED",
-                  "CALM",
-                  "UNKNOWN"
-                ]
-              },
+              "Type": {},
               "Confidence": {
-                "shape": "S8"
+                "type": "float"
               }
             }
           }
@@ -1739,7 +1375,7 @@
           "shape": "Sl"
         },
         "Confidence": {
-          "shape": "S8"
+          "type": "float"
         }
       }
     },
@@ -1748,7 +1384,7 @@
       "members": {
         "Name": {},
         "Confidence": {
-          "shape": "S8"
+          "type": "float"
         }
       }
     },
@@ -1756,58 +1392,32 @@
       "type": "structure",
       "members": {
         "Confidence": {
-          "shape": "S8"
+          "type": "float"
         },
         "Name": {},
         "ParentName": {}
       }
     },
-    "S2m": {
-      "type": "string",
-      "pattern": "[0-9A-Za-z]*"
-    },
     "S2o": {
       "type": "list",
       "member": {}
-    },
-    "S2r": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9-_]+$"
-    },
-    "S2s": {
-      "type": "integer",
-      "min": 1
-    },
-    "S2t": {
-      "type": "string",
-      "max": 255
-    },
-    "S2w": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "SUCCEEDED",
-        "FAILED"
-      ]
     },
     "S2y": {
       "type": "structure",
       "members": {
         "Codec": {},
         "DurationMillis": {
-          "shape": "S1g"
+          "type": "long"
         },
         "Format": {},
         "FrameRate": {
           "type": "float"
         },
         "FrameHeight": {
-          "shape": "S1g"
+          "type": "long"
         },
         "FrameWidth": {
-          "shape": "S1g"
+          "type": "long"
         }
       }
     },
@@ -1831,7 +1441,7 @@
         "type": "structure",
         "members": {
           "Similarity": {
-            "shape": "S8"
+            "type": "float"
           },
           "Face": {
             "shape": "S3l"
@@ -1842,39 +1452,16 @@
     "S3l": {
       "type": "structure",
       "members": {
-        "FaceId": {
-          "shape": "S1a"
-        },
+        "FaceId": {},
         "BoundingBox": {
           "shape": "Sb"
         },
-        "ImageId": {
-          "type": "string",
-          "pattern": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-        },
-        "ExternalImageId": {
-          "shape": "S3n"
-        },
+        "ImageId": {},
+        "ExternalImageId": {},
         "Confidence": {
-          "shape": "S8"
+          "type": "float"
         }
       }
-    },
-    "S3n": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.\\-:]+"
-    },
-    "S49": {
-      "type": "integer",
-      "max": 4096,
-      "min": 0
-    },
-    "S4q": {
-      "type": "integer",
-      "max": 4096,
-      "min": 1
     },
     "S4v": {
       "type": "structure",
@@ -1884,12 +1471,6 @@
         }
       }
     },
-    "S4w": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9-_]+$"
-    },
     "S4x": {
       "type": "structure",
       "required": [
@@ -1897,20 +1478,9 @@
         "RoleArn"
       ],
       "members": {
-        "SNSTopicArn": {
-          "type": "string",
-          "pattern": "(^arn:aws:sns:.*:\\w{12}:.+$)"
-        },
-        "RoleArn": {
-          "shape": "S13"
-        }
+        "SNSTopicArn": {},
+        "RoleArn": {}
       }
-    },
-    "S4z": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_.\\-:]+"
     }
   }
 }

--- a/apis/resource-groups-2017-11-27.min.json
+++ b/apis/resource-groups-2017-11-27.min.json
@@ -23,12 +23,8 @@
           "ResourceQuery"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "Description": {
-            "shape": "S3"
-          },
+          "Name": {},
+          "Description": {},
           "ResourceQuery": {
             "shape": "S4"
           },
@@ -64,7 +60,6 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -91,7 +86,6 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -118,7 +112,6 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           }
@@ -145,7 +138,6 @@
         ],
         "members": {
           "Arn": {
-            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           }
@@ -154,9 +146,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {
-            "shape": "Sc"
-          },
+          "Arn": {},
           "Tags": {
             "shape": "S7"
           }
@@ -174,7 +164,6 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
@@ -187,30 +176,18 @@
                 "Values"
               ],
               "members": {
-                "Name": {
-                  "type": "string",
-                  "enum": [
-                    "resource-type"
-                  ]
-                },
+                "Name": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 128,
-                    "min": 1,
-                    "pattern": "AWS::[a-zA-Z0-9]+::[a-zA-Z0-9]+"
-                  },
-                  "max": 5,
-                  "min": 1
+                  "member": {}
                 }
               }
             }
           },
           "MaxResults": {
-            "shape": "Ss",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -236,9 +213,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "Ss",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -273,7 +250,7 @@
             "shape": "S4"
           },
           "MaxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -301,7 +278,6 @@
         ],
         "members": {
           "Arn": {
-            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           },
@@ -313,9 +289,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {
-            "shape": "Sc"
-          },
+          "Arn": {},
           "Tags": {
             "shape": "S7"
           }
@@ -335,7 +309,6 @@
         ],
         "members": {
           "Arn": {
-            "shape": "Sc",
             "location": "uri",
             "locationName": "Arn"
           },
@@ -347,9 +320,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Arn": {
-            "shape": "Sc"
-          },
+          "Arn": {},
           "Keys": {
             "shape": "S17"
           }
@@ -368,13 +339,10 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
-          "Description": {
-            "shape": "S3"
-          }
+          "Description": {}
         }
       },
       "output": {
@@ -399,7 +367,6 @@
         ],
         "members": {
           "GroupName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "GroupName"
           },
@@ -419,17 +386,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9_\\.-]+"
-    },
-    "S3": {
-      "type": "string",
-      "max": 512,
-      "pattern": "[\\sa-zA-Z0-9_\\.-]*"
-    },
     "S4": {
       "type": "structure",
       "required": [
@@ -437,35 +393,14 @@
         "Query"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "TAG_FILTERS_1_0"
-          ]
-        },
-        "Query": {
-          "type": "string",
-          "max": 2048
-        }
+        "Type": {},
+        "Query": {}
       }
     },
     "S7": {
       "type": "map",
-      "key": {
-        "shape": "S8"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "min": 0,
-        "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-      }
-    },
-    "S8": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+      "key": {},
+      "value": {}
     },
     "Sb": {
       "type": "structure",
@@ -474,20 +409,10 @@
         "Name"
       ],
       "members": {
-        "GroupArn": {
-          "shape": "Sc"
-        },
-        "Name": {
-          "shape": "S2"
-        },
-        "Description": {
-          "shape": "S3"
-        }
+        "GroupArn": {},
+        "Name": {},
+        "Description": {}
       }
-    },
-    "Sc": {
-      "type": "string",
-      "pattern": "arn:aws:resource-groups:[a-z]{2}-[a-z]+-\\d{1}:[0-9]{12}:group/[a-zA-Z0-9_\\.-]{1,128}"
     },
     "Sj": {
       "type": "structure",
@@ -496,40 +421,25 @@
         "ResourceQuery"
       ],
       "members": {
-        "GroupName": {
-          "shape": "S2"
-        },
+        "GroupName": {},
         "ResourceQuery": {
           "shape": "S4"
         }
       }
-    },
-    "Ss": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
     },
     "Sv": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "ResourceArn": {
-            "type": "string",
-            "pattern": "arn:aws:[a-z0-9\\-]*:([a-z]{2}-[a-z]+-\\d{1})?:([0-9]{12})?:.+"
-          },
-          "ResourceType": {
-            "type": "string",
-            "pattern": "AWS::[a-zA-Z0-9]+::\\w+"
-          }
+          "ResourceArn": {},
+          "ResourceType": {}
         }
       }
     },
     "S17": {
       "type": "list",
-      "member": {
-        "shape": "S8"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/resourcegroupstaggingapi-2017-01-26.min.json
+++ b/apis/resourcegroupstaggingapi-2017-01-26.min.json
@@ -16,29 +16,19 @@
       "input": {
         "type": "structure",
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          },
+          "PaginationToken": {},
           "TagFilters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S5"
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "shape": "S7"
-                  },
-                  "max": 20,
-                  "min": 0
+                  "member": {}
                 }
               }
-            },
-            "max": 50,
-            "min": 0
+            }
           },
           "ResourcesPerPage": {
             "type": "integer"
@@ -48,28 +38,20 @@
           },
           "ResourceTypeFilters": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 256,
-              "min": 0
-            }
+            "member": {}
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          },
+          "PaginationToken": {},
           "ResourceTagMappingList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "ResourceARN": {
-                  "shape": "Sf"
-                },
+                "ResourceARN": {},
                 "Tags": {
                   "type": "list",
                   "member": {
@@ -79,12 +61,8 @@
                       "Value"
                     ],
                     "members": {
-                      "Key": {
-                        "shape": "S5"
-                      },
-                      "Value": {
-                        "shape": "S7"
-                      }
+                      "Key": {},
+                      "Value": {}
                     }
                   }
                 }
@@ -98,22 +76,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          }
+          "PaginationToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          },
+          "PaginationToken": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            }
+            "member": {}
           }
         }
       }
@@ -125,25 +97,17 @@
           "Key"
         ],
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          },
-          "Key": {
-            "shape": "S5"
-          }
+          "PaginationToken": {},
+          "Key": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "PaginationToken": {
-            "shape": "S2"
-          },
+          "PaginationToken": {},
           "TagValues": {
             "type": "list",
-            "member": {
-              "shape": "S7"
-            }
+            "member": {}
           }
         }
       }
@@ -161,14 +125,8 @@
           },
           "Tags": {
             "type": "map",
-            "key": {
-              "shape": "S5"
-            },
-            "value": {
-              "shape": "S7"
-            },
-            "max": 50,
-            "min": 1
+            "key": {},
+            "value": {}
           }
         }
       },
@@ -194,11 +152,7 @@
           },
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -213,52 +167,20 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "Sf": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
     "Sp": {
       "type": "list",
-      "member": {
-        "shape": "Sf"
-      },
-      "max": 20,
-      "min": 1
+      "member": {}
     },
     "Ss": {
       "type": "map",
-      "key": {
-        "shape": "Sf"
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
           "StatusCode": {
             "type": "integer"
           },
-          "ErrorCode": {
-            "type": "string",
-            "enum": [
-              "InternalServiceException",
-              "InvalidParameterException"
-            ]
-          },
+          "ErrorCode": {},
           "ErrorMessage": {}
         }
       }

--- a/apis/route53-2013-04-01.min.json
+++ b/apis/route53-2013-04-01.min.json
@@ -28,7 +28,6 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -66,7 +65,6 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -76,9 +74,7 @@
               "Changes"
             ],
             "members": {
-              "Comment": {
-                "shape": "Sb"
-              },
+              "Comment": {},
               "Changes": {
                 "type": "list",
                 "member": {
@@ -89,20 +85,12 @@
                     "ResourceRecordSet"
                   ],
                   "members": {
-                    "Action": {
-                      "type": "string",
-                      "enum": [
-                        "CREATE",
-                        "DELETE",
-                        "UPSERT"
-                      ]
-                    },
+                    "Action": {},
                     "ResourceRecordSet": {
                       "shape": "Sh"
                     }
                   }
-                },
-                "min": 1
+                }
               }
             }
           }
@@ -136,12 +124,10 @@
         ],
         "members": {
           "ResourceType": {
-            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceId": {
-            "shape": "S14",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -151,11 +137,8 @@
           "RemoveTagKeys": {
             "type": "list",
             "member": {
-              "shape": "S17",
               "locationName": "Key"
-            },
-            "max": 10,
-            "min": 1
+            }
           }
         }
       },
@@ -180,9 +163,7 @@
           "HealthCheckConfig"
         ],
         "members": {
-          "CallerReference": {
-            "shape": "S1c"
-          },
+          "CallerReference": {},
           "HealthCheckConfig": {
             "shape": "S1d"
           }
@@ -199,7 +180,6 @@
             "shape": "S1y"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -222,21 +202,15 @@
           "CallerReference"
         ],
         "members": {
-          "Name": {
-            "shape": "Si"
-          },
+          "Name": {},
           "VPC": {
             "shape": "S3"
           },
-          "CallerReference": {
-            "shape": "S2f"
-          },
+          "CallerReference": {},
           "HostedZoneConfig": {
             "shape": "S2g"
           },
-          "DelegationSetId": {
-            "shape": "S2"
-          }
+          "DelegationSetId": {}
         }
       },
       "output": {
@@ -261,7 +235,6 @@
             "shape": "S3"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -284,9 +257,7 @@
           "CloudWatchLogsLogGroupArn"
         ],
         "members": {
-          "HostedZoneId": {
-            "shape": "S2"
-          },
+          "HostedZoneId": {},
           "CloudWatchLogsLogGroupArn": {}
         }
       },
@@ -301,7 +272,6 @@
             "shape": "S2q"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -323,12 +293,8 @@
           "CallerReference"
         ],
         "members": {
-          "CallerReference": {
-            "shape": "S2f"
-          },
-          "HostedZoneId": {
-            "shape": "S2"
-          }
+          "CallerReference": {},
+          "HostedZoneId": {}
         }
       },
       "output": {
@@ -342,7 +308,6 @@
             "shape": "S2l"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -365,15 +330,9 @@
           "Document"
         ],
         "members": {
-          "Name": {
-            "shape": "S2v"
-          },
-          "Document": {
-            "shape": "S2w"
-          },
-          "Comment": {
-            "shape": "S2x"
-          }
+          "Name": {},
+          "Document": {},
+          "Comment": {}
         }
       },
       "output": {
@@ -387,7 +346,6 @@
             "shape": "S2z"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -413,20 +371,14 @@
           "TrafficPolicyVersion"
         ],
         "members": {
-          "HostedZoneId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "Si"
-          },
+          "HostedZoneId": {},
+          "Name": {},
           "TTL": {
-            "shape": "St"
+            "type": "long"
           },
-          "TrafficPolicyId": {
-            "shape": "S30"
-          },
+          "TrafficPolicyId": {},
           "TrafficPolicyVersion": {
-            "shape": "S31"
+            "type": "integer"
           }
         }
       },
@@ -441,7 +393,6 @@
             "shape": "S34"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -465,16 +416,11 @@
         ],
         "members": {
           "Id": {
-            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
-          "Document": {
-            "shape": "S2w"
-          },
-          "Comment": {
-            "shape": "S2x"
-          }
+          "Document": {},
+          "Comment": {}
         }
       },
       "output": {
@@ -488,7 +434,6 @@
             "shape": "S2z"
           },
           "Location": {
-            "shape": "S2d",
             "location": "header",
             "locationName": "Location"
           }
@@ -511,7 +456,6 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -527,9 +471,7 @@
           "VPC"
         ],
         "members": {
-          "HostedZoneId": {
-            "shape": "S2"
-          },
+          "HostedZoneId": {},
           "VPC": {
             "shape": "S3"
           }
@@ -548,7 +490,6 @@
         ],
         "members": {
           "HealthCheckId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -571,7 +512,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -601,7 +541,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2r",
             "location": "uri",
             "locationName": "Id"
           }
@@ -624,7 +563,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -648,14 +586,13 @@
         ],
         "members": {
           "Id": {
-            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
-            "shape": "S31",
             "location": "uri",
-            "locationName": "Version"
+            "locationName": "Version",
+            "type": "integer"
           }
         }
       },
@@ -676,7 +613,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           }
@@ -703,7 +639,6 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -733,7 +668,6 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
@@ -767,7 +701,6 @@
         ],
         "members": {
           "Type": {
-            "shape": "S3t",
             "location": "uri",
             "locationName": "Type"
           }
@@ -787,16 +720,14 @@
               "Value"
             ],
             "members": {
-              "Type": {
-                "shape": "S3t"
-              },
+              "Type": {},
               "Value": {
-                "shape": "S3w"
+                "type": "long"
               }
             }
           },
           "Count": {
-            "shape": "S3x"
+            "type": "long"
           }
         }
       }
@@ -813,7 +744,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -862,17 +792,14 @@
         "type": "structure",
         "members": {
           "ContinentCode": {
-            "shape": "So",
             "location": "querystring",
             "locationName": "continentcode"
           },
           "CountryCode": {
-            "shape": "Sp",
             "location": "querystring",
             "locationName": "countrycode"
           },
           "SubdivisionCode": {
-            "shape": "Sq",
             "location": "querystring",
             "locationName": "subdivisioncode"
           }
@@ -902,7 +829,6 @@
         ],
         "members": {
           "HealthCheckId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -953,7 +879,6 @@
         ],
         "members": {
           "HealthCheckId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -983,7 +908,6 @@
         ],
         "members": {
           "HealthCheckId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           }
@@ -1013,7 +937,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1071,12 +994,10 @@
         ],
         "members": {
           "Type": {
-            "shape": "S4u",
             "location": "uri",
             "locationName": "Type"
           },
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1096,16 +1017,14 @@
               "Value"
             ],
             "members": {
-              "Type": {
-                "shape": "S4u"
-              },
+              "Type": {},
               "Value": {
-                "shape": "S3w"
+                "type": "long"
               }
             }
           },
           "Count": {
-            "shape": "S3x"
+            "type": "long"
           }
         }
       }
@@ -1122,7 +1041,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2r",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1152,7 +1070,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1183,12 +1100,10 @@
         ],
         "members": {
           "Type": {
-            "shape": "S52",
             "location": "uri",
             "locationName": "Type"
           },
           "DelegationSetId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1208,16 +1123,14 @@
               "Value"
             ],
             "members": {
-              "Type": {
-                "shape": "S52"
-              },
+              "Type": {},
               "Value": {
-                "shape": "S3w"
+                "type": "long"
               }
             }
           },
           "Count": {
-            "shape": "S3x"
+            "type": "long"
           }
         }
       }
@@ -1235,14 +1148,13 @@
         ],
         "members": {
           "Id": {
-            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
-            "shape": "S31",
             "location": "uri",
-            "locationName": "Version"
+            "locationName": "Version",
+            "type": "integer"
           }
         }
       },
@@ -1270,7 +1182,6 @@
         ],
         "members": {
           "Id": {
-            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           }
@@ -1318,17 +1229,14 @@
         "type": "structure",
         "members": {
           "StartContinentCode": {
-            "shape": "So",
             "location": "querystring",
             "locationName": "startcontinentcode"
           },
           "StartCountryCode": {
-            "shape": "Sp",
             "location": "querystring",
             "locationName": "startcountrycode"
           },
           "StartSubdivisionCode": {
-            "shape": "Sq",
             "location": "querystring",
             "locationName": "startsubdivisioncode"
           },
@@ -1356,15 +1264,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextContinentCode": {
-            "shape": "So"
-          },
-          "NextCountryCode": {
-            "shape": "Sp"
-          },
-          "NextSubdivisionCode": {
-            "shape": "Sq"
-          },
+          "NextContinentCode": {},
+          "NextCountryCode": {},
+          "NextSubdivisionCode": {},
           "MaxItems": {}
         }
       }
@@ -1378,7 +1280,6 @@
         "type": "structure",
         "members": {
           "Marker": {
-            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1404,15 +1305,11 @@
               "locationName": "HealthCheck"
             }
           },
-          "Marker": {
-            "shape": "S5i"
-          },
+          "Marker": {},
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {
-            "shape": "S5i"
-          },
+          "NextMarker": {},
           "MaxItems": {}
         }
       }
@@ -1426,7 +1323,6 @@
         "type": "structure",
         "members": {
           "Marker": {
-            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1435,7 +1331,6 @@
             "locationName": "maxitems"
           },
           "DelegationSetId": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "delegationsetid"
           }
@@ -1453,15 +1348,11 @@
           "HostedZones": {
             "shape": "S5n"
           },
-          "Marker": {
-            "shape": "S5i"
-          },
+          "Marker": {},
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {
-            "shape": "S5i"
-          },
+          "NextMarker": {},
           "MaxItems": {}
         }
       }
@@ -1475,12 +1366,10 @@
         "type": "structure",
         "members": {
           "DNSName": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "dnsname"
           },
           "HostedZoneId": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
@@ -1501,21 +1390,13 @@
           "HostedZones": {
             "shape": "S5n"
           },
-          "DNSName": {
-            "shape": "Si"
-          },
-          "HostedZoneId": {
-            "shape": "S2"
-          },
+          "DNSName": {},
+          "HostedZoneId": {},
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextDNSName": {
-            "shape": "Si"
-          },
-          "NextHostedZoneId": {
-            "shape": "S2"
-          },
+          "NextDNSName": {},
+          "NextHostedZoneId": {},
           "MaxItems": {}
         }
       }
@@ -1529,12 +1410,10 @@
         "type": "structure",
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "NextToken": {
-            "shape": "S5r",
             "location": "querystring",
             "locationName": "nexttoken"
           },
@@ -1557,9 +1436,7 @@
               "locationName": "QueryLoggingConfig"
             }
           },
-          "NextToken": {
-            "shape": "S5r"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1575,22 +1452,18 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
           "StartRecordName": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "name"
           },
           "StartRecordType": {
-            "shape": "Sj",
             "location": "querystring",
             "locationName": "type"
           },
           "StartRecordIdentifier": {
-            "shape": "Sk",
             "location": "querystring",
             "locationName": "identifier"
           },
@@ -1618,15 +1491,9 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextRecordName": {
-            "shape": "Si"
-          },
-          "NextRecordType": {
-            "shape": "Sj"
-          },
-          "NextRecordIdentifier": {
-            "shape": "Sk"
-          },
+          "NextRecordName": {},
+          "NextRecordType": {},
+          "NextRecordIdentifier": {},
           "MaxItems": {}
         }
       }
@@ -1640,7 +1507,6 @@
         "type": "structure",
         "members": {
           "Marker": {
-            "shape": "S5i",
             "location": "querystring",
             "locationName": "marker"
           },
@@ -1666,15 +1532,11 @@
               "locationName": "DelegationSet"
             }
           },
-          "Marker": {
-            "shape": "S5i"
-          },
+          "Marker": {},
           "IsTruncated": {
             "type": "boolean"
           },
-          "NextMarker": {
-            "shape": "S5i"
-          },
+          "NextMarker": {},
           "MaxItems": {}
         }
       }
@@ -1692,12 +1554,10 @@
         ],
         "members": {
           "ResourceType": {
-            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceId": {
-            "shape": "S14",
             "location": "uri",
             "locationName": "ResourceId"
           }
@@ -1731,18 +1591,14 @@
         ],
         "members": {
           "ResourceType": {
-            "shape": "S13",
             "location": "uri",
             "locationName": "ResourceType"
           },
           "ResourceIds": {
             "type": "list",
             "member": {
-              "shape": "S14",
               "locationName": "ResourceId"
-            },
-            "max": 10,
-            "min": 1
+            }
           }
         }
       },
@@ -1771,7 +1627,6 @@
         "type": "structure",
         "members": {
           "TrafficPolicyIdMarker": {
-            "shape": "S30",
             "location": "querystring",
             "locationName": "trafficpolicyid"
           },
@@ -1803,20 +1658,14 @@
                 "TrafficPolicyCount"
               ],
               "members": {
-                "Id": {
-                  "shape": "S30"
-                },
-                "Name": {
-                  "shape": "S2v"
-                },
-                "Type": {
-                  "shape": "Sj"
-                },
+                "Id": {},
+                "Name": {},
+                "Type": {},
                 "LatestVersion": {
-                  "shape": "S31"
+                  "type": "integer"
                 },
                 "TrafficPolicyCount": {
-                  "shape": "S31"
+                  "type": "integer"
                 }
               }
             }
@@ -1824,9 +1673,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "TrafficPolicyIdMarker": {
-            "shape": "S30"
-          },
+          "TrafficPolicyIdMarker": {},
           "MaxItems": {}
         }
       }
@@ -1840,17 +1687,14 @@
         "type": "structure",
         "members": {
           "HostedZoneIdMarker": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1871,15 +1715,9 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "HostedZoneIdMarker": {
-            "shape": "S2"
-          },
-          "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si"
-          },
-          "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj"
-          },
+          "HostedZoneIdMarker": {},
+          "TrafficPolicyInstanceNameMarker": {},
+          "TrafficPolicyInstanceTypeMarker": {},
           "IsTruncated": {
             "type": "boolean"
           },
@@ -1899,17 +1737,14 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "id"
           },
           "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1930,12 +1765,8 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si"
-          },
-          "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj"
-          },
+          "TrafficPolicyInstanceNameMarker": {},
+          "TrafficPolicyInstanceTypeMarker": {},
           "IsTruncated": {
             "type": "boolean"
           },
@@ -1956,27 +1787,23 @@
         ],
         "members": {
           "TrafficPolicyId": {
-            "shape": "S30",
             "location": "querystring",
             "locationName": "id"
           },
           "TrafficPolicyVersion": {
-            "shape": "S31",
             "location": "querystring",
-            "locationName": "version"
+            "locationName": "version",
+            "type": "integer"
           },
           "HostedZoneIdMarker": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "trafficpolicyinstancename"
           },
           "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj",
             "location": "querystring",
             "locationName": "trafficpolicyinstancetype"
           },
@@ -1997,15 +1824,9 @@
           "TrafficPolicyInstances": {
             "shape": "S6e"
           },
-          "HostedZoneIdMarker": {
-            "shape": "S2"
-          },
-          "TrafficPolicyInstanceNameMarker": {
-            "shape": "Si"
-          },
-          "TrafficPolicyInstanceTypeMarker": {
-            "shape": "Sj"
-          },
+          "HostedZoneIdMarker": {},
+          "TrafficPolicyInstanceNameMarker": {},
+          "TrafficPolicyInstanceTypeMarker": {},
           "IsTruncated": {
             "type": "boolean"
           },
@@ -2025,12 +1846,10 @@
         ],
         "members": {
           "Id": {
-            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "TrafficPolicyVersionMarker": {
-            "shape": "S6k",
             "location": "querystring",
             "locationName": "trafficpolicyversion"
           },
@@ -2059,9 +1878,7 @@
           "IsTruncated": {
             "type": "boolean"
           },
-          "TrafficPolicyVersionMarker": {
-            "shape": "S6k"
-          },
+          "TrafficPolicyVersionMarker": {},
           "MaxItems": {}
         }
       }
@@ -2078,12 +1895,10 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
           "NextToken": {
-            "shape": "S5r",
             "location": "querystring",
             "locationName": "nexttoken"
           },
@@ -2100,12 +1915,8 @@
           "VPCs"
         ],
         "members": {
-          "HostedZoneId": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S5r"
-          },
+          "HostedZoneId": {},
+          "NextToken": {},
           "VPCs": {
             "shape": "S4p"
           }
@@ -2126,36 +1937,28 @@
         ],
         "members": {
           "HostedZoneId": {
-            "shape": "S2",
             "location": "querystring",
             "locationName": "hostedzoneid"
           },
           "RecordName": {
-            "shape": "Si",
             "location": "querystring",
             "locationName": "recordname"
           },
           "RecordType": {
-            "shape": "Sj",
             "location": "querystring",
             "locationName": "recordtype"
           },
           "ResolverIP": {
-            "shape": "S1e",
             "location": "querystring",
             "locationName": "resolverip"
           },
           "EDNS0ClientSubnetIP": {
-            "shape": "S1e",
             "location": "querystring",
             "locationName": "edns0clientsubnetip"
           },
           "EDNS0ClientSubnetMask": {
             "location": "querystring",
-            "locationName": "edns0clientsubnetmask",
-            "type": "string",
-            "max": 3,
-            "min": 0
+            "locationName": "edns0clientsubnetmask"
           }
         }
       },
@@ -2170,24 +1973,13 @@
           "Protocol"
         ],
         "members": {
-          "Nameserver": {
-            "type": "string",
-            "max": 255,
-            "min": 0
-          },
-          "RecordName": {
-            "shape": "Si"
-          },
-          "RecordType": {
-            "shape": "Sj"
-          },
+          "Nameserver": {},
+          "RecordName": {},
+          "RecordType": {},
           "RecordData": {
             "type": "list",
             "member": {
-              "locationName": "RecordDataEntry",
-              "type": "string",
-              "max": 512,
-              "min": 0
+              "locationName": "RecordDataEntry"
             }
           },
           "ResponseCode": {},
@@ -2210,36 +2002,27 @@
         ],
         "members": {
           "HealthCheckId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "HealthCheckId"
           },
           "HealthCheckVersion": {
-            "shape": "S21"
+            "type": "long"
           },
-          "IPAddress": {
-            "shape": "S1e"
-          },
+          "IPAddress": {},
           "Port": {
-            "shape": "S1f"
+            "type": "integer"
           },
-          "ResourcePath": {
-            "shape": "S1h"
-          },
-          "FullyQualifiedDomainName": {
-            "shape": "S1i"
-          },
-          "SearchString": {
-            "shape": "S1j"
-          },
+          "ResourcePath": {},
+          "FullyQualifiedDomainName": {},
+          "SearchString": {},
           "FailureThreshold": {
-            "shape": "S1l"
+            "type": "integer"
           },
           "Inverted": {
             "type": "boolean"
           },
           "HealthThreshold": {
-            "shape": "S1o"
+            "type": "integer"
           },
           "ChildHealthChecks": {
             "shape": "S1p"
@@ -2253,24 +2036,12 @@
           "AlarmIdentifier": {
             "shape": "S1t"
           },
-          "InsufficientDataHealthStatus": {
-            "shape": "S1w"
-          },
+          "InsufficientDataHealthStatus": {},
           "ResetElements": {
             "type": "list",
             "member": {
-              "locationName": "ResettableElementName",
-              "type": "string",
-              "enum": [
-                "FullyQualifiedDomainName",
-                "Regions",
-                "ResourcePath",
-                "ChildHealthChecks"
-              ],
-              "max": 64,
-              "min": 1
-            },
-            "max": 64
+              "locationName": "ResettableElementName"
+            }
           }
         }
       },
@@ -2301,13 +2072,10 @@
         ],
         "members": {
           "Id": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "Id"
           },
-          "Comment": {
-            "shape": "Sb"
-          }
+          "Comment": {}
         }
       },
       "output": {
@@ -2339,18 +2107,15 @@
         ],
         "members": {
           "Id": {
-            "shape": "S30",
             "location": "uri",
             "locationName": "Id"
           },
           "Version": {
-            "shape": "S31",
             "location": "uri",
-            "locationName": "Version"
+            "locationName": "Version",
+            "type": "integer"
           },
-          "Comment": {
-            "shape": "S2x"
-          }
+          "Comment": {}
         }
       },
       "output": {
@@ -2383,18 +2148,15 @@
         ],
         "members": {
           "Id": {
-            "shape": "S10",
             "location": "uri",
             "locationName": "Id"
           },
           "TTL": {
-            "shape": "St"
+            "type": "long"
           },
-          "TrafficPolicyId": {
-            "shape": "S30"
-          },
+          "TrafficPolicyId": {},
           "TrafficPolicyVersion": {
-            "shape": "S31"
+            "type": "integer"
           }
         }
       },
@@ -2412,41 +2174,11 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 32
-    },
     "S3": {
       "type": "structure",
       "members": {
-        "VPCRegion": {
-          "type": "string",
-          "enum": [
-            "us-east-1",
-            "us-east-2",
-            "us-west-1",
-            "us-west-2",
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "eu-central-1",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ap-south-1",
-            "ap-northeast-1",
-            "ap-northeast-2",
-            "ap-northeast-3",
-            "sa-east-1",
-            "ca-central-1",
-            "cn-north-1"
-          ],
-          "max": 64,
-          "min": 1
-        },
-        "VPCId": {
-          "type": "string",
-          "max": 1024
-        }
+        "VPCRegion": {},
+        "VPCId": {}
       }
     },
     "S8": {
@@ -2457,27 +2189,13 @@
         "SubmittedAt"
       ],
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "INSYNC"
-          ]
-        },
+        "Id": {},
+        "Status": {},
         "SubmittedAt": {
           "type": "timestamp"
         },
-        "Comment": {
-          "shape": "Sb"
-        }
+        "Comment": {}
       }
-    },
-    "Sb": {
-      "type": "string",
-      "max": 256
     },
     "Sh": {
       "type": "structure",
@@ -2486,71 +2204,27 @@
         "Type"
       ],
       "members": {
-        "Name": {
-          "shape": "Si"
-        },
-        "Type": {
-          "shape": "Sj"
-        },
-        "SetIdentifier": {
-          "shape": "Sk"
-        },
+        "Name": {},
+        "Type": {},
+        "SetIdentifier": {},
         "Weight": {
-          "type": "long",
-          "max": 255,
-          "min": 0
+          "type": "long"
         },
-        "Region": {
-          "type": "string",
-          "enum": [
-            "us-east-1",
-            "us-east-2",
-            "us-west-1",
-            "us-west-2",
-            "ca-central-1",
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "eu-central-1",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ap-northeast-1",
-            "ap-northeast-2",
-            "ap-northeast-3",
-            "sa-east-1",
-            "cn-north-1",
-            "cn-northwest-1",
-            "ap-south-1"
-          ],
-          "max": 64,
-          "min": 1
-        },
+        "Region": {},
         "GeoLocation": {
           "type": "structure",
           "members": {
-            "ContinentCode": {
-              "shape": "So"
-            },
-            "CountryCode": {
-              "shape": "Sp"
-            },
-            "SubdivisionCode": {
-              "shape": "Sq"
-            }
+            "ContinentCode": {},
+            "CountryCode": {},
+            "SubdivisionCode": {}
           }
         },
-        "Failover": {
-          "type": "string",
-          "enum": [
-            "PRIMARY",
-            "SECONDARY"
-          ]
-        },
+        "Failover": {},
         "MultiValueAnswer": {
           "type": "boolean"
         },
         "TTL": {
-          "shape": "St"
+          "type": "long"
         },
         "ResourceRecords": {
           "type": "list",
@@ -2561,13 +2235,9 @@
               "Value"
             ],
             "members": {
-              "Value": {
-                "type": "string",
-                "max": 4000
-              }
+              "Value": {}
             }
-          },
-          "min": 1
+          }
         },
         "AliasTarget": {
           "type": "structure",
@@ -2577,90 +2247,16 @@
             "EvaluateTargetHealth"
           ],
           "members": {
-            "HostedZoneId": {
-              "shape": "S2"
-            },
-            "DNSName": {
-              "shape": "Si"
-            },
+            "HostedZoneId": {},
+            "DNSName": {},
             "EvaluateTargetHealth": {
               "type": "boolean"
             }
           }
         },
-        "HealthCheckId": {
-          "shape": "Sz"
-        },
-        "TrafficPolicyInstanceId": {
-          "shape": "S10"
-        }
+        "HealthCheckId": {},
+        "TrafficPolicyInstanceId": {}
       }
-    },
-    "Si": {
-      "type": "string",
-      "max": 1024
-    },
-    "Sj": {
-      "type": "string",
-      "enum": [
-        "SOA",
-        "A",
-        "TXT",
-        "NS",
-        "CNAME",
-        "MX",
-        "NAPTR",
-        "PTR",
-        "SRV",
-        "SPF",
-        "AAAA",
-        "CAA"
-      ]
-    },
-    "Sk": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "So": {
-      "type": "string",
-      "max": 2,
-      "min": 2
-    },
-    "Sp": {
-      "type": "string",
-      "max": 2,
-      "min": 1
-    },
-    "Sq": {
-      "type": "string",
-      "max": 3,
-      "min": 1
-    },
-    "St": {
-      "type": "long",
-      "max": 2147483647,
-      "min": 0
-    },
-    "Sz": {
-      "type": "string",
-      "max": 64
-    },
-    "S10": {
-      "type": "string",
-      "max": 36,
-      "min": 1
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "healthcheck",
-        "hostedzone"
-      ]
-    },
-    "S14": {
-      "type": "string",
-      "max": 64
     },
     "S15": {
       "type": "list",
@@ -2668,26 +2264,10 @@
         "locationName": "Tag",
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S17"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S17": {
-      "type": "string",
-      "max": 128
-    },
-    "S1c": {
-      "type": "string",
-      "max": 64,
-      "min": 1
+      }
     },
     "S1d": {
       "type": "structure",
@@ -2695,40 +2275,19 @@
         "Type"
       ],
       "members": {
-        "IPAddress": {
-          "shape": "S1e"
-        },
+        "IPAddress": {},
         "Port": {
-          "shape": "S1f"
+          "type": "integer"
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "HTTP",
-            "HTTPS",
-            "HTTP_STR_MATCH",
-            "HTTPS_STR_MATCH",
-            "TCP",
-            "CALCULATED",
-            "CLOUDWATCH_METRIC"
-          ]
-        },
-        "ResourcePath": {
-          "shape": "S1h"
-        },
-        "FullyQualifiedDomainName": {
-          "shape": "S1i"
-        },
-        "SearchString": {
-          "shape": "S1j"
-        },
+        "Type": {},
+        "ResourcePath": {},
+        "FullyQualifiedDomainName": {},
+        "SearchString": {},
         "RequestInterval": {
-          "type": "integer",
-          "max": 30,
-          "min": 10
+          "type": "integer"
         },
         "FailureThreshold": {
-          "shape": "S1l"
+          "type": "integer"
         },
         "MeasureLatency": {
           "type": "boolean"
@@ -2737,7 +2296,7 @@
           "type": "boolean"
         },
         "HealthThreshold": {
-          "shape": "S1o"
+          "type": "integer"
         },
         "ChildHealthChecks": {
           "shape": "S1p"
@@ -2751,74 +2310,20 @@
         "AlarmIdentifier": {
           "shape": "S1t"
         },
-        "InsufficientDataHealthStatus": {
-          "shape": "S1w"
-        }
+        "InsufficientDataHealthStatus": {}
       }
-    },
-    "S1e": {
-      "type": "string",
-      "max": 45,
-      "pattern": "(^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))$|^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$)"
-    },
-    "S1f": {
-      "type": "integer",
-      "max": 65535,
-      "min": 1
-    },
-    "S1h": {
-      "type": "string",
-      "max": 255
-    },
-    "S1i": {
-      "type": "string",
-      "max": 255
-    },
-    "S1j": {
-      "type": "string",
-      "max": 255
-    },
-    "S1l": {
-      "type": "integer",
-      "max": 10,
-      "min": 1
-    },
-    "S1o": {
-      "type": "integer",
-      "max": 256,
-      "min": 0
     },
     "S1p": {
       "type": "list",
       "member": {
-        "shape": "Sz",
         "locationName": "ChildHealthCheck"
-      },
-      "max": 256
+      }
     },
     "S1r": {
       "type": "list",
       "member": {
-        "shape": "S1s",
         "locationName": "Region"
-      },
-      "max": 64,
-      "min": 3
-    },
-    "S1s": {
-      "type": "string",
-      "enum": [
-        "us-east-1",
-        "us-west-1",
-        "us-west-2",
-        "eu-west-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-northeast-1",
-        "sa-east-1"
-      ],
-      "max": 64,
-      "min": 1
+      }
     },
     "S1t": {
       "type": "structure",
@@ -2827,43 +2332,9 @@
         "Name"
       ],
       "members": {
-        "Region": {
-          "type": "string",
-          "enum": [
-            "us-east-1",
-            "us-east-2",
-            "us-west-1",
-            "us-west-2",
-            "ca-central-1",
-            "eu-central-1",
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "ap-south-1",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ap-northeast-1",
-            "ap-northeast-2",
-            "ap-northeast-3",
-            "sa-east-1"
-          ],
-          "max": 64,
-          "min": 1
-        },
-        "Name": {
-          "type": "string",
-          "max": 256,
-          "min": 1
-        }
+        "Region": {},
+        "Name": {}
       }
-    },
-    "S1w": {
-      "type": "string",
-      "enum": [
-        "Healthy",
-        "Unhealthy",
-        "LastKnownStatus"
-      ]
     },
     "S1y": {
       "type": "structure",
@@ -2874,12 +2345,8 @@
         "HealthCheckVersion"
       ],
       "members": {
-        "Id": {
-          "shape": "Sz"
-        },
-        "CallerReference": {
-          "shape": "S1c"
-        },
+        "Id": {},
+        "CallerReference": {},
         "LinkedService": {
           "shape": "S1z"
         },
@@ -2887,7 +2354,7 @@
           "shape": "S1d"
         },
         "HealthCheckVersion": {
-          "shape": "S21"
+          "type": "long"
         },
         "CloudWatchAlarmConfiguration": {
           "type": "structure",
@@ -2902,45 +2369,18 @@
           ],
           "members": {
             "EvaluationPeriods": {
-              "type": "integer",
-              "min": 1
+              "type": "integer"
             },
             "Threshold": {
               "type": "double"
             },
-            "ComparisonOperator": {
-              "type": "string",
-              "enum": [
-                "GreaterThanOrEqualToThreshold",
-                "GreaterThanThreshold",
-                "LessThanThreshold",
-                "LessThanOrEqualToThreshold"
-              ]
-            },
+            "ComparisonOperator": {},
             "Period": {
-              "type": "integer",
-              "min": 60
+              "type": "integer"
             },
-            "MetricName": {
-              "type": "string",
-              "max": 255,
-              "min": 1
-            },
-            "Namespace": {
-              "type": "string",
-              "max": 255,
-              "min": 1
-            },
-            "Statistic": {
-              "type": "string",
-              "enum": [
-                "Average",
-                "Sum",
-                "SampleCount",
-                "Maximum",
-                "Minimum"
-              ]
-            },
+            "MetricName": {},
+            "Namespace": {},
+            "Statistic": {},
             "Dimensions": {
               "type": "list",
               "member": {
@@ -2951,15 +2391,10 @@
                   "Value"
                 ],
                 "members": {
-                  "Name": {
-                    "shape": "S2c"
-                  },
-                  "Value": {
-                    "shape": "S2c"
-                  }
+                  "Name": {},
+                  "Value": {}
                 }
-              },
-              "max": 10
+              }
             }
           }
         }
@@ -2968,39 +2403,14 @@
     "S1z": {
       "type": "structure",
       "members": {
-        "ServicePrincipal": {
-          "type": "string",
-          "max": 128
-        },
-        "Description": {
-          "shape": "Sb"
-        }
+        "ServicePrincipal": {},
+        "Description": {}
       }
-    },
-    "S21": {
-      "type": "long",
-      "min": 1
-    },
-    "S2c": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S2d": {
-      "type": "string",
-      "max": 1024
-    },
-    "S2f": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S2g": {
       "type": "structure",
       "members": {
-        "Comment": {
-          "shape": "Sb"
-        },
+        "Comment": {},
         "PrivateZone": {
           "type": "boolean"
         }
@@ -3014,15 +2424,9 @@
         "CallerReference"
       ],
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "Si"
-        },
-        "CallerReference": {
-          "shape": "S2f"
-        },
+        "Id": {},
+        "Name": {},
+        "CallerReference": {},
         "Config": {
           "shape": "S2g"
         },
@@ -3040,19 +2444,13 @@
         "NameServers"
       ],
       "members": {
-        "Id": {
-          "shape": "S2"
-        },
-        "CallerReference": {
-          "shape": "S2f"
-        },
+        "Id": {},
+        "CallerReference": {},
         "NameServers": {
           "type": "list",
           "member": {
-            "shape": "Si",
             "locationName": "NameServer"
-          },
-          "min": 1
+          }
         }
       }
     },
@@ -3064,31 +2462,10 @@
         "CloudWatchLogsLogGroupArn"
       ],
       "members": {
-        "Id": {
-          "shape": "S2r"
-        },
-        "HostedZoneId": {
-          "shape": "S2"
-        },
+        "Id": {},
+        "HostedZoneId": {},
         "CloudWatchLogsLogGroupArn": {}
       }
-    },
-    "S2r": {
-      "type": "string",
-      "max": 36,
-      "min": 1
-    },
-    "S2v": {
-      "type": "string",
-      "max": 512
-    },
-    "S2w": {
-      "type": "string",
-      "max": 102400
-    },
-    "S2x": {
-      "type": "string",
-      "max": 1024
     },
     "S2z": {
       "type": "structure",
@@ -3100,35 +2477,15 @@
         "Document"
       ],
       "members": {
-        "Id": {
-          "shape": "S30"
-        },
+        "Id": {},
         "Version": {
-          "shape": "S31"
+          "type": "integer"
         },
-        "Name": {
-          "shape": "S2v"
-        },
-        "Type": {
-          "shape": "Sj"
-        },
-        "Document": {
-          "shape": "S2w"
-        },
-        "Comment": {
-          "shape": "S2x"
-        }
+        "Name": {},
+        "Type": {},
+        "Document": {},
+        "Comment": {}
       }
-    },
-    "S30": {
-      "type": "string",
-      "max": 36,
-      "min": 1
-    },
-    "S31": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
     },
     "S34": {
       "type": "structure",
@@ -3144,79 +2501,30 @@
         "TrafficPolicyType"
       ],
       "members": {
-        "Id": {
-          "shape": "S10"
-        },
-        "HostedZoneId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "Si"
-        },
+        "Id": {},
+        "HostedZoneId": {},
+        "Name": {},
         "TTL": {
-          "shape": "St"
+          "type": "long"
         },
         "State": {},
-        "Message": {
-          "type": "string",
-          "max": 1024
-        },
-        "TrafficPolicyId": {
-          "shape": "S30"
-        },
+        "Message": {},
+        "TrafficPolicyId": {},
         "TrafficPolicyVersion": {
-          "shape": "S31"
+          "type": "integer"
         },
-        "TrafficPolicyType": {
-          "shape": "Sj"
-        }
+        "TrafficPolicyType": {}
       }
-    },
-    "S3t": {
-      "type": "string",
-      "enum": [
-        "MAX_HEALTH_CHECKS_BY_OWNER",
-        "MAX_HOSTED_ZONES_BY_OWNER",
-        "MAX_TRAFFIC_POLICY_INSTANCES_BY_OWNER",
-        "MAX_REUSABLE_DELEGATION_SETS_BY_OWNER",
-        "MAX_TRAFFIC_POLICIES_BY_OWNER"
-      ]
-    },
-    "S3w": {
-      "type": "long",
-      "min": 1
-    },
-    "S3x": {
-      "type": "long",
-      "min": 0
     },
     "S46": {
       "type": "structure",
       "members": {
-        "ContinentCode": {
-          "shape": "So"
-        },
-        "ContinentName": {
-          "type": "string",
-          "max": 32,
-          "min": 1
-        },
-        "CountryCode": {
-          "shape": "Sp"
-        },
-        "CountryName": {
-          "type": "string",
-          "max": 64,
-          "min": 1
-        },
-        "SubdivisionCode": {
-          "shape": "Sq"
-        },
-        "SubdivisionName": {
-          "type": "string",
-          "max": 64,
-          "min": 1
-        }
+        "ContinentCode": {},
+        "ContinentName": {},
+        "CountryCode": {},
+        "CountryName": {},
+        "SubdivisionCode": {},
+        "SubdivisionName": {}
       }
     },
     "S4h": {
@@ -3225,12 +2533,8 @@
         "locationName": "HealthCheckObservation",
         "type": "structure",
         "members": {
-          "Region": {
-            "shape": "S1s"
-          },
-          "IPAddress": {
-            "shape": "S1e"
-          },
+          "Region": {},
+          "IPAddress": {},
           "StatusReport": {
             "type": "structure",
             "members": {
@@ -3248,25 +2552,7 @@
       "member": {
         "shape": "S3",
         "locationName": "VPC"
-      },
-      "min": 1
-    },
-    "S4u": {
-      "type": "string",
-      "enum": [
-        "MAX_RRSETS_BY_ZONE",
-        "MAX_VPCS_ASSOCIATED_BY_ZONE"
-      ]
-    },
-    "S52": {
-      "type": "string",
-      "enum": [
-        "MAX_ZONES_BY_REUSABLE_DELEGATION_SET"
-      ]
-    },
-    "S5i": {
-      "type": "string",
-      "max": 64
+      }
     },
     "S5n": {
       "type": "list",
@@ -3275,19 +2561,11 @@
         "locationName": "HostedZone"
       }
     },
-    "S5r": {
-      "type": "string",
-      "max": 256
-    },
     "S63": {
       "type": "structure",
       "members": {
-        "ResourceType": {
-          "shape": "S13"
-        },
-        "ResourceId": {
-          "shape": "S14"
-        },
+        "ResourceType": {},
+        "ResourceId": {},
         "Tags": {
           "shape": "S15"
         }
@@ -3299,10 +2577,6 @@
         "shape": "S34",
         "locationName": "TrafficPolicyInstance"
       }
-    },
-    "S6k": {
-      "type": "string",
-      "max": 4
     }
   }
 }

--- a/apis/route53domains-2014-05-15.min.json
+++ b/apis/route53domains-2014-05-15.min.json
@@ -19,12 +19,8 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "IdnLangCode": {
-            "shape": "S3"
-          }
+          "DomainName": {},
+          "IdnLangCode": {}
         }
       },
       "output": {
@@ -33,19 +29,7 @@
           "Availability"
         ],
         "members": {
-          "Availability": {
-            "type": "string",
-            "enum": [
-              "AVAILABLE",
-              "AVAILABLE_RESERVED",
-              "AVAILABLE_PREORDER",
-              "UNAVAILABLE",
-              "UNAVAILABLE_PREMIUM",
-              "UNAVAILABLE_RESTRICTED",
-              "RESERVED",
-              "DONT_KNOW"
-            ]
-          }
+          "Availability": {}
         }
       }
     },
@@ -56,9 +40,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AuthCode": {
             "shape": "S7"
           }
@@ -73,14 +55,7 @@
           "Transferability": {
             "type": "structure",
             "members": {
-              "Transferable": {
-                "type": "string",
-                "enum": [
-                  "TRANSFERABLE",
-                  "UNTRANSFERABLE",
-                  "DONT_KNOW"
-                ]
-              }
+              "Transferable": {}
             }
           }
         }
@@ -94,9 +69,7 @@
           "TagsToDelete"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "TagsToDelete": {
             "type": "list",
             "member": {}
@@ -115,9 +88,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -132,9 +103,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -143,9 +112,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -156,9 +123,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -173,9 +138,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -184,9 +147,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -194,25 +155,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "domainName": {
-            "shape": "S2"
-          }
+          "domainName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "domainName": {
-            "shape": "S2"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "PENDING",
-              "DONE",
-              "EXPIRED"
-            ]
-          }
+          "domainName": {},
+          "status": {}
         }
       }
     },
@@ -223,9 +173,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -238,9 +186,7 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "Nameservers": {
             "shape": "St"
           },
@@ -268,12 +214,8 @@
           "RegistrarName": {},
           "WhoIsServer": {},
           "RegistrarUrl": {},
-          "AbuseContactEmail": {
-            "shape": "S18"
-          },
-          "AbuseContactPhone": {
-            "shape": "S17"
-          },
+          "AbuseContactEmail": {},
+          "AbuseContactPhone": {},
           "RegistryDomainId": {},
           "CreationDate": {
             "type": "timestamp"
@@ -302,9 +244,7 @@
           "OnlyAvailable"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "SuggestionCount": {
             "type": "integer"
           },
@@ -321,9 +261,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {
-                  "shape": "S2"
-                },
+                "DomainName": {},
                 "Availability": {}
               }
             }
@@ -338,27 +276,17 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          },
-          "Status": {
-            "shape": "S1u"
-          },
+          "OperationId": {},
+          "Status": {},
           "Message": {},
-          "DomainName": {
-            "shape": "S2"
-          },
-          "Type": {
-            "shape": "S1w"
-          },
+          "DomainName": {},
+          "Type": {},
           "SubmittedDate": {
             "type": "timestamp"
           }
@@ -369,11 +297,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {
-            "shape": "S1y"
-          },
+          "Marker": {},
           "MaxItems": {
-            "shape": "S1z"
+            "type": "integer"
           }
         }
       },
@@ -391,9 +317,7 @@
                 "DomainName"
               ],
               "members": {
-                "DomainName": {
-                  "shape": "S2"
-                },
+                "DomainName": {},
                 "AutoRenew": {
                   "type": "boolean"
                 },
@@ -406,9 +330,7 @@
               }
             }
           },
-          "NextPageMarker": {
-            "shape": "S1y"
-          }
+          "NextPageMarker": {}
         }
       }
     },
@@ -419,11 +341,9 @@
           "SubmittedSince": {
             "type": "timestamp"
           },
-          "Marker": {
-            "shape": "S1y"
-          },
+          "Marker": {},
           "MaxItems": {
-            "shape": "S1z"
+            "type": "integer"
           }
         }
       },
@@ -444,24 +364,16 @@
                 "SubmittedDate"
               ],
               "members": {
-                "OperationId": {
-                  "shape": "Sj"
-                },
-                "Status": {
-                  "shape": "S1u"
-                },
-                "Type": {
-                  "shape": "S1w"
-                },
+                "OperationId": {},
+                "Status": {},
+                "Type": {},
                 "SubmittedDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextPageMarker": {
-            "shape": "S1y"
-          }
+          "NextPageMarker": {}
         }
       }
     },
@@ -472,9 +384,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -500,14 +410,10 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "IdnLangCode": {
-            "shape": "S3"
-          },
+          "DomainName": {},
+          "IdnLangCode": {},
           "DurationInYears": {
-            "shape": "S2d"
+            "type": "integer"
           },
           "AutoRenew": {
             "type": "boolean"
@@ -538,9 +444,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -552,11 +456,9 @@
           "CurrentExpiryYear"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "DurationInYears": {
-            "shape": "S2d"
+            "type": "integer"
           },
           "CurrentExpiryYear": {
             "type": "integer"
@@ -569,9 +471,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -579,20 +479,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "domainName": {
-            "shape": "S2"
-          }
+          "domainName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "domainName": {
-            "shape": "S2"
-          },
-          "emailAddress": {
-            "shape": "S18"
-          },
+          "domainName": {},
+          "emailAddress": {},
           "isAlreadyVerified": {
             "type": "boolean"
           }
@@ -606,9 +500,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          }
+          "DomainName": {}
         }
       },
       "output": {
@@ -634,14 +526,10 @@
           "TechContact"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
-          "IdnLangCode": {
-            "shape": "S3"
-          },
+          "DomainName": {},
+          "IdnLangCode": {},
           "DurationInYears": {
-            "shape": "S2d"
+            "type": "integer"
           },
           "Nameservers": {
             "shape": "St"
@@ -678,9 +566,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -691,9 +577,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AdminContact": {
             "shape": "Sz"
           },
@@ -711,9 +595,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -724,9 +606,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "AdminPrivacy": {
             "type": "boolean"
           },
@@ -744,9 +624,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -758,9 +636,7 @@
           "Nameservers"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "FIAuthKey": {
             "deprecated": true
           },
@@ -775,9 +651,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "Sj"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -788,9 +662,7 @@
           "DomainName"
         ],
         "members": {
-          "DomainName": {
-            "shape": "S2"
-          },
+          "DomainName": {},
           "TagsToUpdate": {
             "shape": "S29"
           }
@@ -811,31 +683,23 @@
           "End": {
             "type": "timestamp"
           },
-          "Marker": {
-            "shape": "S1y"
-          },
+          "Marker": {},
           "MaxItems": {
-            "shape": "S1z"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextPageMarker": {
-            "shape": "S1y"
-          },
+          "NextPageMarker": {},
           "BillingRecords": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "DomainName": {
-                  "shape": "S2"
-                },
-                "Operation": {
-                  "shape": "S1w"
-                },
+                "DomainName": {},
+                "Operation": {},
                 "InvoiceId": {},
                 "BillDate": {
                   "type": "timestamp"
@@ -851,22 +715,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 255
-    },
-    "S3": {
-      "type": "string",
-      "max": 3
-    },
     "S7": {
       "type": "string",
-      "max": 1024,
       "sensitive": true
-    },
-    "Sj": {
-      "type": "string",
-      "max": 255
     },
     "St": {
       "type": "list",
@@ -876,17 +727,10 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "type": "string",
-            "max": 255,
-            "pattern": "[a-zA-Z0-9_\\-.]*"
-          },
+          "Name": {},
           "GlueIps": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 45
-            }
+            "member": {}
           }
         }
       }
@@ -894,286 +738,19 @@
     "Sz": {
       "type": "structure",
       "members": {
-        "FirstName": {
-          "shape": "S10"
-        },
-        "LastName": {
-          "shape": "S10"
-        },
-        "ContactType": {
-          "type": "string",
-          "enum": [
-            "PERSON",
-            "COMPANY",
-            "ASSOCIATION",
-            "PUBLIC_BODY",
-            "RESELLER"
-          ]
-        },
-        "OrganizationName": {
-          "shape": "S10"
-        },
-        "AddressLine1": {
-          "shape": "S12"
-        },
-        "AddressLine2": {
-          "shape": "S12"
-        },
-        "City": {
-          "type": "string",
-          "max": 255
-        },
-        "State": {
-          "type": "string",
-          "max": 255
-        },
-        "CountryCode": {
-          "type": "string",
-          "enum": [
-            "AD",
-            "AE",
-            "AF",
-            "AG",
-            "AI",
-            "AL",
-            "AM",
-            "AN",
-            "AO",
-            "AQ",
-            "AR",
-            "AS",
-            "AT",
-            "AU",
-            "AW",
-            "AZ",
-            "BA",
-            "BB",
-            "BD",
-            "BE",
-            "BF",
-            "BG",
-            "BH",
-            "BI",
-            "BJ",
-            "BL",
-            "BM",
-            "BN",
-            "BO",
-            "BR",
-            "BS",
-            "BT",
-            "BW",
-            "BY",
-            "BZ",
-            "CA",
-            "CC",
-            "CD",
-            "CF",
-            "CG",
-            "CH",
-            "CI",
-            "CK",
-            "CL",
-            "CM",
-            "CN",
-            "CO",
-            "CR",
-            "CU",
-            "CV",
-            "CX",
-            "CY",
-            "CZ",
-            "DE",
-            "DJ",
-            "DK",
-            "DM",
-            "DO",
-            "DZ",
-            "EC",
-            "EE",
-            "EG",
-            "ER",
-            "ES",
-            "ET",
-            "FI",
-            "FJ",
-            "FK",
-            "FM",
-            "FO",
-            "FR",
-            "GA",
-            "GB",
-            "GD",
-            "GE",
-            "GH",
-            "GI",
-            "GL",
-            "GM",
-            "GN",
-            "GQ",
-            "GR",
-            "GT",
-            "GU",
-            "GW",
-            "GY",
-            "HK",
-            "HN",
-            "HR",
-            "HT",
-            "HU",
-            "ID",
-            "IE",
-            "IL",
-            "IM",
-            "IN",
-            "IQ",
-            "IR",
-            "IS",
-            "IT",
-            "JM",
-            "JO",
-            "JP",
-            "KE",
-            "KG",
-            "KH",
-            "KI",
-            "KM",
-            "KN",
-            "KP",
-            "KR",
-            "KW",
-            "KY",
-            "KZ",
-            "LA",
-            "LB",
-            "LC",
-            "LI",
-            "LK",
-            "LR",
-            "LS",
-            "LT",
-            "LU",
-            "LV",
-            "LY",
-            "MA",
-            "MC",
-            "MD",
-            "ME",
-            "MF",
-            "MG",
-            "MH",
-            "MK",
-            "ML",
-            "MM",
-            "MN",
-            "MO",
-            "MP",
-            "MR",
-            "MS",
-            "MT",
-            "MU",
-            "MV",
-            "MW",
-            "MX",
-            "MY",
-            "MZ",
-            "NA",
-            "NC",
-            "NE",
-            "NG",
-            "NI",
-            "NL",
-            "NO",
-            "NP",
-            "NR",
-            "NU",
-            "NZ",
-            "OM",
-            "PA",
-            "PE",
-            "PF",
-            "PG",
-            "PH",
-            "PK",
-            "PL",
-            "PM",
-            "PN",
-            "PR",
-            "PT",
-            "PW",
-            "PY",
-            "QA",
-            "RO",
-            "RS",
-            "RU",
-            "RW",
-            "SA",
-            "SB",
-            "SC",
-            "SD",
-            "SE",
-            "SG",
-            "SH",
-            "SI",
-            "SK",
-            "SL",
-            "SM",
-            "SN",
-            "SO",
-            "SR",
-            "ST",
-            "SV",
-            "SY",
-            "SZ",
-            "TC",
-            "TD",
-            "TG",
-            "TH",
-            "TJ",
-            "TK",
-            "TL",
-            "TM",
-            "TN",
-            "TO",
-            "TR",
-            "TT",
-            "TV",
-            "TW",
-            "TZ",
-            "UA",
-            "UG",
-            "US",
-            "UY",
-            "UZ",
-            "VA",
-            "VC",
-            "VE",
-            "VG",
-            "VI",
-            "VN",
-            "VU",
-            "WF",
-            "WS",
-            "YE",
-            "YT",
-            "ZA",
-            "ZM",
-            "ZW"
-          ]
-        },
-        "ZipCode": {
-          "type": "string",
-          "max": 255
-        },
-        "PhoneNumber": {
-          "shape": "S17"
-        },
-        "Email": {
-          "shape": "S18"
-        },
-        "Fax": {
-          "shape": "S17"
-        },
+        "FirstName": {},
+        "LastName": {},
+        "ContactType": {},
+        "OrganizationName": {},
+        "AddressLine1": {},
+        "AddressLine2": {},
+        "City": {},
+        "State": {},
+        "CountryCode": {},
+        "ZipCode": {},
+        "PhoneNumber": {},
+        "Email": {},
+        "Fax": {},
         "ExtraParams": {
           "type": "list",
           "member": {
@@ -1183,101 +760,13 @@
               "Value"
             ],
             "members": {
-              "Name": {
-                "type": "string",
-                "enum": [
-                  "DUNS_NUMBER",
-                  "BRAND_NUMBER",
-                  "BIRTH_DEPARTMENT",
-                  "BIRTH_DATE_IN_YYYY_MM_DD",
-                  "BIRTH_COUNTRY",
-                  "BIRTH_CITY",
-                  "DOCUMENT_NUMBER",
-                  "AU_ID_NUMBER",
-                  "AU_ID_TYPE",
-                  "CA_LEGAL_TYPE",
-                  "CA_BUSINESS_ENTITY_TYPE",
-                  "ES_IDENTIFICATION",
-                  "ES_IDENTIFICATION_TYPE",
-                  "ES_LEGAL_FORM",
-                  "FI_BUSINESS_NUMBER",
-                  "FI_ID_NUMBER",
-                  "FI_NATIONALITY",
-                  "FI_ORGANIZATION_TYPE",
-                  "IT_PIN",
-                  "IT_REGISTRANT_ENTITY_TYPE",
-                  "RU_PASSPORT_DATA",
-                  "SE_ID_NUMBER",
-                  "SG_ID_NUMBER",
-                  "VAT_NUMBER",
-                  "UK_CONTACT_TYPE",
-                  "UK_COMPANY_NUMBER"
-                ]
-              },
-              "Value": {
-                "type": "string",
-                "max": 2048
-              }
+              "Name": {},
+              "Value": {}
             }
           }
         }
       },
       "sensitive": true
-    },
-    "S10": {
-      "type": "string",
-      "max": 255
-    },
-    "S12": {
-      "type": "string",
-      "max": 255
-    },
-    "S17": {
-      "type": "string",
-      "max": 30
-    },
-    "S18": {
-      "type": "string",
-      "max": 254
-    },
-    "S1u": {
-      "type": "string",
-      "enum": [
-        "SUBMITTED",
-        "IN_PROGRESS",
-        "ERROR",
-        "SUCCESSFUL",
-        "FAILED"
-      ]
-    },
-    "S1w": {
-      "type": "string",
-      "enum": [
-        "REGISTER_DOMAIN",
-        "DELETE_DOMAIN",
-        "TRANSFER_IN_DOMAIN",
-        "UPDATE_DOMAIN_CONTACT",
-        "UPDATE_NAMESERVER",
-        "CHANGE_PRIVACY_PROTECTION",
-        "DOMAIN_LOCK",
-        "ENABLE_AUTORENEW",
-        "DISABLE_AUTORENEW",
-        "ADD_DNSSEC",
-        "REMOVE_DNSSEC",
-        "EXPIRE_DOMAIN",
-        "TRANSFER_OUT_DOMAIN",
-        "CHANGE_DOMAIN_OWNER",
-        "RENEW_DOMAIN",
-        "PUSH_DOMAIN"
-      ]
-    },
-    "S1y": {
-      "type": "string",
-      "max": 4096
-    },
-    "S1z": {
-      "type": "integer",
-      "max": 100
     },
     "S29": {
       "type": "list",
@@ -1288,11 +777,6 @@
           "Value": {}
         }
       }
-    },
-    "S2d": {
-      "type": "integer",
-      "max": 10,
-      "min": 1
     }
   }
 }

--- a/apis/runtime.lex-2016-11-28.min.json
+++ b/apis/runtime.lex-2016-11-28.min.json
@@ -35,7 +35,6 @@
             "locationName": "botAlias"
           },
           "userId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "userId"
           },
@@ -92,12 +91,10 @@
             "locationName": "x-amz-lex-message"
           },
           "messageFormat": {
-            "shape": "Sd",
             "location": "header",
             "locationName": "x-amz-lex-message-format"
           },
           "dialogState": {
-            "shape": "Se",
             "location": "header",
             "locationName": "x-amz-lex-dialog-state"
           },
@@ -139,7 +136,6 @@
             "locationName": "botAlias"
           },
           "userId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "userId"
           },
@@ -167,40 +163,23 @@
           "message": {
             "shape": "Sc"
           },
-          "messageFormat": {
-            "shape": "Sd"
-          },
-          "dialogState": {
-            "shape": "Se"
-          },
+          "messageFormat": {},
+          "dialogState": {},
           "slotToElicit": {},
           "responseCard": {
             "type": "structure",
             "members": {
               "version": {},
-              "contentType": {
-                "type": "string",
-                "enum": [
-                  "application/vnd.amazonaws.card.generic"
-                ]
-              },
+              "contentType": {},
               "genericAttachments": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "title": {
-                      "shape": "Sm"
-                    },
-                    "subTitle": {
-                      "shape": "Sm"
-                    },
-                    "attachmentLinkUrl": {
-                      "shape": "Sn"
-                    },
-                    "imageUrl": {
-                      "shape": "Sn"
-                    },
+                    "title": {},
+                    "subTitle": {},
+                    "attachmentLinkUrl": {},
+                    "imageUrl": {},
                     "buttons": {
                       "type": "list",
                       "member": {
@@ -210,25 +189,13 @@
                           "value"
                         ],
                         "members": {
-                          "text": {
-                            "type": "string",
-                            "max": 15,
-                            "min": 1
-                          },
-                          "value": {
-                            "type": "string",
-                            "max": 1000,
-                            "min": 1
-                          }
+                          "text": {},
+                          "value": {}
                         }
-                      },
-                      "max": 5,
-                      "min": 0
+                      }
                     }
                   }
-                },
-                "max": 10,
-                "min": 0
+                }
               }
             }
           }
@@ -237,12 +204,6 @@
     }
   },
   "shapes": {
-    "S4": {
-      "type": "string",
-      "max": 100,
-      "min": 2,
-      "pattern": "[0-9a-zA-Z._:-]+"
-    },
     "S5": {
       "type": "string",
       "sensitive": true
@@ -253,45 +214,13 @@
     },
     "Sc": {
       "type": "string",
-      "max": 1024,
-      "min": 1,
       "sensitive": true
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "PlainText",
-        "CustomPayload",
-        "SSML",
-        "Composite"
-      ]
-    },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "ElicitIntent",
-        "ConfirmIntent",
-        "ElicitSlot",
-        "Fulfilled",
-        "ReadyForFulfillment",
-        "Failed"
-      ]
     },
     "Sg": {
       "type": "map",
       "key": {},
       "value": {},
       "sensitive": true
-    },
-    "Sm": {
-      "type": "string",
-      "max": 80,
-      "min": 1
-    },
-    "Sn": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
     }
   }
 }

--- a/apis/runtime.sagemaker-2017-05-13.min.json
+++ b/apis/runtime.sagemaker-2017-05-13.min.json
@@ -25,21 +25,16 @@
         "members": {
           "EndpointName": {
             "location": "uri",
-            "locationName": "EndpointName",
-            "type": "string",
-            "max": 63,
-            "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+            "locationName": "EndpointName"
           },
           "Body": {
             "shape": "S3"
           },
           "ContentType": {
-            "shape": "S4",
             "location": "header",
             "locationName": "Content-Type"
           },
           "Accept": {
-            "shape": "S4",
             "location": "header",
             "locationName": "Accept"
           },
@@ -61,12 +56,10 @@
             "shape": "S3"
           },
           "ContentType": {
-            "shape": "S4",
             "location": "header",
             "locationName": "Content-Type"
           },
           "InvokedProductionVariant": {
-            "shape": "S4",
             "location": "header",
             "locationName": "x-Amzn-Invoked-Production-Variant"
           },
@@ -83,16 +76,10 @@
   "shapes": {
     "S3": {
       "type": "blob",
-      "max": 5242880,
       "sensitive": true
-    },
-    "S4": {
-      "type": "string",
-      "max": 1024
     },
     "S5": {
       "type": "string",
-      "max": 1024,
       "sensitive": true
     }
   }

--- a/apis/s3-2006-03-01.min.json
+++ b/apis/s3-2006-03-01.min.json
@@ -31,7 +31,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -40,7 +39,6 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -50,7 +48,6 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -74,7 +71,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -106,7 +102,6 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -118,16 +113,13 @@
         "members": {
           "Location": {},
           "Bucket": {},
-          "Key": {
-            "shape": "S3"
-          },
+          "Key": {},
           "Expiration": {
             "location": "header",
             "locationName": "x-amz-expiration"
           },
           "ETag": {},
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -141,7 +133,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -162,7 +153,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -191,7 +181,6 @@
             "locationName": "Content-Type"
           },
           "CopySource": {
-            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-copy-source"
           },
@@ -235,7 +224,6 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -246,29 +234,17 @@
           },
           "MetadataDirective": {
             "location": "header",
-            "locationName": "x-amz-metadata-directive",
-            "type": "string",
-            "enum": [
-              "COPY",
-              "REPLACE"
-            ]
+            "locationName": "x-amz-metadata-directive"
           },
           "TaggingDirective": {
             "location": "header",
-            "locationName": "x-amz-tagging-directive",
-            "type": "string",
-            "enum": [
-              "COPY",
-              "REPLACE"
-            ]
+            "locationName": "x-amz-tagging-directive"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
-            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -308,7 +284,6 @@
             "locationName": "x-amz-copy-source-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -343,7 +318,6 @@
             "locationName": "x-amz-version-id"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -361,7 +335,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -382,7 +355,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "S1k",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -397,9 +369,7 @@
             },
             "type": "structure",
             "members": {
-              "LocationConstraint": {
-                "shape": "S1m"
-              }
+              "LocationConstraint": {}
             }
           },
           "GrantFullControl": {
@@ -448,7 +418,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -498,7 +467,6 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -508,12 +476,10 @@
             "locationName": "x-amz-meta-"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
-            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -540,7 +506,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -565,12 +530,9 @@
           "Bucket": {
             "locationName": "Bucket"
           },
-          "Key": {
-            "shape": "S3"
-          },
+          "Key": {},
           "UploadId": {},
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -588,7 +550,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -826,7 +787,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -839,7 +799,6 @@
             "locationName": "versionId"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -858,7 +817,6 @@
             "locationName": "x-amz-version-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -882,7 +840,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -936,9 +893,7 @@
                     "Key"
                   ],
                   "members": {
-                    "Key": {
-                      "shape": "S3"
-                    },
+                    "Key": {},
                     "VersionId": {}
                   }
                 },
@@ -954,7 +909,6 @@
             "locationName": "x-amz-mfa"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -969,9 +923,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S3"
-                },
+                "Key": {},
                 "VersionId": {},
                 "DeleteMarker": {
                   "type": "boolean"
@@ -982,7 +934,6 @@
             "flattened": true
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
@@ -992,9 +943,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S3"
-                },
+                "Key": {},
                 "VersionId": {},
                 "Code": {},
                 "Message": {}
@@ -1026,9 +975,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "S2s"
-          }
+          "Status": {}
         }
       }
     },
@@ -1255,9 +1202,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "LocationConstraint": {
-            "shape": "S1m"
-          }
+          "LocationConstraint": {}
         }
       }
     },
@@ -1416,9 +1361,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "Payer": {
-            "shape": "S71"
-          }
+          "Payer": {}
         }
       }
     },
@@ -1471,16 +1414,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "S76"
-          },
+          "Status": {},
           "MFADelete": {
-            "locationName": "MfaDelete",
-            "type": "string",
-            "enum": [
-              "Enabled",
-              "Disabled"
-            ]
+            "locationName": "MfaDelete"
           }
         }
       }
@@ -1555,7 +1491,6 @@
             "type": "timestamp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1606,7 +1541,6 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -1698,7 +1632,6 @@
             "locationName": "x-amz-website-redirect-location"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -1721,17 +1654,14 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "StorageClass": {
-            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
           "ReplicationStatus": {
-            "shape": "S88",
             "location": "header",
             "locationName": "x-amz-replication-status"
           },
@@ -1766,7 +1696,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1775,7 +1704,6 @@
             "locationName": "versionId"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -1792,7 +1720,6 @@
             "locationName": "AccessControlList"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -1816,7 +1743,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1859,12 +1785,10 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -1878,7 +1802,6 @@
             "type": "blob"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -1939,7 +1862,6 @@
             "type": "timestamp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -1965,7 +1887,6 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -2049,7 +1970,6 @@
             "locationName": "x-amz-website-redirect-location"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -2072,17 +1992,14 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "StorageClass": {
-            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
           "ReplicationStatus": {
-            "shape": "S88",
             "location": "header",
             "locationName": "x-amz-replication-status"
           },
@@ -2261,7 +2178,6 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
-            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2307,15 +2223,11 @@
               "type": "structure",
               "members": {
                 "UploadId": {},
-                "Key": {
-                  "shape": "S3"
-                },
+                "Key": {},
                 "Initiated": {
                   "type": "timestamp"
                 },
-                "StorageClass": {
-                  "shape": "S16"
-                },
+                "StorageClass": {},
                 "Owner": {
                   "shape": "S2v"
                 },
@@ -2329,9 +2241,7 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {
-            "shape": "S92"
-          }
+          "EncodingType": {}
         }
       }
     },
@@ -2355,7 +2265,6 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
-            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2398,15 +2307,8 @@
                 "Size": {
                   "type": "integer"
                 },
-                "StorageClass": {
-                  "type": "string",
-                  "enum": [
-                    "STANDARD"
-                  ]
-                },
-                "Key": {
-                  "shape": "S3"
-                },
+                "StorageClass": {},
+                "Key": {},
                 "VersionId": {},
                 "IsLatest": {
                   "type": "boolean"
@@ -2430,9 +2332,7 @@
                 "Owner": {
                   "shape": "S2v"
                 },
-                "Key": {
-                  "shape": "S3"
-                },
+                "Key": {},
                 "VersionId": {},
                 "IsLatest": {
                   "type": "boolean"
@@ -2453,9 +2353,7 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {
-            "shape": "S92"
-          }
+          "EncodingType": {}
         }
       },
       "alias": "GetBucketObjectVersions"
@@ -2480,7 +2378,6 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
-            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2498,7 +2395,6 @@
             "locationName": "prefix"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2524,9 +2420,7 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {
-            "shape": "S92"
-          }
+          "EncodingType": {}
         }
       },
       "alias": "GetBucket"
@@ -2551,7 +2445,6 @@
             "locationName": "delimiter"
           },
           "EncodingType": {
-            "shape": "S92",
             "location": "querystring",
             "locationName": "encoding-type"
           },
@@ -2578,7 +2471,6 @@
             "locationName": "start-after"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2602,9 +2494,7 @@
           "CommonPrefixes": {
             "shape": "S9d"
           },
-          "EncodingType": {
-            "shape": "S92"
-          },
+          "EncodingType": {},
           "KeyCount": {
             "type": "integer"
           },
@@ -2632,7 +2522,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -2651,7 +2540,6 @@
             "locationName": "uploadId"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -2670,9 +2558,7 @@
             "locationName": "x-amz-abort-rule-id"
           },
           "Bucket": {},
-          "Key": {
-            "shape": "S3"
-          },
+          "Key": {},
           "UploadId": {},
           "PartNumberMarker": {
             "type": "integer"
@@ -2712,11 +2598,8 @@
           "Owner": {
             "shape": "S2v"
           },
-          "StorageClass": {
-            "shape": "S16"
-          },
+          "StorageClass": {},
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -2746,9 +2629,7 @@
             },
             "type": "structure",
             "members": {
-              "Status": {
-                "shape": "S2s"
-              }
+              "Status": {}
             }
           }
         },
@@ -2767,7 +2648,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "S1k",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3238,9 +3118,7 @@
               "Payer"
             ],
             "members": {
-              "Payer": {
-                "shape": "S71"
-              }
+              "Payer": {}
             }
           }
         },
@@ -3310,16 +3188,9 @@
             "type": "structure",
             "members": {
               "MFADelete": {
-                "locationName": "MfaDelete",
-                "type": "string",
-                "enum": [
-                  "Enabled",
-                  "Disabled"
-                ]
+                "locationName": "MfaDelete"
               },
-              "Status": {
-                "shape": "S76"
-              }
+              "Status": {}
             }
           }
         },
@@ -3384,7 +3255,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3447,7 +3317,6 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3457,12 +3326,10 @@
             "locationName": "x-amz-meta-"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
           "StorageClass": {
-            "shape": "S16",
             "location": "header",
             "locationName": "x-amz-storage-class"
           },
@@ -3489,7 +3356,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -3512,7 +3378,6 @@
             "locationName": "ETag"
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -3534,7 +3399,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -3554,7 +3418,6 @@
         ],
         "members": {
           "ACL": {
-            "shape": "Sl",
             "location": "header",
             "locationName": "x-amz-acl"
           },
@@ -3594,12 +3457,10 @@
             "locationName": "x-amz-grant-write-acp"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           },
@@ -3614,7 +3475,6 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -3639,7 +3499,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3687,7 +3546,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3711,20 +3569,11 @@
                   "Tier"
                 ],
                 "members": {
-                  "Tier": {
-                    "shape": "Sbe"
-                  }
+                  "Tier": {}
                 }
               },
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "SELECT"
-                ]
-              },
-              "Tier": {
-                "shape": "Sbe"
-              },
+              "Type": {},
+              "Tier": {},
               "Description": {},
               "SelectParameters": {
                 "type": "structure",
@@ -3738,9 +3587,7 @@
                   "InputSerialization": {
                     "shape": "Sbi"
                   },
-                  "ExpressionType": {
-                    "shape": "Sbv"
-                  },
+                  "ExpressionType": {},
                   "Expression": {},
                   "OutputSerialization": {
                     "shape": "Sbx"
@@ -3765,18 +3612,14 @@
                           "EncryptionType"
                         ],
                         "members": {
-                          "EncryptionType": {
-                            "shape": "Sh"
-                          },
+                          "EncryptionType": {},
                           "KMSKeyId": {
                             "shape": "Sj"
                           },
                           "KMSContext": {}
                         }
                       },
-                      "CannedACL": {
-                        "shape": "Sl"
-                      },
+                      "CannedACL": {},
                       "AccessControlList": {
                         "shape": "S2y"
                       },
@@ -3794,9 +3637,7 @@
                           }
                         }
                       },
-                      "StorageClass": {
-                        "shape": "S16"
-                      }
+                      "StorageClass": {}
                     }
                   }
                 }
@@ -3804,7 +3645,6 @@
             }
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -3815,7 +3655,6 @@
         "type": "structure",
         "members": {
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           },
@@ -3851,7 +3690,6 @@
             "locationName": "Bucket"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -3869,9 +3707,7 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "Expression": {},
-          "ExpressionType": {
-            "shape": "Sbv"
-          },
+          "ExpressionType": {},
           "RequestProgress": {
             "type": "structure",
             "members": {
@@ -3995,7 +3831,6 @@
             "locationName": "Content-MD5"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -4022,7 +3857,6 @@
             "locationName": "x-amz-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -4033,7 +3867,6 @@
         "type": "structure",
         "members": {
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -4055,7 +3888,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -4082,7 +3914,6 @@
             "locationName": "Bucket"
           },
           "CopySource": {
-            "shape": "Sr",
             "location": "header",
             "locationName": "x-amz-copy-source"
           },
@@ -4109,7 +3940,6 @@
             "locationName": "x-amz-copy-source-range"
           },
           "Key": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "Key"
           },
@@ -4149,7 +3979,6 @@
             "locationName": "x-amz-copy-source-server-side-encryption-customer-key-MD5"
           },
           "RequestPayer": {
-            "shape": "S5",
             "location": "header",
             "locationName": "x-amz-request-payer"
           }
@@ -4172,7 +4001,6 @@
             }
           },
           "ServerSideEncryption": {
-            "shape": "Sh",
             "location": "header",
             "locationName": "x-amz-server-side-encryption"
           },
@@ -4190,7 +4018,6 @@
             "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
           },
           "RequestCharged": {
-            "shape": "S7",
             "location": "header",
             "locationName": "x-amz-request-charged"
           }
@@ -4200,62 +4027,14 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "min": 1
-    },
-    "S5": {
-      "type": "string",
-      "enum": [
-        "requester"
-      ]
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "requester"
-      ]
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "AES256",
-        "aws:kms"
-      ]
-    },
     "Sj": {
       "type": "string",
       "sensitive": true
-    },
-    "Sl": {
-      "type": "string",
-      "enum": [
-        "private",
-        "public-read",
-        "public-read-write",
-        "authenticated-read",
-        "aws-exec-read",
-        "bucket-owner-read",
-        "bucket-owner-full-control"
-      ]
-    },
-    "Sr": {
-      "type": "string",
-      "pattern": "\\/.+\\/.+"
     },
     "S11": {
       "type": "map",
       "key": {},
       "value": {}
-    },
-    "S16": {
-      "type": "string",
-      "enum": [
-        "STANDARD",
-        "REDUCED_REDUNDANCY",
-        "STANDARD_IA",
-        "ONEZONE_IA"
-      ]
     },
     "S19": {
       "type": "blob",
@@ -4264,38 +4043,6 @@
     "S1c": {
       "type": "blob",
       "sensitive": true
-    },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "private",
-        "public-read",
-        "public-read-write",
-        "authenticated-read"
-      ]
-    },
-    "S1m": {
-      "type": "string",
-      "enum": [
-        "EU",
-        "eu-west-1",
-        "us-west-1",
-        "us-west-2",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-northeast-1",
-        "sa-east-1",
-        "cn-north-1",
-        "eu-central-1"
-      ]
-    },
-    "S2s": {
-      "type": "string",
-      "enum": [
-        "Enabled",
-        "Suspended"
-      ]
     },
     "S2v": {
       "type": "structure",
@@ -4313,16 +4060,7 @@
           "Grantee": {
             "shape": "S30"
           },
-          "Permission": {
-            "type": "string",
-            "enum": [
-              "FULL_CONTROL",
-              "WRITE",
-              "WRITE_ACP",
-              "READ",
-              "READ_ACP"
-            ]
-          }
+          "Permission": {}
         }
       }
     },
@@ -4337,13 +4075,7 @@
         "ID": {},
         "Type": {
           "locationName": "xsi:type",
-          "xmlAttribute": true,
-          "type": "string",
-          "enum": [
-            "CanonicalUser",
-            "AmazonCustomerByEmail",
-            "Group"
-          ]
+          "xmlAttribute": true
         },
         "URI": {}
       },
@@ -4390,12 +4122,7 @@
                 "Destination"
               ],
               "members": {
-                "OutputSchemaVersion": {
-                  "type": "string",
-                  "enum": [
-                    "V_1"
-                  ]
-                },
+                "OutputSchemaVersion": {},
                 "Destination": {
                   "type": "structure",
                   "required": [
@@ -4409,12 +4136,7 @@
                         "Bucket"
                       ],
                       "members": {
-                        "Format": {
-                          "type": "string",
-                          "enum": [
-                            "CSV"
-                          ]
-                        },
+                        "Format": {},
                         "BucketAccountId": {},
                         "Bucket": {},
                         "Prefix": {}
@@ -4435,9 +4157,7 @@
         "Value"
       ],
       "members": {
-        "Key": {
-          "shape": "S3"
-        },
+        "Key": {},
         "Value": {}
       }
     },
@@ -4506,9 +4226,7 @@
                   "SSEAlgorithm"
                 ],
                 "members": {
-                  "SSEAlgorithm": {
-                    "shape": "Sh"
-                  },
+                  "SSEAlgorithm": {},
                   "KMSMasterKeyID": {
                     "shape": "Sj"
                   }
@@ -4545,13 +4263,7 @@
               "members": {
                 "AccountId": {},
                 "Bucket": {},
-                "Format": {
-                  "type": "string",
-                  "enum": [
-                    "CSV",
-                    "ORC"
-                  ]
-                },
+                "Format": {},
                 "Prefix": {},
                 "Encryption": {
                   "type": "structure",
@@ -4592,27 +4304,11 @@
           }
         },
         "Id": {},
-        "IncludedObjectVersions": {
-          "type": "string",
-          "enum": [
-            "All",
-            "Current"
-          ]
-        },
+        "IncludedObjectVersions": {},
         "OptionalFields": {
           "type": "list",
           "member": {
-            "locationName": "Field",
-            "type": "string",
-            "enum": [
-              "Size",
-              "LastModifiedDate",
-              "StorageClass",
-              "ETag",
-              "IsMultipartUploaded",
-              "ReplicationStatus",
-              "EncryptionStatus"
-            ]
+            "locationName": "Field"
           }
         },
         "Schedule": {
@@ -4621,13 +4317,7 @@
             "Frequency"
           ],
           "members": {
-            "Frequency": {
-              "type": "string",
-              "enum": [
-                "Daily",
-                "Weekly"
-              ]
-            }
+            "Frequency": {}
           }
         }
       }
@@ -4646,9 +4336,7 @@
           },
           "ID": {},
           "Prefix": {},
-          "Status": {
-            "shape": "S4s"
-          },
+          "Status": {},
           "Transition": {
             "shape": "S4t"
           },
@@ -4683,13 +4371,6 @@
       "type": "timestamp",
       "timestampFormat": "iso8601"
     },
-    "S4s": {
-      "type": "string",
-      "enum": [
-        "Enabled",
-        "Disabled"
-      ]
-    },
     "S4t": {
       "type": "structure",
       "members": {
@@ -4699,18 +4380,8 @@
         "Days": {
           "type": "integer"
         },
-        "StorageClass": {
-          "shape": "S4u"
-        }
+        "StorageClass": {}
       }
-    },
-    "S4u": {
-      "type": "string",
-      "enum": [
-        "GLACIER",
-        "STANDARD_IA",
-        "ONEZONE_IA"
-      ]
     },
     "S4v": {
       "type": "structure",
@@ -4718,9 +4389,7 @@
         "NoncurrentDays": {
           "type": "integer"
         },
-        "StorageClass": {
-          "shape": "S4u"
-        }
+        "StorageClass": {}
       }
     },
     "S4w": {
@@ -4774,9 +4443,7 @@
               }
             }
           },
-          "Status": {
-            "shape": "S4s"
-          },
+          "Status": {},
           "Transitions": {
             "locationName": "Transition",
             "type": "list",
@@ -4820,14 +4487,7 @@
               "Grantee": {
                 "shape": "S30"
               },
-              "Permission": {
-                "type": "string",
-                "enum": [
-                  "FULL_CONTROL",
-                  "READ",
-                  "WRITE"
-                ]
-              }
+              "Permission": {}
             }
           }
         },
@@ -4887,7 +4547,6 @@
               "locationName": "Event"
             },
             "Event": {
-              "shape": "S5r",
               "deprecated": true
             },
             "Topic": {}
@@ -4898,7 +4557,6 @@
           "members": {
             "Id": {},
             "Event": {
-              "shape": "S5r",
               "deprecated": true
             },
             "Events": {
@@ -4913,7 +4571,6 @@
           "members": {
             "Id": {},
             "Event": {
-              "shape": "S5r",
               "deprecated": true
             },
             "Events": {
@@ -4928,24 +4585,8 @@
     },
     "S5q": {
       "type": "list",
-      "member": {
-        "shape": "S5r"
-      },
+      "member": {},
       "flattened": true
-    },
-    "S5r": {
-      "type": "string",
-      "enum": [
-        "s3:ReducedRedundancyLostObject",
-        "s3:ObjectCreated:*",
-        "s3:ObjectCreated:Put",
-        "s3:ObjectCreated:Post",
-        "s3:ObjectCreated:Copy",
-        "s3:ObjectCreated:CompleteMultipartUpload",
-        "s3:ObjectRemoved:*",
-        "s3:ObjectRemoved:Delete",
-        "s3:ObjectRemoved:DeleteMarkerCreated"
-      ]
     },
     "S5y": {
       "type": "structure",
@@ -5040,13 +4681,7 @@
               "member": {
                 "type": "structure",
                 "members": {
-                  "Name": {
-                    "type": "string",
-                    "enum": [
-                      "prefix",
-                      "suffix"
-                    ]
-                  },
+                  "Name": {},
                   "Value": {}
                 }
               },
@@ -5101,13 +4736,7 @@
                   }
                 }
               },
-              "Status": {
-                "type": "string",
-                "enum": [
-                  "Enabled",
-                  "Disabled"
-                ]
-              },
+              "Status": {},
               "SourceSelectionCriteria": {
                 "type": "structure",
                 "members": {
@@ -5117,13 +4746,7 @@
                       "Status"
                     ],
                     "members": {
-                      "Status": {
-                        "type": "string",
-                        "enum": [
-                          "Enabled",
-                          "Disabled"
-                        ]
-                      }
+                      "Status": {}
                     }
                   }
                 }
@@ -5136,21 +4759,14 @@
                 "members": {
                   "Bucket": {},
                   "Account": {},
-                  "StorageClass": {
-                    "shape": "S16"
-                  },
+                  "StorageClass": {},
                   "AccessControlTranslation": {
                     "type": "structure",
                     "required": [
                       "Owner"
                     ],
                     "members": {
-                      "Owner": {
-                        "type": "string",
-                        "enum": [
-                          "Destination"
-                        ]
-                      }
+                      "Owner": {}
                     }
                   },
                   "EncryptionConfiguration": {
@@ -5164,13 +4780,7 @@
               "DeleteMarkerReplication": {
                 "type": "structure",
                 "members": {
-                  "Status": {
-                    "type": "string",
-                    "enum": [
-                      "Enabled",
-                      "Disabled"
-                    ]
-                  }
+                  "Status": {}
                 }
               }
             }
@@ -5179,20 +4789,6 @@
         }
       }
     },
-    "S71": {
-      "type": "string",
-      "enum": [
-        "Requester",
-        "BucketOwner"
-      ]
-    },
-    "S76": {
-      "type": "string",
-      "enum": [
-        "Enabled",
-        "Suspended"
-      ]
-    },
     "S7a": {
       "type": "structure",
       "required": [
@@ -5200,17 +4796,8 @@
       ],
       "members": {
         "HostName": {},
-        "Protocol": {
-          "shape": "S7c"
-        }
+        "Protocol": {}
       }
-    },
-    "S7c": {
-      "type": "string",
-      "enum": [
-        "http",
-        "https"
-      ]
     },
     "S7d": {
       "type": "structure",
@@ -5227,9 +4814,7 @@
         "Key"
       ],
       "members": {
-        "Key": {
-          "shape": "S3"
-        }
+        "Key": {}
       }
     },
     "S7g": {
@@ -5253,30 +4838,13 @@
             "members": {
               "HostName": {},
               "HttpRedirectCode": {},
-              "Protocol": {
-                "shape": "S7c"
-              },
+              "Protocol": {},
               "ReplaceKeyPrefixWith": {},
               "ReplaceKeyWith": {}
             }
           }
         }
       }
-    },
-    "S88": {
-      "type": "string",
-      "enum": [
-        "COMPLETE",
-        "PENDING",
-        "FAILED",
-        "REPLICA"
-      ]
-    },
-    "S92": {
-      "type": "string",
-      "enum": [
-        "url"
-      ]
     },
     "S9c": {
       "type": "structure",
@@ -5300,9 +4868,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S3"
-          },
+          "Key": {},
           "LastModified": {
             "type": "timestamp"
           },
@@ -5310,16 +4876,7 @@
           "Size": {
             "type": "integer"
           },
-          "StorageClass": {
-            "type": "string",
-            "enum": [
-              "STANDARD",
-              "REDUCED_REDUNDANCY",
-              "GLACIER",
-              "STANDARD_IA",
-              "ONEZONE_IA"
-            ]
-          },
+          "StorageClass": {},
           "Owner": {
             "shape": "S2v"
           }
@@ -5350,28 +4907,13 @@
         }
       }
     },
-    "Sbe": {
-      "type": "string",
-      "enum": [
-        "Standard",
-        "Bulk",
-        "Expedited"
-      ]
-    },
     "Sbi": {
       "type": "structure",
       "members": {
         "CSV": {
           "type": "structure",
           "members": {
-            "FileHeaderInfo": {
-              "type": "string",
-              "enum": [
-                "USE",
-                "IGNORE",
-                "NONE"
-              ]
-            },
+            "FileHeaderInfo": {},
             "Comments": {},
             "QuoteEscapeCharacter": {},
             "RecordDelimiter": {},
@@ -5382,24 +4924,11 @@
             }
           }
         },
-        "CompressionType": {
-          "type": "string",
-          "enum": [
-            "NONE",
-            "GZIP",
-            "BZIP2"
-          ]
-        },
+        "CompressionType": {},
         "JSON": {
           "type": "structure",
           "members": {
-            "Type": {
-              "type": "string",
-              "enum": [
-                "DOCUMENT",
-                "LINES"
-              ]
-            }
+            "Type": {}
           }
         },
         "Parquet": {
@@ -5408,25 +4937,13 @@
         }
       }
     },
-    "Sbv": {
-      "type": "string",
-      "enum": [
-        "SQL"
-      ]
-    },
     "Sbx": {
       "type": "structure",
       "members": {
         "CSV": {
           "type": "structure",
           "members": {
-            "QuoteFields": {
-              "type": "string",
-              "enum": [
-                "ALWAYS",
-                "ASNEEDED"
-              ]
-            },
+            "QuoteFields": {},
             "QuoteEscapeCharacter": {},
             "RecordDelimiter": {},
             "FieldDelimiter": {},

--- a/apis/sagemaker-2017-07-24.min.json
+++ b/apis/sagemaker-2017-07-24.min.json
@@ -22,9 +22,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          },
+          "ResourceArn": {},
           "Tags": {
             "shape": "S3"
           }
@@ -47,12 +45,8 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          },
-          "EndpointConfigName": {
-            "shape": "Sa"
-          },
+          "EndpointName": {},
+          "EndpointConfigName": {},
           "Tags": {
             "shape": "S3"
           }
@@ -64,9 +58,7 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {
-            "shape": "Sc"
-          }
+          "EndpointArn": {}
         }
       }
     },
@@ -78,18 +70,14 @@
           "ProductionVariants"
         ],
         "members": {
-          "EndpointConfigName": {
-            "shape": "Sa"
-          },
+          "EndpointConfigName": {},
           "ProductionVariants": {
             "shape": "Se"
           },
           "Tags": {
             "shape": "S3"
           },
-          "KmsKeyId": {
-            "shape": "Sl"
-          }
+          "KmsKeyId": {}
         }
       },
       "output": {
@@ -98,9 +86,7 @@
           "EndpointConfigArn"
         ],
         "members": {
-          "EndpointConfigArn": {
-            "shape": "Sn"
-          }
+          "EndpointConfigArn": {}
         }
       }
     },
@@ -113,9 +99,7 @@
           "TrainingJobDefinition"
         ],
         "members": {
-          "HyperParameterTuningJobName": {
-            "shape": "Sp"
-          },
+          "HyperParameterTuningJobName": {},
           "HyperParameterTuningJobConfig": {
             "shape": "Sq"
           },
@@ -133,9 +117,7 @@
           "HyperParameterTuningJobArn"
         ],
         "members": {
-          "HyperParameterTuningJobArn": {
-            "shape": "S25"
-          }
+          "HyperParameterTuningJobArn": {}
         }
       }
     },
@@ -148,15 +130,11 @@
           "ExecutionRoleArn"
         ],
         "members": {
-          "ModelName": {
-            "shape": "Sh"
-          },
+          "ModelName": {},
           "PrimaryContainer": {
             "shape": "S27"
           },
-          "ExecutionRoleArn": {
-            "shape": "S1g"
-          },
+          "ExecutionRoleArn": {},
           "Tags": {
             "shape": "S3"
           },
@@ -171,9 +149,7 @@
           "ModelArn"
         ],
         "members": {
-          "ModelArn": {
-            "shape": "S2f"
-          }
+          "ModelArn": {}
         }
       }
     },
@@ -186,41 +162,25 @@
           "RoleArn"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          },
-          "InstanceType": {
-            "shape": "S2i"
-          },
-          "SubnetId": {
-            "shape": "S1w"
-          },
+          "NotebookInstanceName": {},
+          "InstanceType": {},
+          "SubnetId": {},
           "SecurityGroupIds": {
             "shape": "S2j"
           },
-          "RoleArn": {
-            "shape": "S1g"
-          },
-          "KmsKeyId": {
-            "shape": "Sl"
-          },
+          "RoleArn": {},
+          "KmsKeyId": {},
           "Tags": {
             "shape": "S3"
           },
-          "LifecycleConfigName": {
-            "shape": "S2k"
-          },
-          "DirectInternetAccess": {
-            "shape": "S2l"
-          }
+          "LifecycleConfigName": {},
+          "DirectInternetAccess": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceArn": {
-            "shape": "S2n"
-          }
+          "NotebookInstanceArn": {}
         }
       }
     },
@@ -231,9 +191,7 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          },
+          "NotebookInstanceLifecycleConfigName": {},
           "OnCreate": {
             "shape": "S2p"
           },
@@ -245,9 +203,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceLifecycleConfigArn": {
-            "shape": "S2t"
-          }
+          "NotebookInstanceLifecycleConfigArn": {}
         }
       }
     },
@@ -258,13 +214,9 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          },
+          "NotebookInstanceName": {},
           "SessionExpirationDurationInSeconds": {
-            "type": "integer",
-            "max": 43200,
-            "min": 1800
+            "type": "integer"
           }
         }
       },
@@ -288,18 +240,14 @@
           "StoppingCondition"
         ],
         "members": {
-          "TrainingJobName": {
-            "shape": "S2z"
-          },
+          "TrainingJobName": {},
           "HyperParameters": {
             "shape": "S19"
           },
           "AlgorithmSpecification": {
             "shape": "S30"
           },
-          "RoleArn": {
-            "shape": "S1g"
-          },
+          "RoleArn": {},
           "InputDataConfig": {
             "shape": "S1h"
           },
@@ -326,9 +274,7 @@
           "TrainingJobArn"
         ],
         "members": {
-          "TrainingJobArn": {
-            "shape": "S32"
-          }
+          "TrainingJobArn": {}
         }
       }
     },
@@ -343,21 +289,15 @@
           "TransformResources"
         ],
         "members": {
-          "TransformJobName": {
-            "shape": "S34"
-          },
-          "ModelName": {
-            "shape": "Sh"
-          },
+          "TransformJobName": {},
+          "ModelName": {},
           "MaxConcurrentTransforms": {
-            "shape": "S35"
+            "type": "integer"
           },
           "MaxPayloadInMB": {
-            "shape": "S36"
+            "type": "integer"
           },
-          "BatchStrategy": {
-            "shape": "S37"
-          },
+          "BatchStrategy": {},
           "Environment": {
             "shape": "S38"
           },
@@ -381,9 +321,7 @@
           "TransformJobArn"
         ],
         "members": {
-          "TransformJobArn": {
-            "shape": "S3m"
-          }
+          "TransformJobArn": {}
         }
       }
     },
@@ -394,9 +332,7 @@
           "EndpointName"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          }
+          "EndpointName": {}
         }
       }
     },
@@ -407,9 +343,7 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointConfigName": {
-            "shape": "Sa"
-          }
+          "EndpointConfigName": {}
         }
       }
     },
@@ -420,9 +354,7 @@
           "ModelName"
         ],
         "members": {
-          "ModelName": {
-            "shape": "Sh"
-          }
+          "ModelName": {}
         }
       }
     },
@@ -433,9 +365,7 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          }
+          "NotebookInstanceName": {}
         }
       }
     },
@@ -446,9 +376,7 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          }
+          "NotebookInstanceLifecycleConfigName": {}
         }
       }
     },
@@ -460,16 +388,10 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          },
+          "ResourceArn": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S5"
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -485,9 +407,7 @@
           "EndpointName"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          }
+          "EndpointName": {}
         }
       },
       "output": {
@@ -501,15 +421,9 @@
           "LastModifiedTime"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          },
-          "EndpointArn": {
-            "shape": "Sc"
-          },
-          "EndpointConfigName": {
-            "shape": "Sa"
-          },
+          "EndpointName": {},
+          "EndpointArn": {},
+          "EndpointConfigName": {},
           "ProductionVariants": {
             "type": "list",
             "member": {
@@ -518,20 +432,14 @@
                 "VariantName"
               ],
               "members": {
-                "VariantName": {
-                  "shape": "Sg"
-                },
+                "VariantName": {},
                 "DeployedImages": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "SpecifiedImage": {
-                        "shape": "S29"
-                      },
-                      "ResolvedImage": {
-                        "shape": "S29"
-                      },
+                      "SpecifiedImage": {},
+                      "ResolvedImage": {},
                       "ResolutionTime": {
                         "type": "timestamp"
                       }
@@ -539,27 +447,22 @@
                   }
                 },
                 "CurrentWeight": {
-                  "shape": "Sk"
+                  "type": "float"
                 },
                 "DesiredWeight": {
-                  "shape": "Sk"
+                  "type": "float"
                 },
                 "CurrentInstanceCount": {
-                  "shape": "Si"
+                  "type": "integer"
                 },
                 "DesiredInstanceCount": {
-                  "shape": "Si"
+                  "type": "integer"
                 }
               }
-            },
-            "min": 1
+            }
           },
-          "EndpointStatus": {
-            "shape": "S42"
-          },
-          "FailureReason": {
-            "shape": "S43"
-          },
+          "EndpointStatus": {},
+          "FailureReason": {},
           "CreationTime": {
             "type": "timestamp"
           },
@@ -576,9 +479,7 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointConfigName": {
-            "shape": "Sa"
-          }
+          "EndpointConfigName": {}
         }
       },
       "output": {
@@ -590,18 +491,12 @@
           "CreationTime"
         ],
         "members": {
-          "EndpointConfigName": {
-            "shape": "Sa"
-          },
-          "EndpointConfigArn": {
-            "shape": "Sn"
-          },
+          "EndpointConfigName": {},
+          "EndpointConfigArn": {},
           "ProductionVariants": {
             "shape": "Se"
           },
-          "KmsKeyId": {
-            "shape": "Sl"
-          },
+          "KmsKeyId": {},
           "CreationTime": {
             "type": "timestamp"
           }
@@ -615,9 +510,7 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {
-            "shape": "Sp"
-          }
+          "HyperParameterTuningJobName": {}
         }
       },
       "output": {
@@ -633,21 +526,15 @@
           "ObjectiveStatusCounters"
         ],
         "members": {
-          "HyperParameterTuningJobName": {
-            "shape": "Sp"
-          },
-          "HyperParameterTuningJobArn": {
-            "shape": "S25"
-          },
+          "HyperParameterTuningJobName": {},
+          "HyperParameterTuningJobArn": {},
           "HyperParameterTuningJobConfig": {
             "shape": "Sq"
           },
           "TrainingJobDefinition": {
             "shape": "S18"
           },
-          "HyperParameterTuningJobStatus": {
-            "shape": "S48"
-          },
+          "HyperParameterTuningJobStatus": {},
           "CreationTime": {
             "type": "timestamp"
           },
@@ -666,9 +553,7 @@
           "BestTrainingJob": {
             "shape": "S4d"
           },
-          "FailureReason": {
-            "shape": "S43"
-          }
+          "FailureReason": {}
         }
       }
     },
@@ -679,9 +564,7 @@
           "ModelName"
         ],
         "members": {
-          "ModelName": {
-            "shape": "Sh"
-          }
+          "ModelName": {}
         }
       },
       "output": {
@@ -694,24 +577,18 @@
           "ModelArn"
         ],
         "members": {
-          "ModelName": {
-            "shape": "Sh"
-          },
+          "ModelName": {},
           "PrimaryContainer": {
             "shape": "S27"
           },
-          "ExecutionRoleArn": {
-            "shape": "S1g"
-          },
+          "ExecutionRoleArn": {},
           "VpcConfig": {
             "shape": "S1s"
           },
           "CreationTime": {
             "type": "timestamp"
           },
-          "ModelArn": {
-            "shape": "S2f"
-          }
+          "ModelArn": {}
         }
       }
     },
@@ -722,42 +599,24 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          }
+          "NotebookInstanceName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceArn": {
-            "shape": "S2n"
-          },
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          },
-          "NotebookInstanceStatus": {
-            "shape": "S4m"
-          },
-          "FailureReason": {
-            "shape": "S43"
-          },
+          "NotebookInstanceArn": {},
+          "NotebookInstanceName": {},
+          "NotebookInstanceStatus": {},
+          "FailureReason": {},
           "Url": {},
-          "InstanceType": {
-            "shape": "S2i"
-          },
-          "SubnetId": {
-            "shape": "S1w"
-          },
+          "InstanceType": {},
+          "SubnetId": {},
           "SecurityGroups": {
             "shape": "S2j"
           },
-          "RoleArn": {
-            "shape": "S1g"
-          },
-          "KmsKeyId": {
-            "shape": "Sl"
-          },
+          "RoleArn": {},
+          "KmsKeyId": {},
           "NetworkInterfaceId": {},
           "LastModifiedTime": {
             "type": "timestamp"
@@ -765,12 +624,8 @@
           "CreationTime": {
             "type": "timestamp"
           },
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          },
-          "DirectInternetAccess": {
-            "shape": "S2l"
-          }
+          "NotebookInstanceLifecycleConfigName": {},
+          "DirectInternetAccess": {}
         }
       }
     },
@@ -781,20 +636,14 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          }
+          "NotebookInstanceLifecycleConfigName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NotebookInstanceLifecycleConfigArn": {
-            "shape": "S2t"
-          },
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          },
+          "NotebookInstanceLifecycleConfigArn": {},
+          "NotebookInstanceLifecycleConfigName": {},
           "OnCreate": {
             "shape": "S2p"
           },
@@ -817,9 +666,7 @@
           "TrainingJobName"
         ],
         "members": {
-          "TrainingJobName": {
-            "shape": "S2z"
-          }
+          "TrainingJobName": {}
         }
       },
       "output": {
@@ -837,44 +684,28 @@
           "CreationTime"
         ],
         "members": {
-          "TrainingJobName": {
-            "shape": "S2z"
-          },
-          "TrainingJobArn": {
-            "shape": "S32"
-          },
-          "TuningJobArn": {
-            "shape": "S25"
-          },
+          "TrainingJobName": {},
+          "TrainingJobArn": {},
+          "TuningJobArn": {},
           "ModelArtifacts": {
             "type": "structure",
             "required": [
               "S3ModelArtifacts"
             ],
             "members": {
-              "S3ModelArtifacts": {
-                "shape": "S1n"
-              }
+              "S3ModelArtifacts": {}
             }
           },
-          "TrainingJobStatus": {
-            "shape": "S4e"
-          },
-          "SecondaryStatus": {
-            "shape": "S4v"
-          },
-          "FailureReason": {
-            "shape": "S43"
-          },
+          "TrainingJobStatus": {},
+          "SecondaryStatus": {},
+          "FailureReason": {},
           "HyperParameters": {
             "shape": "S19"
           },
           "AlgorithmSpecification": {
             "shape": "S30"
           },
-          "RoleArn": {
-            "shape": "S1g"
-          },
+          "RoleArn": {},
           "InputDataConfig": {
             "shape": "S1h"
           },
@@ -911,9 +742,7 @@
                 "StartTime"
               ],
               "members": {
-                "Status": {
-                  "shape": "S4v"
-                },
+                "Status": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -934,9 +763,7 @@
           "TransformJobName"
         ],
         "members": {
-          "TransformJobName": {
-            "shape": "S34"
-          }
+          "TransformJobName": {}
         }
       },
       "output": {
@@ -951,30 +778,18 @@
           "CreationTime"
         ],
         "members": {
-          "TransformJobName": {
-            "shape": "S34"
-          },
-          "TransformJobArn": {
-            "shape": "S3m"
-          },
-          "TransformJobStatus": {
-            "shape": "S51"
-          },
-          "FailureReason": {
-            "shape": "S43"
-          },
-          "ModelName": {
-            "shape": "Sh"
-          },
+          "TransformJobName": {},
+          "TransformJobArn": {},
+          "TransformJobStatus": {},
+          "FailureReason": {},
+          "ModelName": {},
           "MaxConcurrentTransforms": {
-            "shape": "S35"
+            "type": "integer"
           },
           "MaxPayloadInMB": {
-            "shape": "S36"
+            "type": "integer"
           },
-          "BatchStrategy": {
-            "shape": "S37"
-          },
+          "BatchStrategy": {},
           "Environment": {
             "shape": "S38"
           },
@@ -1003,26 +818,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime"
-            ]
-          },
-          "SortOrder": {
-            "shape": "S54"
-          },
-          "NextToken": {
-            "shape": "S55"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "NameContains": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9-]+"
-          },
+          "NameContains": {},
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1047,21 +849,15 @@
                 "CreationTime"
               ],
               "members": {
-                "EndpointConfigName": {
-                  "shape": "Sa"
-                },
-                "EndpointConfigArn": {
-                  "shape": "Sn"
-                },
+                "EndpointConfigName": {},
+                "EndpointConfigArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S55"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1069,27 +865,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime",
-              "Status"
-            ]
-          },
-          "SortOrder": {
-            "shape": "S54"
-          },
-          "NextToken": {
-            "shape": "S55"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "NameContains": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9-]+"
-          },
+          "NameContains": {},
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1102,9 +884,7 @@
           "LastModifiedTimeAfter": {
             "type": "timestamp"
           },
-          "StatusEquals": {
-            "shape": "S42"
-          }
+          "StatusEquals": {}
         }
       },
       "output": {
@@ -1125,27 +905,19 @@
                 "EndpointStatus"
               ],
               "members": {
-                "EndpointName": {
-                  "shape": "S9"
-                },
-                "EndpointArn": {
-                  "shape": "Sc"
-                },
+                "EndpointName": {},
+                "EndpointArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "EndpointStatus": {
-                  "shape": "S42"
-                }
+                "EndpointStatus": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S55"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1153,26 +925,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "Status",
-              "CreationTime"
-            ]
-          },
-          "SortOrder": {
-            "shape": "S5k"
-          },
-          "NameContains": {
-            "shape": "S5l"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NameContains": {},
           "CreationTimeAfter": {
             "type": "timestamp"
           },
@@ -1185,9 +944,7 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "StatusEquals": {
-            "shape": "S48"
-          }
+          "StatusEquals": {}
         }
       },
       "output": {
@@ -1210,18 +967,10 @@
                 "ObjectiveStatusCounters"
               ],
               "members": {
-                "HyperParameterTuningJobName": {
-                  "shape": "Sp"
-                },
-                "HyperParameterTuningJobArn": {
-                  "shape": "S25"
-                },
-                "HyperParameterTuningJobStatus": {
-                  "shape": "S48"
-                },
-                "Strategy": {
-                  "shape": "Sr"
-                },
+                "HyperParameterTuningJobName": {},
+                "HyperParameterTuningJobArn": {},
+                "HyperParameterTuningJobStatus": {},
+                "Strategy": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1243,9 +992,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S5i"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1253,26 +1000,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime"
-            ]
-          },
-          "SortOrder": {
-            "shape": "S54"
-          },
-          "NextToken": {
-            "shape": "S55"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "NameContains": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9-]+"
-          },
+          "NameContains": {},
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1297,21 +1031,15 @@
                 "CreationTime"
               ],
               "members": {
-                "ModelName": {
-                  "shape": "Sh"
-                },
-                "ModelArn": {
-                  "shape": "S2f"
-                },
+                "ModelName": {},
+                "ModelArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S55"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1319,31 +1047,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime",
-              "LastModifiedTime"
-            ]
-          },
-          "SortOrder": {
-            "type": "string",
-            "enum": [
-              "Ascending",
-              "Descending"
-            ]
-          },
-          "NameContains": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9-]+"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NameContains": {},
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1361,9 +1071,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "NotebookInstanceLifecycleConfigs": {
             "type": "list",
             "member": {
@@ -1373,12 +1081,8 @@
                 "NotebookInstanceLifecycleConfigArn"
               ],
               "members": {
-                "NotebookInstanceLifecycleConfigName": {
-                  "shape": "S2k"
-                },
-                "NotebookInstanceLifecycleConfigArn": {
-                  "shape": "S2t"
-                },
+                "NotebookInstanceLifecycleConfigName": {},
+                "NotebookInstanceLifecycleConfigArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1395,31 +1099,13 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime",
-              "Status"
-            ]
-          },
-          "SortOrder": {
-            "type": "string",
-            "enum": [
-              "Ascending",
-              "Descending"
-            ]
-          },
-          "NameContains": {
-            "type": "string",
-            "pattern": "[a-zA-Z0-9-]+"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "NameContains": {},
           "CreationTimeBefore": {
             "type": "timestamp"
           },
@@ -1432,20 +1118,14 @@
           "LastModifiedTimeAfter": {
             "type": "timestamp"
           },
-          "StatusEquals": {
-            "shape": "S4m"
-          },
-          "NotebookInstanceLifecycleConfigNameContains": {
-            "shape": "S2k"
-          }
+          "StatusEquals": {},
+          "NotebookInstanceLifecycleConfigNameContains": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "NotebookInstances": {
             "type": "list",
             "member": {
@@ -1455,28 +1135,18 @@
                 "NotebookInstanceArn"
               ],
               "members": {
-                "NotebookInstanceName": {
-                  "shape": "S2h"
-                },
-                "NotebookInstanceArn": {
-                  "shape": "S2n"
-                },
-                "NotebookInstanceStatus": {
-                  "shape": "S4m"
-                },
+                "NotebookInstanceName": {},
+                "NotebookInstanceArn": {},
+                "NotebookInstanceStatus": {},
                 "Url": {},
-                "InstanceType": {
-                  "shape": "S2i"
-                },
+                "InstanceType": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "NotebookInstanceLifecycleConfigName": {
-                  "shape": "S2k"
-                }
+                "NotebookInstanceLifecycleConfigName": {}
               }
             }
           }
@@ -1490,15 +1160,10 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "ResourceArn": {},
+          "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "min": 50
+            "type": "integer"
           }
         }
       },
@@ -1508,9 +1173,7 @@
           "Tags": {
             "shape": "S3"
           },
-          "NextToken": {
-            "shape": "S5i"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1518,11 +1181,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
           "CreationTimeAfter": {
             "type": "timestamp"
@@ -1536,18 +1197,10 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "NameContains": {
-            "shape": "S5l"
-          },
-          "StatusEquals": {
-            "shape": "S4e"
-          },
-          "SortBy": {
-            "shape": "S6d"
-          },
-          "SortOrder": {
-            "shape": "S5k"
-          }
+          "NameContains": {},
+          "StatusEquals": {},
+          "SortBy": {},
+          "SortOrder": {}
         }
       },
       "output": {
@@ -1567,12 +1220,8 @@
                 "TrainingJobStatus"
               ],
               "members": {
-                "TrainingJobName": {
-                  "shape": "S2z"
-                },
-                "TrainingJobArn": {
-                  "shape": "S32"
-                },
+                "TrainingJobName": {},
+                "TrainingJobArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1582,15 +1231,11 @@
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "TrainingJobStatus": {
-                  "shape": "S4e"
-                }
+                "TrainingJobStatus": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S5i"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1601,30 +1246,14 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {
-            "shape": "Sp"
-          },
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "HyperParameterTuningJobName": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           },
-          "StatusEquals": {
-            "shape": "S4e"
-          },
-          "SortBy": {
-            "type": "string",
-            "enum": [
-              "Name",
-              "CreationTime",
-              "Status",
-              "FinalObjectiveMetricValue"
-            ]
-          },
-          "SortOrder": {
-            "shape": "S5k"
-          }
+          "StatusEquals": {},
+          "SortBy": {},
+          "SortOrder": {}
         }
       },
       "output": {
@@ -1639,9 +1268,7 @@
               "shape": "S4d"
             }
           },
-          "NextToken": {
-            "shape": "S5i"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1661,23 +1288,13 @@
           "LastModifiedTimeBefore": {
             "type": "timestamp"
           },
-          "NameContains": {
-            "shape": "S5l"
-          },
-          "StatusEquals": {
-            "shape": "S51"
-          },
-          "SortBy": {
-            "shape": "S6d"
-          },
-          "SortOrder": {
-            "shape": "S5k"
-          },
-          "NextToken": {
-            "shape": "S5i"
-          },
+          "NameContains": {},
+          "StatusEquals": {},
+          "SortBy": {},
+          "SortOrder": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S56"
+            "type": "integer"
           }
         }
       },
@@ -1698,12 +1315,8 @@
                 "TransformJobStatus"
               ],
               "members": {
-                "TransformJobName": {
-                  "shape": "S34"
-                },
-                "TransformJobArn": {
-                  "shape": "S3m"
-                },
+                "TransformJobName": {},
+                "TransformJobArn": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
@@ -1713,18 +1326,12 @@
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "TransformJobStatus": {
-                  "shape": "S51"
-                },
-                "FailureReason": {
-                  "shape": "S43"
-                }
+                "TransformJobStatus": {},
+                "FailureReason": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S5i"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -1735,9 +1342,7 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          }
+          "NotebookInstanceName": {}
         }
       }
     },
@@ -1748,9 +1353,7 @@
           "HyperParameterTuningJobName"
         ],
         "members": {
-          "HyperParameterTuningJobName": {
-            "shape": "Sp"
-          }
+          "HyperParameterTuningJobName": {}
         }
       }
     },
@@ -1761,9 +1364,7 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          }
+          "NotebookInstanceName": {}
         }
       }
     },
@@ -1774,9 +1375,7 @@
           "TrainingJobName"
         ],
         "members": {
-          "TrainingJobName": {
-            "shape": "S2z"
-          }
+          "TrainingJobName": {}
         }
       }
     },
@@ -1787,9 +1386,7 @@
           "TransformJobName"
         ],
         "members": {
-          "TransformJobName": {
-            "shape": "S34"
-          }
+          "TransformJobName": {}
         }
       }
     },
@@ -1801,12 +1398,8 @@
           "EndpointConfigName"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          },
-          "EndpointConfigName": {
-            "shape": "Sa"
-          }
+          "EndpointName": {},
+          "EndpointConfigName": {}
         }
       },
       "output": {
@@ -1815,9 +1408,7 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {
-            "shape": "Sc"
-          }
+          "EndpointArn": {}
         }
       }
     },
@@ -1829,9 +1420,7 @@
           "DesiredWeightsAndCapacities"
         ],
         "members": {
-          "EndpointName": {
-            "shape": "S9"
-          },
+          "EndpointName": {},
           "DesiredWeightsAndCapacities": {
             "type": "list",
             "member": {
@@ -1840,18 +1429,15 @@
                 "VariantName"
               ],
               "members": {
-                "VariantName": {
-                  "shape": "Sg"
-                },
+                "VariantName": {},
                 "DesiredWeight": {
-                  "shape": "Sk"
+                  "type": "float"
                 },
                 "DesiredInstanceCount": {
-                  "shape": "Si"
+                  "type": "integer"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
@@ -1861,9 +1447,7 @@
           "EndpointArn"
         ],
         "members": {
-          "EndpointArn": {
-            "shape": "Sc"
-          }
+          "EndpointArn": {}
         }
       }
     },
@@ -1874,18 +1458,10 @@
           "NotebookInstanceName"
         ],
         "members": {
-          "NotebookInstanceName": {
-            "shape": "S2h"
-          },
-          "InstanceType": {
-            "shape": "S2i"
-          },
-          "RoleArn": {
-            "shape": "S1g"
-          },
-          "LifecycleConfigName": {
-            "shape": "S2k"
-          },
+          "NotebookInstanceName": {},
+          "InstanceType": {},
+          "RoleArn": {},
+          "LifecycleConfigName": {},
           "DisassociateLifecycleConfig": {
             "type": "boolean"
           }
@@ -1903,9 +1479,7 @@
           "NotebookInstanceLifecycleConfigName"
         ],
         "members": {
-          "NotebookInstanceLifecycleConfigName": {
-            "shape": "S2k"
-          },
+          "NotebookInstanceLifecycleConfigName": {},
           "OnCreate": {
             "shape": "S2p"
           },
@@ -1921,10 +1495,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 256
-    },
     "S3": {
       "type": "list",
       "member": {
@@ -1934,40 +1504,10 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S5"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
-      },
-      "max": 50,
-      "min": 0
-    },
-    "S5": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^((?!aws:)[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "S9": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "Sc": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
+      }
     },
     "Se": {
       "type": "list",
@@ -1980,91 +1520,17 @@
           "InstanceType"
         ],
         "members": {
-          "VariantName": {
-            "shape": "Sg"
-          },
-          "ModelName": {
-            "shape": "Sh"
-          },
+          "VariantName": {},
+          "ModelName": {},
           "InitialInstanceCount": {
-            "shape": "Si"
+            "type": "integer"
           },
-          "InstanceType": {
-            "type": "string",
-            "enum": [
-              "ml.t2.medium",
-              "ml.t2.large",
-              "ml.t2.xlarge",
-              "ml.t2.2xlarge",
-              "ml.m4.xlarge",
-              "ml.m4.2xlarge",
-              "ml.m4.4xlarge",
-              "ml.m4.10xlarge",
-              "ml.m4.16xlarge",
-              "ml.m5.large",
-              "ml.m5.xlarge",
-              "ml.m5.2xlarge",
-              "ml.m5.4xlarge",
-              "ml.m5.12xlarge",
-              "ml.m5.24xlarge",
-              "ml.c4.large",
-              "ml.c4.xlarge",
-              "ml.c4.2xlarge",
-              "ml.c4.4xlarge",
-              "ml.c4.8xlarge",
-              "ml.p2.xlarge",
-              "ml.p2.8xlarge",
-              "ml.p2.16xlarge",
-              "ml.p3.2xlarge",
-              "ml.p3.8xlarge",
-              "ml.p3.16xlarge",
-              "ml.c5.large",
-              "ml.c5.xlarge",
-              "ml.c5.2xlarge",
-              "ml.c5.4xlarge",
-              "ml.c5.9xlarge",
-              "ml.c5.18xlarge"
-            ]
-          },
+          "InstanceType": {},
           "InitialVariantWeight": {
-            "shape": "Sk"
+            "type": "float"
           }
         }
-      },
-      "min": 1
-    },
-    "Sg": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "Sh": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "Si": {
-      "type": "integer",
-      "min": 1
-    },
-    "Sk": {
-      "type": "float",
-      "min": 0
-    },
-    "Sl": {
-      "type": "string",
-      "max": 2048
-    },
-    "Sn": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "Sp": {
-      "type": "string",
-      "max": 32,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+      }
     },
     "Sq": {
       "type": "structure",
@@ -2075,9 +1541,7 @@
         "ParameterRanges"
       ],
       "members": {
-        "Strategy": {
-          "shape": "Sr"
-        },
+        "Strategy": {},
         "HyperParameterTuningJobObjective": {
           "type": "structure",
           "required": [
@@ -2085,12 +1549,8 @@
             "MetricName"
           ],
           "members": {
-            "Type": {
-              "shape": "St"
-            },
-            "MetricName": {
-              "shape": "Su"
-            }
+            "Type": {},
+            "MetricName": {}
           }
         },
         "ResourceLimits": {
@@ -2109,19 +1569,11 @@
                   "MaxValue"
                 ],
                 "members": {
-                  "Name": {
-                    "shape": "S11"
-                  },
-                  "MinValue": {
-                    "shape": "S12"
-                  },
-                  "MaxValue": {
-                    "shape": "S12"
-                  }
+                  "Name": {},
+                  "MinValue": {},
+                  "MaxValue": {}
                 }
-              },
-              "max": 20,
-              "min": 0
+              }
             },
             "ContinuousParameterRanges": {
               "type": "list",
@@ -2133,19 +1585,11 @@
                   "MaxValue"
                 ],
                 "members": {
-                  "Name": {
-                    "shape": "S11"
-                  },
-                  "MinValue": {
-                    "shape": "S12"
-                  },
-                  "MaxValue": {
-                    "shape": "S12"
-                  }
+                  "Name": {},
+                  "MinValue": {},
+                  "MaxValue": {}
                 }
-              },
-              "max": 20,
-              "min": 0
+              }
             },
             "CategoricalParameterRanges": {
               "type": "list",
@@ -2156,43 +1600,17 @@
                   "Values"
                 ],
                 "members": {
-                  "Name": {
-                    "shape": "S11"
-                  },
+                  "Name": {},
                   "Values": {
                     "type": "list",
-                    "member": {
-                      "shape": "S12"
-                    },
-                    "max": 20,
-                    "min": 1
+                    "member": {}
                   }
                 }
-              },
-              "max": 20,
-              "min": 0
+              }
             }
           }
         }
       }
-    },
-    "Sr": {
-      "type": "string",
-      "enum": [
-        "Bayesian"
-      ]
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "Maximize",
-        "Minimize"
-      ]
-    },
-    "Su": {
-      "type": "string",
-      "max": 255,
-      "min": 1
     },
     "Sv": {
       "type": "structure",
@@ -2202,22 +1620,12 @@
       ],
       "members": {
         "MaxNumberOfTrainingJobs": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "MaxParallelTrainingJobs": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         }
       }
-    },
-    "S11": {
-      "type": "string",
-      "max": 256
-    },
-    "S12": {
-      "type": "string",
-      "max": 256
     },
     "S18": {
       "type": "structure",
@@ -2240,12 +1648,8 @@
             "TrainingInputMode"
           ],
           "members": {
-            "TrainingImage": {
-              "shape": "S1b"
-            },
-            "TrainingInputMode": {
-              "shape": "S1c"
-            },
+            "TrainingImage": {},
+            "TrainingInputMode": {},
             "MetricDefinitions": {
               "type": "list",
               "member": {
@@ -2255,24 +1659,14 @@
                   "Regex"
                 ],
                 "members": {
-                  "Name": {
-                    "shape": "Su"
-                  },
-                  "Regex": {
-                    "type": "string",
-                    "max": 500,
-                    "min": 1
-                  }
+                  "Name": {},
+                  "Regex": {}
                 }
-              },
-              "max": 20,
-              "min": 0
+              }
             }
           }
         },
-        "RoleArn": {
-          "shape": "S1g"
-        },
+        "RoleArn": {},
         "InputDataConfig": {
           "shape": "S1h"
         },
@@ -2292,31 +1686,8 @@
     },
     "S19": {
       "type": "map",
-      "key": {
-        "shape": "S11"
-      },
-      "value": {
-        "shape": "S12"
-      },
-      "max": 100,
-      "min": 0
-    },
-    "S1b": {
-      "type": "string",
-      "max": 255
-    },
-    "S1c": {
-      "type": "string",
-      "enum": [
-        "Pipe",
-        "File"
-      ]
-    },
-    "S1g": {
-      "type": "string",
-      "max": 2048,
-      "min": 20,
-      "pattern": "^arn:aws[a-z\\-]*:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+      "key": {},
+      "value": {}
     },
     "S1h": {
       "type": "list",
@@ -2327,12 +1698,7 @@
           "DataSource"
         ],
         "members": {
-          "ChannelName": {
-            "type": "string",
-            "max": 64,
-            "min": 1,
-            "pattern": "[A-Za-z0-9\\.\\-_]+"
-          },
+          "ChannelName": {},
           "DataSource": {
             "type": "structure",
             "required": [
@@ -2346,63 +1712,18 @@
                   "S3Uri"
                 ],
                 "members": {
-                  "S3DataType": {
-                    "shape": "S1m"
-                  },
-                  "S3Uri": {
-                    "shape": "S1n"
-                  },
-                  "S3DataDistributionType": {
-                    "type": "string",
-                    "enum": [
-                      "FullyReplicated",
-                      "ShardedByS3Key"
-                    ]
-                  }
+                  "S3DataType": {},
+                  "S3Uri": {},
+                  "S3DataDistributionType": {}
                 }
               }
             }
           },
-          "ContentType": {
-            "shape": "S1p"
-          },
-          "CompressionType": {
-            "shape": "S1q"
-          },
-          "RecordWrapperType": {
-            "type": "string",
-            "enum": [
-              "None",
-              "RecordIO"
-            ]
-          }
+          "ContentType": {},
+          "CompressionType": {},
+          "RecordWrapperType": {}
         }
-      },
-      "max": 8,
-      "min": 1
-    },
-    "S1m": {
-      "type": "string",
-      "enum": [
-        "ManifestFile",
-        "S3Prefix"
-      ]
-    },
-    "S1n": {
-      "type": "string",
-      "max": 1024,
-      "pattern": "^(https|s3)://([^/]+)/?(.*)$"
-    },
-    "S1p": {
-      "type": "string",
-      "max": 256
-    },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "None",
-        "Gzip"
-      ]
+      }
     },
     "S1s": {
       "type": "structure",
@@ -2413,29 +1734,13 @@
       "members": {
         "SecurityGroupIds": {
           "type": "list",
-          "member": {
-            "shape": "S1u"
-          },
-          "max": 5,
-          "min": 1
+          "member": {}
         },
         "Subnets": {
           "type": "list",
-          "member": {
-            "shape": "S1w"
-          },
-          "max": 16,
-          "min": 1
+          "member": {}
         }
       }
-    },
-    "S1u": {
-      "type": "string",
-      "max": 32
-    },
-    "S1w": {
-      "type": "string",
-      "max": 32
     },
     "S1x": {
       "type": "structure",
@@ -2443,12 +1748,8 @@
         "S3OutputPath"
       ],
       "members": {
-        "KmsKeyId": {
-          "shape": "Sl"
-        },
-        "S3OutputPath": {
-          "shape": "S1n"
-        }
+        "KmsKeyId": {},
+        "S3OutputPath": {}
       }
     },
     "S1y": {
@@ -2459,63 +1760,23 @@
         "VolumeSizeInGB"
       ],
       "members": {
-        "InstanceType": {
-          "type": "string",
-          "enum": [
-            "ml.m4.xlarge",
-            "ml.m4.2xlarge",
-            "ml.m4.4xlarge",
-            "ml.m4.10xlarge",
-            "ml.m4.16xlarge",
-            "ml.m5.large",
-            "ml.m5.xlarge",
-            "ml.m5.2xlarge",
-            "ml.m5.4xlarge",
-            "ml.m5.12xlarge",
-            "ml.m5.24xlarge",
-            "ml.c4.xlarge",
-            "ml.c4.2xlarge",
-            "ml.c4.4xlarge",
-            "ml.c4.8xlarge",
-            "ml.p2.xlarge",
-            "ml.p2.8xlarge",
-            "ml.p2.16xlarge",
-            "ml.p3.2xlarge",
-            "ml.p3.8xlarge",
-            "ml.p3.16xlarge",
-            "ml.c5.xlarge",
-            "ml.c5.2xlarge",
-            "ml.c5.4xlarge",
-            "ml.c5.9xlarge",
-            "ml.c5.18xlarge"
-          ]
-        },
+        "InstanceType": {},
         "InstanceCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "VolumeSizeInGB": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
-        "VolumeKmsKeyId": {
-          "shape": "Sl"
-        }
+        "VolumeKmsKeyId": {}
       }
     },
     "S22": {
       "type": "structure",
       "members": {
         "MaxRuntimeInSeconds": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         }
       }
-    },
-    "S25": {
-      "type": "string",
-      "max": 256,
-      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:hyper-parameter-tuning-job/.*"
     },
     "S27": {
       "type": "structure",
@@ -2523,115 +1784,28 @@
         "Image"
       ],
       "members": {
-        "ContainerHostname": {
-          "type": "string",
-          "max": 63,
-          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-        },
-        "Image": {
-          "shape": "S29"
-        },
-        "ModelDataUrl": {
-          "type": "string",
-          "max": 1024,
-          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
-        },
+        "ContainerHostname": {},
+        "Image": {},
+        "ModelDataUrl": {},
         "Environment": {
           "type": "map",
-          "key": {
-            "type": "string",
-            "max": 1024,
-            "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
-          },
-          "value": {
-            "type": "string",
-            "max": 1024
-          },
-          "max": 16
+          "key": {},
+          "value": {}
         }
       }
     },
-    "S29": {
-      "type": "string",
-      "max": 255,
-      "pattern": "[\\S]+"
-    },
-    "S2f": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S2h": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "S2i": {
-      "type": "string",
-      "enum": [
-        "ml.t2.medium",
-        "ml.t2.large",
-        "ml.t2.xlarge",
-        "ml.t2.2xlarge",
-        "ml.m4.xlarge",
-        "ml.m4.2xlarge",
-        "ml.m4.4xlarge",
-        "ml.m4.10xlarge",
-        "ml.m4.16xlarge",
-        "ml.p2.xlarge",
-        "ml.p2.8xlarge",
-        "ml.p2.16xlarge",
-        "ml.p3.2xlarge",
-        "ml.p3.8xlarge",
-        "ml.p3.16xlarge"
-      ]
-    },
     "S2j": {
       "type": "list",
-      "member": {
-        "shape": "S1u"
-      },
-      "max": 5
-    },
-    "S2k": {
-      "type": "string",
-      "max": 63,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "S2l": {
-      "type": "string",
-      "enum": [
-        "Enabled",
-        "Disabled"
-      ]
-    },
-    "S2n": {
-      "type": "string",
-      "max": 256
+      "member": {}
     },
     "S2p": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Content": {
-            "type": "string",
-            "max": 16384,
-            "min": 1
-          }
+          "Content": {}
         }
-      },
-      "max": 1
-    },
-    "S2t": {
-      "type": "string",
-      "max": 256
-    },
-    "S2z": {
-      "type": "string",
-      "max": 63,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
+      }
     },
     "S30": {
       "type": "structure",
@@ -2640,52 +1814,14 @@
         "TrainingInputMode"
       ],
       "members": {
-        "TrainingImage": {
-          "shape": "S1b"
-        },
-        "TrainingInputMode": {
-          "shape": "S1c"
-        }
+        "TrainingImage": {},
+        "TrainingInputMode": {}
       }
-    },
-    "S32": {
-      "type": "string",
-      "max": 256,
-      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:training-job/.*"
-    },
-    "S34": {
-      "type": "string",
-      "max": 63,
-      "min": 1,
-      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*"
-    },
-    "S35": {
-      "type": "integer",
-      "min": 0
-    },
-    "S36": {
-      "type": "integer",
-      "min": 0
-    },
-    "S37": {
-      "type": "string",
-      "enum": [
-        "MultiRecord",
-        "SingleRecord"
-      ]
     },
     "S38": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 1024,
-        "pattern": "[a-zA-Z_][a-zA-Z0-9_]*"
-      },
-      "value": {
-        "type": "string",
-        "max": 10240
-      },
-      "max": 16
+      "key": {},
+      "value": {}
     },
     "S3b": {
       "type": "structure",
@@ -2706,30 +1842,15 @@
                 "S3Uri"
               ],
               "members": {
-                "S3DataType": {
-                  "shape": "S1m"
-                },
-                "S3Uri": {
-                  "shape": "S1n"
-                }
+                "S3DataType": {},
+                "S3Uri": {}
               }
             }
           }
         },
-        "ContentType": {
-          "shape": "S1p"
-        },
-        "CompressionType": {
-          "shape": "S1q"
-        },
-        "SplitType": {
-          "type": "string",
-          "enum": [
-            "None",
-            "Line",
-            "RecordIO"
-          ]
-        }
+        "ContentType": {},
+        "CompressionType": {},
+        "SplitType": {}
       }
     },
     "S3f": {
@@ -2738,23 +1859,10 @@
         "S3OutputPath"
       ],
       "members": {
-        "S3OutputPath": {
-          "shape": "S1n"
-        },
-        "Accept": {
-          "type": "string",
-          "max": 256
-        },
-        "AssembleWith": {
-          "type": "string",
-          "enum": [
-            "None",
-            "Line"
-          ]
-        },
-        "KmsKeyId": {
-          "shape": "Sl"
-        }
+        "S3OutputPath": {},
+        "Accept": {},
+        "AssembleWith": {},
+        "KmsKeyId": {}
       }
     },
     "S3i": {
@@ -2764,119 +1872,46 @@
         "InstanceCount"
       ],
       "members": {
-        "InstanceType": {
-          "type": "string",
-          "enum": [
-            "ml.m4.xlarge",
-            "ml.m4.2xlarge",
-            "ml.m4.4xlarge",
-            "ml.m4.10xlarge",
-            "ml.m4.16xlarge",
-            "ml.c4.xlarge",
-            "ml.c4.2xlarge",
-            "ml.c4.4xlarge",
-            "ml.c4.8xlarge",
-            "ml.p2.xlarge",
-            "ml.p2.8xlarge",
-            "ml.p2.16xlarge",
-            "ml.p3.2xlarge",
-            "ml.p3.8xlarge",
-            "ml.p3.16xlarge",
-            "ml.c5.xlarge",
-            "ml.c5.2xlarge",
-            "ml.c5.4xlarge",
-            "ml.c5.9xlarge",
-            "ml.c5.18xlarge",
-            "ml.m5.large",
-            "ml.m5.xlarge",
-            "ml.m5.2xlarge",
-            "ml.m5.4xlarge",
-            "ml.m5.12xlarge",
-            "ml.m5.24xlarge"
-          ]
-        },
+        "InstanceType": {},
         "InstanceCount": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
-        "VolumeKmsKeyId": {
-          "shape": "Sl"
-        }
+        "VolumeKmsKeyId": {}
       }
-    },
-    "S3m": {
-      "type": "string",
-      "max": 256,
-      "pattern": "arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:transform-job/.*"
-    },
-    "S42": {
-      "type": "string",
-      "enum": [
-        "OutOfService",
-        "Creating",
-        "Updating",
-        "SystemUpdating",
-        "RollingBack",
-        "InService",
-        "Deleting",
-        "Failed"
-      ]
-    },
-    "S43": {
-      "type": "string",
-      "max": 1024
-    },
-    "S48": {
-      "type": "string",
-      "enum": [
-        "Completed",
-        "InProgress",
-        "Failed",
-        "Stopped",
-        "Stopping"
-      ]
     },
     "S49": {
       "type": "structure",
       "members": {
         "Completed": {
-          "shape": "S4a"
+          "type": "integer"
         },
         "InProgress": {
-          "shape": "S4a"
+          "type": "integer"
         },
         "RetryableError": {
-          "shape": "S4a"
+          "type": "integer"
         },
         "NonRetryableError": {
-          "shape": "S4a"
+          "type": "integer"
         },
         "Stopped": {
-          "shape": "S4a"
+          "type": "integer"
         }
       }
-    },
-    "S4a": {
-      "type": "integer",
-      "min": 0
     },
     "S4b": {
       "type": "structure",
       "members": {
         "Succeeded": {
-          "shape": "S4c"
+          "type": "integer"
         },
         "Pending": {
-          "shape": "S4c"
+          "type": "integer"
         },
         "Failed": {
-          "shape": "S4c"
+          "type": "integer"
         }
       }
-    },
-    "S4c": {
-      "type": "integer",
-      "min": 0
     },
     "S4d": {
       "type": "structure",
@@ -2888,12 +1923,8 @@
         "TunedHyperParameters"
       ],
       "members": {
-        "TrainingJobName": {
-          "shape": "S2z"
-        },
-        "TrainingJobArn": {
-          "shape": "S32"
-        },
+        "TrainingJobName": {},
+        "TrainingJobArn": {},
         "CreationTime": {
           "type": "timestamp"
         },
@@ -2903,15 +1934,11 @@
         "TrainingEndTime": {
           "type": "timestamp"
         },
-        "TrainingJobStatus": {
-          "shape": "S4e"
-        },
+        "TrainingJobStatus": {},
         "TunedHyperParameters": {
           "shape": "S19"
         },
-        "FailureReason": {
-          "shape": "S43"
-        },
+        "FailureReason": {},
         "FinalHyperParameterTuningJobObjectiveMetric": {
           "type": "structure",
           "required": [
@@ -2919,115 +1946,15 @@
             "Value"
           ],
           "members": {
-            "Type": {
-              "shape": "St"
-            },
-            "MetricName": {
-              "shape": "Su"
-            },
+            "Type": {},
+            "MetricName": {},
             "Value": {
               "type": "float"
             }
           }
         },
-        "ObjectiveStatus": {
-          "type": "string",
-          "enum": [
-            "Succeeded",
-            "Pending",
-            "Failed"
-          ]
-        }
+        "ObjectiveStatus": {}
       }
-    },
-    "S4e": {
-      "type": "string",
-      "enum": [
-        "InProgress",
-        "Completed",
-        "Failed",
-        "Stopping",
-        "Stopped"
-      ]
-    },
-    "S4m": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "InService",
-        "Stopping",
-        "Stopped",
-        "Failed",
-        "Deleting",
-        "Updating"
-      ]
-    },
-    "S4v": {
-      "type": "string",
-      "enum": [
-        "Starting",
-        "LaunchingMLInstances",
-        "PreparingTrainingStack",
-        "Downloading",
-        "DownloadingTrainingImage",
-        "Training",
-        "Uploading",
-        "Stopping",
-        "Stopped",
-        "MaxRuntimeExceeded",
-        "Completed",
-        "Failed"
-      ]
-    },
-    "S51": {
-      "type": "string",
-      "enum": [
-        "InProgress",
-        "Completed",
-        "Failed",
-        "Stopping",
-        "Stopped"
-      ]
-    },
-    "S54": {
-      "type": "string",
-      "enum": [
-        "Ascending",
-        "Descending"
-      ]
-    },
-    "S55": {
-      "type": "string",
-      "max": 8192
-    },
-    "S56": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "S5i": {
-      "type": "string",
-      "max": 8192
-    },
-    "S5k": {
-      "type": "string",
-      "enum": [
-        "Ascending",
-        "Descending"
-      ]
-    },
-    "S5l": {
-      "type": "string",
-      "max": 63,
-      "pattern": "[a-zA-Z0-9\\-]+"
-    },
-    "S6d": {
-      "type": "string",
-      "enum": [
-        "Name",
-        "CreationTime",
-        "Status"
-      ]
     }
   }
 }

--- a/apis/secretsmanager-2017-10-17.min.json
+++ b/apis/secretsmanager-2017-10-17.min.json
@@ -20,23 +20,15 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          }
+          "SecretId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          }
+          "ARN": {},
+          "Name": {},
+          "VersionId": {}
         }
       }
     },
@@ -47,19 +39,12 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S8"
-          },
+          "Name": {},
           "ClientRequestToken": {
-            "shape": "S9",
             "idempotencyToken": true
           },
-          "Description": {
-            "shape": "Sa"
-          },
-          "KmsKeyId": {
-            "shape": "Sb"
-          },
+          "Description": {},
+          "KmsKeyId": {},
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -74,15 +59,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          }
+          "ARN": {},
+          "Name": {},
+          "VersionId": {}
         }
       }
     },
@@ -93,20 +72,14 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          }
+          "SecretId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S8"
-          }
+          "ARN": {},
+          "Name": {}
         }
       }
     },
@@ -117,9 +90,7 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "RecoveryWindowInDays": {
             "type": "long"
           },
@@ -131,12 +102,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
+          "ARN": {},
+          "Name": {},
           "DeletionDate": {
             "type": "timestamp"
           }
@@ -150,32 +117,20 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          }
+          "SecretId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "Description": {
-            "shape": "Sa"
-          },
-          "KmsKeyId": {
-            "shape": "Sb"
-          },
+          "ARN": {},
+          "Name": {},
+          "Description": {},
+          "KmsKeyId": {},
           "RotationEnabled": {
             "type": "boolean"
           },
-          "RotationLambdaARN": {
-            "shape": "St"
-          },
+          "RotationLambdaARN": {},
           "RotationRules": {
             "shape": "Su"
           },
@@ -205,15 +160,9 @@
         "type": "structure",
         "members": {
           "PasswordLength": {
-            "type": "long",
-            "max": 4096,
-            "min": 1
+            "type": "long"
           },
-          "ExcludeCharacters": {
-            "type": "string",
-            "max": 4096,
-            "min": 0
-          },
+          "ExcludeCharacters": {},
           "ExcludeNumbers": {
             "type": "boolean"
           },
@@ -237,11 +186,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "RandomPassword": {
-            "type": "string",
-            "max": 4096,
-            "min": 0
-          }
+          "RandomPassword": {}
         }
       }
     },
@@ -252,23 +197,15 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          }
+          "SecretId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S8"
-          },
-          "ResourcePolicy": {
-            "shape": "S1g"
-          }
+          "ARN": {},
+          "Name": {},
+          "ResourcePolicy": {}
         }
       }
     },
@@ -279,29 +216,17 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
-          "VersionId": {
-            "shape": "S6"
-          },
-          "VersionStage": {
-            "shape": "S12"
-          }
+          "SecretId": {},
+          "VersionId": {},
+          "VersionStage": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          },
+          "ARN": {},
+          "Name": {},
+          "VersionId": {},
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -324,15 +249,11 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "MaxResults": {
-            "shape": "S1l"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1m"
-          },
+          "NextToken": {},
           "IncludeDeprecated": {
             "type": "boolean"
           }
@@ -346,9 +267,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "VersionId": {
-                  "shape": "S6"
-                },
+                "VersionId": {},
                 "VersionStages": {
                   "shape": "S11"
                 },
@@ -361,15 +280,9 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1m"
-          },
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          }
+          "NextToken": {},
+          "ARN": {},
+          "Name": {}
         }
       }
     },
@@ -378,11 +291,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S1l"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1m"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -393,24 +304,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "ARN": {
-                  "shape": "S4"
-                },
-                "Name": {
-                  "shape": "S5"
-                },
-                "Description": {
-                  "shape": "Sa"
-                },
-                "KmsKeyId": {
-                  "shape": "Sb"
-                },
+                "ARN": {},
+                "Name": {},
+                "Description": {},
+                "KmsKeyId": {},
                 "RotationEnabled": {
                   "type": "boolean"
                 },
-                "RotationLambdaARN": {
-                  "shape": "St"
-                },
+                "RotationLambdaARN": {},
                 "RotationRules": {
                   "shape": "Su"
                 },
@@ -435,9 +336,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1m"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -449,23 +348,15 @@
           "ResourcePolicy"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
-          "ResourcePolicy": {
-            "shape": "S1g"
-          }
+          "SecretId": {},
+          "ResourcePolicy": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S8"
-          }
+          "ARN": {},
+          "Name": {}
         }
       }
     },
@@ -476,11 +367,8 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "ClientRequestToken": {
-            "shape": "S9",
             "idempotencyToken": true
           },
           "SecretBinary": {
@@ -497,15 +385,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          },
+          "ARN": {},
+          "Name": {},
+          "VersionId": {},
           "VersionStages": {
             "shape": "S11"
           }
@@ -519,20 +401,14 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          }
+          "SecretId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          }
+          "ARN": {},
+          "Name": {}
         }
       }
     },
@@ -543,16 +419,11 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "ClientRequestToken": {
-            "shape": "S9",
             "idempotencyToken": true
           },
-          "RotationLambdaARN": {
-            "shape": "St"
-          },
+          "RotationLambdaARN": {},
           "RotationRules": {
             "shape": "Su"
           }
@@ -561,15 +432,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          }
+          "ARN": {},
+          "Name": {},
+          "VersionId": {}
         }
       }
     },
@@ -581,9 +446,7 @@
           "Tags"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "Tags": {
             "shape": "Se"
           }
@@ -598,14 +461,10 @@
           "TagKeys"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sg"
-            }
+            "member": {}
           }
         }
       }
@@ -617,19 +476,12 @@
           "SecretId"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
+          "SecretId": {},
           "ClientRequestToken": {
-            "shape": "S9",
             "idempotencyToken": true
           },
-          "Description": {
-            "shape": "Sa"
-          },
-          "KmsKeyId": {
-            "shape": "Sb"
-          },
+          "Description": {},
+          "KmsKeyId": {},
           "SecretBinary": {
             "shape": "Sc"
           },
@@ -641,15 +493,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          },
-          "VersionId": {
-            "shape": "S6"
-          }
+          "ARN": {},
+          "Name": {},
+          "VersionId": {}
         }
       }
     },
@@ -661,83 +507,28 @@
           "VersionStage"
         ],
         "members": {
-          "SecretId": {
-            "shape": "S2"
-          },
-          "VersionStage": {
-            "shape": "S12"
-          },
-          "RemoveFromVersionId": {
-            "shape": "S6"
-          },
-          "MoveToVersionId": {
-            "shape": "S6"
-          }
+          "SecretId": {},
+          "VersionStage": {},
+          "RemoveFromVersionId": {},
+          "MoveToVersionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ARN": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "S5"
-          }
+          "ARN": {},
+          "Name": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S4": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S5": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 64,
-      "min": 32
-    },
-    "S8": {
-      "type": "string",
-      "max": 512,
-      "min": 1
-    },
-    "S9": {
-      "type": "string",
-      "max": 64,
-      "min": 32
-    },
-    "Sa": {
-      "type": "string",
-      "max": 2048
-    },
-    "Sb": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
-    },
     "Sc": {
       "type": "blob",
-      "max": 4096,
-      "min": 0,
       "sensitive": true
     },
     "Sd": {
       "type": "string",
-      "max": 4096,
-      "min": 0,
       "sensitive": true
     },
     "Se": {
@@ -745,73 +536,29 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "Sg"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 0
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "Sg": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "St": {
-      "type": "string",
-      "max": 2048,
-      "min": 0
     },
     "Su": {
       "type": "structure",
       "members": {
         "AutomaticallyAfterDays": {
-          "type": "long",
-          "max": 1000,
-          "min": 1
+          "type": "long"
         }
       }
     },
     "S10": {
       "type": "map",
-      "key": {
-        "shape": "S6"
-      },
+      "key": {},
       "value": {
         "shape": "S11"
       }
     },
     "S11": {
       "type": "list",
-      "member": {
-        "shape": "S12"
-      },
-      "max": 20,
-      "min": 1
-    },
-    "S12": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S1g": {
-      "type": "string",
-      "max": 4096,
-      "min": 1
-    },
-    "S1l": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "S1m": {
-      "type": "string",
-      "max": 4096,
-      "min": 1
+      "member": {}
     }
   }
 }

--- a/apis/serverlessrepo-2017-09-08.min.json
+++ b/apis/serverlessrepo-2017-09-08.min.json
@@ -352,9 +352,9 @@
             "locationName": "applicationId"
           },
           "MaxItems": {
-            "shape": "So",
             "location": "querystring",
-            "locationName": "maxItems"
+            "locationName": "maxItems",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -410,9 +410,9 @@
         "type": "structure",
         "members": {
           "MaxItems": {
-            "shape": "So",
             "location": "querystring",
-            "locationName": "maxItems"
+            "locationName": "maxItems",
+            "type": "integer"
           },
           "NextToken": {
             "location": "querystring",
@@ -697,11 +697,6 @@
           "Actions"
         ]
       }
-    },
-    "So": {
-      "type": "integer",
-      "min": 1,
-      "max": 100
     }
   }
 }

--- a/apis/servicecatalog-2015-12-10.min.json
+++ b/apis/servicecatalog-2015-12-10.min.json
@@ -20,9 +20,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          }
+          "PortfolioId": {}
         }
       },
       "output": {
@@ -40,15 +38,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "PrincipalARN": {
-            "shape": "S6"
-          },
-          "PrincipalType": {
-            "shape": "S7"
-          }
+          "PortfolioId": {},
+          "PrincipalARN": {},
+          "PrincipalType": {}
         }
       },
       "output": {
@@ -65,15 +57,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "SourcePortfolioId": {
-            "shape": "S3"
-          }
+          "ProductId": {},
+          "PortfolioId": {},
+          "SourcePortfolioId": {}
         }
       },
       "output": {
@@ -90,9 +76,7 @@
         ],
         "members": {
           "ResourceId": {},
-          "TagOptionId": {
-            "shape": "Sd"
-          }
+          "TagOptionId": {}
         }
       },
       "output": {
@@ -109,42 +93,22 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "SourceProductArn": {
-            "type": "string",
-            "max": 1224,
-            "min": 1,
-            "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
-          },
-          "TargetProductId": {
-            "shape": "S3"
-          },
-          "TargetProductName": {
-            "shape": "Sh"
-          },
+          "SourceProductArn": {},
+          "TargetProductId": {},
+          "TargetProductName": {},
           "SourceProvisioningArtifactIdentifiers": {
             "type": "list",
             "member": {
               "type": "map",
-              "key": {
-                "type": "string",
-                "enum": [
-                  "Id"
-                ]
-              },
+              "key": {},
               "value": {}
             }
           },
           "CopyOptions": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "enum": [
-                "CopyTags"
-              ]
-            }
+            "member": {}
           },
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -152,9 +116,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "CopyProductToken": {
-            "shape": "S3"
-          }
+          "CopyProductToken": {}
         }
       }
     },
@@ -170,21 +132,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "ProductId": {
-            "shape": "S3"
-          },
+          "PortfolioId": {},
+          "ProductId": {},
           "Parameters": {},
-          "Type": {
-            "shape": "Ss"
-          },
-          "Description": {
-            "shape": "St"
-          },
+          "Type": {},
+          "Description": {},
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -196,9 +149,7 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -212,20 +163,13 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "DisplayName": {
-            "shape": "Sz"
-          },
-          "Description": {
-            "shape": "S10"
-          },
-          "ProviderName": {
-            "shape": "S11"
-          },
+          "DisplayName": {},
+          "Description": {},
+          "ProviderName": {},
           "Tags": {
             "shape": "S12"
           },
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -251,12 +195,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "AccountId": {
-            "shape": "Sw"
-          }
+          "PortfolioId": {},
+          "AccountId": {}
         }
       },
       "output": {
@@ -276,30 +216,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Name": {
-            "shape": "Sh"
-          },
-          "Owner": {
-            "shape": "S1e"
-          },
-          "Description": {
-            "shape": "S1f"
-          },
-          "Distributor": {
-            "shape": "S1e"
-          },
-          "SupportDescription": {
-            "shape": "S1g"
-          },
-          "SupportEmail": {
-            "shape": "S1h"
-          },
-          "SupportUrl": {
-            "shape": "S1i"
-          },
-          "ProductType": {
-            "shape": "S1j"
-          },
+          "Name": {},
+          "Owner": {},
+          "Description": {},
+          "Distributor": {},
+          "SupportDescription": {},
+          "SupportEmail": {},
+          "SupportUrl": {},
+          "ProductType": {},
           "Tags": {
             "shape": "S12"
           },
@@ -307,7 +231,6 @@
             "shape": "S1k"
           },
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -341,29 +264,18 @@
         "members": {
           "AcceptLanguage": {},
           "PlanName": {},
-          "PlanType": {
-            "shape": "S21"
-          },
+          "PlanType": {},
           "NotificationArns": {
             "shape": "S22"
           },
-          "PathId": {
-            "shape": "S3"
-          },
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisionedProductName": {
-            "shape": "S24"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
+          "PathId": {},
+          "ProductId": {},
+          "ProvisionedProductName": {},
+          "ProvisioningArtifactId": {},
           "ProvisioningParameters": {
             "shape": "S25"
           },
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           },
           "Tags": {
@@ -375,18 +287,10 @@
         "type": "structure",
         "members": {
           "PlanName": {},
-          "PlanId": {
-            "shape": "S3"
-          },
-          "ProvisionProductId": {
-            "shape": "S3"
-          },
-          "ProvisionedProductName": {
-            "shape": "S24"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          }
+          "PlanId": {},
+          "ProvisionProductId": {},
+          "ProvisionedProductName": {},
+          "ProvisioningArtifactId": {}
         }
       }
     },
@@ -400,14 +304,11 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
+          "ProductId": {},
           "Parameters": {
             "shape": "S1k"
           },
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -421,9 +322,7 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -435,12 +334,8 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S2e"
-          },
-          "Value": {
-            "shape": "S2f"
-          }
+          "Key": {},
+          "Value": {}
         }
       },
       "output": {
@@ -460,9 +355,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -478,9 +371,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -497,12 +388,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "AccountId": {
-            "shape": "Sw"
-          }
+          "PortfolioId": {},
+          "AccountId": {}
         }
       },
       "output": {
@@ -518,9 +405,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -536,9 +421,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {
-            "shape": "S3"
-          },
+          "PlanId": {},
           "IgnoreErrors": {
             "type": "boolean"
           }
@@ -558,12 +441,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          }
+          "ProductId": {},
+          "ProvisioningArtifactId": {}
         }
       },
       "output": {
@@ -578,9 +457,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "Sd"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -596,9 +473,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -608,9 +483,7 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -622,25 +495,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "CopyProductToken": {
-            "shape": "S3"
-          }
+          "CopyProductToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CopyProductStatus": {
-            "type": "string",
-            "enum": [
-              "SUCCEEDED",
-              "IN_PROGRESS",
-              "FAILED"
-            ]
-          },
-          "TargetProductId": {
-            "shape": "S3"
-          },
+          "CopyProductStatus": {},
+          "TargetProductId": {},
           "StatusDetail": {}
         }
       }
@@ -653,9 +515,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -681,9 +541,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -706,9 +564,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -722,9 +578,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
+                "Id": {},
                 "Name": {},
                 "Description": {},
                 "CreatedTime": {
@@ -753,9 +607,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -778,9 +630,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -809,15 +659,11 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {
-            "shape": "S3"
-          },
+          "PlanId": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -829,39 +675,15 @@
               "CreatedTime": {
                 "type": "timestamp"
               },
-              "PathId": {
-                "shape": "S3"
-              },
-              "ProductId": {
-                "shape": "S3"
-              },
+              "PathId": {},
+              "ProductId": {},
               "PlanName": {},
-              "PlanId": {
-                "shape": "S3"
-              },
-              "ProvisionProductId": {
-                "shape": "S3"
-              },
-              "ProvisionProductName": {
-                "shape": "S24"
-              },
-              "PlanType": {
-                "shape": "S21"
-              },
-              "ProvisioningArtifactId": {
-                "shape": "S3"
-              },
-              "Status": {
-                "type": "string",
-                "enum": [
-                  "CREATE_IN_PROGRESS",
-                  "CREATE_SUCCESS",
-                  "CREATE_FAILED",
-                  "EXECUTE_IN_PROGRESS",
-                  "EXECUTE_SUCCESS",
-                  "EXECUTE_FAILED"
-                ]
-              },
+              "PlanId": {},
+              "ProvisionProductId": {},
+              "ProvisionProductName": {},
+              "PlanType": {},
+              "ProvisioningArtifactId": {},
+              "Status": {},
               "UpdatedTime": {
                 "type": "timestamp"
               },
@@ -874,10 +696,7 @@
               "Tags": {
                 "shape": "S1a"
               },
-              "StatusMessage": {
-                "type": "string",
-                "pattern": "[\\u0009\\u000a\\u000d\\u0020-\\uD7FF\\uE000-\\uFFFD]*"
-              }
+              "StatusMessage": {}
             }
           },
           "ResourceChanges": {
@@ -885,34 +704,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Action": {
-                  "type": "string",
-                  "enum": [
-                    "ADD",
-                    "MODIFY",
-                    "REMOVE"
-                  ]
-                },
+                "Action": {},
                 "LogicalResourceId": {},
                 "PhysicalResourceId": {},
-                "ResourceType": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1
-                },
-                "Replacement": {
-                  "type": "string",
-                  "enum": [
-                    "TRUE",
-                    "FALSE",
-                    "CONDITIONAL"
-                  ]
-                },
+                "ResourceType": {},
+                "Replacement": {},
                 "Scope": {
                   "type": "list",
-                  "member": {
-                    "shape": "S4a"
-                  }
+                  "member": {}
                 },
                 "Details": {
                   "type": "list",
@@ -922,27 +721,12 @@
                       "Target": {
                         "type": "structure",
                         "members": {
-                          "Attribute": {
-                            "shape": "S4a"
-                          },
+                          "Attribute": {},
                           "Name": {},
-                          "RequiresRecreation": {
-                            "type": "string",
-                            "enum": [
-                              "NEVER",
-                              "CONDITIONALLY",
-                              "ALWAYS"
-                            ]
-                          }
+                          "RequiresRecreation": {}
                         }
                       },
-                      "Evaluation": {
-                        "type": "string",
-                        "enum": [
-                          "STATIC",
-                          "DYNAMIC"
-                        ]
-                      },
+                      "Evaluation": {},
                       "CausingEntity": {}
                     }
                   }
@@ -950,9 +734,7 @@
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -965,12 +747,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
-          "ProductId": {
-            "shape": "S3"
-          },
+          "ProvisioningArtifactId": {},
+          "ProductId": {},
           "Verbose": {
             "type": "boolean"
           }
@@ -985,9 +763,7 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -1000,15 +776,9 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
-          "PathId": {
-            "shape": "S3"
-          }
+          "ProductId": {},
+          "ProvisioningArtifactId": {},
+          "PathId": {}
         }
       },
       "output": {
@@ -1019,9 +789,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ParameterKey": {
-                  "shape": "S27"
-                },
+                "ParameterKey": {},
                 "DefaultValue": {},
                 "ParameterType": {},
                 "IsNoEcho": {
@@ -1058,14 +826,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S2e"
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "shape": "S2f"
-                  }
+                  "member": {}
                 }
               }
             }
@@ -1081,14 +845,10 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          },
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "Id": {},
+          "PageToken": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           }
         }
       },
@@ -1109,9 +869,7 @@
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1122,9 +880,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "Sd"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -1145,12 +901,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "PrincipalARN": {
-            "shape": "S6"
-          }
+          "PortfolioId": {},
+          "PrincipalARN": {}
         }
       },
       "output": {
@@ -1167,12 +919,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "PortfolioId": {
-            "shape": "S3"
-          }
+          "ProductId": {},
+          "PortfolioId": {}
         }
       },
       "output": {
@@ -1189,9 +937,7 @@
         ],
         "members": {
           "ResourceId": {},
-          "TagOptionId": {
-            "shape": "Sd"
-          }
+          "TagOptionId": {}
         }
       },
       "output": {
@@ -1208,11 +954,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PlanId": {
-            "shape": "S3"
-          },
+          "PlanId": {},
           "IdempotencyToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -1231,19 +974,11 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "PageToken": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PortfolioShareType": {
-            "type": "string",
-            "enum": [
-              "IMPORTED",
-              "AWS_SERVICECATALOG"
-            ]
-          }
+          "PortfolioShareType": {}
         }
       },
       "output": {
@@ -1252,9 +987,7 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1266,18 +999,12 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
-          "ProductId": {
-            "shape": "S3"
-          },
+          "PortfolioId": {},
+          "ProductId": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1289,9 +1016,7 @@
               "shape": "Sv"
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1303,15 +1028,11 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
+          "ProductId": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1322,9 +1043,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
+                "Id": {},
                 "ConstraintSummaries": {
                   "shape": "S4w"
                 },
@@ -1335,9 +1054,7 @@
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1349,9 +1066,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          }
+          "PortfolioId": {}
         }
       },
       "output": {
@@ -1359,13 +1074,9 @@
         "members": {
           "AccountIds": {
             "type": "list",
-            "member": {
-              "shape": "Sw"
-            }
+            "member": {}
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1374,11 +1085,9 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "PageToken": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           }
         }
       },
@@ -1388,9 +1097,7 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1402,14 +1109,10 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "ProductId": {},
+          "PageToken": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           }
         }
       },
@@ -1419,9 +1122,7 @@
           "PortfolioDetails": {
             "shape": "S5z"
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1433,15 +1134,11 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
+          "PortfolioId": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1452,18 +1149,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "PrincipalARN": {
-                  "shape": "S6"
-                },
-                "PrincipalType": {
-                  "shape": "S7"
-                }
+                "PrincipalARN": {},
+                "PrincipalType": {}
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1472,15 +1163,11 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "ProvisionProductId": {
-            "shape": "S3"
-          },
+          "ProvisionProductId": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "PageToken": {},
           "AccessLevelFilter": {
             "shape": "S6k"
           }
@@ -1495,27 +1182,15 @@
               "type": "structure",
               "members": {
                 "PlanName": {},
-                "PlanId": {
-                  "shape": "S3"
-                },
-                "ProvisionProductId": {
-                  "shape": "S3"
-                },
-                "ProvisionProductName": {
-                  "shape": "S24"
-                },
-                "PlanType": {
-                  "shape": "S21"
-                },
-                "ProvisioningArtifactId": {
-                  "shape": "S3"
-                }
+                "PlanId": {},
+                "ProvisionProductId": {},
+                "ProvisionProductName": {},
+                "PlanType": {},
+                "ProvisioningArtifactId": {}
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1527,9 +1202,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          }
+          "ProductId": {}
         }
       },
       "output": {
@@ -1541,9 +1214,7 @@
               "shape": "S1x"
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1563,11 +1234,9 @@
             }
           },
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1579,9 +1248,7 @@
               "shape": "S57"
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1592,16 +1259,12 @@
           "TagOptionId"
         ],
         "members": {
-          "TagOptionId": {
-            "shape": "Sd"
-          },
+          "TagOptionId": {},
           "ResourceType": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1622,9 +1285,7 @@
               }
             }
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       }
     },
@@ -1635,23 +1296,17 @@
           "Filters": {
             "type": "structure",
             "members": {
-              "Key": {
-                "shape": "S2e"
-              },
-              "Value": {
-                "shape": "S2f"
-              },
+              "Key": {},
+              "Value": {},
               "Active": {
                 "type": "boolean"
               }
             }
           },
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1660,9 +1315,7 @@
           "TagOptionDetails": {
             "shape": "S36"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       }
     },
@@ -1677,29 +1330,17 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
-          "PathId": {
-            "shape": "S3"
-          },
-          "ProvisionedProductName": {
-            "shape": "S24"
-          },
+          "ProductId": {},
+          "ProvisioningArtifactId": {},
+          "PathId": {},
+          "ProvisionedProductName": {},
           "ProvisioningParameters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "shape": "S27"
-                },
-                "Value": {
-                  "shape": "S28"
-                }
+                "Key": {},
+                "Value": {}
               }
             }
           },
@@ -1710,7 +1351,6 @@
             "shape": "S22"
           },
           "ProvisionToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -1732,9 +1372,7 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          }
+          "PortfolioId": {}
         }
       },
       "output": {
@@ -1751,11 +1389,9 @@
             "shape": "S6k"
           },
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1767,9 +1403,7 @@
               "shape": "S3k"
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1782,17 +1416,11 @@
             "shape": "S7m"
           },
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "SortBy": {
-            "shape": "S7q"
-          },
-          "SortOrder": {
-            "shape": "S7r"
-          },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "SortBy": {},
+          "SortOrder": {},
+          "PageToken": {}
         }
       },
       "output": {
@@ -1820,9 +1448,7 @@
               }
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1831,30 +1457,17 @@
         "type": "structure",
         "members": {
           "AcceptLanguage": {},
-          "PortfolioId": {
-            "shape": "S3"
-          },
+          "PortfolioId": {},
           "Filters": {
             "shape": "S7m"
           },
-          "SortBy": {
-            "shape": "S7q"
-          },
-          "SortOrder": {
-            "shape": "S7r"
-          },
-          "PageToken": {
-            "shape": "S3w"
-          },
+          "SortBy": {},
+          "SortOrder": {},
+          "PageToken": {},
           "PageSize": {
-            "shape": "S3v"
+            "type": "integer"
           },
-          "ProductSource": {
-            "type": "string",
-            "enum": [
-              "ACCOUNT"
-            ]
-          }
+          "ProductSource": {}
         }
       },
       "output": {
@@ -1866,9 +1479,7 @@
               "shape": "S1s"
             }
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1882,29 +1493,18 @@
           },
           "Filters": {
             "type": "map",
-            "key": {
-              "type": "string",
-              "enum": [
-                "SearchQuery"
-              ]
-            },
+            "key": {},
             "value": {
               "type": "list",
               "member": {}
             }
           },
           "SortBy": {},
-          "SortOrder": {
-            "shape": "S7r"
-          },
+          "SortOrder": {},
           "PageSize": {
-            "type": "integer",
-            "max": 100,
-            "min": 0
+            "type": "integer"
           },
-          "PageToken": {
-            "shape": "S3w"
-          }
+          "PageToken": {}
         }
       },
       "output": {
@@ -1915,39 +1515,23 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S3l"
-                },
-                "Arn": {
-                  "shape": "S3l"
-                },
+                "Name": {},
+                "Arn": {},
                 "Type": {},
-                "Id": {
-                  "shape": "S3"
-                },
-                "Status": {
-                  "shape": "S3o"
-                },
+                "Id": {},
+                "Status": {},
                 "StatusMessage": {},
                 "CreatedTime": {
                   "type": "timestamp"
                 },
-                "IdempotencyToken": {
-                  "shape": "So"
-                },
-                "LastRecordId": {
-                  "shape": "S3"
-                },
+                "IdempotencyToken": {},
+                "LastRecordId": {},
                 "Tags": {
                   "shape": "S1a"
                 },
                 "PhysicalId": {},
-                "ProductId": {
-                  "shape": "S3"
-                },
-                "ProvisioningArtifactId": {
-                  "shape": "S3"
-                },
+                "ProductId": {},
+                "ProvisioningArtifactId": {},
                 "UserArn": {},
                 "UserArnSession": {}
               }
@@ -1956,9 +1540,7 @@
           "TotalResultsCount": {
             "type": "integer"
           },
-          "NextPageToken": {
-            "shape": "S3w"
-          }
+          "NextPageToken": {}
         }
       }
     },
@@ -1969,14 +1551,9 @@
           "TerminateToken"
         ],
         "members": {
-          "ProvisionedProductName": {
-            "shape": "S3l"
-          },
-          "ProvisionedProductId": {
-            "shape": "S3"
-          },
+          "ProvisionedProductName": {},
+          "ProvisionedProductId": {},
           "TerminateToken": {
-            "shape": "So",
             "idempotencyToken": true
           },
           "IgnoreErrors": {
@@ -2002,12 +1579,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          },
-          "Description": {
-            "shape": "St"
-          }
+          "Id": {},
+          "Description": {}
         }
       },
       "output": {
@@ -2017,9 +1590,7 @@
             "shape": "Sv"
           },
           "ConstraintParameters": {},
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -2031,18 +1602,10 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          },
-          "DisplayName": {
-            "shape": "Sz"
-          },
-          "Description": {
-            "shape": "S10"
-          },
-          "ProviderName": {
-            "shape": "S11"
-          },
+          "Id": {},
+          "DisplayName": {},
+          "Description": {},
+          "ProviderName": {},
           "AddTags": {
             "shape": "S12"
           },
@@ -2071,30 +1634,14 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "Id": {
-            "shape": "S3"
-          },
-          "Name": {
-            "shape": "Sh"
-          },
-          "Owner": {
-            "shape": "S1e"
-          },
-          "Description": {
-            "shape": "S1f"
-          },
-          "Distributor": {
-            "shape": "S1e"
-          },
-          "SupportDescription": {
-            "shape": "S1g"
-          },
-          "SupportEmail": {
-            "shape": "S1h"
-          },
-          "SupportUrl": {
-            "shape": "S1i"
-          },
+          "Id": {},
+          "Name": {},
+          "Owner": {},
+          "Description": {},
+          "Distributor": {},
+          "SupportDescription": {},
+          "SupportEmail": {},
+          "SupportUrl": {},
           "AddTags": {
             "shape": "S12"
           },
@@ -2123,26 +1670,15 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProvisionedProductName": {
-            "shape": "S3l"
-          },
-          "ProvisionedProductId": {
-            "shape": "S3"
-          },
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
-          "PathId": {
-            "shape": "S3"
-          },
+          "ProvisionedProductName": {},
+          "ProvisionedProductId": {},
+          "ProductId": {},
+          "ProvisioningArtifactId": {},
+          "PathId": {},
           "ProvisioningParameters": {
             "shape": "S25"
           },
           "UpdateToken": {
-            "shape": "So",
             "idempotencyToken": true
           }
         }
@@ -2165,12 +1701,8 @@
         ],
         "members": {
           "AcceptLanguage": {},
-          "ProductId": {
-            "shape": "S3"
-          },
-          "ProvisioningArtifactId": {
-            "shape": "S3"
-          },
+          "ProductId": {},
+          "ProvisioningArtifactId": {},
           "Name": {},
           "Description": {},
           "Active": {
@@ -2187,9 +1719,7 @@
           "Info": {
             "shape": "S1n"
           },
-          "Status": {
-            "shape": "Sx"
-          }
+          "Status": {}
         }
       }
     },
@@ -2200,12 +1730,8 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "Sd"
-          },
-          "Value": {
-            "shape": "S2f"
-          },
+          "Id": {},
+          "Value": {},
           "Active": {
             "type": "boolean"
           }
@@ -2222,95 +1748,20 @@
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 1000,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "IAM"
-      ]
-    },
-    "Sd": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 8191
-    },
-    "So": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
-    },
-    "Ss": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "St": {
-      "type": "string",
-      "max": 2000
-    },
     "Sv": {
       "type": "structure",
       "members": {
-        "ConstraintId": {
-          "shape": "S3"
-        },
-        "Type": {
-          "shape": "Ss"
-        },
-        "Description": {
-          "shape": "St"
-        },
-        "Owner": {
-          "shape": "Sw"
-        }
+        "ConstraintId": {},
+        "Type": {},
+        "Description": {},
+        "Owner": {}
       }
-    },
-    "Sw": {
-      "type": "string",
-      "pattern": "^[0-9]{12}$"
-    },
-    "Sx": {
-      "type": "string",
-      "enum": [
-        "AVAILABLE",
-        "CREATING",
-        "FAILED"
-      ]
-    },
-    "Sz": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S10": {
-      "type": "string",
-      "max": 2000
-    },
-    "S11": {
-      "type": "string",
-      "max": 50,
-      "min": 1
     },
     "S12": {
       "type": "list",
       "member": {
         "shape": "S13"
-      },
-      "max": 20
+      }
     },
     "S13": {
       "type": "structure",
@@ -2319,85 +1770,28 @@
         "Value"
       ],
       "members": {
-        "Key": {
-          "shape": "S14"
-        },
-        "Value": {
-          "type": "string",
-          "max": 256,
-          "min": 1,
-          "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-        }
+        "Key": {},
+        "Value": {}
       }
-    },
-    "S14": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
     },
     "S17": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
-        "ARN": {
-          "shape": "S18"
-        },
-        "DisplayName": {
-          "shape": "Sz"
-        },
-        "Description": {
-          "shape": "S10"
-        },
+        "Id": {},
+        "ARN": {},
+        "DisplayName": {},
+        "Description": {},
         "CreatedTime": {
           "type": "timestamp"
         },
-        "ProviderName": {
-          "shape": "S11"
-        }
+        "ProviderName": {}
       }
-    },
-    "S18": {
-      "type": "string",
-      "max": 150,
-      "min": 1
     },
     "S1a": {
       "type": "list",
       "member": {
         "shape": "S13"
-      },
-      "max": 50
-    },
-    "S1e": {
-      "type": "string",
-      "max": 8191
-    },
-    "S1f": {
-      "type": "string",
-      "max": 8191
-    },
-    "S1g": {
-      "type": "string",
-      "max": 8191
-    },
-    "S1h": {
-      "type": "string",
-      "max": 254
-    },
-    "S1i": {
-      "type": "string",
-      "max": 2083
-    },
-    "S1j": {
-      "type": "string",
-      "enum": [
-        "CLOUD_FORMATION_TEMPLATE",
-        "MARKETPLACE"
-      ],
-      "max": 8191
+      }
     },
     "S1k": {
       "type": "structure",
@@ -2410,25 +1804,13 @@
         "Info": {
           "shape": "S1n"
         },
-        "Type": {
-          "shape": "S1q"
-        }
+        "Type": {}
       }
     },
     "S1n": {
       "type": "map",
       "key": {},
-      "value": {},
-      "max": 100,
-      "min": 1
-    },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "CLOUD_FORMATION_TEMPLATE",
-        "MARKETPLACE_AMI",
-        "MARKETPLACE_CAR"
-      ]
+      "value": {}
     },
     "S1s": {
       "type": "structure",
@@ -2436,12 +1818,8 @@
         "ProductViewSummary": {
           "shape": "S1t"
         },
-        "Status": {
-          "shape": "Sx"
-        },
-        "ProductARN": {
-          "shape": "S18"
-        },
+        "Status": {},
+        "ProductARN": {},
         "CreatedTime": {
           "type": "timestamp"
         }
@@ -2450,50 +1828,28 @@
     "S1t": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
-        "ProductId": {
-          "shape": "S3"
-        },
-        "Name": {
-          "shape": "Sh"
-        },
-        "Owner": {
-          "shape": "S1e"
-        },
-        "ShortDescription": {
-          "shape": "S1f"
-        },
-        "Type": {
-          "shape": "S1j"
-        },
+        "Id": {},
+        "ProductId": {},
+        "Name": {},
+        "Owner": {},
+        "ShortDescription": {},
+        "Type": {},
         "Distributor": {},
         "HasDefaultPath": {
           "type": "boolean"
         },
-        "SupportEmail": {
-          "shape": "S1h"
-        },
-        "SupportDescription": {
-          "shape": "S1g"
-        },
-        "SupportUrl": {
-          "shape": "S1i"
-        }
+        "SupportEmail": {},
+        "SupportDescription": {},
+        "SupportUrl": {}
       }
     },
     "S1x": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
+        "Id": {},
         "Name": {},
         "Description": {},
-        "Type": {
-          "shape": "S1q"
-        },
+        "Type": {},
         "CreatedTime": {
           "type": "timestamp"
         },
@@ -2502,81 +1858,32 @@
         }
       }
     },
-    "S21": {
-      "type": "string",
-      "enum": [
-        "CLOUDFORMATION"
-      ]
-    },
     "S22": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 1224,
-        "min": 1,
-        "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
-      },
-      "max": 5
-    },
-    "S24": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9._-]*"
+      "member": {}
     },
     "S25": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "shape": "S27"
-          },
-          "Value": {
-            "shape": "S28"
-          },
+          "Key": {},
+          "Value": {},
           "UsePreviousValue": {
             "type": "boolean"
           }
         }
       }
     },
-    "S27": {
-      "type": "string",
-      "max": 1000,
-      "min": 1
-    },
-    "S28": {
-      "type": "string",
-      "max": 4096
-    },
-    "S2e": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "S2f": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
     "S2h": {
       "type": "structure",
       "members": {
-        "Key": {
-          "shape": "S2e"
-        },
-        "Value": {
-          "shape": "S2f"
-        },
+        "Key": {},
+        "Value": {},
         "Active": {
           "type": "boolean"
         },
-        "Id": {
-          "shape": "Sd"
-        }
+        "Id": {}
       }
     },
     "S36": {
@@ -2590,9 +1897,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "Id": {
-            "shape": "S3"
-          },
+          "Id": {},
           "Name": {},
           "Description": {},
           "CreatedTime": {
@@ -2604,96 +1909,35 @@
     "S3k": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S3l"
-        },
-        "Arn": {
-          "shape": "S3l"
-        },
+        "Name": {},
+        "Arn": {},
         "Type": {},
         "Id": {},
-        "Status": {
-          "shape": "S3o"
-        },
+        "Status": {},
         "StatusMessage": {},
         "CreatedTime": {
           "type": "timestamp"
         },
-        "IdempotencyToken": {
-          "shape": "So"
-        },
+        "IdempotencyToken": {},
         "LastRecordId": {}
       }
-    },
-    "S3l": {
-      "type": "string",
-      "max": 1224,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}|arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
-    },
-    "S3o": {
-      "type": "string",
-      "enum": [
-        "AVAILABLE",
-        "UNDER_CHANGE",
-        "TAINTED",
-        "ERROR",
-        "PLAN_IN_PROGRESS"
-      ]
-    },
-    "S3v": {
-      "type": "integer",
-      "max": 20,
-      "min": 0
-    },
-    "S3w": {
-      "type": "string",
-      "pattern": "[\\u0009\\u000a\\u000d\\u0020-\\uD7FF\\uE000-\\uFFFD]*"
-    },
-    "S4a": {
-      "type": "string",
-      "enum": [
-        "PROPERTIES",
-        "METADATA",
-        "CREATIONPOLICY",
-        "UPDATEPOLICY",
-        "DELETIONPOLICY",
-        "TAGS"
-      ]
     },
     "S4w": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Type": {
-            "shape": "Ss"
-          },
-          "Description": {
-            "shape": "St"
-          }
+          "Type": {},
+          "Description": {}
         }
       }
     },
     "S57": {
       "type": "structure",
       "members": {
-        "RecordId": {
-          "shape": "S3"
-        },
-        "ProvisionedProductName": {
-          "shape": "S24"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "CREATED",
-            "IN_PROGRESS",
-            "IN_PROGRESS_IN_ERROR",
-            "SUCCEEDED",
-            "FAILED"
-          ]
-        },
+        "RecordId": {},
+        "ProvisionedProductName": {},
+        "Status": {},
         "CreatedTime": {
           "type": "timestamp"
         },
@@ -2702,18 +1946,10 @@
         },
         "ProvisionedProductType": {},
         "RecordType": {},
-        "ProvisionedProductId": {
-          "shape": "S3"
-        },
-        "ProductId": {
-          "shape": "S3"
-        },
-        "ProvisioningArtifactId": {
-          "shape": "S3"
-        },
-        "PathId": {
-          "shape": "S3"
-        },
+        "ProvisionedProductId": {},
+        "ProductId": {},
+        "ProvisioningArtifactId": {},
+        "PathId": {},
         "RecordErrors": {
           "type": "list",
           "member": {
@@ -2729,21 +1965,10 @@
           "member": {
             "type": "structure",
             "members": {
-              "Key": {
-                "type": "string",
-                "max": 128,
-                "min": 1,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
-              },
-              "Value": {
-                "type": "string",
-                "max": 256,
-                "min": 1,
-                "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-%@]*)$"
-              }
+              "Key": {},
+              "Value": {}
             }
-          },
-          "max": 50
+          }
         }
       }
     },
@@ -2756,53 +1981,21 @@
     "S6k": {
       "type": "structure",
       "members": {
-        "Key": {
-          "type": "string",
-          "enum": [
-            "Account",
-            "Role",
-            "User"
-          ]
-        },
+        "Key": {},
         "Value": {}
       }
     },
     "S7m": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "enum": [
-          "FullTextSearch",
-          "Owner",
-          "ProductType",
-          "SourceProductId"
-        ]
-      },
+      "key": {},
       "value": {
         "type": "list",
         "member": {}
       }
     },
-    "S7q": {
-      "type": "string",
-      "enum": [
-        "Title",
-        "VersionCount",
-        "CreationDate"
-      ]
-    },
-    "S7r": {
-      "type": "string",
-      "enum": [
-        "ASCENDING",
-        "DESCENDING"
-      ]
-    },
     "S8n": {
       "type": "list",
-      "member": {
-        "shape": "S14"
-      }
+      "member": {}
     }
   }
 }

--- a/apis/servicediscovery-2017-03-14.min.json
+++ b/apis/servicediscovery-2017-03-14.min.json
@@ -21,27 +21,18 @@
           "Vpc"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "CreatorRequestId": {
-            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {
-            "shape": "S4"
-          },
-          "Vpc": {
-            "shape": "S3"
-          }
+          "Description": {},
+          "Vpc": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -52,24 +43,17 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "CreatorRequestId": {
-            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {
-            "shape": "S4"
-          }
+          "Description": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -81,16 +65,11 @@
           "DnsConfig"
         ],
         "members": {
-          "Name": {
-            "shape": "Sa"
-          },
+          "Name": {},
           "CreatorRequestId": {
-            "shape": "S3",
             "idempotencyToken": true
           },
-          "Description": {
-            "shape": "S4"
-          },
+          "Description": {},
           "DnsConfig": {
             "shape": "Sb"
           },
@@ -118,17 +97,13 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -139,9 +114,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -157,20 +130,14 @@
           "InstanceId"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          }
+          "ServiceId": {},
+          "InstanceId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -182,12 +149,8 @@
           "InstanceId"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          }
+          "ServiceId": {},
+          "InstanceId": {}
         }
       },
       "output": {
@@ -199,12 +162,8 @@
               "Id"
             ],
             "members": {
-              "Id": {
-                "shape": "S3"
-              },
-              "CreatorRequestId": {
-                "shape": "S3"
-              },
+              "Id": {},
+              "CreatorRequestId": {},
               "Attributes": {
                 "shape": "S10"
               }
@@ -220,22 +179,15 @@
           "ServiceId"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
+          "ServiceId": {},
           "Instances": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            },
-            "min": 1
+            "member": {}
           },
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -243,21 +195,10 @@
         "members": {
           "Status": {
             "type": "map",
-            "key": {
-              "shape": "S3"
-            },
-            "value": {
-              "type": "string",
-              "enum": [
-                "HEALTHY",
-                "UNHEALTHY",
-                "UNKNOWN"
-              ]
-            }
+            "key": {},
+            "value": {}
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -268,9 +209,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -279,21 +218,11 @@
           "Namespace": {
             "type": "structure",
             "members": {
-              "Id": {
-                "shape": "S3"
-              },
-              "Arn": {
-                "shape": "So"
-              },
-              "Name": {
-                "shape": "S2"
-              },
-              "Type": {
-                "shape": "S1d"
-              },
-              "Description": {
-                "shape": "S4"
-              },
+              "Id": {},
+              "Arn": {},
+              "Name": {},
+              "Type": {},
+              "Description": {},
               "ServiceCount": {
                 "type": "integer"
               },
@@ -303,9 +232,7 @@
                   "DnsProperties": {
                     "type": "structure",
                     "members": {
-                      "HostedZoneId": {
-                        "shape": "S3"
-                      }
+                      "HostedZoneId": {}
                     }
                   }
                 }
@@ -313,9 +240,7 @@
               "CreateDate": {
                 "type": "timestamp"
               },
-              "CreatorRequestId": {
-                "shape": "S3"
-              }
+              "CreatorRequestId": {}
             }
           }
         }
@@ -328,9 +253,7 @@
           "OperationId"
         ],
         "members": {
-          "OperationId": {
-            "shape": "S3"
-          }
+          "OperationId": {}
         }
       },
       "output": {
@@ -339,22 +262,9 @@
           "Operation": {
             "type": "structure",
             "members": {
-              "Id": {
-                "shape": "S6"
-              },
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "CREATE_NAMESPACE",
-                  "DELETE_NAMESPACE",
-                  "UPDATE_SERVICE",
-                  "REGISTER_INSTANCE",
-                  "DEREGISTER_INSTANCE"
-                ]
-              },
-              "Status": {
-                "shape": "S1k"
-              },
+              "Id": {},
+              "Type": {},
+              "Status": {},
               "ErrorMessage": {},
               "ErrorCode": {},
               "CreateDate": {
@@ -365,17 +275,8 @@
               },
               "Targets": {
                 "type": "map",
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "NAMESPACE",
-                    "SERVICE",
-                    "INSTANCE"
-                  ]
-                },
-                "value": {
-                  "shape": "S3"
-                }
+                "key": {},
+                "value": {}
               }
             }
           }
@@ -389,9 +290,7 @@
           "Id"
         ],
         "members": {
-          "Id": {
-            "shape": "S3"
-          }
+          "Id": {}
         }
       },
       "output": {
@@ -410,14 +309,10 @@
           "ServiceId"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
-          "NextToken": {
-            "shape": "S16"
-          },
+          "ServiceId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           }
         }
       },
@@ -429,18 +324,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
+                "Id": {},
                 "Attributes": {
                   "shape": "S10"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -448,11 +339,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S16"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           },
           "Filters": {
             "type": "list",
@@ -463,18 +352,11 @@
                 "Values"
               ],
               "members": {
-                "Name": {
-                  "type": "string",
-                  "enum": [
-                    "TYPE"
-                  ]
-                },
+                "Name": {},
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {
-                  "shape": "S21"
-                }
+                "Condition": {}
               }
             }
           }
@@ -488,24 +370,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
-                "Arn": {
-                  "shape": "So"
-                },
-                "Name": {
-                  "shape": "S2"
-                },
-                "Type": {
-                  "shape": "S1d"
-                }
+                "Id": {},
+                "Arn": {},
+                "Name": {},
+                "Type": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -513,11 +385,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S16"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           },
           "Filters": {
             "type": "list",
@@ -528,22 +398,11 @@
                 "Values"
               ],
               "members": {
-                "Name": {
-                  "type": "string",
-                  "enum": [
-                    "NAMESPACE_ID",
-                    "SERVICE_ID",
-                    "STATUS",
-                    "TYPE",
-                    "UPDATE_DATE"
-                  ]
-                },
+                "Name": {},
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {
-                  "shape": "S21"
-                }
+                "Condition": {}
               }
             }
           }
@@ -557,18 +416,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S6"
-                },
-                "Status": {
-                  "shape": "S1k"
-                }
+                "Id": {},
+                "Status": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -576,11 +429,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S16"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S15"
+            "type": "integer"
           },
           "Filters": {
             "type": "list",
@@ -591,18 +442,11 @@
                 "Values"
               ],
               "members": {
-                "Name": {
-                  "type": "string",
-                  "enum": [
-                    "NAMESPACE_ID"
-                  ]
-                },
+                "Name": {},
                 "Values": {
                   "shape": "S1z"
                 },
-                "Condition": {
-                  "shape": "S21"
-                }
+                "Condition": {}
               }
             }
           }
@@ -616,27 +460,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
-                "Arn": {
-                  "shape": "So"
-                },
-                "Name": {
-                  "shape": "Sa"
-                },
-                "Description": {
-                  "shape": "S4"
-                },
+                "Id": {},
+                "Arn": {},
+                "Name": {},
+                "Description": {},
                 "InstanceCount": {
                   "type": "integer"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S16"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -649,14 +483,9 @@
           "Attributes"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          },
+          "ServiceId": {},
+          "InstanceId": {},
           "CreatorRequestId": {
-            "shape": "S3",
             "idempotencyToken": true
           },
           "Attributes": {
@@ -667,9 +496,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     },
@@ -682,19 +509,9 @@
           "Status"
         ],
         "members": {
-          "ServiceId": {
-            "shape": "S3"
-          },
-          "InstanceId": {
-            "shape": "S3"
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "HEALTHY",
-              "UNHEALTHY"
-            ]
-          }
+          "ServiceId": {},
+          "InstanceId": {},
+          "Status": {}
         }
       }
     },
@@ -706,18 +523,14 @@
           "Service"
         ],
         "members": {
-          "Id": {
-            "shape": "S3"
-          },
+          "Id": {},
           "Service": {
             "type": "structure",
             "required": [
               "DnsConfig"
             ],
             "members": {
-              "Description": {
-                "shape": "S4"
-              },
+              "Description": {},
               "DnsConfig": {
                 "type": "structure",
                 "required": [
@@ -739,34 +552,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "OperationId": {
-            "shape": "S6"
-          }
+          "OperationId": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 1024
-    },
-    "S3": {
-      "type": "string",
-      "max": 64
-    },
-    "S4": {
-      "type": "string",
-      "max": 1024
-    },
-    "S6": {
-      "type": "string",
-      "max": 255
-    },
-    "Sa": {
-      "type": "string",
-      "pattern": "((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(\\.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^\\.$)"
-    },
     "Sb": {
       "type": "structure",
       "required": [
@@ -774,16 +565,8 @@
         "DnsRecords"
       ],
       "members": {
-        "NamespaceId": {
-          "shape": "S3"
-        },
-        "RoutingPolicy": {
-          "type": "string",
-          "enum": [
-            "MULTIVALUE",
-            "WEIGHTED"
-          ]
-        },
+        "NamespaceId": {},
+        "RoutingPolicy": {},
         "DnsRecords": {
           "shape": "Sd"
         }
@@ -798,19 +581,9 @@
           "TTL"
         ],
         "members": {
-          "Type": {
-            "type": "string",
-            "enum": [
-              "SRV",
-              "A",
-              "AAAA",
-              "CNAME"
-            ]
-          },
+          "Type": {},
           "TTL": {
-            "type": "long",
-            "max": 2147483647,
-            "min": 0
+            "type": "long"
           }
         }
       }
@@ -818,51 +591,28 @@
     "Sh": {
       "type": "structure",
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "HTTP",
-            "HTTPS",
-            "TCP"
-          ]
-        },
-        "ResourcePath": {
-          "type": "string",
-          "max": 255
-        },
+        "Type": {},
+        "ResourcePath": {},
         "FailureThreshold": {
-          "shape": "Sk"
+          "type": "integer"
         }
       }
-    },
-    "Sk": {
-      "type": "integer",
-      "max": 10,
-      "min": 1
     },
     "Sl": {
       "type": "structure",
       "members": {
         "FailureThreshold": {
-          "shape": "Sk"
+          "type": "integer"
         }
       }
     },
     "Sn": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
-        "Arn": {
-          "shape": "So"
-        },
-        "Name": {
-          "shape": "Sa"
-        },
-        "Description": {
-          "shape": "S4"
-        },
+        "Id": {},
+        "Arn": {},
+        "Name": {},
+        "Description": {},
         "InstanceCount": {
           "type": "integer"
         },
@@ -878,66 +628,17 @@
         "CreateDate": {
           "type": "timestamp"
         },
-        "CreatorRequestId": {
-          "shape": "S3"
-        }
+        "CreatorRequestId": {}
       }
-    },
-    "So": {
-      "type": "string",
-      "max": 255
     },
     "S10": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 255
-      },
-      "value": {
-        "type": "string",
-        "max": 255
-      }
-    },
-    "S15": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "S16": {
-      "type": "string",
-      "max": 4096
-    },
-    "S1d": {
-      "type": "string",
-      "enum": [
-        "DNS_PUBLIC",
-        "DNS_PRIVATE"
-      ]
-    },
-    "S1k": {
-      "type": "string",
-      "enum": [
-        "SUBMITTED",
-        "PENDING",
-        "SUCCESS",
-        "FAIL"
-      ]
+      "key": {},
+      "value": {}
     },
     "S1z": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      }
-    },
-    "S21": {
-      "type": "string",
-      "enum": [
-        "EQ",
-        "IN",
-        "BETWEEN"
-      ]
+      "member": {}
     }
   }
 }

--- a/apis/shield-2016-06-02.min.json
+++ b/apis/shield-2016-06-02.min.json
@@ -20,9 +20,7 @@
           "LogBucket"
         ],
         "members": {
-          "LogBucket": {
-            "shape": "S2"
-          }
+          "LogBucket": {}
         }
       },
       "output": {
@@ -37,9 +35,7 @@
           "RoleArn"
         ],
         "members": {
-          "RoleArn": {
-            "shape": "S5"
-          }
+          "RoleArn": {}
         }
       },
       "output": {
@@ -55,20 +51,14 @@
           "ResourceArn"
         ],
         "members": {
-          "Name": {
-            "shape": "S8"
-          },
-          "ResourceArn": {
-            "shape": "S9"
-          }
+          "Name": {},
+          "ResourceArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ProtectionId": {
-            "shape": "Sb"
-          }
+          "ProtectionId": {}
         }
       }
     },
@@ -89,9 +79,7 @@
           "ProtectionId"
         ],
         "members": {
-          "ProtectionId": {
-            "shape": "Sb"
-          }
+          "ProtectionId": {}
         }
       },
       "output": {
@@ -119,9 +107,7 @@
           "AttackId"
         ],
         "members": {
-          "AttackId": {
-            "shape": "Sj"
-          }
+          "AttackId": {}
         }
       },
       "output": {
@@ -130,24 +116,14 @@
           "Attack": {
             "type": "structure",
             "members": {
-              "AttackId": {
-                "shape": "Sj"
-              },
-              "ResourceArn": {
-                "shape": "S9"
-              },
+              "AttackId": {},
+              "ResourceArn": {},
               "SubResources": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "Type": {
-                      "type": "string",
-                      "enum": [
-                        "IP",
-                        "URL"
-                      ]
-                    },
+                    "Type": {},
                     "Id": {},
                     "AttackVectors": {
                       "type": "list",
@@ -184,24 +160,8 @@
                 "member": {
                   "type": "structure",
                   "members": {
-                    "AttackLayer": {
-                      "type": "string",
-                      "enum": [
-                        "NETWORK",
-                        "APPLICATION"
-                      ]
-                    },
-                    "AttackPropertyIdentifier": {
-                      "type": "string",
-                      "enum": [
-                        "DESTINATION_URL",
-                        "REFERRER",
-                        "SOURCE_ASN",
-                        "SOURCE_COUNTRY",
-                        "SOURCE_IP_ADDRESS",
-                        "SOURCE_USER_AGENT"
-                      ]
-                    },
+                    "AttackLayer": {},
+                    "AttackPropertyIdentifier": {},
                     "TopContributors": {
                       "type": "list",
                       "member": {
@@ -214,15 +174,7 @@
                         }
                       }
                     },
-                    "Unit": {
-                      "type": "string",
-                      "enum": [
-                        "BITS",
-                        "BYTES",
-                        "PACKETS",
-                        "REQUESTS"
-                      ]
-                    },
+                    "Unit": {},
                     "Total": {
                       "type": "long"
                     }
@@ -251,16 +203,10 @@
       "output": {
         "type": "structure",
         "members": {
-          "RoleArn": {
-            "shape": "S5"
-          },
+          "RoleArn": {},
           "LogBucketList": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            },
-            "max": 10,
-            "min": 0
+            "member": {}
           }
         }
       }
@@ -286,9 +232,7 @@
           "ProtectionId"
         ],
         "members": {
-          "ProtectionId": {
-            "shape": "Sb"
-          }
+          "ProtectionId": {}
         }
       },
       "output": {
@@ -318,12 +262,9 @@
                 "type": "timestamp"
               },
               "TimeCommitmentInSeconds": {
-                "type": "long",
-                "min": 0
+                "type": "long"
               },
-              "AutoRenew": {
-                "shape": "S1n"
-              },
+              "AutoRenew": {},
               "Limits": {
                 "type": "list",
                 "member": {
@@ -348,9 +289,7 @@
           "LogBucket"
         ],
         "members": {
-          "LogBucket": {
-            "shape": "S2"
-          }
+          "LogBucket": {}
         }
       },
       "output": {
@@ -379,13 +318,7 @@
           "SubscriptionState"
         ],
         "members": {
-          "SubscriptionState": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "INACTIVE"
-            ]
-          }
+          "SubscriptionState": {}
         }
       }
     },
@@ -395,9 +328,7 @@
         "members": {
           "ResourceArns": {
             "type": "list",
-            "member": {
-              "shape": "S9"
-            }
+            "member": {}
           },
           "StartTime": {
             "shape": "S1z"
@@ -405,11 +336,9 @@
           "EndTime": {
             "shape": "S1z"
           },
-          "NextToken": {
-            "shape": "S20"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S21"
+            "type": "integer"
           }
         }
       },
@@ -444,9 +373,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S20"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -454,11 +381,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S20"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S21"
+            "type": "integer"
           }
         }
       },
@@ -471,9 +396,7 @@
               "shape": "S1h"
             }
           },
-          "NextToken": {
-            "shape": "S20"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -495,9 +418,7 @@
       "input": {
         "type": "structure",
         "members": {
-          "AutoRenew": {
-            "shape": "S1n"
-          }
+          "AutoRenew": {}
         }
       },
       "output": {
@@ -507,39 +428,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 63,
-      "min": 3,
-      "pattern": "^([a-z]|(\\d(?!\\d{0,2}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})))([a-z\\d]|(\\.(?!(\\.|-)))|(-(?!\\.))){1,61}[a-z\\d]$"
-    },
-    "S5": {
-      "type": "string",
-      "max": 96,
-      "pattern": "^arn:aws:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
-    },
-    "S8": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[ a-zA-Z0-9_\\\\.\\\\-]*"
-    },
-    "S9": {
-      "type": "string",
-      "min": 1
-    },
-    "Sb": {
-      "type": "string",
-      "max": 36,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\\\-]*"
-    },
-    "Sj": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9\\\\-]*"
-    },
     "Ss": {
       "type": "list",
       "member": {
@@ -570,35 +458,17 @@
           "EmailAddress"
         ],
         "members": {
-          "EmailAddress": {
-            "type": "string",
-            "pattern": "^\\S+@\\S+\\.\\S+$"
-          }
+          "EmailAddress": {}
         }
-      },
-      "max": 10,
-      "min": 0
+      }
     },
     "S1h": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "Sb"
-        },
-        "Name": {
-          "shape": "S8"
-        },
-        "ResourceArn": {
-          "shape": "S9"
-        }
+        "Id": {},
+        "Name": {},
+        "ResourceArn": {}
       }
-    },
-    "S1n": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED"
-      ]
     },
     "S1z": {
       "type": "structure",
@@ -610,15 +480,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S20": {
-      "type": "string",
-      "min": 1
-    },
-    "S21": {
-      "type": "integer",
-      "max": 10000,
-      "min": 0
     }
   }
 }

--- a/apis/signer-2017-08-25.min.json
+++ b/apis/signer-2017-08-25.min.json
@@ -25,7 +25,6 @@
         ],
         "members": {
           "profileName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           }
@@ -60,9 +59,7 @@
             "shape": "Sb"
           },
           "platformId": {},
-          "profileName": {
-            "shape": "S2"
-          },
+          "profileName": {},
           "overrides": {
             "shape": "Se"
           },
@@ -76,9 +73,7 @@
             "type": "timestamp"
           },
           "requestedBy": {},
-          "status": {
-            "shape": "So"
-          },
+          "status": {},
           "statusReason": {},
           "signedObject": {
             "shape": "Sq"
@@ -110,9 +105,7 @@
           "displayName": {},
           "partner": {},
           "target": {},
-          "category": {
-            "shape": "Sx"
-          },
+          "category": {},
           "signingConfiguration": {
             "shape": "Sy"
           },
@@ -137,7 +130,6 @@
         ],
         "members": {
           "profileName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           }
@@ -146,9 +138,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "profileName": {
-            "shape": "S2"
-          },
+          "profileName": {},
           "signingMaterial": {
             "shape": "Sb"
           },
@@ -159,9 +149,7 @@
           "signingParameters": {
             "shape": "Si"
           },
-          "status": {
-            "shape": "S19"
-          }
+          "status": {}
         }
       }
     },
@@ -174,7 +162,6 @@
         "type": "structure",
         "members": {
           "status": {
-            "shape": "So",
             "location": "querystring",
             "locationName": "status"
           },
@@ -187,9 +174,9 @@
             "locationName": "requestedBy"
           },
           "maxResults": {
-            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -218,9 +205,7 @@
                 "createdAt": {
                   "type": "timestamp"
                 },
-                "status": {
-                  "shape": "So"
-                }
+                "status": {}
               }
             }
           },
@@ -249,9 +234,9 @@
             "locationName": "target"
           },
           "maxResults": {
-            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -271,9 +256,7 @@
                 "displayName": {},
                 "partner": {},
                 "target": {},
-                "category": {
-                  "shape": "Sx"
-                },
+                "category": {},
                 "signingConfiguration": {
                   "shape": "Sy"
                 },
@@ -304,9 +287,9 @@
             "type": "boolean"
           },
           "maxResults": {
-            "shape": "S1b",
             "location": "querystring",
-            "locationName": "maxResults"
+            "locationName": "maxResults",
+            "type": "integer"
           },
           "nextToken": {
             "location": "querystring",
@@ -322,9 +305,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "profileName": {
-                  "shape": "S2"
-                },
+                "profileName": {},
                 "signingMaterial": {
                   "shape": "Sb"
                 },
@@ -332,9 +313,7 @@
                 "signingParameters": {
                   "shape": "Si"
                 },
-                "status": {
-                  "shape": "S19"
-                }
+                "status": {}
               }
             }
           },
@@ -356,7 +335,6 @@
         ],
         "members": {
           "profileName": {
-            "shape": "S2",
             "location": "uri",
             "locationName": "profileName"
           },
@@ -406,9 +384,7 @@
               }
             }
           },
-          "profileName": {
-            "shape": "S2"
-          },
+          "profileName": {},
           "clientRequestToken": {
             "idempotencyToken": true
           }
@@ -423,12 +399,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 20,
-      "min": 2,
-      "pattern": "^[a-zA-Z0-9_]{2,}"
-    },
     "S6": {
       "type": "structure",
       "members": {
@@ -462,42 +432,16 @@
         "signingConfiguration": {
           "type": "structure",
           "members": {
-            "encryptionAlgorithm": {
-              "shape": "Sg"
-            },
-            "hashAlgorithm": {
-              "shape": "Sh"
-            }
+            "encryptionAlgorithm": {},
+            "hashAlgorithm": {}
           }
         }
       }
-    },
-    "Sg": {
-      "type": "string",
-      "enum": [
-        "RSA",
-        "ECDSA"
-      ]
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "SHA1",
-        "SHA256"
-      ]
     },
     "Si": {
       "type": "map",
       "key": {},
       "value": {}
-    },
-    "So": {
-      "type": "string",
-      "enum": [
-        "InProgress",
-        "Failed",
-        "Succeeded"
-      ]
     },
     "Sq": {
       "type": "structure",
@@ -510,12 +454,6 @@
           }
         }
       }
-    },
-    "Sx": {
-      "type": "string",
-      "enum": [
-        "AWSIoT"
-      ]
     },
     "Sy": {
       "type": "structure",
@@ -533,13 +471,9 @@
           "members": {
             "allowedValues": {
               "type": "list",
-              "member": {
-                "shape": "Sg"
-              }
+              "member": {}
             },
-            "defaultValue": {
-              "shape": "Sg"
-            }
+            "defaultValue": {}
           }
         },
         "hashAlgorithmOptions": {
@@ -551,13 +485,9 @@
           "members": {
             "allowedValues": {
               "type": "list",
-              "member": {
-                "shape": "Sh"
-              }
+              "member": {}
             },
-            "defaultValue": {
-              "shape": "Sh"
-            }
+            "defaultValue": {}
           }
         }
       }
@@ -571,32 +501,10 @@
       "members": {
         "supportedFormats": {
           "type": "list",
-          "member": {
-            "shape": "S15"
-          }
+          "member": {}
         },
-        "defaultFormat": {
-          "shape": "S15"
-        }
+        "defaultFormat": {}
       }
-    },
-    "S15": {
-      "type": "string",
-      "enum": [
-        "JSON"
-      ]
-    },
-    "S19": {
-      "type": "string",
-      "enum": [
-        "Active",
-        "Canceled"
-      ]
-    },
-    "S1b": {
-      "type": "integer",
-      "max": 25,
-      "min": 1
     }
   }
 }

--- a/apis/sms-2016-10-24.min.json
+++ b/apis/sms-2016-10-24.min.json
@@ -29,9 +29,7 @@
           "frequency": {
             "type": "integer"
           },
-          "licenseType": {
-            "shape": "S5"
-          },
+          "licenseType": {},
           "roleName": {},
           "description": {}
         }
@@ -104,27 +102,15 @@
               "members": {
                 "connectorId": {},
                 "version": {},
-                "status": {
-                  "type": "string",
-                  "enum": [
-                    "HEALTHY",
-                    "UNHEALTHY"
-                  ]
-                },
+                "status": {},
                 "capabilityList": {
                   "type": "list",
                   "member": {
-                    "locationName": "item",
-                    "type": "string",
-                    "enum": [
-                      "VSPHERE"
-                    ]
+                    "locationName": "item"
                   }
                 },
                 "vmManagerName": {},
-                "vmManagerType": {
-                  "shape": "Ss"
-                },
+                "vmManagerType": {},
                 "vmManagerId": {},
                 "ipAddress": {},
                 "macAddress": {},
@@ -206,16 +192,7 @@
           "lastModifiedOn": {
             "type": "timestamp"
           },
-          "serverCatalogStatus": {
-            "type": "string",
-            "enum": [
-              "NOT_IMPORTED",
-              "IMPORTING",
-              "AVAILABLE",
-              "DELETED",
-              "EXPIRED"
-            ]
-          },
+          "serverCatalogStatus": {},
           "serverList": {
             "type": "list",
             "member": {
@@ -223,9 +200,7 @@
               "type": "structure",
               "members": {
                 "serverId": {},
-                "serverType": {
-                  "shape": "S10"
-                },
+                "serverType": {},
                 "vmServer": {
                   "shape": "S11"
                 },
@@ -282,9 +257,7 @@
           "nextReplicationRunStartTime": {
             "type": "timestamp"
           },
-          "licenseType": {
-            "shape": "S5"
-          },
+          "licenseType": {},
           "roleName": {},
           "description": {}
         }
@@ -296,27 +269,12 @@
     }
   },
   "shapes": {
-    "S5": {
-      "type": "string",
-      "enum": [
-        "AWS",
-        "BYOL"
-      ]
-    },
-    "Ss": {
-      "type": "string",
-      "enum": [
-        "VSPHERE"
-      ]
-    },
     "Sz": {
       "type": "structure",
       "members": {
         "replicationJobId": {},
         "serverId": {},
-        "serverType": {
-          "shape": "S10"
-        },
+        "serverType": {},
         "vmServer": {
           "shape": "S11"
         },
@@ -329,33 +287,16 @@
         "nextReplicationRunStartTime": {
           "type": "timestamp"
         },
-        "licenseType": {
-          "shape": "S5"
-        },
+        "licenseType": {},
         "roleName": {},
         "latestAmiId": {},
-        "state": {
-          "type": "string",
-          "enum": [
-            "PENDING",
-            "ACTIVE",
-            "FAILED",
-            "DELETING",
-            "DELETED"
-          ]
-        },
+        "state": {},
         "statusMessage": {},
         "description": {},
         "replicationRunList": {
           "shape": "S19"
         }
       }
-    },
-    "S10": {
-      "type": "string",
-      "enum": [
-        "VIRTUAL_MACHINE"
-      ]
     },
     "S11": {
       "type": "structure",
@@ -369,9 +310,7 @@
         },
         "vmName": {},
         "vmManagerName": {},
-        "vmManagerType": {
-          "shape": "Ss"
-        },
+        "vmManagerType": {},
         "vmPath": {}
       }
     },
@@ -382,25 +321,8 @@
         "type": "structure",
         "members": {
           "replicationRunId": {},
-          "state": {
-            "type": "string",
-            "enum": [
-              "PENDING",
-              "MISSED",
-              "ACTIVE",
-              "FAILED",
-              "COMPLETED",
-              "DELETING",
-              "DELETED"
-            ]
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "ON_DEMAND",
-              "AUTOMATIC"
-            ]
-          },
+          "state": {},
+          "type": {},
           "statusMessage": {},
           "amiId": {},
           "scheduledStartTime": {

--- a/apis/snowball-2016-06-30.min.json
+++ b/apis/snowball-2016-06-30.min.json
@@ -20,9 +20,7 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          }
+          "ClusterId": {}
         }
       },
       "output": {
@@ -37,9 +35,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S5"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -62,9 +58,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "AddressId": {
-            "shape": "Sa"
-          }
+          "AddressId": {}
         }
       }
     },
@@ -79,44 +73,26 @@
           "ShippingOption"
         ],
         "members": {
-          "JobType": {
-            "shape": "Se"
-          },
+          "JobType": {},
           "Resources": {
             "shape": "Sf"
           },
-          "Description": {
-            "shape": "Sa"
-          },
-          "AddressId": {
-            "shape": "S9"
-          },
-          "KmsKeyARN": {
-            "shape": "Sr"
-          },
-          "RoleARN": {
-            "shape": "Ss"
-          },
-          "SnowballType": {
-            "shape": "St"
-          },
-          "ShippingOption": {
-            "shape": "Su"
-          },
+          "Description": {},
+          "AddressId": {},
+          "KmsKeyARN": {},
+          "RoleARN": {},
+          "SnowballType": {},
+          "ShippingOption": {},
           "Notification": {
             "shape": "Sv"
           },
-          "ForwardingAddressId": {
-            "shape": "S9"
-          }
+          "ForwardingAddressId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          }
+          "ClusterId": {}
         }
       }
     },
@@ -124,50 +100,28 @@
       "input": {
         "type": "structure",
         "members": {
-          "JobType": {
-            "shape": "Se"
-          },
+          "JobType": {},
           "Resources": {
             "shape": "Sf"
           },
-          "Description": {
-            "shape": "Sa"
-          },
-          "AddressId": {
-            "shape": "S9"
-          },
-          "KmsKeyARN": {
-            "shape": "Sr"
-          },
-          "RoleARN": {
-            "shape": "Ss"
-          },
-          "SnowballCapacityPreference": {
-            "shape": "S11"
-          },
-          "ShippingOption": {
-            "shape": "Su"
-          },
+          "Description": {},
+          "AddressId": {},
+          "KmsKeyARN": {},
+          "RoleARN": {},
+          "SnowballCapacityPreference": {},
+          "ShippingOption": {},
           "Notification": {
             "shape": "Sv"
           },
-          "ClusterId": {
-            "shape": "S2"
-          },
-          "SnowballType": {
-            "shape": "St"
-          },
-          "ForwardingAddressId": {
-            "shape": "S9"
-          }
+          "ClusterId": {},
+          "SnowballType": {},
+          "ForwardingAddressId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "S5"
-          }
+          "JobId": {}
         }
       }
     },
@@ -178,9 +132,7 @@
           "AddressId"
         ],
         "members": {
-          "AddressId": {
-            "shape": "S9"
-          }
+          "AddressId": {}
         }
       },
       "output": {
@@ -197,11 +149,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S16"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -213,9 +163,7 @@
               "shape": "S8"
             }
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -226,9 +174,7 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          }
+          "ClusterId": {}
         }
       },
       "output": {
@@ -237,45 +183,25 @@
           "ClusterMetadata": {
             "type": "structure",
             "members": {
-              "ClusterId": {
-                "shape": "Sa"
-              },
-              "Description": {
-                "shape": "Sa"
-              },
-              "KmsKeyARN": {
-                "shape": "Sr"
-              },
-              "RoleARN": {
-                "shape": "Ss"
-              },
-              "ClusterState": {
-                "shape": "S1c"
-              },
-              "JobType": {
-                "shape": "Se"
-              },
-              "SnowballType": {
-                "shape": "St"
-              },
+              "ClusterId": {},
+              "Description": {},
+              "KmsKeyARN": {},
+              "RoleARN": {},
+              "ClusterState": {},
+              "JobType": {},
+              "SnowballType": {},
               "CreationDate": {
                 "type": "timestamp"
               },
               "Resources": {
                 "shape": "Sf"
               },
-              "AddressId": {
-                "shape": "S9"
-              },
-              "ShippingOption": {
-                "shape": "Su"
-              },
+              "AddressId": {},
+              "ShippingOption": {},
               "Notification": {
                 "shape": "Sv"
               },
-              "ForwardingAddressId": {
-                "shape": "S9"
-              }
+              "ForwardingAddressId": {}
             }
           }
         }
@@ -288,9 +214,7 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S5"
-          }
+          "JobId": {}
         }
       },
       "output": {
@@ -315,17 +239,13 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S5"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ManifestURI": {
-            "shape": "Sa"
-          }
+          "ManifestURI": {}
         }
       }
     },
@@ -336,17 +256,13 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S5"
-          }
+          "JobId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UnlockCode": {
-            "shape": "Sa"
-          }
+          "UnlockCode": {}
         }
       }
     },
@@ -374,15 +290,11 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          },
+          "ClusterId": {},
           "MaxResults": {
-            "shape": "S16"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -391,9 +303,7 @@
           "JobListEntries": {
             "shape": "S1w"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -402,11 +312,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S16"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -417,24 +325,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "ClusterId": {
-                  "shape": "Sa"
-                },
-                "ClusterState": {
-                  "shape": "S1c"
-                },
+                "ClusterId": {},
+                "ClusterState": {},
                 "CreationDate": {
                   "type": "timestamp"
                 },
-                "Description": {
-                  "shape": "Sa"
-                }
+                "Description": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -443,11 +343,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S16"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -458,18 +356,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "AmiId": {
-                  "shape": "Sa"
-                },
-                "Name": {
-                  "shape": "Sa"
-                }
+                "AmiId": {},
+                "Name": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -478,11 +370,9 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S16"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -491,9 +381,7 @@
           "JobListEntries": {
             "shape": "S1w"
           },
-          "NextToken": {
-            "shape": "Sa"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -504,30 +392,18 @@
           "ClusterId"
         ],
         "members": {
-          "ClusterId": {
-            "shape": "S2"
-          },
-          "RoleARN": {
-            "shape": "Ss"
-          },
-          "Description": {
-            "shape": "Sa"
-          },
+          "ClusterId": {},
+          "RoleARN": {},
+          "Description": {},
           "Resources": {
             "shape": "Sf"
           },
-          "AddressId": {
-            "shape": "S9"
-          },
-          "ShippingOption": {
-            "shape": "Su"
-          },
+          "AddressId": {},
+          "ShippingOption": {},
           "Notification": {
             "shape": "Sv"
           },
-          "ForwardingAddressId": {
-            "shape": "S9"
-          }
+          "ForwardingAddressId": {}
         }
       },
       "output": {
@@ -542,33 +418,19 @@
           "JobId"
         ],
         "members": {
-          "JobId": {
-            "shape": "S5"
-          },
-          "RoleARN": {
-            "shape": "Ss"
-          },
+          "JobId": {},
+          "RoleARN": {},
           "Notification": {
             "shape": "Sv"
           },
           "Resources": {
             "shape": "Sf"
           },
-          "AddressId": {
-            "shape": "S9"
-          },
-          "ShippingOption": {
-            "shape": "Su"
-          },
-          "Description": {
-            "shape": "Sa"
-          },
-          "SnowballCapacityPreference": {
-            "shape": "S11"
-          },
-          "ForwardingAddressId": {
-            "shape": "S9"
-          }
+          "AddressId": {},
+          "ShippingOption": {},
+          "Description": {},
+          "SnowballCapacityPreference": {},
+          "ForwardingAddressId": {}
         }
       },
       "output": {
@@ -578,82 +440,26 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 39,
-      "min": 39,
-      "pattern": "CID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "S5": {
-      "type": "string",
-      "max": 39,
-      "min": 39,
-      "pattern": "(M|J)ID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
     "S8": {
       "type": "structure",
       "members": {
-        "AddressId": {
-          "shape": "S9"
-        },
-        "Name": {
-          "shape": "Sa"
-        },
-        "Company": {
-          "shape": "Sa"
-        },
-        "Street1": {
-          "shape": "Sa"
-        },
-        "Street2": {
-          "shape": "Sa"
-        },
-        "Street3": {
-          "shape": "Sa"
-        },
-        "City": {
-          "shape": "Sa"
-        },
-        "StateOrProvince": {
-          "shape": "Sa"
-        },
-        "PrefectureOrDistrict": {
-          "shape": "Sa"
-        },
-        "Landmark": {
-          "shape": "Sa"
-        },
-        "Country": {
-          "shape": "Sa"
-        },
-        "PostalCode": {
-          "shape": "Sa"
-        },
-        "PhoneNumber": {
-          "shape": "Sa"
-        },
+        "AddressId": {},
+        "Name": {},
+        "Company": {},
+        "Street1": {},
+        "Street2": {},
+        "Street3": {},
+        "City": {},
+        "StateOrProvince": {},
+        "PrefectureOrDistrict": {},
+        "Landmark": {},
+        "Country": {},
+        "PostalCode": {},
+        "PhoneNumber": {},
         "IsRestricted": {
           "type": "boolean"
         }
       }
-    },
-    "S9": {
-      "type": "string",
-      "max": 40,
-      "min": 40,
-      "pattern": "ADID[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    },
-    "Sa": {
-      "type": "string",
-      "min": 1
-    },
-    "Se": {
-      "type": "string",
-      "enum": [
-        "IMPORT",
-        "EXPORT",
-        "LOCAL_USE"
-      ]
     },
     "Sf": {
       "type": "structure",
@@ -663,18 +469,12 @@
           "member": {
             "type": "structure",
             "members": {
-              "BucketArn": {
-                "shape": "Si"
-              },
+              "BucketArn": {},
               "KeyRange": {
                 "type": "structure",
                 "members": {
-                  "BeginMarker": {
-                    "shape": "Sa"
-                  },
-                  "EndMarker": {
-                    "shape": "Sa"
-                  }
+                  "BeginMarker": {},
+                  "EndMarker": {}
                 }
               }
             }
@@ -685,17 +485,13 @@
           "member": {
             "type": "structure",
             "members": {
-              "LambdaArn": {
-                "shape": "Si"
-              },
+              "LambdaArn": {},
               "EventTriggers": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "EventResourceARN": {
-                      "shape": "Si"
-                    }
+                    "EventResourceARN": {}
                   }
                 }
               }
@@ -710,150 +506,47 @@
               "AmiId"
             ],
             "members": {
-              "AmiId": {
-                "type": "string",
-                "max": 21,
-                "min": 12,
-                "pattern": "(ami-[0-9a-f]{8})|(ami-[0-9a-f]{17})"
-              },
-              "SnowballAmiId": {
-                "shape": "Sa"
-              }
+              "AmiId": {},
+              "SnowballAmiId": {}
             }
           }
         }
       }
     },
-    "Si": {
-      "type": "string",
-      "max": 255
-    },
-    "Sr": {
-      "type": "string",
-      "max": 255,
-      "pattern": "arn:aws.*:kms:.*:[0-9]{12}:key/.*"
-    },
-    "Ss": {
-      "type": "string",
-      "max": 255,
-      "pattern": "arn:aws.*:iam::[0-9]{12}:role/.*"
-    },
-    "St": {
-      "type": "string",
-      "enum": [
-        "STANDARD",
-        "EDGE"
-      ]
-    },
-    "Su": {
-      "type": "string",
-      "enum": [
-        "SECOND_DAY",
-        "NEXT_DAY",
-        "EXPRESS",
-        "STANDARD"
-      ]
-    },
     "Sv": {
       "type": "structure",
       "members": {
-        "SnsTopicARN": {
-          "type": "string",
-          "max": 255,
-          "pattern": "arn:aws.*:sns:.*:[0-9]{12}:.*"
-        },
+        "SnsTopicARN": {},
         "JobStatesToNotify": {
           "type": "list",
-          "member": {
-            "shape": "Sy"
-          }
+          "member": {}
         },
         "NotifyAll": {
           "type": "boolean"
         }
       }
     },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "New",
-        "PreparingAppliance",
-        "PreparingShipment",
-        "InTransitToCustomer",
-        "WithCustomer",
-        "InTransitToAWS",
-        "WithAWSSortingFacility",
-        "WithAWS",
-        "InProgress",
-        "Complete",
-        "Cancelled",
-        "Listing",
-        "Pending"
-      ]
-    },
-    "S11": {
-      "type": "string",
-      "enum": [
-        "T50",
-        "T80",
-        "T100",
-        "NoPreference"
-      ]
-    },
-    "S16": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
-    },
-    "S1c": {
-      "type": "string",
-      "enum": [
-        "AwaitingQuorum",
-        "Pending",
-        "InUse",
-        "Complete",
-        "Cancelled"
-      ]
-    },
     "S1g": {
       "type": "structure",
       "members": {
-        "JobId": {
-          "shape": "Sa"
-        },
-        "JobState": {
-          "shape": "Sy"
-        },
-        "JobType": {
-          "shape": "Se"
-        },
-        "SnowballType": {
-          "shape": "St"
-        },
+        "JobId": {},
+        "JobState": {},
+        "JobType": {},
+        "SnowballType": {},
         "CreationDate": {
           "type": "timestamp"
         },
         "Resources": {
           "shape": "Sf"
         },
-        "Description": {
-          "shape": "Sa"
-        },
-        "KmsKeyARN": {
-          "shape": "Sr"
-        },
-        "RoleARN": {
-          "shape": "Ss"
-        },
-        "AddressId": {
-          "shape": "S9"
-        },
+        "Description": {},
+        "KmsKeyARN": {},
+        "RoleARN": {},
+        "AddressId": {},
         "ShippingDetails": {
           "type": "structure",
           "members": {
-            "ShippingOption": {
-              "shape": "Su"
-            },
+            "ShippingOption": {},
             "InboundShipment": {
               "shape": "S1i"
             },
@@ -862,9 +555,7 @@
             }
           }
         },
-        "SnowballCapacityPreference": {
-          "shape": "S11"
-        },
+        "SnowballCapacityPreference": {},
         "Notification": {
           "shape": "Sv"
         },
@@ -888,34 +579,20 @@
         "JobLogInfo": {
           "type": "structure",
           "members": {
-            "JobCompletionReportURI": {
-              "shape": "Sa"
-            },
-            "JobSuccessLogURI": {
-              "shape": "Sa"
-            },
-            "JobFailureLogURI": {
-              "shape": "Sa"
-            }
+            "JobCompletionReportURI": {},
+            "JobSuccessLogURI": {},
+            "JobFailureLogURI": {}
           }
         },
-        "ClusterId": {
-          "shape": "Sa"
-        },
-        "ForwardingAddressId": {
-          "shape": "S9"
-        }
+        "ClusterId": {},
+        "ForwardingAddressId": {}
       }
     },
     "S1i": {
       "type": "structure",
       "members": {
-        "Status": {
-          "shape": "Sa"
-        },
-        "TrackingNumber": {
-          "shape": "Sa"
-        }
+        "Status": {},
+        "TrackingNumber": {}
       }
     },
     "S1w": {
@@ -923,27 +600,17 @@
       "member": {
         "type": "structure",
         "members": {
-          "JobId": {
-            "shape": "Sa"
-          },
-          "JobState": {
-            "shape": "Sy"
-          },
+          "JobId": {},
+          "JobState": {},
           "IsMaster": {
             "type": "boolean"
           },
-          "JobType": {
-            "shape": "Se"
-          },
-          "SnowballType": {
-            "shape": "St"
-          },
+          "JobType": {},
+          "SnowballType": {},
           "CreationDate": {
             "type": "timestamp"
           },
-          "Description": {
-            "shape": "Sa"
-          }
+          "Description": {}
         }
       }
     }

--- a/apis/sqs-2012-11-05.min.json
+++ b/apis/sqs-2012-11-05.min.json
@@ -380,17 +380,7 @@
                   "locationName": "Attribute",
                   "type": "map",
                   "key": {
-                    "locationName": "Name",
-                    "type": "string",
-                    "enum": [
-                      "SenderId",
-                      "SentTimestamp",
-                      "ApproximateReceiveCount",
-                      "ApproximateFirstReceiveTimestamp",
-                      "SequenceNumber",
-                      "MessageDeduplicationId",
-                      "MessageGroupId"
-                    ]
+                    "locationName": "Name"
                   },
                   "value": {
                     "locationName": "Value"
@@ -600,7 +590,6 @@
     "Sh": {
       "type": "map",
       "key": {
-        "shape": "Si",
         "locationName": "Name"
       },
       "value": {
@@ -609,33 +598,9 @@
       "flattened": true,
       "locationName": "Attribute"
     },
-    "Si": {
-      "type": "string",
-      "enum": [
-        "All",
-        "Policy",
-        "VisibilityTimeout",
-        "MaximumMessageSize",
-        "MessageRetentionPeriod",
-        "ApproximateNumberOfMessages",
-        "ApproximateNumberOfMessagesNotVisible",
-        "CreatedTimestamp",
-        "LastModifiedTimestamp",
-        "QueueArn",
-        "ApproximateNumberOfMessagesDelayed",
-        "DelaySeconds",
-        "ReceiveMessageWaitTimeSeconds",
-        "RedrivePolicy",
-        "FifoQueue",
-        "ContentBasedDeduplication",
-        "KmsMasterKeyId",
-        "KmsDataKeyReusePeriodSeconds"
-      ]
-    },
     "St": {
       "type": "list",
       "member": {
-        "shape": "Si",
         "locationName": "AttributeName"
       },
       "flattened": true

--- a/apis/ssm-2014-11-06.min.json
+++ b/apis/ssm-2014-11-06.min.json
@@ -22,9 +22,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceType": {
-            "shape": "S2"
-          },
+          "ResourceType": {},
           "ResourceId": {},
           "Tags": {
             "shape": "S4"
@@ -43,9 +41,7 @@
           "CommandId"
         ],
         "members": {
-          "CommandId": {
-            "shape": "Sa"
-          },
+          "CommandId": {},
           "InstanceIds": {
             "shape": "Sb"
           }
@@ -63,17 +59,11 @@
           "IamRole"
         ],
         "members": {
-          "Description": {
-            "shape": "Sf"
-          },
-          "DefaultInstanceName": {
-            "shape": "Sg"
-          },
-          "IamRole": {
-            "shape": "Sh"
-          },
+          "Description": {},
+          "DefaultInstanceName": {},
+          "IamRole": {},
           "RegistrationLimit": {
-            "shape": "Si"
+            "type": "integer"
           },
           "ExpirationDate": {
             "type": "timestamp"
@@ -83,14 +73,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "ActivationId": {
-            "shape": "Sl"
-          },
-          "ActivationCode": {
-            "type": "string",
-            "max": 250,
-            "min": 20
-          }
+          "ActivationId": {},
+          "ActivationCode": {}
         }
       }
     },
@@ -101,30 +85,20 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "Name": {},
+          "DocumentVersion": {},
+          "InstanceId": {},
           "Parameters": {
             "shape": "Sq"
           },
           "Targets": {
             "shape": "Su"
           },
-          "ScheduleExpression": {
-            "shape": "Sz"
-          },
+          "ScheduleExpression": {},
           "OutputLocation": {
             "shape": "S10"
           },
-          "AssociationName": {
-            "shape": "S15"
-          }
+          "AssociationName": {}
         }
       },
       "output": {
@@ -147,8 +121,7 @@
             "type": "list",
             "member": {
               "shape": "S1l"
-            },
-            "min": 1
+            }
           }
         }
       },
@@ -170,14 +143,7 @@
                   "shape": "S1l"
                 },
                 "Message": {},
-                "Fault": {
-                  "type": "string",
-                  "enum": [
-                    "Client",
-                    "Server",
-                    "Unknown"
-                  ]
-                }
+                "Fault": {}
               }
             }
           }
@@ -192,21 +158,11 @@
           "Name"
         ],
         "members": {
-          "Content": {
-            "shape": "S1t"
-          },
-          "Name": {
-            "shape": "So"
-          },
-          "DocumentType": {
-            "shape": "S1u"
-          },
-          "DocumentFormat": {
-            "shape": "S1v"
-          },
-          "TargetType": {
-            "shape": "S1w"
-          }
+          "Content": {},
+          "Name": {},
+          "DocumentType": {},
+          "DocumentFormat": {},
+          "TargetType": {}
         }
       },
       "output": {
@@ -229,26 +185,21 @@
           "AllowUnassociatedTargets"
         ],
         "members": {
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {
-            "shape": "S2i"
-          },
+          "Schedule": {},
           "Duration": {
-            "shape": "S2j"
+            "type": "integer"
           },
           "Cutoff": {
-            "shape": "S2k"
+            "type": "integer"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
           },
           "ClientToken": {
-            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -256,9 +207,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          }
+          "WindowId": {}
         }
       }
     },
@@ -269,12 +218,8 @@
           "Name"
         ],
         "members": {
-          "OperatingSystem": {
-            "shape": "S2q"
-          },
-          "Name": {
-            "shape": "S2r"
-          },
+          "OperatingSystem": {},
+          "Name": {},
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -284,23 +229,18 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {
-            "shape": "S31"
-          },
+          "ApprovedPatchesComplianceLevel": {},
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
           "RejectedPatches": {
             "shape": "S34"
           },
-          "Description": {
-            "shape": "S36"
-          },
+          "Description": {},
           "Sources": {
             "shape": "S37"
           },
           "ClientToken": {
-            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -308,9 +248,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       }
     },
@@ -322,9 +260,7 @@
           "S3Destination"
         ],
         "members": {
-          "SyncName": {
-            "shape": "S3g"
-          },
+          "SyncName": {},
           "S3Destination": {
             "shape": "S3h"
           }
@@ -342,9 +278,7 @@
           "ActivationId"
         ],
         "members": {
-          "ActivationId": {
-            "shape": "Sl"
-          }
+          "ActivationId": {}
         }
       },
       "output": {
@@ -356,15 +290,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "AssociationId": {
-            "shape": "S1i"
-          }
+          "Name": {},
+          "InstanceId": {},
+          "AssociationId": {}
         }
       },
       "output": {
@@ -379,9 +307,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -396,21 +322,12 @@
           "TypeName"
         ],
         "members": {
-          "TypeName": {
-            "shape": "S3v"
-          },
-          "SchemaDeleteOption": {
-            "type": "string",
-            "enum": [
-              "DisableSchema",
-              "DeleteSchema"
-            ]
-          },
+          "TypeName": {},
+          "SchemaDeleteOption": {},
           "DryRun": {
             "type": "boolean"
           },
           "ClientToken": {
-            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -419,9 +336,7 @@
         "type": "structure",
         "members": {
           "DeletionId": {},
-          "TypeName": {
-            "shape": "S3v"
-          },
+          "TypeName": {},
           "DeletionSummary": {
             "shape": "S40"
           }
@@ -435,17 +350,13 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          }
+          "WindowId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          }
+          "WindowId": {}
         }
       }
     },
@@ -456,9 +367,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S4a"
-          }
+          "Name": {}
         }
       },
       "output": {
@@ -497,17 +406,13 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       }
     },
@@ -518,9 +423,7 @@
           "SyncName"
         ],
         "members": {
-          "SyncName": {
-            "shape": "S3g"
-          }
+          "SyncName": {}
         }
       },
       "output": {
@@ -535,9 +438,7 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "S4k"
-          }
+          "InstanceId": {}
         }
       },
       "output": {
@@ -553,23 +454,15 @@
           "PatchGroup"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "PatchGroup": {
-            "shape": "S4n"
-          }
+          "BaselineId": {},
+          "PatchGroup": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "PatchGroup": {
-            "shape": "S4n"
-          }
+          "BaselineId": {},
+          "PatchGroup": {}
         }
       }
     },
@@ -581,12 +474,8 @@
           "WindowTargetId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTargetId": {
-            "shape": "S4q"
-          },
+          "WindowId": {},
+          "WindowTargetId": {},
           "Safe": {
             "type": "boolean"
           }
@@ -595,12 +484,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTargetId": {
-            "shape": "S4q"
-          }
+          "WindowId": {},
+          "WindowTargetId": {}
         }
       }
     },
@@ -612,23 +497,15 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          }
+          "WindowId": {},
+          "WindowTaskId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          }
+          "WindowId": {},
+          "WindowTaskId": {}
         }
       }
     },
@@ -641,14 +518,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "FilterKey": {
-                  "type": "string",
-                  "enum": [
-                    "ActivationIds",
-                    "DefaultInstanceName",
-                    "IamRole"
-                  ]
-                },
+                "FilterKey": {},
                 "FilterValues": {
                   "type": "list",
                   "member": {}
@@ -657,7 +527,7 @@
             }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -670,25 +540,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "ActivationId": {
-                  "shape": "Sl"
-                },
-                "Description": {
-                  "shape": "Sf"
-                },
-                "DefaultInstanceName": {
-                  "shape": "Sg"
-                },
-                "IamRole": {
-                  "shape": "Sh"
-                },
+                "ActivationId": {},
+                "Description": {},
+                "DefaultInstanceName": {},
+                "IamRole": {},
                 "RegistrationLimit": {
-                  "shape": "Si"
+                  "type": "integer"
                 },
                 "RegistrationsCount": {
-                  "type": "integer",
-                  "max": 1000,
-                  "min": 1
+                  "type": "integer"
                 },
                 "ExpirationDate": {
                   "type": "timestamp"
@@ -710,18 +570,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "AssociationId": {
-            "shape": "S1i"
-          },
-          "AssociationVersion": {
-            "shape": "S18"
-          }
+          "Name": {},
+          "InstanceId": {},
+          "AssociationId": {},
+          "AssociationVersion": {}
         }
       },
       "output": {
@@ -741,12 +593,8 @@
           "ExecutionId"
         ],
         "members": {
-          "AssociationId": {
-            "shape": "S1i"
-          },
-          "ExecutionId": {
-            "shape": "S5b"
-          },
+          "AssociationId": {},
+          "ExecutionId": {},
           "Filters": {
             "type": "list",
             "member": {
@@ -756,24 +604,13 @@
                 "Value"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "enum": [
-                    "Status",
-                    "ResourceId",
-                    "ResourceType"
-                  ]
-                },
-                "Value": {
-                  "type": "string",
-                  "min": 1
-                }
+                "Key": {},
+                "Value": {}
               }
-            },
-            "min": 1
+            }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -786,25 +623,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                },
-                "ExecutionId": {
-                  "shape": "S5b"
-                },
-                "ResourceId": {
-                  "type": "string",
-                  "max": 100,
-                  "min": 1
-                },
-                "ResourceType": {
-                  "type": "string",
-                  "max": 50,
-                  "min": 1
-                },
+                "AssociationId": {},
+                "AssociationVersion": {},
+                "ExecutionId": {},
+                "ResourceId": {},
+                "ResourceType": {},
                 "Status": {},
                 "DetailedStatus": {},
                 "LastExecutionDate": {
@@ -813,11 +636,7 @@
                 "OutputSource": {
                   "type": "structure",
                   "members": {
-                    "OutputSourceId": {
-                      "type": "string",
-                      "max": 36,
-                      "min": 36
-                    },
+                    "OutputSourceId": {},
                     "OutputSourceType": {}
                   }
                 }
@@ -835,9 +654,7 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {
-            "shape": "S1i"
-          },
+          "AssociationId": {},
           "Filters": {
             "type": "list",
             "member": {
@@ -848,32 +665,14 @@
                 "Type"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "enum": [
-                    "ExecutionId",
-                    "Status",
-                    "CreatedTime"
-                  ]
-                },
-                "Value": {
-                  "type": "string",
-                  "min": 1
-                },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "EQUAL",
-                    "LESS_THAN",
-                    "GREATER_THAN"
-                  ]
-                }
+                "Key": {},
+                "Value": {},
+                "Type": {}
               }
-            },
-            "min": 1
+            }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -886,15 +685,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                },
-                "ExecutionId": {
-                  "shape": "S5b"
-                },
+                "AssociationId": {},
+                "AssociationVersion": {},
+                "ExecutionId": {},
                 "Status": {},
                 "DetailedStatus": {},
                 "CreatedTime": {
@@ -924,35 +717,16 @@
                 "Values"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "enum": [
-                    "DocumentNamePrefix",
-                    "ExecutionStatus",
-                    "ExecutionId",
-                    "ParentExecutionId",
-                    "CurrentAction",
-                    "StartTimeBefore",
-                    "StartTimeAfter"
-                  ]
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 150,
-                    "min": 1
-                  },
-                  "max": 10,
-                  "min": 1
+                  "member": {}
                 }
               }
-            },
-            "max": 10,
-            "min": 1
+            }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -965,18 +739,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "AutomationExecutionId": {
-                  "shape": "S67"
-                },
-                "DocumentName": {
-                  "shape": "So"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
-                "AutomationExecutionStatus": {
-                  "shape": "S68"
-                },
+                "AutomationExecutionId": {},
+                "DocumentName": {},
+                "DocumentVersion": {},
+                "AutomationExecutionStatus": {},
                 "ExecutionStartTime": {
                   "type": "timestamp"
                 },
@@ -988,18 +754,12 @@
                 "Outputs": {
                   "shape": "S69"
                 },
-                "Mode": {
-                  "shape": "S6d"
-                },
-                "ParentAutomationExecutionId": {
-                  "shape": "S67"
-                },
+                "Mode": {},
+                "ParentAutomationExecutionId": {},
                 "CurrentStepName": {},
                 "CurrentAction": {},
                 "FailureMessage": {},
-                "TargetParameterName": {
-                  "shape": "S6a"
-                },
+                "TargetParameterName": {},
                 "Targets": {
                   "shape": "Su"
                 },
@@ -1009,12 +769,8 @@
                 "ResolvedTargets": {
                   "shape": "S6j"
                 },
-                "MaxConcurrency": {
-                  "shape": "S6l"
-                },
-                "MaxErrors": {
-                  "shape": "S6m"
-                },
+                "MaxConcurrency": {},
+                "MaxErrors": {},
                 "Target": {}
               }
             }
@@ -1030,9 +786,7 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {
-            "shape": "S67"
-          },
+          "AutomationExecutionId": {},
           "Filters": {
             "type": "list",
             "member": {
@@ -1042,35 +796,17 @@
                 "Values"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "enum": [
-                    "StartTimeBefore",
-                    "StartTimeAfter",
-                    "StepExecutionStatus",
-                    "StepExecutionId",
-                    "StepName",
-                    "Action"
-                  ]
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 150,
-                    "min": 1
-                  },
-                  "max": 10,
-                  "min": 1
+                  "member": {}
                 }
               }
-            },
-            "max": 6,
-            "min": 1
+            }
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "ReverseOrder": {
             "type": "boolean"
@@ -1095,7 +831,7 @@
             "shape": "S74"
           },
           "MaxResults": {
-            "shape": "S79"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1120,12 +856,8 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S22"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          }
+          "Name": {},
+          "DocumentVersion": {}
         }
       },
       "output": {
@@ -1145,12 +877,8 @@
           "PermissionType"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "PermissionType": {
-            "shape": "S7r"
-          }
+          "Name": {},
+          "PermissionType": {}
         }
       },
       "output": {
@@ -1169,13 +897,9 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "InstanceId": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 5,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1188,18 +912,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "InstanceId": {
-                  "shape": "Sc"
-                },
-                "Content": {
-                  "shape": "S1t"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                }
+                "AssociationId": {},
+                "InstanceId": {},
+                "Content": {},
+                "AssociationVersion": {}
               }
             }
           },
@@ -1214,11 +930,9 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
+          "BaselineId": {},
           "MaxResults": {
-            "shape": "S79"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1237,18 +951,8 @@
                 "PatchStatus": {
                   "type": "structure",
                   "members": {
-                    "DeploymentStatus": {
-                      "type": "string",
-                      "enum": [
-                        "APPROVED",
-                        "PENDING_APPROVAL",
-                        "EXPLICIT_APPROVED",
-                        "EXPLICIT_REJECTED"
-                      ]
-                    },
-                    "ComplianceLevel": {
-                      "shape": "S31"
-                    },
+                    "DeploymentStatus": {},
+                    "ComplianceLevel": {},
                     "ApprovalDate": {
                       "type": "timestamp"
                     }
@@ -1268,11 +972,9 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "InstanceId": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1285,35 +987,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "Name": {
-                  "shape": "So"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                },
-                "InstanceId": {
-                  "shape": "Sc"
-                },
+                "AssociationId": {},
+                "Name": {},
+                "DocumentVersion": {},
+                "AssociationVersion": {},
+                "InstanceId": {},
                 "ExecutionDate": {
                   "type": "timestamp"
                 },
                 "Status": {},
                 "DetailedStatus": {},
-                "ExecutionSummary": {
-                  "type": "string",
-                  "max": 512,
-                  "min": 1
-                },
-                "ErrorCode": {
-                  "type": "string",
-                  "max": 10
-                },
+                "ExecutionSummary": {},
+                "ErrorCode": {},
                 "OutputUrl": {
                   "type": "structure",
                   "members": {
@@ -1325,9 +1010,7 @@
                     }
                   }
                 },
-                "AssociationName": {
-                  "shape": "S15"
-                }
+                "AssociationName": {}
               }
             }
           },
@@ -1348,25 +1031,12 @@
                 "valueSet"
               ],
               "members": {
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "InstanceIds",
-                    "AgentVersion",
-                    "PingStatus",
-                    "PlatformTypes",
-                    "ActivationIds",
-                    "IamRole",
-                    "ResourceType",
-                    "AssociationStatus"
-                  ]
-                },
+                "key": {},
                 "valueSet": {
                   "shape": "S8j"
                 }
               }
-            },
-            "min": 0
+            }
           },
           "Filters": {
             "type": "list",
@@ -1377,21 +1047,15 @@
                 "Values"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "min": 1
-                },
+                "Key": {},
                 "Values": {
                   "shape": "S8j"
                 }
               }
-            },
-            "min": 0
+            }
           },
           "MaxResults": {
-            "type": "integer",
-            "max": 50,
-            "min": 5
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1404,60 +1068,27 @@
             "member": {
               "type": "structure",
               "members": {
-                "InstanceId": {
-                  "shape": "Sc"
-                },
-                "PingStatus": {
-                  "type": "string",
-                  "enum": [
-                    "Online",
-                    "ConnectionLost",
-                    "Inactive"
-                  ]
-                },
+                "InstanceId": {},
+                "PingStatus": {},
                 "LastPingDateTime": {
                   "type": "timestamp"
                 },
-                "AgentVersion": {
-                  "type": "string",
-                  "pattern": "^[0-9]{1,6}(\\.[0-9]{1,6}){2,3}$"
-                },
+                "AgentVersion": {},
                 "IsLatestVersion": {
                   "type": "boolean"
                 },
-                "PlatformType": {
-                  "shape": "S2d"
-                },
+                "PlatformType": {},
                 "PlatformName": {},
                 "PlatformVersion": {},
-                "ActivationId": {
-                  "shape": "Sl"
-                },
-                "IamRole": {
-                  "shape": "Sh"
-                },
+                "ActivationId": {},
+                "IamRole": {},
                 "RegistrationDate": {
                   "type": "timestamp"
                 },
-                "ResourceType": {
-                  "type": "string",
-                  "enum": [
-                    "ManagedInstance",
-                    "Document",
-                    "EC2Instance"
-                  ]
-                },
+                "ResourceType": {},
                 "Name": {},
-                "IPAddress": {
-                  "type": "string",
-                  "max": 46,
-                  "min": 1
-                },
-                "ComputerName": {
-                  "type": "string",
-                  "max": 255,
-                  "min": 1
-                },
+                "IPAddress": {},
+                "ComputerName": {},
                 "AssociationStatus": {},
                 "LastAssociationExecutionDate": {
                   "type": "timestamp"
@@ -1497,7 +1128,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S90"
+            "type": "integer"
           }
         }
       },
@@ -1521,9 +1152,7 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {
-            "shape": "S4n"
-          },
+          "PatchGroup": {},
           "Filters": {
             "type": "list",
             "member": {
@@ -1534,34 +1163,18 @@
                 "Type"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "max": 200,
-                  "min": 1
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {},
-                  "max": 1,
-                  "min": 1
+                  "member": {}
                 },
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "Equal",
-                    "NotEqual",
-                    "LessThan",
-                    "GreaterThan"
-                  ]
-                }
+                "Type": {}
               }
-            },
-            "max": 4,
-            "min": 0
+            }
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S90"
+            "type": "integer"
           }
         }
       },
@@ -1572,9 +1185,7 @@
             "type": "list",
             "member": {
               "shape": "S93"
-            },
-            "max": 5,
-            "min": 1
+            }
           },
           "NextToken": {}
         }
@@ -1587,15 +1198,13 @@
           "InstanceId"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "InstanceId": {},
           "Filters": {
             "shape": "S74"
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S90"
+            "type": "integer"
           }
         }
       },
@@ -1619,16 +1228,7 @@
                 "KBId": {},
                 "Classification": {},
                 "Severity": {},
-                "State": {
-                  "type": "string",
-                  "enum": [
-                    "INSTALLED",
-                    "INSTALLED_OTHER",
-                    "MISSING",
-                    "NOT_APPLICABLE",
-                    "FAILED"
-                  ]
-                },
+                "State": {},
                 "InstalledTime": {
                   "type": "timestamp"
                 }
@@ -1646,7 +1246,7 @@
           "DeletionId": {},
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -1659,19 +1259,11 @@
               "type": "structure",
               "members": {
                 "DeletionId": {},
-                "TypeName": {
-                  "shape": "S3v"
-                },
+                "TypeName": {},
                 "DeletionStartTime": {
                   "type": "timestamp"
                 },
-                "LastStatus": {
-                  "type": "string",
-                  "enum": [
-                    "InProgress",
-                    "Complete"
-                  ]
-                },
+                "LastStatus": {},
                 "LastStatusMessage": {},
                 "DeletionSummary": {
                   "shape": "S40"
@@ -1694,17 +1286,13 @@
           "TaskId"
         ],
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
-          "TaskId": {
-            "shape": "Sa1"
-          },
+          "WindowExecutionId": {},
+          "TaskId": {},
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1717,28 +1305,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowExecutionId": {
-                  "shape": "Sa0"
-                },
-                "TaskExecutionId": {
-                  "shape": "Sa1"
-                },
-                "InvocationId": {
-                  "shape": "Sab"
-                },
+                "WindowExecutionId": {},
+                "TaskExecutionId": {},
+                "InvocationId": {},
                 "ExecutionId": {},
-                "TaskType": {
-                  "shape": "Sad"
-                },
+                "TaskType": {},
                 "Parameters": {
                   "shape": "Sae"
                 },
-                "Status": {
-                  "shape": "Saf"
-                },
-                "StatusDetails": {
-                  "shape": "Sag"
-                },
+                "Status": {},
+                "StatusDetails": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -1748,9 +1324,7 @@
                 "OwnerInformation": {
                   "shape": "S95"
                 },
-                "WindowTargetId": {
-                  "shape": "Sah"
-                }
+                "WindowTargetId": {}
               }
             }
           },
@@ -1765,14 +1339,12 @@
           "WindowExecutionId"
         ],
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
+          "WindowExecutionId": {},
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1785,30 +1357,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowExecutionId": {
-                  "shape": "Sa0"
-                },
-                "TaskExecutionId": {
-                  "shape": "Sa1"
-                },
-                "Status": {
-                  "shape": "Saf"
-                },
-                "StatusDetails": {
-                  "shape": "Sag"
-                },
+                "WindowExecutionId": {},
+                "TaskExecutionId": {},
+                "Status": {},
+                "StatusDetails": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
                 "EndTime": {
                   "type": "timestamp"
                 },
-                "TaskArn": {
-                  "shape": "Sam"
-                },
-                "TaskType": {
-                  "shape": "Sad"
-                }
+                "TaskArn": {},
+                "TaskType": {}
               }
             }
           },
@@ -1823,14 +1383,12 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
+          "WindowId": {},
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1843,18 +1401,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {
-                  "shape": "S2o"
-                },
-                "WindowExecutionId": {
-                  "shape": "Sa0"
-                },
-                "Status": {
-                  "shape": "Saf"
-                },
-                "StatusDetails": {
-                  "shape": "Sag"
-                },
+                "WindowId": {},
+                "WindowExecutionId": {},
+                "Status": {},
+                "StatusDetails": {},
                 "StartTime": {
                   "type": "timestamp"
                 },
@@ -1875,14 +1425,12 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
+          "WindowId": {},
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1895,24 +1443,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {
-                  "shape": "S2o"
-                },
-                "WindowTargetId": {
-                  "shape": "S4q"
-                },
-                "ResourceType": {
-                  "shape": "Sav"
-                },
+                "WindowId": {},
+                "WindowTargetId": {},
+                "ResourceType": {},
                 "Targets": {
                   "shape": "Su"
                 },
                 "OwnerInformation": {
                   "shape": "S95"
                 },
-                "Name": {
-                  "shape": "S2g"
-                },
+                "Name": {},
                 "Description": {
                   "shape": "S2h"
                 }
@@ -1930,14 +1470,12 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
+          "WindowId": {},
           "Filters": {
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -1950,18 +1488,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {
-                  "shape": "S2o"
-                },
-                "WindowTaskId": {
-                  "shape": "S4t"
-                },
-                "TaskArn": {
-                  "shape": "Sam"
-                },
-                "Type": {
-                  "shape": "Sad"
-                },
+                "WindowId": {},
+                "WindowTaskId": {},
+                "TaskArn": {},
+                "Type": {},
                 "Targets": {
                   "shape": "Su"
                 },
@@ -1969,21 +1499,15 @@
                   "shape": "Sb0"
                 },
                 "Priority": {
-                  "shape": "Sb5"
+                  "type": "integer"
                 },
                 "LoggingInfo": {
                   "shape": "Sb6"
                 },
                 "ServiceRoleArn": {},
-                "MaxConcurrency": {
-                  "shape": "S6l"
-                },
-                "MaxErrors": {
-                  "shape": "S6m"
-                },
-                "Name": {
-                  "shape": "S2g"
-                },
+                "MaxConcurrency": {},
+                "MaxErrors": {},
+                "Name": {},
                 "Description": {
                   "shape": "S2h"
                 }
@@ -2002,7 +1526,7 @@
             "shape": "Sa2"
           },
           "MaxResults": {
-            "shape": "Sa7"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -2015,12 +1539,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "WindowId": {
-                  "shape": "S2o"
-                },
-                "Name": {
-                  "shape": "S2g"
-                },
+                "WindowId": {},
+                "Name": {},
                 "Description": {
                   "shape": "S2h"
                 },
@@ -2028,10 +1548,10 @@
                   "type": "boolean"
                 },
                 "Duration": {
-                  "shape": "S2j"
+                  "type": "integer"
                 },
                 "Cutoff": {
-                  "shape": "S2k"
+                  "type": "integer"
                 }
               }
             }
@@ -2053,23 +1573,10 @@
                 "Values"
               ],
               "members": {
-                "Key": {
-                  "type": "string",
-                  "enum": [
-                    "Name",
-                    "Type",
-                    "KeyId"
-                  ]
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 1024,
-                    "min": 1
-                  },
-                  "max": 50,
-                  "min": 1
+                  "member": {}
                 }
               }
             }
@@ -2078,7 +1585,7 @@
             "shape": "Sbj"
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -2091,25 +1598,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S4a"
-                },
-                "Type": {
-                  "shape": "Sbs"
-                },
-                "KeyId": {
-                  "shape": "Sbt"
-                },
+                "Name": {},
+                "Type": {},
+                "KeyId": {},
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
                 "LastModifiedUser": {},
-                "Description": {
-                  "shape": "Sbu"
-                },
-                "AllowedPattern": {
-                  "shape": "Sbv"
-                },
+                "Description": {},
+                "AllowedPattern": {},
                 "Version": {
                   "type": "long"
                 }
@@ -2128,7 +1625,7 @@
             "shape": "S74"
           },
           "MaxResults": {
-            "shape": "S79"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -2153,9 +1650,7 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {
-            "shape": "S4n"
-          }
+          "PatchGroup": {}
         }
       },
       "output": {
@@ -2187,7 +1682,7 @@
         "type": "structure",
         "members": {
           "MaxResults": {
-            "shape": "S79"
+            "type": "integer"
           },
           "Filters": {
             "shape": "S74"
@@ -2203,9 +1698,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "PatchGroup": {
-                  "shape": "S4n"
-                },
+                "PatchGroup": {},
                 "BaselineIdentity": {
                   "shape": "Sc0"
                 }
@@ -2223,17 +1716,9 @@
           "State"
         ],
         "members": {
-          "State": {
-            "type": "string",
-            "enum": [
-              "Active",
-              "History"
-            ]
-          },
+          "State": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 200,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {},
           "Filters": {
@@ -2245,25 +1730,10 @@
                 "value"
               ],
               "members": {
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "InvokedAfter",
-                    "InvokedBefore",
-                    "Target",
-                    "Owner",
-                    "Status"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "max": 200,
-                  "min": 1
-                }
+                "key": {},
+                "value": {}
               }
-            },
-            "max": 5,
-            "min": 1
+            }
           }
         }
       },
@@ -2275,55 +1745,23 @@
             "member": {
               "type": "structure",
               "members": {
-                "SessionId": {
-                  "shape": "Sci"
-                },
-                "Target": {
-                  "shape": "Scj"
-                },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "Connected",
-                    "Connecting",
-                    "Disconnected",
-                    "Terminated",
-                    "Terminating",
-                    "Failed"
-                  ]
-                },
+                "SessionId": {},
+                "Target": {},
+                "Status": {},
                 "StartDate": {
                   "type": "timestamp"
                 },
                 "EndDate": {
                   "type": "timestamp"
                 },
-                "DocumentName": {
-                  "shape": "So"
-                },
-                "Owner": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1
-                },
-                "Details": {
-                  "type": "string",
-                  "max": 1024,
-                  "min": 1
-                },
+                "DocumentName": {},
+                "Owner": {},
+                "Details": {},
                 "OutputUrl": {
                   "type": "structure",
                   "members": {
-                    "S3OutputUrl": {
-                      "type": "string",
-                      "max": 2083,
-                      "min": 1
-                    },
-                    "CloudWatchOutputUrl": {
-                      "type": "string",
-                      "max": 2083,
-                      "min": 1
-                    }
+                    "S3OutputUrl": {},
+                    "CloudWatchOutputUrl": {}
                   }
                 }
               }
@@ -2340,9 +1778,7 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {
-            "shape": "S67"
-          }
+          "AutomationExecutionId": {}
         }
       },
       "output": {
@@ -2351,24 +1787,16 @@
           "AutomationExecution": {
             "type": "structure",
             "members": {
-              "AutomationExecutionId": {
-                "shape": "S67"
-              },
-              "DocumentName": {
-                "shape": "So"
-              },
-              "DocumentVersion": {
-                "shape": "Sp"
-              },
+              "AutomationExecutionId": {},
+              "DocumentName": {},
+              "DocumentVersion": {},
               "ExecutionStartTime": {
                 "type": "timestamp"
               },
               "ExecutionEndTime": {
                 "type": "timestamp"
               },
-              "AutomationExecutionStatus": {
-                "shape": "S68"
-              },
+              "AutomationExecutionStatus": {},
               "StepExecutions": {
                 "shape": "S6u"
               },
@@ -2382,18 +1810,12 @@
                 "shape": "S69"
               },
               "FailureMessage": {},
-              "Mode": {
-                "shape": "S6d"
-              },
-              "ParentAutomationExecutionId": {
-                "shape": "S67"
-              },
+              "Mode": {},
+              "ParentAutomationExecutionId": {},
               "ExecutedBy": {},
               "CurrentStepName": {},
               "CurrentAction": {},
-              "TargetParameterName": {
-                "shape": "S6a"
-              },
+              "TargetParameterName": {},
               "Targets": {
                 "shape": "Su"
               },
@@ -2403,12 +1825,8 @@
               "ResolvedTargets": {
                 "shape": "S6j"
               },
-              "MaxConcurrency": {
-                "shape": "S6l"
-              },
-              "MaxErrors": {
-                "shape": "S6m"
-              },
+              "MaxConcurrency": {},
+              "MaxErrors": {},
               "Target": {}
             }
           }
@@ -2423,65 +1841,31 @@
           "InstanceId"
         ],
         "members": {
-          "CommandId": {
-            "shape": "Sa"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "PluginName": {
-            "shape": "Scu"
-          }
+          "CommandId": {},
+          "InstanceId": {},
+          "PluginName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "CommandId": {
-            "shape": "Sa"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "Comment": {
-            "shape": "Scw"
-          },
-          "DocumentName": {
-            "shape": "So"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "PluginName": {
-            "shape": "Scu"
-          },
+          "CommandId": {},
+          "InstanceId": {},
+          "Comment": {},
+          "DocumentName": {},
+          "DocumentVersion": {},
+          "PluginName": {},
           "ResponseCode": {
             "type": "integer"
           },
-          "ExecutionStartDateTime": {
-            "shape": "Scy"
-          },
-          "ExecutionElapsedTime": {
-            "shape": "Scy"
-          },
-          "ExecutionEndDateTime": {
-            "shape": "Scy"
-          },
-          "Status": {
-            "shape": "Scz"
-          },
-          "StatusDetails": {
-            "shape": "Sd0"
-          },
-          "StandardOutputContent": {
-            "type": "string",
-            "max": 24000
-          },
+          "ExecutionStartDateTime": {},
+          "ExecutionElapsedTime": {},
+          "ExecutionEndDateTime": {},
+          "Status": {},
+          "StatusDetails": {},
+          "StandardOutputContent": {},
           "StandardOutputUrl": {},
-          "StandardErrorContent": {
-            "type": "string",
-            "max": 8000
-          },
+          "StandardErrorContent": {},
           "StandardErrorUrl": {},
           "CloudWatchOutputConfig": {
             "shape": "Sd3"
@@ -2496,24 +1880,14 @@
           "Target"
         ],
         "members": {
-          "Target": {
-            "shape": "Scj"
-          }
+          "Target": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Target": {
-            "shape": "Scj"
-          },
-          "Status": {
-            "type": "string",
-            "enum": [
-              "Connected",
-              "NotConnected"
-            ]
-          }
+          "Target": {},
+          "Status": {}
         }
       }
     },
@@ -2521,20 +1895,14 @@
       "input": {
         "type": "structure",
         "members": {
-          "OperatingSystem": {
-            "shape": "S2q"
-          }
+          "OperatingSystem": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "OperatingSystem": {
-            "shape": "S2q"
-          }
+          "BaselineId": {},
+          "OperatingSystem": {}
         }
       }
     },
@@ -2546,23 +1914,15 @@
           "SnapshotId"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "SnapshotId": {
-            "shape": "S94"
-          }
+          "InstanceId": {},
+          "SnapshotId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "SnapshotId": {
-            "shape": "S94"
-          },
+          "InstanceId": {},
+          "SnapshotId": {},
           "SnapshotDownloadUrl": {},
           "Product": {}
         }
@@ -2575,35 +1935,19 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S22"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "DocumentFormat": {
-            "shape": "S1v"
-          }
+          "Name": {},
+          "DocumentVersion": {},
+          "DocumentFormat": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Name": {
-            "shape": "S22"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "Content": {
-            "shape": "S1t"
-          },
-          "DocumentType": {
-            "shape": "S1u"
-          },
-          "DocumentFormat": {
-            "shape": "S1v"
-          }
+          "Name": {},
+          "DocumentVersion": {},
+          "Content": {},
+          "DocumentType": {},
+          "DocumentFormat": {}
         }
       }
     },
@@ -2625,17 +1969,13 @@
                 "TypeName"
               ],
               "members": {
-                "TypeName": {
-                  "shape": "S3v"
-                }
+                "TypeName": {}
               }
-            },
-            "max": 1,
-            "min": 1
+            }
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -2659,18 +1999,10 @@
                       "Content"
                     ],
                     "members": {
-                      "TypeName": {
-                        "shape": "S3v"
-                      },
-                      "SchemaVersion": {
-                        "shape": "S45"
-                      },
-                      "CaptureTime": {
-                        "shape": "Se3"
-                      },
-                      "ContentHash": {
-                        "shape": "Se4"
-                      },
+                      "TypeName": {},
+                      "SchemaVersion": {},
+                      "CaptureTime": {},
+                      "ContentHash": {},
                       "Content": {
                         "shape": "Se5"
                       }
@@ -2688,16 +2020,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "TypeName": {
-            "type": "string",
-            "max": 100,
-            "min": 0
-          },
+          "TypeName": {},
           "NextToken": {},
           "MaxResults": {
-            "type": "integer",
-            "max": 200,
-            "min": 50
+            "type": "integer"
           },
           "Aggregator": {
             "type": "boolean"
@@ -2719,12 +2045,8 @@
                 "Attributes"
               ],
               "members": {
-                "TypeName": {
-                  "shape": "S3v"
-                },
-                "Version": {
-                  "shape": "S45"
-                },
+                "TypeName": {},
+                "Version": {},
                 "Attributes": {
                   "type": "list",
                   "member": {
@@ -2735,17 +2057,9 @@
                     ],
                     "members": {
                       "Name": {},
-                      "DataType": {
-                        "type": "string",
-                        "enum": [
-                          "string",
-                          "number"
-                        ]
-                      }
+                      "DataType": {}
                     }
-                  },
-                  "max": 50,
-                  "min": 1
+                  }
                 },
                 "DisplayName": {}
               }
@@ -2762,31 +2076,23 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          }
+          "WindowId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "Name": {
-            "shape": "S2g"
-          },
+          "WindowId": {},
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {
-            "shape": "S2i"
-          },
+          "Schedule": {},
           "Duration": {
-            "shape": "S2j"
+            "type": "integer"
           },
           "Cutoff": {
-            "shape": "S2k"
+            "type": "integer"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -2810,29 +2116,19 @@
           "WindowExecutionId"
         ],
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          }
+          "WindowExecutionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
+          "WindowExecutionId": {},
           "TaskIds": {
             "type": "list",
-            "member": {
-              "shape": "Sa1"
-            }
+            "member": {}
           },
-          "Status": {
-            "shape": "Saf"
-          },
-          "StatusDetails": {
-            "shape": "Sag"
-          },
+          "Status": {},
+          "StatusDetails": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -2850,30 +2146,18 @@
           "TaskId"
         ],
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
-          "TaskId": {
-            "shape": "Sa1"
-          }
+          "WindowExecutionId": {},
+          "TaskId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
-          "TaskExecutionId": {
-            "shape": "Sa1"
-          },
-          "TaskArn": {
-            "shape": "Sam"
-          },
+          "WindowExecutionId": {},
+          "TaskExecutionId": {},
+          "TaskArn": {},
           "ServiceRole": {},
-          "Type": {
-            "shape": "Sad"
-          },
+          "Type": {},
           "TaskParameters": {
             "type": "list",
             "member": {
@@ -2882,20 +2166,12 @@
             "sensitive": true
           },
           "Priority": {
-            "shape": "Sb5"
+            "type": "integer"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
-          "Status": {
-            "shape": "Saf"
-          },
-          "StatusDetails": {
-            "shape": "Sag"
-          },
+          "MaxConcurrency": {},
+          "MaxErrors": {},
+          "Status": {},
+          "StatusDetails": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -2914,42 +2190,24 @@
           "InvocationId"
         ],
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
-          "TaskId": {
-            "shape": "Sa1"
-          },
-          "InvocationId": {
-            "shape": "Sab"
-          }
+          "WindowExecutionId": {},
+          "TaskId": {},
+          "InvocationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowExecutionId": {
-            "shape": "Sa0"
-          },
-          "TaskExecutionId": {
-            "shape": "Sa1"
-          },
-          "InvocationId": {
-            "shape": "Sab"
-          },
+          "WindowExecutionId": {},
+          "TaskExecutionId": {},
+          "InvocationId": {},
           "ExecutionId": {},
-          "TaskType": {
-            "shape": "Sad"
-          },
+          "TaskType": {},
           "Parameters": {
             "shape": "Sae"
           },
-          "Status": {
-            "shape": "Saf"
-          },
-          "StatusDetails": {
-            "shape": "Sag"
-          },
+          "Status": {},
+          "StatusDetails": {},
           "StartTime": {
             "type": "timestamp"
           },
@@ -2959,9 +2217,7 @@
           "OwnerInformation": {
             "shape": "S95"
           },
-          "WindowTargetId": {
-            "shape": "Sah"
-          }
+          "WindowTargetId": {}
         }
       }
     },
@@ -2973,33 +2229,21 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          }
+          "WindowId": {},
+          "WindowTaskId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          },
+          "WindowId": {},
+          "WindowTaskId": {},
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {
-            "shape": "Sam"
-          },
+          "TaskArn": {},
           "ServiceRoleArn": {},
-          "TaskType": {
-            "shape": "Sad"
-          },
+          "TaskType": {},
           "TaskParameters": {
             "shape": "Sb0"
           },
@@ -3007,20 +2251,14 @@
             "shape": "Sey"
           },
           "Priority": {
-            "shape": "Sb5"
+            "type": "integer"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
+          "MaxConcurrency": {},
+          "MaxErrors": {},
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           }
@@ -3034,9 +2272,7 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S4a"
-          },
+          "Name": {},
           "WithDecryption": {
             "type": "boolean"
           }
@@ -3058,14 +2294,12 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "S4a"
-          },
+          "Name": {},
           "WithDecryption": {
             "type": "boolean"
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3078,28 +2312,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S4a"
-                },
-                "Type": {
-                  "shape": "Sbs"
-                },
-                "KeyId": {
-                  "shape": "Sbt"
-                },
+                "Name": {},
+                "Type": {},
+                "KeyId": {},
                 "LastModifiedDate": {
                   "type": "timestamp"
                 },
                 "LastModifiedUser": {},
-                "Description": {
-                  "shape": "Sbu"
-                },
-                "Value": {
-                  "shape": "Sfh"
-                },
-                "AllowedPattern": {
-                  "shape": "Sbv"
-                },
+                "Description": {},
+                "Value": {},
+                "AllowedPattern": {},
                 "Version": {
                   "type": "long"
                 },
@@ -3147,9 +2369,7 @@
           "Path"
         ],
         "members": {
-          "Path": {
-            "shape": "S4a"
-          },
+          "Path": {},
           "Recursive": {
             "type": "boolean"
           },
@@ -3160,9 +2380,7 @@
             "type": "boolean"
           },
           "MaxResults": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3184,23 +2402,15 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "Name": {
-            "shape": "S2r"
-          },
-          "OperatingSystem": {
-            "shape": "S2q"
-          },
+          "BaselineId": {},
+          "Name": {},
+          "OperatingSystem": {},
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -3210,9 +2420,7 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {
-            "shape": "S31"
-          },
+          "ApprovedPatchesComplianceLevel": {},
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
@@ -3221,9 +2429,7 @@
           },
           "PatchGroups": {
             "type": "list",
-            "member": {
-              "shape": "S4n"
-            }
+            "member": {}
           },
           "CreatedDate": {
             "type": "timestamp"
@@ -3231,9 +2437,7 @@
           "ModifiedDate": {
             "type": "timestamp"
           },
-          "Description": {
-            "shape": "S36"
-          },
+          "Description": {},
           "Sources": {
             "shape": "S37"
           }
@@ -3247,26 +2451,16 @@
           "PatchGroup"
         ],
         "members": {
-          "PatchGroup": {
-            "shape": "S4n"
-          },
-          "OperatingSystem": {
-            "shape": "S2q"
-          }
+          "PatchGroup": {},
+          "OperatingSystem": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "PatchGroup": {
-            "shape": "S4n"
-          },
-          "OperatingSystem": {
-            "shape": "S2q"
-          }
+          "BaselineId": {},
+          "PatchGroup": {},
+          "OperatingSystem": {}
         }
       }
     },
@@ -3278,9 +2472,7 @@
           "Labels"
         ],
         "members": {
-          "Name": {
-            "shape": "S4a"
-          },
+          "Name": {},
           "ParameterVersion": {
             "type": "long"
           },
@@ -3305,11 +2497,9 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {
-            "shape": "S1i"
-          },
+          "AssociationId": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3322,39 +2512,26 @@
             "member": {
               "type": "structure",
               "members": {
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                },
+                "AssociationId": {},
+                "AssociationVersion": {},
                 "CreatedDate": {
                   "type": "timestamp"
                 },
-                "Name": {
-                  "shape": "So"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
+                "Name": {},
+                "DocumentVersion": {},
                 "Parameters": {
                   "shape": "Sq"
                 },
                 "Targets": {
                   "shape": "Su"
                 },
-                "ScheduleExpression": {
-                  "shape": "Sz"
-                },
+                "ScheduleExpression": {},
                 "OutputLocation": {
                   "shape": "S10"
                 },
-                "AssociationName": {
-                  "shape": "S15"
-                }
+                "AssociationName": {}
               }
-            },
-            "min": 1
+            }
           },
           "NextToken": {}
         }
@@ -3373,28 +2550,13 @@
                 "value"
               ],
               "members": {
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "InstanceId",
-                    "Name",
-                    "AssociationId",
-                    "AssociationStatusName",
-                    "LastExecutedBefore",
-                    "LastExecutedAfter",
-                    "AssociationName"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "min": 1
-                }
+                "key": {},
+                "value": {}
               }
-            },
-            "min": 1
+            }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3407,21 +2569,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "So"
-                },
-                "InstanceId": {
-                  "shape": "Sc"
-                },
-                "AssociationId": {
-                  "shape": "S1i"
-                },
-                "AssociationVersion": {
-                  "shape": "S18"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
+                "Name": {},
+                "InstanceId": {},
+                "AssociationId": {},
+                "AssociationVersion": {},
+                "DocumentVersion": {},
                 "Targets": {
                   "shape": "Su"
                 },
@@ -3431,12 +2583,8 @@
                 "Overview": {
                   "shape": "S1e"
                 },
-                "ScheduleExpression": {
-                  "shape": "Sz"
-                },
-                "AssociationName": {
-                  "shape": "S15"
-                }
+                "ScheduleExpression": {},
+                "AssociationName": {}
               }
             }
           },
@@ -3448,14 +2596,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "CommandId": {
-            "shape": "Sa"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "CommandId": {},
+          "InstanceId": {},
           "MaxResults": {
-            "shape": "Sgf"
+            "type": "integer"
           },
           "NextToken": {},
           "Filters": {
@@ -3474,38 +2618,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "CommandId": {
-                  "shape": "Sa"
-                },
-                "InstanceId": {
-                  "shape": "Sc"
-                },
-                "InstanceName": {
-                  "type": "string",
-                  "max": 255
-                },
-                "Comment": {
-                  "shape": "Scw"
-                },
-                "DocumentName": {
-                  "shape": "So"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
+                "CommandId": {},
+                "InstanceId": {},
+                "InstanceName": {},
+                "Comment": {},
+                "DocumentName": {},
+                "DocumentVersion": {},
                 "RequestedDateTime": {
                   "type": "timestamp"
                 },
-                "Status": {
-                  "shape": "Scz"
-                },
-                "StatusDetails": {
-                  "shape": "Sd0"
-                },
-                "TraceOutput": {
-                  "type": "string",
-                  "max": 2500
-                },
+                "Status": {},
+                "StatusDetails": {},
+                "TraceOutput": {},
                 "StandardOutputUrl": {},
                 "StandardErrorUrl": {},
                 "CommandPlugins": {
@@ -3513,23 +2637,9 @@
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Name": {
-                        "shape": "Scu"
-                      },
-                      "Status": {
-                        "type": "string",
-                        "enum": [
-                          "Pending",
-                          "InProgress",
-                          "Success",
-                          "TimedOut",
-                          "Cancelled",
-                          "Failed"
-                        ]
-                      },
-                      "StatusDetails": {
-                        "shape": "Sd0"
-                      },
+                      "Name": {},
+                      "Status": {},
+                      "StatusDetails": {},
                       "ResponseCode": {
                         "type": "integer"
                       },
@@ -3539,21 +2649,12 @@
                       "ResponseFinishDateTime": {
                         "type": "timestamp"
                       },
-                      "Output": {
-                        "type": "string",
-                        "max": 2500
-                      },
+                      "Output": {},
                       "StandardOutputUrl": {},
                       "StandardErrorUrl": {},
-                      "OutputS3Region": {
-                        "shape": "S12"
-                      },
-                      "OutputS3BucketName": {
-                        "shape": "S13"
-                      },
-                      "OutputS3KeyPrefix": {
-                        "shape": "S14"
-                      }
+                      "OutputS3Region": {},
+                      "OutputS3BucketName": {},
+                      "OutputS3KeyPrefix": {}
                     }
                   }
                 },
@@ -3575,14 +2676,10 @@
       "input": {
         "type": "structure",
         "members": {
-          "CommandId": {
-            "shape": "Sa"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "CommandId": {},
+          "InstanceId": {},
           "MaxResults": {
-            "shape": "Sgf"
+            "type": "integer"
           },
           "NextToken": {},
           "Filters": {
@@ -3612,21 +2709,15 @@
           },
           "ResourceIds": {
             "type": "list",
-            "member": {
-              "shape": "Sha"
-            },
-            "min": 1
+            "member": {}
           },
           "ResourceTypes": {
             "type": "list",
-            "member": {
-              "shape": "Shc"
-            },
-            "min": 1
+            "member": {}
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -3638,27 +2729,13 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {
-                  "shape": "Shg"
-                },
-                "ResourceType": {
-                  "shape": "Shc"
-                },
-                "ResourceId": {
-                  "shape": "Sha"
-                },
-                "Id": {
-                  "shape": "Shh"
-                },
-                "Title": {
-                  "shape": "Shi"
-                },
-                "Status": {
-                  "shape": "Shj"
-                },
-                "Severity": {
-                  "shape": "Shk"
-                },
+                "ComplianceType": {},
+                "ResourceType": {},
+                "ResourceId": {},
+                "Id": {},
+                "Title": {},
+                "Status": {},
+                "Severity": {},
                 "ExecutionSummary": {
                   "shape": "Shl"
                 },
@@ -3681,7 +2758,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -3693,9 +2770,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {
-                  "shape": "Shg"
-                },
+                "ComplianceType": {},
                 "CompliantSummary": {
                   "shape": "Sht"
                 },
@@ -3716,11 +2791,9 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
+          "Name": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3733,24 +2806,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "So"
-                },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
+                "Name": {},
+                "DocumentVersion": {},
                 "CreatedDate": {
                   "type": "timestamp"
                 },
                 "IsDefaultVersion": {
                   "type": "boolean"
                 },
-                "DocumentFormat": {
-                  "shape": "S1v"
-                }
+                "DocumentFormat": {}
               }
-            },
-            "min": 1
+            }
           },
           "NextToken": {}
         }
@@ -3769,48 +2835,26 @@
                 "value"
               ],
               "members": {
-                "key": {
-                  "type": "string",
-                  "enum": [
-                    "Name",
-                    "Owner",
-                    "PlatformTypes",
-                    "DocumentType"
-                  ]
-                },
-                "value": {
-                  "type": "string",
-                  "min": 1
-                }
+                "key": {},
+                "value": {}
               }
-            },
-            "min": 1
+            }
           },
           "Filters": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "Key": {
-                  "type": "string",
-                  "max": 128,
-                  "min": 1
-                },
+                "Key": {},
                 "Values": {
                   "type": "list",
-                  "member": {
-                    "type": "string",
-                    "max": 256,
-                    "min": 1
-                  }
+                  "member": {}
                 }
               }
-            },
-            "max": 6,
-            "min": 0
+            }
           },
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           },
           "NextToken": {}
         }
@@ -3823,28 +2867,16 @@
             "member": {
               "type": "structure",
               "members": {
-                "Name": {
-                  "shape": "S22"
-                },
+                "Name": {},
                 "Owner": {},
                 "PlatformTypes": {
                   "shape": "S2c"
                 },
-                "DocumentVersion": {
-                  "shape": "Sp"
-                },
-                "DocumentType": {
-                  "shape": "S1u"
-                },
-                "SchemaVersion": {
-                  "shape": "S2e"
-                },
-                "DocumentFormat": {
-                  "shape": "S1v"
-                },
-                "TargetType": {
-                  "shape": "S1w"
-                },
+                "DocumentVersion": {},
+                "DocumentType": {},
+                "SchemaVersion": {},
+                "DocumentFormat": {},
+                "TargetType": {},
                 "Tags": {
                   "shape": "S4"
                 }
@@ -3863,36 +2895,24 @@
           "TypeName"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "TypeName": {
-            "shape": "S3v"
-          },
+          "InstanceId": {},
+          "TypeName": {},
           "Filters": {
             "shape": "Sdi"
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TypeName": {
-            "shape": "S3v"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
-          "SchemaVersion": {
-            "shape": "S45"
-          },
-          "CaptureTime": {
-            "shape": "Se3"
-          },
+          "TypeName": {},
+          "InstanceId": {},
+          "SchemaVersion": {},
+          "CaptureTime": {},
           "Entries": {
             "shape": "Se5"
           },
@@ -3909,7 +2929,7 @@
           },
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -3921,21 +2941,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "ComplianceType": {
-                  "shape": "Shg"
-                },
-                "ResourceType": {
-                  "shape": "Shc"
-                },
-                "ResourceId": {
-                  "shape": "Sha"
-                },
-                "Status": {
-                  "shape": "Shj"
-                },
-                "OverallSeverity": {
-                  "shape": "Shk"
-                },
+                "ComplianceType": {},
+                "ResourceType": {},
+                "ResourceId": {},
+                "Status": {},
+                "OverallSeverity": {},
                 "ExecutionSummary": {
                   "shape": "Shl"
                 },
@@ -3958,7 +2968,7 @@
         "members": {
           "NextToken": {},
           "MaxResults": {
-            "shape": "S51"
+            "type": "integer"
           }
         }
       },
@@ -3970,9 +2980,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "SyncName": {
-                  "shape": "S3g"
-                },
+                "SyncName": {},
                 "S3Destination": {
                   "shape": "S3h"
                 },
@@ -3982,14 +2990,7 @@
                 "LastSuccessfulSyncTime": {
                   "type": "timestamp"
                 },
-                "LastStatus": {
-                  "type": "string",
-                  "enum": [
-                    "Successful",
-                    "Failed",
-                    "InProgress"
-                  ]
-                },
+                "LastStatus": {},
                 "SyncCreatedTime": {
                   "type": "timestamp"
                 },
@@ -4009,9 +3010,7 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceType": {
-            "shape": "S2"
-          },
+          "ResourceType": {},
           "ResourceId": {}
         }
       },
@@ -4032,12 +3031,8 @@
           "PermissionType"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "PermissionType": {
-            "shape": "S7r"
-          },
+          "Name": {},
+          "PermissionType": {},
           "AccountIdsToAdd": {
             "shape": "S7t"
           },
@@ -4062,15 +3057,9 @@
           "Items"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sha"
-          },
-          "ResourceType": {
-            "shape": "Shc"
-          },
-          "ComplianceType": {
-            "shape": "Shg"
-          },
+          "ResourceId": {},
+          "ResourceType": {},
+          "ComplianceType": {},
           "ExecutionSummary": {
             "shape": "Shl"
           },
@@ -4083,30 +3072,17 @@
                 "Status"
               ],
               "members": {
-                "Id": {
-                  "shape": "Shh"
-                },
-                "Title": {
-                  "shape": "Shi"
-                },
-                "Severity": {
-                  "shape": "Shk"
-                },
-                "Status": {
-                  "shape": "Shj"
-                },
+                "Id": {},
+                "Title": {},
+                "Severity": {},
+                "Status": {},
                 "Details": {
                   "shape": "Sho"
                 }
               }
-            },
-            "max": 10000,
-            "min": 0
+            }
           },
-          "ItemContentHash": {
-            "type": "string",
-            "max": 256
-          }
+          "ItemContentHash": {}
         }
       },
       "output": {
@@ -4122,9 +3098,7 @@
           "Items"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "InstanceId": {},
           "Items": {
             "type": "list",
             "member": {
@@ -4135,36 +3109,20 @@
                 "CaptureTime"
               ],
               "members": {
-                "TypeName": {
-                  "shape": "S3v"
-                },
-                "SchemaVersion": {
-                  "shape": "S45"
-                },
-                "CaptureTime": {
-                  "shape": "Se3"
-                },
-                "ContentHash": {
-                  "shape": "Se4"
-                },
+                "TypeName": {},
+                "SchemaVersion": {},
+                "CaptureTime": {},
+                "ContentHash": {},
                 "Content": {
                   "shape": "Se5"
                 },
                 "Context": {
                   "type": "map",
-                  "key": {
-                    "shape": "Se7"
-                  },
-                  "value": {
-                    "shape": "Se8"
-                  },
-                  "max": 50,
-                  "min": 0
+                  "key": {},
+                  "value": {}
                 }
               }
-            },
-            "max": 30,
-            "min": 1
+            }
           }
         }
       },
@@ -4184,27 +3142,15 @@
           "Type"
         ],
         "members": {
-          "Name": {
-            "shape": "S4a"
-          },
-          "Description": {
-            "shape": "Sbu"
-          },
-          "Value": {
-            "shape": "Sfh"
-          },
-          "Type": {
-            "shape": "Sbs"
-          },
-          "KeyId": {
-            "shape": "Sbt"
-          },
+          "Name": {},
+          "Description": {},
+          "Value": {},
+          "Type": {},
+          "KeyId": {},
           "Overwrite": {
             "type": "boolean"
           },
-          "AllowedPattern": {
-            "shape": "Sbv"
-          }
+          "AllowedPattern": {}
         }
       },
       "output": {
@@ -4223,17 +3169,13 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          }
+          "BaselineId": {}
         }
       }
     },
@@ -4245,23 +3187,15 @@
           "PatchGroup"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "PatchGroup": {
-            "shape": "S4n"
-          }
+          "BaselineId": {},
+          "PatchGroup": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "PatchGroup": {
-            "shape": "S4n"
-          }
+          "BaselineId": {},
+          "PatchGroup": {}
         }
       }
     },
@@ -4274,26 +3208,19 @@
           "Targets"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "ResourceType": {
-            "shape": "Sav"
-          },
+          "WindowId": {},
+          "ResourceType": {},
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
           "ClientToken": {
-            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -4301,9 +3228,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowTargetId": {
-            "shape": "S4q"
-          }
+          "WindowTargetId": {}
         }
       }
     },
@@ -4319,19 +3244,13 @@
           "MaxErrors"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
+          "WindowId": {},
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {
-            "shape": "Sam"
-          },
+          "TaskArn": {},
           "ServiceRoleArn": {},
-          "TaskType": {
-            "shape": "Sad"
-          },
+          "TaskType": {},
           "TaskParameters": {
             "shape": "Sb0"
           },
@@ -4339,25 +3258,18 @@
             "shape": "Sey"
           },
           "Priority": {
-            "shape": "Sb5"
+            "type": "integer"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
+          "MaxConcurrency": {},
+          "MaxErrors": {},
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
           "ClientToken": {
-            "shape": "S2m",
             "idempotencyToken": true
           }
         }
@@ -4365,9 +3277,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowTaskId": {
-            "shape": "S4t"
-          }
+          "WindowTaskId": {}
         }
       }
     },
@@ -4380,15 +3290,11 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceType": {
-            "shape": "S2"
-          },
+          "ResourceType": {},
           "ResourceId": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "S6"
-            }
+            "member": {}
           }
         }
       },
@@ -4404,20 +3310,14 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {
-            "shape": "Sci"
-          }
+          "SessionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {
-            "shape": "Sci"
-          },
-          "TokenValue": {
-            "shape": "Sjn"
-          },
+          "SessionId": {},
+          "TokenValue": {},
           "StreamUrl": {}
         }
       }
@@ -4430,19 +3330,8 @@
           "SignalType"
         ],
         "members": {
-          "AutomationExecutionId": {
-            "shape": "S67"
-          },
-          "SignalType": {
-            "type": "string",
-            "enum": [
-              "Approve",
-              "Reject",
-              "StartStep",
-              "StopStep",
-              "Resume"
-            ]
-          },
+          "AutomationExecutionId": {},
+          "SignalType": {},
           "Payload": {
             "shape": "S69"
           }
@@ -4466,42 +3355,22 @@
           "Targets": {
             "shape": "Su"
           },
-          "DocumentName": {
-            "shape": "S22"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "DocumentHash": {
-            "shape": "S20"
-          },
-          "DocumentHashType": {
-            "shape": "S21"
-          },
+          "DocumentName": {},
+          "DocumentVersion": {},
+          "DocumentHash": {},
+          "DocumentHashType": {},
           "TimeoutSeconds": {
-            "shape": "Sf5"
+            "type": "integer"
           },
-          "Comment": {
-            "shape": "Scw"
-          },
+          "Comment": {},
           "Parameters": {
             "shape": "Sq"
           },
-          "OutputS3Region": {
-            "shape": "S12"
-          },
-          "OutputS3BucketName": {
-            "shape": "S13"
-          },
-          "OutputS3KeyPrefix": {
-            "shape": "S14"
-          },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
+          "OutputS3Region": {},
+          "OutputS3BucketName": {},
+          "OutputS3KeyPrefix": {},
+          "MaxConcurrency": {},
+          "MaxErrors": {},
           "ServiceRoleArn": {},
           "NotificationConfig": {
             "shape": "Sf0"
@@ -4529,11 +3398,7 @@
         "members": {
           "AssociationIds": {
             "type": "list",
-            "member": {
-              "shape": "S1i"
-            },
-            "max": 10,
-            "min": 1
+            "member": {}
           }
         }
       },
@@ -4549,47 +3414,28 @@
           "DocumentName"
         ],
         "members": {
-          "DocumentName": {
-            "shape": "S22"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
+          "DocumentName": {},
+          "DocumentVersion": {},
           "Parameters": {
             "shape": "S69"
           },
-          "ClientToken": {
-            "type": "string",
-            "max": 36,
-            "min": 36,
-            "pattern": "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
-          },
-          "Mode": {
-            "shape": "S6d"
-          },
-          "TargetParameterName": {
-            "shape": "S6a"
-          },
+          "ClientToken": {},
+          "Mode": {},
+          "TargetParameterName": {},
           "Targets": {
             "shape": "Su"
           },
           "TargetMaps": {
             "shape": "S6e"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          }
+          "MaxConcurrency": {},
+          "MaxErrors": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "AutomationExecutionId": {
-            "shape": "S67"
-          }
+          "AutomationExecutionId": {}
         }
       }
     },
@@ -4600,26 +3446,14 @@
           "Target"
         ],
         "members": {
-          "Target": {
-            "shape": "Scj"
-          },
-          "DocumentName": {
-            "shape": "S22"
-          },
+          "Target": {},
+          "DocumentName": {},
           "Parameters": {
             "type": "map",
-            "key": {
-              "type": "string",
-              "max": 255,
-              "min": 1
-            },
+            "key": {},
             "value": {
               "type": "list",
-              "member": {
-                "type": "string",
-                "max": 65535,
-                "min": 1
-              }
+              "member": {}
             }
           }
         }
@@ -4627,12 +3461,8 @@
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {
-            "shape": "Sci"
-          },
-          "TokenValue": {
-            "shape": "Sjn"
-          },
+          "SessionId": {},
+          "TokenValue": {},
           "StreamUrl": {}
         }
       }
@@ -4644,16 +3474,8 @@
           "AutomationExecutionId"
         ],
         "members": {
-          "AutomationExecutionId": {
-            "shape": "S67"
-          },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "Complete",
-              "Cancel"
-            ]
-          }
+          "AutomationExecutionId": {},
+          "Type": {}
         }
       },
       "output": {
@@ -4668,17 +3490,13 @@
           "SessionId"
         ],
         "members": {
-          "SessionId": {
-            "shape": "Sci"
-          }
+          "SessionId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SessionId": {
-            "shape": "Sci"
-          }
+          "SessionId": {}
         }
       }
     },
@@ -4689,33 +3507,21 @@
           "AssociationId"
         ],
         "members": {
-          "AssociationId": {
-            "shape": "S1i"
-          },
+          "AssociationId": {},
           "Parameters": {
             "shape": "Sq"
           },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "ScheduleExpression": {
-            "shape": "Sz"
-          },
+          "DocumentVersion": {},
+          "ScheduleExpression": {},
           "OutputLocation": {
             "shape": "S10"
           },
-          "Name": {
-            "shape": "So"
-          },
+          "Name": {},
           "Targets": {
             "shape": "Su"
           },
-          "AssociationName": {
-            "shape": "S15"
-          },
-          "AssociationVersion": {
-            "shape": "S18"
-          }
+          "AssociationName": {},
+          "AssociationVersion": {}
         }
       },
       "output": {
@@ -4736,12 +3542,8 @@
           "AssociationStatus"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "InstanceId": {
-            "shape": "Sc"
-          },
+          "Name": {},
+          "InstanceId": {},
           "AssociationStatus": {
             "shape": "S1a"
           }
@@ -4764,21 +3566,11 @@
           "Name"
         ],
         "members": {
-          "Content": {
-            "shape": "S1t"
-          },
-          "Name": {
-            "shape": "So"
-          },
-          "DocumentVersion": {
-            "shape": "Sp"
-          },
-          "DocumentFormat": {
-            "shape": "S1v"
-          },
-          "TargetType": {
-            "shape": "S1w"
-          }
+          "Content": {},
+          "Name": {},
+          "DocumentVersion": {},
+          "DocumentFormat": {},
+          "TargetType": {}
         }
       },
       "output": {
@@ -4798,13 +3590,8 @@
           "DocumentVersion"
         ],
         "members": {
-          "Name": {
-            "shape": "So"
-          },
-          "DocumentVersion": {
-            "type": "string",
-            "pattern": "(^[1-9][0-9]*$)"
-          }
+          "Name": {},
+          "DocumentVersion": {}
         }
       },
       "output": {
@@ -4813,12 +3600,8 @@
           "Description": {
             "type": "structure",
             "members": {
-              "Name": {
-                "shape": "So"
-              },
-              "DefaultVersion": {
-                "shape": "Sp"
-              }
+              "Name": {},
+              "DefaultVersion": {}
             }
           }
         }
@@ -4831,23 +3614,17 @@
           "WindowId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "Name": {
-            "shape": "S2g"
-          },
+          "WindowId": {},
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {
-            "shape": "S2i"
-          },
+          "Schedule": {},
           "Duration": {
-            "shape": "S2j"
+            "type": "integer"
           },
           "Cutoff": {
-            "shape": "S2k"
+            "type": "integer"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -4863,23 +3640,17 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "Name": {
-            "shape": "S2g"
-          },
+          "WindowId": {},
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
-          "Schedule": {
-            "shape": "S2i"
-          },
+          "Schedule": {},
           "Duration": {
-            "shape": "S2j"
+            "type": "integer"
           },
           "Cutoff": {
-            "shape": "S2k"
+            "type": "integer"
           },
           "AllowUnassociatedTargets": {
             "type": "boolean"
@@ -4898,21 +3669,15 @@
           "WindowTargetId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTargetId": {
-            "shape": "S4q"
-          },
+          "WindowId": {},
+          "WindowTargetId": {},
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
@@ -4924,21 +3689,15 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTargetId": {
-            "shape": "S4q"
-          },
+          "WindowId": {},
+          "WindowTargetId": {},
           "Targets": {
             "shape": "Su"
           },
           "OwnerInformation": {
             "shape": "S95"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           }
@@ -4953,18 +3712,12 @@
           "WindowTaskId"
         ],
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          },
+          "WindowId": {},
+          "WindowTaskId": {},
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {
-            "shape": "Sam"
-          },
+          "TaskArn": {},
           "ServiceRoleArn": {},
           "TaskParameters": {
             "shape": "Sb0"
@@ -4973,20 +3726,14 @@
             "shape": "Sey"
           },
           "Priority": {
-            "shape": "Sb5"
+            "type": "integer"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
+          "MaxConcurrency": {},
+          "MaxErrors": {},
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           },
@@ -4998,18 +3745,12 @@
       "output": {
         "type": "structure",
         "members": {
-          "WindowId": {
-            "shape": "S2o"
-          },
-          "WindowTaskId": {
-            "shape": "S4t"
-          },
+          "WindowId": {},
+          "WindowTaskId": {},
           "Targets": {
             "shape": "Su"
           },
-          "TaskArn": {
-            "shape": "Sam"
-          },
+          "TaskArn": {},
           "ServiceRoleArn": {},
           "TaskParameters": {
             "shape": "Sb0"
@@ -5018,20 +3759,14 @@
             "shape": "Sey"
           },
           "Priority": {
-            "shape": "Sb5"
+            "type": "integer"
           },
-          "MaxConcurrency": {
-            "shape": "S6l"
-          },
-          "MaxErrors": {
-            "shape": "S6m"
-          },
+          "MaxConcurrency": {},
+          "MaxErrors": {},
           "LoggingInfo": {
             "shape": "Sb6"
           },
-          "Name": {
-            "shape": "S2g"
-          },
+          "Name": {},
           "Description": {
             "shape": "S2h"
           }
@@ -5046,12 +3781,8 @@
           "IamRole"
         ],
         "members": {
-          "InstanceId": {
-            "shape": "S4k"
-          },
-          "IamRole": {
-            "shape": "Sh"
-          }
+          "InstanceId": {},
+          "IamRole": {}
         }
       },
       "output": {
@@ -5066,12 +3797,8 @@
           "BaselineId"
         ],
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "Name": {
-            "shape": "S2r"
-          },
+          "BaselineId": {},
+          "Name": {},
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -5081,18 +3808,14 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {
-            "shape": "S31"
-          },
+          "ApprovedPatchesComplianceLevel": {},
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
           "RejectedPatches": {
             "shape": "S34"
           },
-          "Description": {
-            "shape": "S36"
-          },
+          "Description": {},
           "Sources": {
             "shape": "S37"
           },
@@ -5104,15 +3827,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "BaselineId": {
-            "shape": "S3e"
-          },
-          "Name": {
-            "shape": "S2r"
-          },
-          "OperatingSystem": {
-            "shape": "S2q"
-          },
+          "BaselineId": {},
+          "Name": {},
+          "OperatingSystem": {},
           "GlobalFilters": {
             "shape": "S2s"
           },
@@ -5122,9 +3839,7 @@
           "ApprovedPatches": {
             "shape": "S34"
           },
-          "ApprovedPatchesComplianceLevel": {
-            "shape": "S31"
-          },
+          "ApprovedPatchesComplianceLevel": {},
           "ApprovedPatchesEnableNonSecurity": {
             "type": "boolean"
           },
@@ -5137,9 +3852,7 @@
           "ModifiedDate": {
             "type": "timestamp"
           },
-          "Description": {
-            "shape": "S36"
-          },
+          "Description": {},
           "Sources": {
             "shape": "S37"
           }
@@ -5148,16 +3861,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "enum": [
-        "Document",
-        "ManagedInstance",
-        "MaintenanceWindow",
-        "Parameter",
-        "PatchBaseline"
-      ]
-    },
     "S4": {
       "type": "list",
       "member": {
@@ -5167,72 +3870,14 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "S6"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256,
-            "min": 1,
-            "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-          }
+          "Key": {},
+          "Value": {}
         }
       }
     },
-    "S6": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^(?!^(?i)aws:)(?=^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$).*$"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 36,
-      "min": 36
-    },
     "Sb": {
       "type": "list",
-      "member": {
-        "shape": "Sc"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "Sc": {
-      "type": "string",
-      "pattern": "(^i-(\\w{8}|\\w{17})$)|(^mi-\\w{17}$)"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "Sg": {
-      "type": "string",
-      "max": 256,
-      "min": 0,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "Sh": {
-      "type": "string",
-      "max": 64
-    },
-    "Si": {
-      "type": "integer",
-      "max": 1000,
-      "min": 1
-    },
-    "Sl": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-    },
-    "So": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
-    },
-    "Sp": {
-      "type": "string",
-      "pattern": "([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)"
+      "member": {}
     },
     "Sq": {
       "type": "map",
@@ -5247,27 +3892,13 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1,
-            "pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=\\-@]*$"
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {},
-            "max": 50,
-            "min": 0
+            "member": {}
           }
         }
-      },
-      "max": 5,
-      "min": 0
-    },
-    "Sz": {
-      "type": "string",
-      "max": 256,
-      "min": 1
+      }
     },
     "S10": {
       "type": "structure",
@@ -5275,49 +3906,19 @@
         "S3Location": {
           "type": "structure",
           "members": {
-            "OutputS3Region": {
-              "shape": "S12"
-            },
-            "OutputS3BucketName": {
-              "shape": "S13"
-            },
-            "OutputS3KeyPrefix": {
-              "shape": "S14"
-            }
+            "OutputS3Region": {},
+            "OutputS3BucketName": {},
+            "OutputS3KeyPrefix": {}
           }
         }
       }
     },
-    "S12": {
-      "type": "string",
-      "max": 20,
-      "min": 3
-    },
-    "S13": {
-      "type": "string",
-      "max": 63,
-      "min": 3
-    },
-    "S14": {
-      "type": "string",
-      "max": 500
-    },
-    "S15": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
-    },
     "S17": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "So"
-        },
-        "InstanceId": {
-          "shape": "Sc"
-        },
-        "AssociationVersion": {
-          "shape": "S18"
-        },
+        "Name": {},
+        "InstanceId": {},
+        "AssociationVersion": {},
         "Date": {
           "type": "timestamp"
         },
@@ -5330,21 +3931,15 @@
         "Overview": {
           "shape": "S1e"
         },
-        "DocumentVersion": {
-          "shape": "Sp"
-        },
+        "DocumentVersion": {},
         "Parameters": {
           "shape": "Sq"
         },
-        "AssociationId": {
-          "shape": "S1i"
-        },
+        "AssociationId": {},
         "Targets": {
           "shape": "Su"
         },
-        "ScheduleExpression": {
-          "shape": "Sz"
-        },
+        "ScheduleExpression": {},
         "OutputLocation": {
           "shape": "S10"
         },
@@ -5354,14 +3949,8 @@
         "LastSuccessfulExecutionDate": {
           "type": "timestamp"
         },
-        "AssociationName": {
-          "shape": "S15"
-        }
+        "AssociationName": {}
       }
-    },
-    "S18": {
-      "type": "string",
-      "pattern": "([$]LATEST)|([1-9][0-9]*)"
     },
     "S1a": {
       "type": "structure",
@@ -5374,23 +3963,9 @@
         "Date": {
           "type": "timestamp"
         },
-        "Name": {
-          "type": "string",
-          "enum": [
-            "Pending",
-            "Success",
-            "Failed"
-          ]
-        },
-        "Message": {
-          "type": "string",
-          "max": 1024,
-          "min": 1
-        },
-        "AdditionalInfo": {
-          "type": "string",
-          "max": 1024
-        }
+        "Name": {},
+        "Message": {},
+        "AdditionalInfo": {}
       }
     },
     "S1e": {
@@ -5407,96 +3982,41 @@
         }
       }
     },
-    "S1i": {
-      "type": "string",
-      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-    },
     "S1l": {
       "type": "structure",
       "required": [
         "Name"
       ],
       "members": {
-        "Name": {
-          "shape": "So"
-        },
-        "InstanceId": {
-          "shape": "Sc"
-        },
+        "Name": {},
+        "InstanceId": {},
         "Parameters": {
           "shape": "Sq"
         },
-        "DocumentVersion": {
-          "shape": "Sp"
-        },
+        "DocumentVersion": {},
         "Targets": {
           "shape": "Su"
         },
-        "ScheduleExpression": {
-          "shape": "Sz"
-        },
+        "ScheduleExpression": {},
         "OutputLocation": {
           "shape": "S10"
         },
-        "AssociationName": {
-          "shape": "S15"
-        }
+        "AssociationName": {}
       }
-    },
-    "S1t": {
-      "type": "string",
-      "min": 1
-    },
-    "S1u": {
-      "type": "string",
-      "enum": [
-        "Command",
-        "Policy",
-        "Automation",
-        "Session"
-      ]
-    },
-    "S1v": {
-      "type": "string",
-      "enum": [
-        "YAML",
-        "JSON"
-      ]
-    },
-    "S1w": {
-      "type": "string",
-      "max": 200,
-      "pattern": "^\\/[\\w\\.\\-\\:\\/]*$"
     },
     "S1y": {
       "type": "structure",
       "members": {
         "Sha1": {},
-        "Hash": {
-          "shape": "S20"
-        },
-        "HashType": {
-          "shape": "S21"
-        },
-        "Name": {
-          "shape": "S22"
-        },
+        "Hash": {},
+        "HashType": {},
+        "Name": {},
         "Owner": {},
         "CreatedDate": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "Creating",
-            "Active",
-            "Updating",
-            "Deleting"
-          ]
-        },
-        "DocumentVersion": {
-          "shape": "Sp"
-        },
+        "Status": {},
+        "DocumentVersion": {},
         "Description": {},
         "Parameters": {
           "type": "list",
@@ -5504,13 +4024,7 @@
             "type": "structure",
             "members": {
               "Name": {},
-              "Type": {
-                "type": "string",
-                "enum": [
-                  "String",
-                  "StringList"
-                ]
-              },
+              "Type": {},
               "Description": {},
               "DefaultValue": {}
             }
@@ -5519,116 +4033,24 @@
         "PlatformTypes": {
           "shape": "S2c"
         },
-        "DocumentType": {
-          "shape": "S1u"
-        },
-        "SchemaVersion": {
-          "shape": "S2e"
-        },
-        "LatestVersion": {
-          "shape": "Sp"
-        },
-        "DefaultVersion": {
-          "shape": "Sp"
-        },
-        "DocumentFormat": {
-          "shape": "S1v"
-        },
-        "TargetType": {
-          "shape": "S1w"
-        },
+        "DocumentType": {},
+        "SchemaVersion": {},
+        "LatestVersion": {},
+        "DefaultVersion": {},
+        "DocumentFormat": {},
+        "TargetType": {},
         "Tags": {
           "shape": "S4"
         }
       }
     },
-    "S20": {
-      "type": "string",
-      "max": 256
-    },
-    "S21": {
-      "type": "string",
-      "enum": [
-        "Sha256",
-        "Sha1"
-      ]
-    },
-    "S22": {
-      "type": "string",
-      "pattern": "^[a-zA-Z0-9_\\-.:/]{3,128}$"
-    },
     "S2c": {
       "type": "list",
-      "member": {
-        "shape": "S2d"
-      }
-    },
-    "S2d": {
-      "type": "string",
-      "enum": [
-        "Windows",
-        "Linux"
-      ]
-    },
-    "S2e": {
-      "type": "string",
-      "pattern": "([0-9]+)\\.([0-9]+)"
-    },
-    "S2g": {
-      "type": "string",
-      "max": 128,
-      "min": 3,
-      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
+      "member": {}
     },
     "S2h": {
       "type": "string",
-      "max": 128,
-      "min": 1,
       "sensitive": true
-    },
-    "S2i": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S2j": {
-      "type": "integer",
-      "max": 24,
-      "min": 1
-    },
-    "S2k": {
-      "type": "integer",
-      "max": 23,
-      "min": 0
-    },
-    "S2m": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "S2o": {
-      "type": "string",
-      "max": 20,
-      "min": 20,
-      "pattern": "^mw-[0-9a-f]{17}$"
-    },
-    "S2q": {
-      "type": "string",
-      "enum": [
-        "WINDOWS",
-        "AMAZON_LINUX",
-        "AMAZON_LINUX_2",
-        "UBUNTU",
-        "REDHAT_ENTERPRISE_LINUX",
-        "SUSE",
-        "CENTOS"
-      ]
-    },
-    "S2r": {
-      "type": "string",
-      "max": 128,
-      "min": 3,
-      "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
     },
     "S2s": {
       "type": "structure",
@@ -5645,32 +4067,13 @@
               "Values"
             ],
             "members": {
-              "Key": {
-                "type": "string",
-                "enum": [
-                  "PRODUCT",
-                  "CLASSIFICATION",
-                  "MSRC_SEVERITY",
-                  "PATCH_ID",
-                  "SECTION",
-                  "PRIORITY",
-                  "SEVERITY"
-                ]
-              },
+              "Key": {},
               "Values": {
                 "type": "list",
-                "member": {
-                  "type": "string",
-                  "max": 64,
-                  "min": 1
-                },
-                "max": 20,
-                "min": 1
+                "member": {}
               }
             }
-          },
-          "max": 4,
-          "min": 0
+          }
         }
       }
     },
@@ -5692,52 +4095,21 @@
               "PatchFilterGroup": {
                 "shape": "S2s"
               },
-              "ComplianceLevel": {
-                "shape": "S31"
-              },
+              "ComplianceLevel": {},
               "ApproveAfterDays": {
-                "type": "integer",
-                "max": 100,
-                "min": 0
+                "type": "integer"
               },
               "EnableNonSecurity": {
                 "type": "boolean"
               }
             }
-          },
-          "max": 10,
-          "min": 0
+          }
         }
       }
     },
-    "S31": {
-      "type": "string",
-      "enum": [
-        "CRITICAL",
-        "HIGH",
-        "MEDIUM",
-        "LOW",
-        "INFORMATIONAL",
-        "UNSPECIFIED"
-      ]
-    },
     "S34": {
       "type": "list",
-      "member": {
-        "shape": "S35"
-      },
-      "max": 50,
-      "min": 0
-    },
-    "S35": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S36": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
+      "member": {}
     },
     "S37": {
       "type": "list",
@@ -5749,41 +4121,17 @@
           "Configuration"
         ],
         "members": {
-          "Name": {
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9_\\-.]{3,50}$"
-          },
+          "Name": {},
           "Products": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 128,
-              "min": 1
-            },
-            "max": 20,
-            "min": 1
+            "member": {}
           },
           "Configuration": {
             "type": "string",
-            "max": 512,
-            "min": 1,
             "sensitive": true
           }
         }
-      },
-      "max": 20,
-      "min": 0
-    },
-    "S3e": {
-      "type": "string",
-      "max": 128,
-      "min": 20,
-      "pattern": "^[a-zA-Z0-9_\\-:/]{20,128}$"
-    },
-    "S3g": {
-      "type": "string",
-      "max": 64,
-      "min": 1
+      }
     },
     "S3h": {
       "type": "structure",
@@ -5793,40 +4141,12 @@
         "Region"
       ],
       "members": {
-        "BucketName": {
-          "type": "string",
-          "max": 2048,
-          "min": 1
-        },
-        "Prefix": {
-          "type": "string",
-          "max": 256,
-          "min": 1
-        },
-        "SyncFormat": {
-          "type": "string",
-          "enum": [
-            "JsonSerDe"
-          ]
-        },
-        "Region": {
-          "type": "string",
-          "max": 64,
-          "min": 1
-        },
-        "AWSKMSKeyARN": {
-          "type": "string",
-          "max": 512,
-          "min": 1,
-          "pattern": "arn:.*"
-        }
+        "BucketName": {},
+        "Prefix": {},
+        "SyncFormat": {},
+        "Region": {},
+        "AWSKMSKeyARN": {}
       }
-    },
-    "S3v": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "^(AWS|Custom):.*$"
     },
     "S40": {
       "type": "structure",
@@ -5842,9 +4162,7 @@
           "member": {
             "type": "structure",
             "members": {
-              "Version": {
-                "shape": "S45"
-              },
+              "Version": {},
               "Count": {
                 "type": "integer"
               },
@@ -5856,126 +4174,28 @@
         }
       }
     },
-    "S45": {
-      "type": "string",
-      "pattern": "^([0-9]{1,6})(\\.[0-9]{1,6})$"
-    },
-    "S4a": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
     "S4d": {
       "type": "list",
-      "member": {
-        "shape": "S4a"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S4k": {
-      "type": "string",
-      "pattern": "^mi-[0-9a-f]{17}$"
-    },
-    "S4n": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "S4q": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
-    },
-    "S4t": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
-    },
-    "S51": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
-    },
-    "S5b": {
-      "type": "string",
-      "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-    },
-    "S67": {
-      "type": "string",
-      "max": 36,
-      "min": 36
-    },
-    "S68": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "InProgress",
-        "Waiting",
-        "Success",
-        "TimedOut",
-        "Cancelling",
-        "Cancelled",
-        "Failed"
-      ]
+      "member": {}
     },
     "S69": {
       "type": "map",
-      "key": {
-        "shape": "S6a"
-      },
+      "key": {},
       "value": {
         "type": "list",
-        "member": {
-          "type": "string",
-          "max": 512,
-          "min": 1
-        },
-        "max": 10,
-        "min": 0
-      },
-      "max": 200,
-      "min": 1
-    },
-    "S6a": {
-      "type": "string",
-      "max": 30,
-      "min": 1
-    },
-    "S6d": {
-      "type": "string",
-      "enum": [
-        "Auto",
-        "Interactive"
-      ]
+        "member": {}
+      }
     },
     "S6e": {
       "type": "list",
       "member": {
         "type": "map",
-        "key": {
-          "type": "string",
-          "max": 50,
-          "min": 1
-        },
+        "key": {},
         "value": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "max": 50,
-            "min": 1
-          },
-          "max": 25,
-          "min": 0
-        },
-        "max": 20,
-        "min": 1
-      },
-      "max": 300,
-      "min": 0
+          "member": {}
+        }
+      }
     },
     "S6j": {
       "type": "structure",
@@ -5989,28 +4209,13 @@
         }
       }
     },
-    "S6l": {
-      "type": "string",
-      "max": 7,
-      "min": 1,
-      "pattern": "^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$"
-    },
-    "S6m": {
-      "type": "string",
-      "max": 7,
-      "min": 1,
-      "pattern": "^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$"
-    },
     "S6u": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
           "StepName": {},
-          "Action": {
-            "type": "string",
-            "pattern": "^aws:[a-zA-Z]{3,25}$"
-          },
+          "Action": {},
           "TimeoutSeconds": {
             "type": "long"
           },
@@ -6024,9 +4229,7 @@
           "ExecutionEndTime": {
             "type": "timestamp"
           },
-          "StepStatus": {
-            "shape": "S68"
-          },
+          "StepStatus": {},
           "ResponseCode": {},
           "Inputs": {
             "type": "map",
@@ -6061,11 +4264,7 @@
           },
           "ValidNextSteps": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 65535,
-              "min": 1
-            }
+            "member": {}
           }
         }
       }
@@ -6075,35 +4274,18 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 256,
-              "min": 1
-            }
+            "member": {}
           }
         }
-      },
-      "max": 5,
-      "min": 0
-    },
-    "S79": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
+      }
     },
     "S7c": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S35"
-        },
+        "Id": {},
         "ReleaseDate": {
           "type": "timestamp"
         },
@@ -6120,33 +4302,13 @@
         "Language": {}
       }
     },
-    "S7r": {
-      "type": "string",
-      "enum": [
-        "Share"
-      ]
-    },
     "S7t": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "pattern": "(?i)all|[0-9]{12}"
-      },
-      "max": 20
+      "member": {}
     },
     "S8j": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "min": 1
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S90": {
-      "type": "integer",
-      "max": 100,
-      "min": 10
+      "member": {}
     },
     "S93": {
       "type": "structure",
@@ -6159,18 +4321,10 @@
         "Operation"
       ],
       "members": {
-        "InstanceId": {
-          "shape": "Sc"
-        },
-        "PatchGroup": {
-          "shape": "S4n"
-        },
-        "BaselineId": {
-          "shape": "S3e"
-        },
-        "SnapshotId": {
-          "shape": "S94"
-        },
+        "InstanceId": {},
+        "PatchGroup": {},
+        "BaselineId": {},
+        "SnapshotId": {},
         "OwnerInformation": {
           "shape": "S95"
         },
@@ -6195,126 +4349,33 @@
         "OperationEndTime": {
           "type": "timestamp"
         },
-        "Operation": {
-          "type": "string",
-          "enum": [
-            "Scan",
-            "Install"
-          ]
-        }
+        "Operation": {}
       }
-    },
-    "S94": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
     },
     "S95": {
       "type": "string",
-      "max": 128,
-      "min": 1,
       "sensitive": true
-    },
-    "Sa0": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
-    },
-    "Sa1": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
     },
     "Sa2": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 256,
-              "min": 1
-            }
+            "member": {}
           }
         }
-      },
-      "max": 5,
-      "min": 0
-    },
-    "Sa7": {
-      "type": "integer",
-      "max": 100,
-      "min": 10
-    },
-    "Sab": {
-      "type": "string",
-      "max": 36,
-      "min": 36,
-      "pattern": "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}$"
-    },
-    "Sad": {
-      "type": "string",
-      "enum": [
-        "RUN_COMMAND",
-        "AUTOMATION",
-        "STEP_FUNCTIONS",
-        "LAMBDA"
-      ]
+      }
     },
     "Sae": {
       "type": "string",
       "sensitive": true
     },
-    "Saf": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "IN_PROGRESS",
-        "SUCCESS",
-        "FAILED",
-        "TIMED_OUT",
-        "CANCELLING",
-        "CANCELLED",
-        "SKIPPED_OVERLAPPING"
-      ]
-    },
-    "Sag": {
-      "type": "string",
-      "max": 250,
-      "min": 0
-    },
-    "Sah": {
-      "type": "string",
-      "max": 36
-    },
-    "Sam": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "Sav": {
-      "type": "string",
-      "enum": [
-        "INSTANCE"
-      ]
-    },
     "Sb0": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 255,
-        "min": 1
-      },
+      "key": {},
       "value": {
         "type": "structure",
         "members": {
@@ -6322,8 +4383,6 @@
             "type": "list",
             "member": {
               "type": "string",
-              "max": 255,
-              "min": 1,
               "sensitive": true
             },
             "sensitive": true
@@ -6333,10 +4392,6 @@
       },
       "sensitive": true
     },
-    "Sb5": {
-      "type": "integer",
-      "min": 0
-    },
     "Sb6": {
       "type": "structure",
       "required": [
@@ -6344,15 +4399,9 @@
         "S3Region"
       ],
       "members": {
-        "S3BucketName": {
-          "shape": "S13"
-        },
-        "S3KeyPrefix": {
-          "shape": "S14"
-        },
-        "S3Region": {
-          "shape": "S12"
-        }
+        "S3BucketName": {},
+        "S3KeyPrefix": {},
+        "S3Region": {}
       }
     },
     "Sbj": {
@@ -6363,123 +4412,31 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 132,
-            "min": 1,
-            "pattern": "tag:.+|Name|Type|KeyId|Path|Label"
-          },
-          "Option": {
-            "type": "string",
-            "max": 10,
-            "min": 1
-          },
+          "Key": {},
+          "Option": {},
           "Values": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 1024,
-              "min": 1
-            },
-            "max": 50,
-            "min": 1
+            "member": {}
           }
         }
       }
     },
-    "Sbs": {
-      "type": "string",
-      "enum": [
-        "String",
-        "StringList",
-        "SecureString"
-      ]
-    },
-    "Sbt": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "^([a-zA-Z0-9:/_-]+)$"
-    },
-    "Sbu": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
-    "Sbv": {
-      "type": "string",
-      "max": 1024,
-      "min": 0
-    },
     "Sc0": {
       "type": "structure",
       "members": {
-        "BaselineId": {
-          "shape": "S3e"
-        },
-        "BaselineName": {
-          "shape": "S2r"
-        },
-        "OperatingSystem": {
-          "shape": "S2q"
-        },
-        "BaselineDescription": {
-          "shape": "S36"
-        },
+        "BaselineId": {},
+        "BaselineName": {},
+        "OperatingSystem": {},
+        "BaselineDescription": {},
         "DefaultBaseline": {
           "type": "boolean"
         }
       }
     },
-    "Sci": {
-      "type": "string",
-      "max": 96,
-      "min": 1
-    },
-    "Scj": {
-      "type": "string",
-      "max": 50,
-      "min": 1
-    },
-    "Scu": {
-      "type": "string",
-      "min": 4
-    },
-    "Scw": {
-      "type": "string",
-      "max": 100
-    },
-    "Scy": {
-      "type": "string",
-      "pattern": "^([\\-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d(?!:))?)?(\\17[0-5]\\d([\\.,]\\d)?)?([zZ]|([\\-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
-    },
-    "Scz": {
-      "type": "string",
-      "enum": [
-        "Pending",
-        "InProgress",
-        "Delayed",
-        "Success",
-        "Cancelled",
-        "TimedOut",
-        "Failed",
-        "Cancelling"
-      ]
-    },
-    "Sd0": {
-      "type": "string",
-      "max": 100,
-      "min": 0
-    },
     "Sd3": {
       "type": "structure",
       "members": {
-        "CloudWatchLogGroupName": {
-          "type": "string",
-          "max": 512,
-          "min": 1,
-          "pattern": "[\\.\\-_/#A-Za-z0-9]+"
-        },
+        "CloudWatchLogGroupName": {},
         "CloudWatchOutputEnabled": {
           "type": "boolean"
         }
@@ -6494,43 +4451,21 @@
           "Values"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 200,
-            "min": 1
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {},
-            "max": 40,
-            "min": 1
+            "member": {}
           },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "Equal",
-              "NotEqual",
-              "BeginWith",
-              "LessThan",
-              "GreaterThan",
-              "Exists"
-            ]
-          }
+          "Type": {}
         }
-      },
-      "max": 5,
-      "min": 1
+      }
     },
     "Sdo": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "Expression": {
-            "type": "string",
-            "max": 1000,
-            "min": 1
-          },
+          "Expression": {},
           "Aggregators": {
             "shape": "Sdo"
           },
@@ -6543,57 +4478,23 @@
                 "Filters"
               ],
               "members": {
-                "Name": {
-                  "type": "string",
-                  "max": 200,
-                  "min": 1
-                },
+                "Name": {},
                 "Filters": {
                   "shape": "Sdi"
                 }
               }
-            },
-            "max": 10,
-            "min": 1
+            }
           }
         }
-      },
-      "max": 10,
-      "min": 1
-    },
-    "Se3": {
-      "type": "string",
-      "pattern": "^(20)[0-9][0-9]-(0[1-9]|1[012])-([12][0-9]|3[01]|0[1-9])(T)(2[0-3]|[0-1][0-9])(:[0-5][0-9])(:[0-5][0-9])(Z)$"
-    },
-    "Se4": {
-      "type": "string",
-      "max": 256
+      }
     },
     "Se5": {
       "type": "list",
       "member": {
         "type": "map",
-        "key": {
-          "shape": "Se7"
-        },
-        "value": {
-          "shape": "Se8"
-        },
-        "max": 50,
-        "min": 0
-      },
-      "max": 10000,
-      "min": 0
-    },
-    "Se7": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "Se8": {
-      "type": "string",
-      "max": 4096,
-      "min": 0
+        "key": {},
+        "value": {}
+      }
     },
     "Sey": {
       "type": "structure",
@@ -6601,39 +4502,27 @@
         "RunCommand": {
           "type": "structure",
           "members": {
-            "Comment": {
-              "shape": "Scw"
-            },
-            "DocumentHash": {
-              "shape": "S20"
-            },
-            "DocumentHashType": {
-              "shape": "S21"
-            },
+            "Comment": {},
+            "DocumentHash": {},
+            "DocumentHashType": {},
             "NotificationConfig": {
               "shape": "Sf0"
             },
-            "OutputS3BucketName": {
-              "shape": "S13"
-            },
-            "OutputS3KeyPrefix": {
-              "shape": "S14"
-            },
+            "OutputS3BucketName": {},
+            "OutputS3KeyPrefix": {},
             "Parameters": {
               "shape": "Sq"
             },
             "ServiceRoleArn": {},
             "TimeoutSeconds": {
-              "shape": "Sf5"
+              "type": "integer"
             }
           }
         },
         "Automation": {
           "type": "structure",
           "members": {
-            "DocumentVersion": {
-              "shape": "Sp"
-            },
+            "DocumentVersion": {},
             "Parameters": {
               "shape": "S69"
             }
@@ -6644,32 +4533,18 @@
           "members": {
             "Input": {
               "type": "string",
-              "max": 4096,
               "sensitive": true
             },
-            "Name": {
-              "type": "string",
-              "max": 80,
-              "min": 1
-            }
+            "Name": {}
           }
         },
         "Lambda": {
           "type": "structure",
           "members": {
-            "ClientContext": {
-              "type": "string",
-              "max": 8000,
-              "min": 1
-            },
-            "Qualifier": {
-              "type": "string",
-              "max": 128,
-              "min": 1
-            },
+            "ClientContext": {},
+            "Qualifier": {},
             "Payload": {
               "type": "blob",
-              "max": 4096,
               "sensitive": true
             }
           }
@@ -6682,52 +4557,21 @@
         "NotificationArn": {},
         "NotificationEvents": {
           "type": "list",
-          "member": {
-            "type": "string",
-            "enum": [
-              "All",
-              "InProgress",
-              "Success",
-              "TimedOut",
-              "Cancelled",
-              "Failed"
-            ]
-          }
+          "member": {}
         },
-        "NotificationType": {
-          "type": "string",
-          "enum": [
-            "Command",
-            "Invocation"
-          ]
-        }
+        "NotificationType": {}
       }
-    },
-    "Sf5": {
-      "type": "integer",
-      "max": 2592000,
-      "min": 30
     },
     "Sfg": {
       "type": "structure",
       "members": {
-        "Name": {
-          "shape": "S4a"
-        },
-        "Type": {
-          "shape": "Sbs"
-        },
-        "Value": {
-          "shape": "Sfh"
-        },
+        "Name": {},
+        "Type": {},
+        "Value": {},
         "Version": {
           "type": "long"
         },
-        "Selector": {
-          "type": "string",
-          "max": 128,
-          "min": 0
-        },
+        "Selector": {},
         "SourceResult": {},
         "LastModifiedDate": {
           "type": "timestamp"
@@ -6735,31 +4579,15 @@
         "ARN": {}
       }
     },
-    "Sfh": {
-      "type": "string",
-      "max": 4096,
-      "min": 1
-    },
     "Sfn": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 100,
-        "min": 1
-      },
-      "max": 10,
-      "min": 1
+      "member": {}
     },
     "Sfr": {
       "type": "list",
       "member": {
         "shape": "Sfg"
       }
-    },
-    "Sgf": {
-      "type": "integer",
-      "max": 50,
-      "min": 1
     },
     "Sgg": {
       "type": "list",
@@ -6770,41 +4598,18 @@
           "value"
         ],
         "members": {
-          "key": {
-            "type": "string",
-            "enum": [
-              "InvokedAfter",
-              "InvokedBefore",
-              "Status",
-              "ExecutionStage",
-              "DocumentName"
-            ]
-          },
-          "value": {
-            "type": "string",
-            "max": 128,
-            "min": 1
-          }
+          "key": {},
+          "value": {}
         }
-      },
-      "max": 5,
-      "min": 1
+      }
     },
     "Sgw": {
       "type": "structure",
       "members": {
-        "CommandId": {
-          "shape": "Sa"
-        },
-        "DocumentName": {
-          "shape": "So"
-        },
-        "DocumentVersion": {
-          "shape": "Sp"
-        },
-        "Comment": {
-          "shape": "Scw"
-        },
+        "CommandId": {},
+        "DocumentName": {},
+        "DocumentVersion": {},
+        "Comment": {},
         "ExpiresAfter": {
           "type": "timestamp"
         },
@@ -6820,36 +4625,13 @@
         "RequestedDateTime": {
           "type": "timestamp"
         },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "Pending",
-            "InProgress",
-            "Success",
-            "Cancelled",
-            "Failed",
-            "TimedOut",
-            "Cancelling"
-          ]
-        },
-        "StatusDetails": {
-          "shape": "Sd0"
-        },
-        "OutputS3Region": {
-          "shape": "S12"
-        },
-        "OutputS3BucketName": {
-          "shape": "S13"
-        },
-        "OutputS3KeyPrefix": {
-          "shape": "S14"
-        },
-        "MaxConcurrency": {
-          "shape": "S6l"
-        },
-        "MaxErrors": {
-          "shape": "S6m"
-        },
+        "Status": {},
+        "StatusDetails": {},
+        "OutputS3Region": {},
+        "OutputS3BucketName": {},
+        "OutputS3KeyPrefix": {},
+        "MaxConcurrency": {},
+        "MaxErrors": {},
         "TargetCount": {
           "type": "integer"
         },
@@ -6876,72 +4658,14 @@
       "member": {
         "type": "structure",
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 200,
-            "min": 1
-          },
+          "Key": {},
           "Values": {
             "type": "list",
-            "member": {},
-            "max": 20,
-            "min": 1
+            "member": {}
           },
-          "Type": {
-            "type": "string",
-            "enum": [
-              "EQUAL",
-              "NOT_EQUAL",
-              "BEGIN_WITH",
-              "LESS_THAN",
-              "GREATER_THAN"
-            ]
-          }
+          "Type": {}
         }
       }
-    },
-    "Sha": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "Shc": {
-      "type": "string",
-      "max": 50,
-      "min": 1
-    },
-    "Shg": {
-      "type": "string",
-      "max": 100,
-      "min": 1,
-      "pattern": "[A-Za-z0-9_\\-]\\w+|Custom:[a-zA-Z0-9_\\-]\\w+"
-    },
-    "Shh": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "Shi": {
-      "type": "string",
-      "max": 500
-    },
-    "Shj": {
-      "type": "string",
-      "enum": [
-        "COMPLIANT",
-        "NON_COMPLIANT"
-      ]
-    },
-    "Shk": {
-      "type": "string",
-      "enum": [
-        "CRITICAL",
-        "HIGH",
-        "MEDIUM",
-        "LOW",
-        "INFORMATIONAL",
-        "UNSPECIFIED"
-      ]
     },
     "Shl": {
       "type": "structure",
@@ -6952,24 +4676,14 @@
         "ExecutionTime": {
           "type": "timestamp"
         },
-        "ExecutionId": {
-          "type": "string",
-          "max": 100
-        },
-        "ExecutionType": {
-          "type": "string",
-          "max": 50
-        }
+        "ExecutionId": {},
+        "ExecutionType": {}
       }
     },
     "Sho": {
       "type": "map",
-      "key": {
-        "shape": "Se7"
-      },
-      "value": {
-        "shape": "Se8"
-      }
+      "key": {},
+      "value": {}
     },
     "Sht": {
       "type": "structure",
@@ -7015,11 +4729,6 @@
           "shape": "Shv"
         }
       }
-    },
-    "Sjn": {
-      "type": "string",
-      "max": 300,
-      "min": 0
     }
   }
 }

--- a/apis/states-2016-11-23.min.json
+++ b/apis/states-2016-11-23.min.json
@@ -20,9 +20,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          }
+          "name": {}
         }
       },
       "output": {
@@ -32,9 +30,7 @@
           "creationDate"
         ],
         "members": {
-          "activityArn": {
-            "shape": "S4"
-          },
+          "activityArn": {},
           "creationDate": {
             "type": "timestamp"
           }
@@ -51,15 +47,9 @@
           "roleArn"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "definition": {
-            "shape": "S7"
-          },
-          "roleArn": {
-            "shape": "S4"
-          }
+          "name": {},
+          "definition": {},
+          "roleArn": {}
         }
       },
       "output": {
@@ -69,9 +59,7 @@
           "creationDate"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
+          "stateMachineArn": {},
           "creationDate": {
             "type": "timestamp"
           }
@@ -86,9 +74,7 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {
-            "shape": "S4"
-          }
+          "activityArn": {}
         }
       },
       "output": {
@@ -103,9 +89,7 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          }
+          "stateMachineArn": {}
         }
       },
       "output": {
@@ -120,9 +104,7 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {
-            "shape": "S4"
-          }
+          "activityArn": {}
         }
       },
       "output": {
@@ -133,12 +115,8 @@
           "creationDate"
         ],
         "members": {
-          "activityArn": {
-            "shape": "S4"
-          },
-          "name": {
-            "shape": "S2"
-          },
+          "activityArn": {},
+          "name": {},
           "creationDate": {
             "type": "timestamp"
           }
@@ -152,9 +130,7 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          }
+          "executionArn": {}
         }
       },
       "output": {
@@ -167,30 +143,18 @@
           "input"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          },
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "name": {
-            "shape": "S2"
-          },
-          "status": {
-            "shape": "Sh"
-          },
+          "executionArn": {},
+          "stateMachineArn": {},
+          "name": {},
+          "status": {},
           "startDate": {
             "type": "timestamp"
           },
           "stopDate": {
             "type": "timestamp"
           },
-          "input": {
-            "shape": "Si"
-          },
-          "output": {
-            "shape": "Si"
-          }
+          "input": {},
+          "output": {}
         }
       }
     },
@@ -201,9 +165,7 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          }
+          "stateMachineArn": {}
         }
       },
       "output": {
@@ -216,25 +178,11 @@
           "creationDate"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "name": {
-            "shape": "S2"
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "ACTIVE",
-              "DELETING"
-            ]
-          },
-          "definition": {
-            "shape": "S7"
-          },
-          "roleArn": {
-            "shape": "S4"
-          },
+          "stateMachineArn": {},
+          "name": {},
+          "status": {},
+          "definition": {},
+          "roleArn": {},
           "creationDate": {
             "type": "timestamp"
           }
@@ -248,9 +196,7 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          }
+          "executionArn": {}
         }
       },
       "output": {
@@ -263,18 +209,10 @@
           "updateDate"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "name": {
-            "shape": "S2"
-          },
-          "definition": {
-            "shape": "S7"
-          },
-          "roleArn": {
-            "shape": "S4"
-          },
+          "stateMachineArn": {},
+          "name": {},
+          "definition": {},
+          "roleArn": {},
           "updateDate": {
             "type": "timestamp"
           }
@@ -288,23 +226,15 @@
           "activityArn"
         ],
         "members": {
-          "activityArn": {
-            "shape": "S4"
-          },
-          "workerName": {
-            "shape": "S2"
-          }
+          "activityArn": {},
+          "workerName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "taskToken": {
-            "shape": "Sq"
-          },
-          "input": {
-            "shape": "Si"
-          }
+          "taskToken": {},
+          "input": {}
         }
       }
     },
@@ -315,18 +245,14 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          },
+          "executionArn": {},
           "maxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -348,48 +274,7 @@
                 "timestamp": {
                   "type": "timestamp"
                 },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "ActivityFailed",
-                    "ActivityScheduleFailed",
-                    "ActivityScheduled",
-                    "ActivityStarted",
-                    "ActivitySucceeded",
-                    "ActivityTimedOut",
-                    "ChoiceStateEntered",
-                    "ChoiceStateExited",
-                    "ExecutionFailed",
-                    "ExecutionStarted",
-                    "ExecutionSucceeded",
-                    "ExecutionAborted",
-                    "ExecutionTimedOut",
-                    "FailStateEntered",
-                    "LambdaFunctionFailed",
-                    "LambdaFunctionScheduleFailed",
-                    "LambdaFunctionScheduled",
-                    "LambdaFunctionStartFailed",
-                    "LambdaFunctionStarted",
-                    "LambdaFunctionSucceeded",
-                    "LambdaFunctionTimedOut",
-                    "SucceedStateEntered",
-                    "SucceedStateExited",
-                    "TaskStateAborted",
-                    "TaskStateEntered",
-                    "TaskStateExited",
-                    "PassStateEntered",
-                    "PassStateExited",
-                    "ParallelStateAborted",
-                    "ParallelStateEntered",
-                    "ParallelStateExited",
-                    "ParallelStateFailed",
-                    "ParallelStateStarted",
-                    "ParallelStateSucceeded",
-                    "WaitStateAborted",
-                    "WaitStateEntered",
-                    "WaitStateExited"
-                  ]
-                },
+                "type": {},
                 "id": {
                   "type": "long"
                 },
@@ -399,23 +284,15 @@
                 "activityFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "activityScheduleFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "activityScheduledEventDetails": {
@@ -424,12 +301,8 @@
                     "resource"
                   ],
                   "members": {
-                    "resource": {
-                      "shape": "S4"
-                    },
-                    "input": {
-                      "shape": "Si"
-                    },
+                    "resource": {},
+                    "input": {},
                     "timeoutInSeconds": {
                       "type": "long"
                     },
@@ -441,103 +314,68 @@
                 "activityStartedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "workerName": {
-                      "type": "string",
-                      "max": 256
-                    }
+                    "workerName": {}
                   }
                 },
                 "activitySucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {
-                      "shape": "Si"
-                    }
+                    "output": {}
                   }
                 },
                 "activityTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "executionFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "executionStartedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "input": {
-                      "shape": "Si"
-                    },
-                    "roleArn": {
-                      "shape": "S4"
-                    }
+                    "input": {},
+                    "roleArn": {}
                   }
                 },
                 "executionSucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {
-                      "shape": "Si"
-                    }
+                    "output": {}
                   }
                 },
                 "executionAbortedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "executionTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "lambdaFunctionFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "lambdaFunctionScheduleFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "lambdaFunctionScheduledEventDetails": {
@@ -546,12 +384,8 @@
                     "resource"
                   ],
                   "members": {
-                    "resource": {
-                      "shape": "S4"
-                    },
-                    "input": {
-                      "shape": "Si"
-                    },
+                    "resource": {},
+                    "input": {},
                     "timeoutInSeconds": {
                       "type": "long"
                     }
@@ -560,31 +394,21 @@
                 "lambdaFunctionStartFailedEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "lambdaFunctionSucceededEventDetails": {
                   "type": "structure",
                   "members": {
-                    "output": {
-                      "shape": "Si"
-                    }
+                    "output": {}
                   }
                 },
                 "lambdaFunctionTimedOutEventDetails": {
                   "type": "structure",
                   "members": {
-                    "error": {
-                      "shape": "S11"
-                    },
-                    "cause": {
-                      "shape": "S12"
-                    }
+                    "error": {},
+                    "cause": {}
                   }
                 },
                 "stateEnteredEventDetails": {
@@ -593,12 +417,8 @@
                     "name"
                   ],
                   "members": {
-                    "name": {
-                      "shape": "S2"
-                    },
-                    "input": {
-                      "shape": "Si"
-                    }
+                    "name": {},
+                    "input": {}
                   }
                 },
                 "stateExitedEventDetails": {
@@ -607,20 +427,14 @@
                     "name"
                   ],
                   "members": {
-                    "name": {
-                      "shape": "S2"
-                    },
-                    "output": {
-                      "shape": "Si"
-                    }
+                    "name": {},
+                    "output": {}
                   }
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -629,11 +443,9 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -652,21 +464,15 @@
                 "creationDate"
               ],
               "members": {
-                "activityArn": {
-                  "shape": "S4"
-                },
-                "name": {
-                  "shape": "S2"
-                },
+                "activityArn": {},
+                "name": {},
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -677,18 +483,12 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "statusFilter": {
-            "shape": "Sh"
-          },
+          "stateMachineArn": {},
+          "statusFilter": {},
           "maxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -709,18 +509,10 @@
                 "startDate"
               ],
               "members": {
-                "executionArn": {
-                  "shape": "S4"
-                },
-                "stateMachineArn": {
-                  "shape": "S4"
-                },
-                "name": {
-                  "shape": "S2"
-                },
-                "status": {
-                  "shape": "Sh"
-                },
+                "executionArn": {},
+                "stateMachineArn": {},
+                "name": {},
+                "status": {},
                 "startDate": {
                   "type": "timestamp"
                 },
@@ -730,9 +522,7 @@
               }
             }
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -741,11 +531,9 @@
         "type": "structure",
         "members": {
           "maxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       },
       "output": {
@@ -764,21 +552,15 @@
                 "creationDate"
               ],
               "members": {
-                "stateMachineArn": {
-                  "shape": "S4"
-                },
-                "name": {
-                  "shape": "S2"
-                },
+                "stateMachineArn": {},
+                "name": {},
                 "creationDate": {
                   "type": "timestamp"
                 }
               }
             }
           },
-          "nextToken": {
-            "shape": "Su"
-          }
+          "nextToken": {}
         }
       }
     },
@@ -789,15 +571,9 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "Sq"
-          },
-          "error": {
-            "shape": "S11"
-          },
-          "cause": {
-            "shape": "S12"
-          }
+          "taskToken": {},
+          "error": {},
+          "cause": {}
         }
       },
       "output": {
@@ -812,9 +588,7 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "Sq"
-          }
+          "taskToken": {}
         }
       },
       "output": {
@@ -830,12 +604,8 @@
           "output"
         ],
         "members": {
-          "taskToken": {
-            "shape": "Sq"
-          },
-          "output": {
-            "shape": "Si"
-          }
+          "taskToken": {},
+          "output": {}
         }
       },
       "output": {
@@ -850,15 +620,9 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "name": {
-            "shape": "S2"
-          },
-          "input": {
-            "shape": "Si"
-          }
+          "stateMachineArn": {},
+          "name": {},
+          "input": {}
         }
       },
       "output": {
@@ -868,9 +632,7 @@
           "startDate"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          },
+          "executionArn": {},
           "startDate": {
             "type": "timestamp"
           }
@@ -885,15 +647,9 @@
           "executionArn"
         ],
         "members": {
-          "executionArn": {
-            "shape": "S4"
-          },
-          "error": {
-            "shape": "S11"
-          },
-          "cause": {
-            "shape": "S12"
-          }
+          "executionArn": {},
+          "error": {},
+          "cause": {}
         }
       },
       "output": {
@@ -915,15 +671,9 @@
           "stateMachineArn"
         ],
         "members": {
-          "stateMachineArn": {
-            "shape": "S4"
-          },
-          "definition": {
-            "shape": "S7"
-          },
-          "roleArn": {
-            "shape": "S4"
-          }
+          "stateMachineArn": {},
+          "definition": {},
+          "roleArn": {}
         }
       },
       "output": {
@@ -940,60 +690,5 @@
       "idempotent": true
     }
   },
-  "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 80,
-      "min": 1
-    },
-    "S4": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "max": 1048576,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "RUNNING",
-        "SUCCEEDED",
-        "FAILED",
-        "TIMED_OUT",
-        "ABORTED"
-      ]
-    },
-    "Si": {
-      "type": "string",
-      "max": 32768
-    },
-    "Sq": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "Ss": {
-      "type": "integer",
-      "max": 1000,
-      "min": 0
-    },
-    "Su": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S11": {
-      "type": "string",
-      "max": 256,
-      "min": 0
-    },
-    "S12": {
-      "type": "string",
-      "max": 32768,
-      "min": 0
-    }
-  }
+  "shapes": {}
 }

--- a/apis/storagegateway-2013-06-30.min.json
+++ b/apis/storagegateway-2013-06-30.min.json
@@ -22,43 +22,19 @@
           "GatewayRegion"
         ],
         "members": {
-          "ActivationKey": {
-            "type": "string",
-            "max": 50,
-            "min": 1
-          },
-          "GatewayName": {
-            "shape": "S3"
-          },
-          "GatewayTimezone": {
-            "shape": "S4"
-          },
-          "GatewayRegion": {
-            "type": "string",
-            "max": 25,
-            "min": 1
-          },
-          "GatewayType": {
-            "shape": "S6"
-          },
-          "TapeDriveType": {
-            "type": "string",
-            "max": 50,
-            "min": 2
-          },
-          "MediumChangerType": {
-            "type": "string",
-            "max": 50,
-            "min": 2
-          }
+          "ActivationKey": {},
+          "GatewayName": {},
+          "GatewayTimezone": {},
+          "GatewayRegion": {},
+          "GatewayType": {},
+          "TapeDriveType": {},
+          "MediumChangerType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -70,9 +46,7 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           }
@@ -81,9 +55,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -95,9 +67,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          },
+          "ResourceARN": {},
           "Tags": {
             "shape": "Sh"
           }
@@ -106,9 +76,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          }
+          "ResourceARN": {}
         }
       }
     },
@@ -120,9 +88,7 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           }
@@ -131,9 +97,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -145,9 +109,7 @@
           "DiskIds"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           }
@@ -156,9 +118,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -170,20 +130,14 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "GatewayARN": {},
+          "TapeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -195,20 +149,14 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "GatewayARN": {},
+          "TapeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -223,44 +171,26 @@
           "ClientToken"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "VolumeSizeInBytes": {
             "type": "long"
           },
-          "SnapshotId": {
-            "shape": "Sx"
-          },
-          "TargetName": {
-            "shape": "Sy"
-          },
-          "SourceVolumeARN": {
-            "shape": "Sz"
-          },
-          "NetworkInterfaceId": {
-            "shape": "S10"
-          },
-          "ClientToken": {
-            "shape": "S11"
-          },
+          "SnapshotId": {},
+          "TargetName": {},
+          "SourceVolumeARN": {},
+          "NetworkInterfaceId": {},
+          "ClientToken": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          }
+          "KMSKey": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
-          "TargetARN": {
-            "shape": "S15"
-          }
+          "VolumeARN": {},
+          "TargetARN": {}
         }
       }
     },
@@ -274,39 +204,23 @@
           "LocationARN"
         ],
         "members": {
-          "ClientToken": {
-            "shape": "S11"
-          },
+          "ClientToken": {},
           "NFSFileShareDefaults": {
             "shape": "S17"
           },
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          },
-          "Role": {
-            "shape": "S1a"
-          },
-          "LocationARN": {
-            "shape": "S1b"
-          },
-          "DefaultStorageClass": {
-            "shape": "S1c"
-          },
-          "ObjectACL": {
-            "shape": "S1d"
-          },
+          "KMSKey": {},
+          "Role": {},
+          "LocationARN": {},
+          "DefaultStorageClass": {},
+          "ObjectACL": {},
           "ClientList": {
             "shape": "S1e"
           },
-          "Squash": {
-            "shape": "S1g"
-          },
+          "Squash": {},
           "ReadOnly": {
             "type": "boolean"
           },
@@ -321,9 +235,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -337,30 +249,16 @@
           "LocationARN"
         ],
         "members": {
-          "ClientToken": {
-            "shape": "S11"
-          },
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "ClientToken": {},
+          "GatewayARN": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          },
-          "Role": {
-            "shape": "S1a"
-          },
-          "LocationARN": {
-            "shape": "S1b"
-          },
-          "DefaultStorageClass": {
-            "shape": "S1c"
-          },
-          "ObjectACL": {
-            "shape": "S1d"
-          },
+          "KMSKey": {},
+          "Role": {},
+          "LocationARN": {},
+          "DefaultStorageClass": {},
+          "ObjectACL": {},
           "ReadOnly": {
             "type": "boolean"
           },
@@ -376,17 +274,13 @@
           "InvalidUserList": {
             "shape": "S1k"
           },
-          "Authentication": {
-            "shape": "S1m"
-          }
+          "Authentication": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -398,23 +292,15 @@
           "SnapshotDescription"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
-          "SnapshotDescription": {
-            "shape": "S1p"
-          }
+          "VolumeARN": {},
+          "SnapshotDescription": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
-          "SnapshotId": {
-            "shape": "Sx"
-          }
+          "VolumeARN": {},
+          "SnapshotId": {}
         }
       }
     },
@@ -426,23 +312,15 @@
           "SnapshotDescription"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
-          "SnapshotDescription": {
-            "shape": "S1p"
-          }
+          "VolumeARN": {},
+          "SnapshotDescription": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "SnapshotId": {
-            "shape": "Sx"
-          },
-          "VolumeARN": {
-            "shape": "Sz"
-          },
+          "SnapshotId": {},
+          "VolumeARN": {},
           "VolumeRecoveryPointTime": {}
         }
       }
@@ -458,44 +336,28 @@
           "NetworkInterfaceId"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "DiskId": {
-            "shape": "Sd"
-          },
-          "SnapshotId": {
-            "shape": "Sx"
-          },
+          "GatewayARN": {},
+          "DiskId": {},
+          "SnapshotId": {},
           "PreserveExistingData": {
             "type": "boolean"
           },
-          "TargetName": {
-            "shape": "Sy"
-          },
-          "NetworkInterfaceId": {
-            "shape": "S10"
-          },
+          "TargetName": {},
+          "NetworkInterfaceId": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          }
+          "KMSKey": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
+          "VolumeARN": {},
           "VolumeSizeInBytes": {
             "type": "long"
           },
-          "TargetARN": {
-            "shape": "S15"
-          }
+          "TargetARN": {}
         }
       }
     },
@@ -508,29 +370,21 @@
           "TapeBarcode"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "TapeSizeInBytes": {
             "type": "long"
           },
-          "TapeBarcode": {
-            "shape": "S1z"
-          },
+          "TapeBarcode": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          }
+          "KMSKey": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -545,32 +399,19 @@
           "TapeBarcodePrefix"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "TapeSizeInBytes": {
             "type": "long"
           },
-          "ClientToken": {
-            "shape": "S11"
-          },
+          "ClientToken": {},
           "NumTapesToCreate": {
-            "type": "integer",
-            "max": 10,
-            "min": 1
+            "type": "integer"
           },
-          "TapeBarcodePrefix": {
-            "type": "string",
-            "max": 4,
-            "min": 1,
-            "pattern": "^[A-Z]*$"
-          },
+          "TapeBarcodePrefix": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          }
+          "KMSKey": {}
         }
       },
       "output": {
@@ -590,22 +431,14 @@
           "BandwidthType"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "BandwidthType": {
-            "type": "string",
-            "max": 25,
-            "min": 3
-          }
+          "GatewayARN": {},
+          "BandwidthType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -617,23 +450,15 @@
           "InitiatorName"
         ],
         "members": {
-          "TargetARN": {
-            "shape": "S15"
-          },
-          "InitiatorName": {
-            "shape": "S2a"
-          }
+          "TargetARN": {},
+          "InitiatorName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TargetARN": {
-            "shape": "S15"
-          },
-          "InitiatorName": {
-            "shape": "S2a"
-          }
+          "TargetARN": {},
+          "InitiatorName": {}
         }
       }
     },
@@ -644,9 +469,7 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          },
+          "FileShareARN": {},
           "ForceDelete": {
             "type": "boolean"
           }
@@ -655,9 +478,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -668,17 +489,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -689,17 +506,13 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       }
     },
@@ -711,20 +524,14 @@
           "TapeARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "GatewayARN": {},
+          "TapeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -735,17 +542,13 @@
           "TapeARN"
         ],
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -756,17 +559,13 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       }
     },
@@ -777,22 +576,18 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "AverageUploadRateLimitInBitsPerSec": {
-            "shape": "S2q"
+            "type": "long"
           },
           "AverageDownloadRateLimitInBitsPerSec": {
-            "shape": "S2r"
+            "type": "long"
           }
         }
       }
@@ -804,17 +599,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           },
@@ -856,27 +647,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {
-                  "shape": "Sz"
-                },
-                "VolumeId": {
-                  "shape": "S30"
-                },
-                "VolumeType": {
-                  "shape": "S31"
-                },
-                "VolumeStatus": {
-                  "shape": "S32"
-                },
+                "VolumeARN": {},
+                "VolumeId": {},
+                "VolumeType": {},
+                "VolumeStatus": {},
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
                 "VolumeProgress": {
                   "type": "double"
                 },
-                "SourceSnapshotId": {
-                  "shape": "Sx"
-                },
+                "SourceSnapshotId": {},
                 "VolumeiSCSIAttributes": {
                   "shape": "S34"
                 },
@@ -886,9 +667,7 @@
                 "VolumeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                }
+                "KMSKey": {}
               }
             }
           }
@@ -902,9 +681,7 @@
           "TargetARN"
         ],
         "members": {
-          "TargetARN": {
-            "shape": "S15"
-          }
+          "TargetARN": {}
         }
       },
       "output": {
@@ -915,18 +692,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "TargetARN": {
-                  "shape": "S15"
-                },
-                "SecretToAuthenticateInitiator": {
-                  "shape": "S3d"
-                },
-                "InitiatorName": {
-                  "shape": "S2a"
-                },
-                "SecretToAuthenticateTarget": {
-                  "shape": "S3d"
-                }
+                "TargetARN": {},
+                "SecretToAuthenticateInitiator": {},
+                "InitiatorName": {},
+                "SecretToAuthenticateTarget": {}
               }
             }
           }
@@ -940,29 +709,17 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "GatewayId": {
-            "shape": "S3g"
-          },
+          "GatewayARN": {},
+          "GatewayId": {},
           "GatewayName": {},
-          "GatewayTimezone": {
-            "shape": "S4"
-          },
-          "GatewayState": {
-            "type": "string",
-            "max": 25,
-            "min": 2
-          },
+          "GatewayTimezone": {},
+          "GatewayState": {},
           "GatewayNetworkInterfaces": {
             "type": "list",
             "member": {
@@ -974,19 +731,9 @@
               }
             }
           },
-          "GatewayType": {
-            "shape": "S6"
-          },
-          "NextUpdateAvailabilityDate": {
-            "type": "string",
-            "max": 25,
-            "min": 1
-          },
-          "LastSoftwareUpdate": {
-            "type": "string",
-            "max": 25,
-            "min": 1
-          }
+          "GatewayType": {},
+          "NextUpdateAvailabilityDate": {},
+          "LastSoftwareUpdate": {}
         }
       }
     },
@@ -997,29 +744,23 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "HourOfDay": {
-            "shape": "S3o"
+            "type": "integer"
           },
           "MinuteOfHour": {
-            "shape": "S3p"
+            "type": "integer"
           },
           "DayOfWeek": {
-            "shape": "S3q"
+            "type": "integer"
           },
-          "Timezone": {
-            "shape": "S4"
-          }
+          "Timezone": {}
         }
       }
     },
@@ -1046,43 +787,23 @@
                 "NFSFileShareDefaults": {
                   "shape": "S17"
                 },
-                "FileShareARN": {
-                  "shape": "S1i"
-                },
-                "FileShareId": {
-                  "shape": "S3w"
-                },
-                "FileShareStatus": {
-                  "shape": "S3x"
-                },
-                "GatewayARN": {
-                  "shape": "Sa"
-                },
+                "FileShareARN": {},
+                "FileShareId": {},
+                "FileShareStatus": {},
+                "GatewayARN": {},
                 "KMSEncrypted": {
                   "type": "boolean"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                },
+                "KMSKey": {},
                 "Path": {},
-                "Role": {
-                  "shape": "S1a"
-                },
-                "LocationARN": {
-                  "shape": "S1b"
-                },
-                "DefaultStorageClass": {
-                  "shape": "S1c"
-                },
-                "ObjectACL": {
-                  "shape": "S1d"
-                },
+                "Role": {},
+                "LocationARN": {},
+                "DefaultStorageClass": {},
+                "ObjectACL": {},
                 "ClientList": {
                   "shape": "S1e"
                 },
-                "Squash": {
-                  "shape": "S1g"
-                },
+                "Squash": {},
                 "ReadOnly": {
                   "type": "boolean"
                 },
@@ -1118,37 +839,19 @@
             "member": {
               "type": "structure",
               "members": {
-                "FileShareARN": {
-                  "shape": "S1i"
-                },
-                "FileShareId": {
-                  "shape": "S3w"
-                },
-                "FileShareStatus": {
-                  "shape": "S3x"
-                },
-                "GatewayARN": {
-                  "shape": "Sa"
-                },
+                "FileShareARN": {},
+                "FileShareId": {},
+                "FileShareStatus": {},
+                "GatewayARN": {},
                 "KMSEncrypted": {
                   "type": "boolean"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                },
+                "KMSKey": {},
                 "Path": {},
-                "Role": {
-                  "shape": "S1a"
-                },
-                "LocationARN": {
-                  "shape": "S1b"
-                },
-                "DefaultStorageClass": {
-                  "shape": "S1c"
-                },
-                "ObjectACL": {
-                  "shape": "S1d"
-                },
+                "Role": {},
+                "LocationARN": {},
+                "DefaultStorageClass": {},
+                "ObjectACL": {},
                 "ReadOnly": {
                   "type": "boolean"
                 },
@@ -1164,9 +867,7 @@
                 "InvalidUserList": {
                   "shape": "S1k"
                 },
-                "Authentication": {
-                  "shape": "S1m"
-                }
+                "Authentication": {}
               }
             }
           }
@@ -1180,20 +881,14 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "DomainName": {
-            "shape": "S45"
-          },
+          "GatewayARN": {},
+          "DomainName": {},
           "SMBGuestPasswordSet": {
             "type": "boolean"
           }
@@ -1207,29 +902,21 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
+          "VolumeARN": {},
           "StartAt": {
-            "shape": "S3o"
+            "type": "integer"
           },
           "RecurrenceInHours": {
-            "shape": "S48"
+            "type": "integer"
           },
-          "Description": {
-            "shape": "S49"
-          },
-          "Timezone": {
-            "shape": "S4"
-          }
+          "Description": {},
+          "Timezone": {}
         }
       }
     },
@@ -1253,30 +940,18 @@
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {
-                  "shape": "Sz"
-                },
-                "VolumeId": {
-                  "shape": "S30"
-                },
-                "VolumeType": {
-                  "shape": "S31"
-                },
-                "VolumeStatus": {
-                  "shape": "S32"
-                },
+                "VolumeARN": {},
+                "VolumeId": {},
+                "VolumeType": {},
+                "VolumeStatus": {},
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
                 "VolumeProgress": {
                   "type": "double"
                 },
-                "VolumeDiskId": {
-                  "shape": "Sd"
-                },
-                "SourceSnapshotId": {
-                  "shape": "Sx"
-                },
+                "VolumeDiskId": {},
+                "SourceSnapshotId": {},
                 "PreservedExistingData": {
                   "type": "boolean"
                 },
@@ -1289,9 +964,7 @@
                 "VolumeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                }
+                "KMSKey": {}
               }
             }
           }
@@ -1305,11 +978,9 @@
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
@@ -1321,12 +992,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {
-                  "shape": "Sr"
-                },
-                "TapeBarcode": {
-                  "shape": "S1z"
-                },
+                "TapeARN": {},
+                "TapeBarcode": {},
                 "TapeCreatedDate": {
                   "type": "timestamp"
                 },
@@ -1336,22 +1003,16 @@
                 "CompletionTime": {
                   "type": "timestamp"
                 },
-                "RetrievedTo": {
-                  "shape": "Sa"
-                },
+                "RetrievedTo": {},
                 "TapeStatus": {},
                 "TapeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                }
+                "KMSKey": {}
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1362,31 +1023,23 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "GatewayARN": {},
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "TapeRecoveryPointInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {
-                  "shape": "Sr"
-                },
+                "TapeARN": {},
                 "TapeRecoveryPointTime": {
                   "type": "timestamp"
                 },
@@ -1397,9 +1050,7 @@
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1410,17 +1061,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
@@ -1432,12 +1079,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {
-                  "shape": "Sr"
-                },
-                "TapeBarcode": {
-                  "shape": "S1z"
-                },
+                "TapeARN": {},
+                "TapeBarcode": {},
                 "TapeCreatedDate": {
                   "type": "timestamp"
                 },
@@ -1445,24 +1088,18 @@
                   "type": "long"
                 },
                 "TapeStatus": {},
-                "VTLDevice": {
-                  "shape": "S4w"
-                },
+                "VTLDevice": {},
                 "Progress": {
                   "type": "double"
                 },
                 "TapeUsedInBytes": {
                   "type": "long"
                 },
-                "KMSKey": {
-                  "shape": "S13"
-                }
+                "KMSKey": {}
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1473,17 +1110,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           },
@@ -1503,49 +1136,35 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "VTLDeviceARNs": {
             "type": "list",
-            "member": {
-              "shape": "S4w"
-            }
+            "member": {}
           },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "VTLDevices": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VTLDeviceARN": {
-                  "shape": "S4w"
-                },
+                "VTLDeviceARN": {},
                 "VTLDeviceType": {},
                 "VTLDeviceVendor": {},
                 "VTLDeviceProductIdentifier": {},
                 "DeviceiSCSIAttributes": {
                   "type": "structure",
                   "members": {
-                    "TargetARN": {
-                      "shape": "S15"
-                    },
-                    "NetworkInterfaceId": {
-                      "shape": "S10"
-                    },
+                    "TargetARN": {},
+                    "NetworkInterfaceId": {},
                     "NetworkInterfacePort": {
                       "type": "integer"
                     },
@@ -1557,9 +1176,7 @@
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1570,17 +1187,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "DiskIds": {
             "shape": "Sc"
           },
@@ -1600,17 +1213,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -1624,19 +1233,11 @@
           "Password"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "DomainName": {
-            "shape": "S45"
-          },
-          "UserName": {
-            "type": "string",
-            "pattern": "^\\w[\\w\\.\\- ]*$"
-          },
+          "GatewayARN": {},
+          "DomainName": {},
+          "UserName": {},
           "Password": {
             "type": "string",
-            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -1644,9 +1245,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -1654,50 +1253,28 @@
       "input": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Marker": {
-            "shape": "S4f"
-          },
-          "NextMarker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
+          "NextMarker": {},
           "FileShareInfoList": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "FileShareType": {
-                  "type": "string",
-                  "enum": [
-                    "NFS",
-                    "SMB"
-                  ]
-                },
-                "FileShareARN": {
-                  "shape": "S1i"
-                },
-                "FileShareId": {
-                  "shape": "S3w"
-                },
-                "FileShareStatus": {
-                  "shape": "S3x"
-                },
-                "GatewayARN": {
-                  "shape": "Sa"
-                }
+                "FileShareType": {},
+                "FileShareARN": {},
+                "FileShareId": {},
+                "FileShareStatus": {},
+                "GatewayARN": {}
               }
             }
           }
@@ -1708,11 +1285,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "Marker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
@@ -1724,27 +1299,15 @@
             "member": {
               "type": "structure",
               "members": {
-                "GatewayId": {
-                  "shape": "S3g"
-                },
-                "GatewayARN": {
-                  "shape": "Sa"
-                },
-                "GatewayType": {
-                  "shape": "S6"
-                },
-                "GatewayOperationalState": {
-                  "type": "string",
-                  "max": 25,
-                  "min": 2
-                },
+                "GatewayId": {},
+                "GatewayARN": {},
+                "GatewayType": {},
+                "GatewayOperationalState": {},
                 "GatewayName": {}
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1755,36 +1318,26 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "Disks": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "DiskId": {
-                  "shape": "Sd"
-                },
+                "DiskId": {},
                 "DiskPath": {},
                 "DiskNode": {},
                 "DiskStatus": {},
                 "DiskSizeInBytes": {
                   "type": "long"
                 },
-                "DiskAllocationType": {
-                  "type": "string",
-                  "max": 100,
-                  "min": 3
-                },
+                "DiskAllocationType": {},
                 "DiskAllocationResource": {}
               }
             }
@@ -1799,26 +1352,18 @@
           "ResourceARN"
         ],
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "ResourceARN": {},
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "ResourceARN": {},
+          "Marker": {},
           "Tags": {
             "shape": "Sh"
           }
@@ -1832,11 +1377,9 @@
           "TapeARNs": {
             "shape": "S25"
           },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
@@ -1848,25 +1391,17 @@
             "member": {
               "type": "structure",
               "members": {
-                "TapeARN": {
-                  "shape": "Sr"
-                },
-                "TapeBarcode": {
-                  "shape": "S1z"
-                },
+                "TapeARN": {},
+                "TapeBarcode": {},
                 "TapeSizeInBytes": {
                   "type": "long"
                 },
                 "TapeStatus": {},
-                "GatewayARN": {
-                  "shape": "Sa"
-                }
+                "GatewayARN": {}
               }
             }
           },
-          "Marker": {
-            "shape": "S4f"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1877,9 +1412,7 @@
           "VolumeARN"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       },
       "output": {
@@ -1887,11 +1420,7 @@
         "members": {
           "Initiators": {
             "type": "list",
-            "member": {
-              "type": "string",
-              "max": 50,
-              "min": 1
-            }
+            "member": {}
           }
         }
       }
@@ -1903,25 +1432,19 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "VolumeRecoveryPointInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {
-                  "shape": "Sz"
-                },
+                "VolumeARN": {},
                 "VolumeSizeInBytes": {
                   "type": "long"
                 },
@@ -1939,46 +1462,28 @@
       "input": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "GatewayARN": {},
+          "Marker": {},
           "Limit": {
-            "shape": "S36"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "Marker": {
-            "shape": "S4f"
-          },
+          "GatewayARN": {},
+          "Marker": {},
           "VolumeInfos": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VolumeARN": {
-                  "shape": "Sz"
-                },
-                "VolumeId": {
-                  "shape": "S30"
-                },
-                "GatewayARN": {
-                  "shape": "Sa"
-                },
-                "GatewayId": {
-                  "shape": "S3g"
-                },
-                "VolumeType": {
-                  "shape": "S31"
-                },
+                "VolumeARN": {},
+                "VolumeId": {},
+                "GatewayARN": {},
+                "GatewayId": {},
+                "VolumeType": {},
                 "VolumeSizeInBytes": {
                   "type": "long"
                 }
@@ -1995,22 +1500,14 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          },
-          "NotificationId": {
-            "type": "string",
-            "max": 2048,
-            "min": 1
-          }
+          "FileShareARN": {},
+          "NotificationId": {}
         }
       }
     },
@@ -2021,17 +1518,13 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -2043,23 +1536,17 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          },
+          "ResourceARN": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sj"
-            }
+            "member": {}
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceARN": {
-            "shape": "Sg"
-          }
+          "ResourceARN": {}
         }
       }
     },
@@ -2070,17 +1557,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2092,20 +1575,14 @@
           "GatewayARN"
         ],
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          },
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "TapeARN": {},
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -2117,20 +1594,14 @@
           "GatewayARN"
         ],
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          },
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "TapeARN": {},
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TapeARN": {
-            "shape": "Sr"
-          }
+          "TapeARN": {}
         }
       }
     },
@@ -2142,14 +1613,9 @@
           "LocalConsolePassword"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "LocalConsolePassword": {
             "type": "string",
-            "max": 512,
-            "min": 6,
-            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -2157,9 +1623,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2171,14 +1635,9 @@
           "Password"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "Password": {
             "type": "string",
-            "max": 512,
-            "min": 6,
-            "pattern": "^[ -~]+$",
             "sensitive": true
           }
         }
@@ -2186,9 +1645,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2199,17 +1656,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2220,17 +1673,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2241,23 +1690,19 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "AverageUploadRateLimitInBitsPerSec": {
-            "shape": "S2q"
+            "type": "long"
           },
           "AverageDownloadRateLimitInBitsPerSec": {
-            "shape": "S2r"
+            "type": "long"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2270,29 +1715,17 @@
           "InitiatorName"
         ],
         "members": {
-          "TargetARN": {
-            "shape": "S15"
-          },
-          "SecretToAuthenticateInitiator": {
-            "shape": "S3d"
-          },
-          "InitiatorName": {
-            "shape": "S2a"
-          },
-          "SecretToAuthenticateTarget": {
-            "shape": "S3d"
-          }
+          "TargetARN": {},
+          "SecretToAuthenticateInitiator": {},
+          "InitiatorName": {},
+          "SecretToAuthenticateTarget": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "TargetARN": {
-            "shape": "S15"
-          },
-          "InitiatorName": {
-            "shape": "S2a"
-          }
+          "TargetARN": {},
+          "InitiatorName": {}
         }
       }
     },
@@ -2303,23 +1736,15 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
-          "GatewayName": {
-            "shape": "S3"
-          },
-          "GatewayTimezone": {
-            "shape": "S4"
-          }
+          "GatewayARN": {},
+          "GatewayName": {},
+          "GatewayTimezone": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "GatewayName": {}
         }
       }
@@ -2331,17 +1756,13 @@
           "GatewayARN"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2355,26 +1776,22 @@
           "DayOfWeek"
         ],
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          },
+          "GatewayARN": {},
           "HourOfDay": {
-            "shape": "S3o"
+            "type": "integer"
           },
           "MinuteOfHour": {
-            "shape": "S3p"
+            "type": "integer"
           },
           "DayOfWeek": {
-            "shape": "S3q"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GatewayARN": {
-            "shape": "Sa"
-          }
+          "GatewayARN": {}
         }
       }
     },
@@ -2385,30 +1802,20 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          },
+          "FileShareARN": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          },
+          "KMSKey": {},
           "NFSFileShareDefaults": {
             "shape": "S17"
           },
-          "DefaultStorageClass": {
-            "shape": "S1c"
-          },
-          "ObjectACL": {
-            "shape": "S1d"
-          },
+          "DefaultStorageClass": {},
+          "ObjectACL": {},
           "ClientList": {
             "shape": "S1e"
           },
-          "Squash": {
-            "shape": "S1g"
-          },
+          "Squash": {},
           "ReadOnly": {
             "type": "boolean"
           },
@@ -2423,9 +1830,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -2436,21 +1841,13 @@
           "FileShareARN"
         ],
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          },
+          "FileShareARN": {},
           "KMSEncrypted": {
             "type": "boolean"
           },
-          "KMSKey": {
-            "shape": "S13"
-          },
-          "DefaultStorageClass": {
-            "shape": "S1c"
-          },
-          "ObjectACL": {
-            "shape": "S1d"
-          },
+          "KMSKey": {},
+          "DefaultStorageClass": {},
+          "ObjectACL": {},
           "ReadOnly": {
             "type": "boolean"
           },
@@ -2471,9 +1868,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "FileShareARN": {
-            "shape": "S1i"
-          }
+          "FileShareARN": {}
         }
       }
     },
@@ -2486,26 +1881,20 @@
           "RecurrenceInHours"
         ],
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          },
+          "VolumeARN": {},
           "StartAt": {
-            "shape": "S3o"
+            "type": "integer"
           },
           "RecurrenceInHours": {
-            "shape": "S48"
+            "type": "integer"
           },
-          "Description": {
-            "shape": "S49"
-          }
+          "Description": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VolumeARN": {
-            "shape": "Sz"
-          }
+          "VolumeARN": {}
         }
       }
     },
@@ -2517,63 +1906,22 @@
           "DeviceType"
         ],
         "members": {
-          "VTLDeviceARN": {
-            "shape": "S4w"
-          },
-          "DeviceType": {
-            "type": "string",
-            "max": 50,
-            "min": 2
-          }
+          "VTLDeviceARN": {},
+          "DeviceType": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VTLDeviceARN": {
-            "shape": "S4w"
-          }
+          "VTLDeviceARN": {}
         }
       }
     }
   },
   "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 255,
-      "min": 2,
-      "pattern": "^[ -\\.0-\\[\\]-~]*[!-\\.0-\\[\\]-~][ -\\.0-\\[\\]-~]*$"
-    },
-    "S4": {
-      "type": "string",
-      "max": 10,
-      "min": 3
-    },
-    "S6": {
-      "type": "string",
-      "max": 20,
-      "min": 2
-    },
-    "Sa": {
-      "type": "string",
-      "max": 500,
-      "min": 50
-    },
     "Sc": {
       "type": "list",
-      "member": {
-        "shape": "Sd"
-      }
-    },
-    "Sd": {
-      "type": "string",
-      "max": 300,
-      "min": 1
-    },
-    "Sg": {
-      "type": "string",
-      "max": 500,
-      "min": 50
+      "member": {}
     },
     "Sh": {
       "type": "list",
@@ -2584,293 +1932,59 @@
           "Value"
         ],
         "members": {
-          "Key": {
-            "shape": "Sj"
-          },
-          "Value": {
-            "type": "string",
-            "max": 256
-          }
+          "Key": {},
+          "Value": {}
         }
       }
-    },
-    "Sj": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
-    },
-    "Sr": {
-      "type": "string",
-      "max": 500,
-      "min": 50,
-      "pattern": "^arn:(aws|aws-cn|aws-us-gov):storagegateway:[a-z\\-0-9]+:[0-9]+:tape\\/[0-9A-Z]{7,16}$"
-    },
-    "Sx": {
-      "type": "string",
-      "pattern": "\\Asnap-([0-9A-Fa-f]{8}|[0-9A-Fa-f]{17})\\z"
-    },
-    "Sy": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "^[-\\.;a-z0-9]+$"
-    },
-    "Sz": {
-      "type": "string",
-      "max": 500,
-      "min": 50
-    },
-    "S10": {
-      "type": "string",
-      "pattern": "\\A(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}\\z"
-    },
-    "S11": {
-      "type": "string",
-      "max": 100,
-      "min": 5
-    },
-    "S13": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S15": {
-      "type": "string",
-      "max": 800,
-      "min": 50
     },
     "S17": {
       "type": "structure",
       "members": {
-        "FileMode": {
-          "shape": "S18"
-        },
-        "DirectoryMode": {
-          "shape": "S18"
-        },
+        "FileMode": {},
+        "DirectoryMode": {},
         "GroupId": {
-          "shape": "S19"
+          "type": "long"
         },
         "OwnerId": {
-          "shape": "S19"
+          "type": "long"
         }
       }
     },
-    "S18": {
-      "type": "string",
-      "max": 4,
-      "min": 1,
-      "pattern": "^[0-7]{4}$"
-    },
-    "S19": {
-      "type": "long",
-      "max": 4294967294,
-      "min": 0
-    },
-    "S1a": {
-      "type": "string",
-      "max": 2048,
-      "min": 20
-    },
-    "S1b": {
-      "type": "string",
-      "max": 310,
-      "min": 16
-    },
-    "S1c": {
-      "type": "string",
-      "max": 20,
-      "min": 5
-    },
-    "S1d": {
-      "type": "string",
-      "enum": [
-        "private",
-        "public-read",
-        "public-read-write",
-        "authenticated-read",
-        "bucket-owner-read",
-        "bucket-owner-full-control",
-        "aws-exec-read"
-      ]
-    },
     "S1e": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))?$"
-      },
-      "max": 100,
-      "min": 1
-    },
-    "S1g": {
-      "type": "string",
-      "max": 15,
-      "min": 5
-    },
-    "S1i": {
-      "type": "string",
-      "max": 500,
-      "min": 50
+      "member": {}
     },
     "S1k": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 64,
-        "min": 1
-      },
-      "max": 100,
-      "min": 0
-    },
-    "S1m": {
-      "type": "string",
-      "max": 15,
-      "min": 5
-    },
-    "S1p": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S1z": {
-      "type": "string",
-      "max": 16,
-      "min": 7,
-      "pattern": "^[A-Z0-9]*$"
+      "member": {}
     },
     "S25": {
       "type": "list",
-      "member": {
-        "shape": "Sr"
-      }
-    },
-    "S2a": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[0-9a-z:.-]+"
-    },
-    "S2q": {
-      "type": "long",
-      "min": 51200
-    },
-    "S2r": {
-      "type": "long",
-      "min": 102400
+      "member": {}
     },
     "S2w": {
       "type": "list",
-      "member": {
-        "shape": "Sz"
-      }
-    },
-    "S30": {
-      "type": "string",
-      "max": 30,
-      "min": 12
-    },
-    "S31": {
-      "type": "string",
-      "max": 100,
-      "min": 3
-    },
-    "S32": {
-      "type": "string",
-      "max": 50,
-      "min": 3
+      "member": {}
     },
     "S34": {
       "type": "structure",
       "members": {
-        "TargetARN": {
-          "shape": "S15"
-        },
-        "NetworkInterfaceId": {
-          "shape": "S10"
-        },
+        "TargetARN": {},
+        "NetworkInterfaceId": {},
         "NetworkInterfacePort": {
           "type": "integer"
         },
         "LunNumber": {
-          "shape": "S36"
+          "type": "integer"
         },
         "ChapEnabled": {
           "type": "boolean"
         }
       }
     },
-    "S36": {
-      "type": "integer",
-      "min": 1
-    },
-    "S3d": {
-      "type": "string",
-      "max": 100,
-      "min": 1
-    },
-    "S3g": {
-      "type": "string",
-      "max": 30,
-      "min": 12
-    },
-    "S3o": {
-      "type": "integer",
-      "max": 23,
-      "min": 0
-    },
-    "S3p": {
-      "type": "integer",
-      "max": 59,
-      "min": 0
-    },
-    "S3q": {
-      "type": "integer",
-      "max": 6,
-      "min": 0
-    },
     "S3s": {
       "type": "list",
-      "member": {
-        "shape": "S1i"
-      },
-      "max": 10,
-      "min": 1
-    },
-    "S3w": {
-      "type": "string",
-      "max": 30,
-      "min": 12
-    },
-    "S3x": {
-      "type": "string",
-      "max": 50,
-      "min": 3
-    },
-    "S45": {
-      "type": "string",
-      "pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
-    },
-    "S48": {
-      "type": "integer",
-      "max": 24,
-      "min": 1
-    },
-    "S49": {
-      "type": "string",
-      "max": 255,
-      "min": 1
-    },
-    "S4f": {
-      "type": "string",
-      "max": 1000,
-      "min": 1
-    },
-    "S4w": {
-      "type": "string",
-      "max": 500,
-      "min": 50
+      "member": {}
     }
   }
 }

--- a/apis/streams.dynamodb-2012-08-10.min.json
+++ b/apis/streams.dynamodb-2012-08-10.min.json
@@ -20,15 +20,11 @@
           "StreamArn"
         ],
         "members": {
-          "StreamArn": {
-            "shape": "S2"
-          },
+          "StreamArn": {},
           "Limit": {
-            "shape": "S3"
+            "type": "integer"
           },
-          "ExclusiveStartShardId": {
-            "shape": "S4"
-          }
+          "ExclusiveStartShardId": {}
         }
       },
       "output": {
@@ -37,28 +33,14 @@
           "StreamDescription": {
             "type": "structure",
             "members": {
-              "StreamArn": {
-                "shape": "S2"
-              },
+              "StreamArn": {},
               "StreamLabel": {},
-              "StreamStatus": {
-                "type": "string",
-                "enum": [
-                  "ENABLING",
-                  "ENABLED",
-                  "DISABLING",
-                  "DISABLED"
-                ]
-              },
-              "StreamViewType": {
-                "shape": "S9"
-              },
+              "StreamStatus": {},
+              "StreamViewType": {},
               "CreationRequestDateTime": {
                 "type": "timestamp"
               },
-              "TableName": {
-                "shape": "Sb"
-              },
+              "TableName": {},
               "KeySchema": {
                 "type": "list",
                 "member": {
@@ -68,51 +50,29 @@
                     "KeyType"
                   ],
                   "members": {
-                    "AttributeName": {
-                      "type": "string",
-                      "max": 255,
-                      "min": 1
-                    },
-                    "KeyType": {
-                      "type": "string",
-                      "enum": [
-                        "HASH",
-                        "RANGE"
-                      ]
-                    }
+                    "AttributeName": {},
+                    "KeyType": {}
                   }
-                },
-                "max": 2,
-                "min": 1
+                }
               },
               "Shards": {
                 "type": "list",
                 "member": {
                   "type": "structure",
                   "members": {
-                    "ShardId": {
-                      "shape": "S4"
-                    },
+                    "ShardId": {},
                     "SequenceNumberRange": {
                       "type": "structure",
                       "members": {
-                        "StartingSequenceNumber": {
-                          "shape": "Sj"
-                        },
-                        "EndingSequenceNumber": {
-                          "shape": "Sj"
-                        }
+                        "StartingSequenceNumber": {},
+                        "EndingSequenceNumber": {}
                       }
                     },
-                    "ParentShardId": {
-                      "shape": "S4"
-                    }
+                    "ParentShardId": {}
                   }
                 }
               },
-              "LastEvaluatedShardId": {
-                "shape": "S4"
-              }
+              "LastEvaluatedShardId": {}
             }
           }
         }
@@ -125,11 +85,9 @@
           "ShardIterator"
         ],
         "members": {
-          "ShardIterator": {
-            "shape": "Sl"
-          },
+          "ShardIterator": {},
           "Limit": {
-            "shape": "S3"
+            "type": "integer"
           }
         }
       },
@@ -142,14 +100,7 @@
               "type": "structure",
               "members": {
                 "eventID": {},
-                "eventName": {
-                  "type": "string",
-                  "enum": [
-                    "INSERT",
-                    "MODIFY",
-                    "REMOVE"
-                  ]
-                },
+                "eventName": {},
                 "eventVersion": {},
                 "eventSource": {},
                 "awsRegion": {},
@@ -168,16 +119,11 @@
                     "OldImage": {
                       "shape": "Sr"
                     },
-                    "SequenceNumber": {
-                      "shape": "Sj"
-                    },
+                    "SequenceNumber": {},
                     "SizeBytes": {
-                      "type": "long",
-                      "min": 1
+                      "type": "long"
                     },
-                    "StreamViewType": {
-                      "shape": "S9"
-                    }
+                    "StreamViewType": {}
                   }
                 },
                 "userIdentity": {
@@ -190,9 +136,7 @@
               }
             }
           },
-          "NextShardIterator": {
-            "shape": "Sl"
-          }
+          "NextShardIterator": {}
         }
       }
     },
@@ -205,32 +149,16 @@
           "ShardIteratorType"
         ],
         "members": {
-          "StreamArn": {
-            "shape": "S2"
-          },
-          "ShardId": {
-            "shape": "S4"
-          },
-          "ShardIteratorType": {
-            "type": "string",
-            "enum": [
-              "TRIM_HORIZON",
-              "LATEST",
-              "AT_SEQUENCE_NUMBER",
-              "AFTER_SEQUENCE_NUMBER"
-            ]
-          },
-          "SequenceNumber": {
-            "shape": "Sj"
-          }
+          "StreamArn": {},
+          "ShardId": {},
+          "ShardIteratorType": {},
+          "SequenceNumber": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ShardIterator": {
-            "shape": "Sl"
-          }
+          "ShardIterator": {}
         }
       }
     },
@@ -238,15 +166,11 @@
       "input": {
         "type": "structure",
         "members": {
-          "TableName": {
-            "shape": "Sb"
-          },
+          "TableName": {},
           "Limit": {
-            "shape": "S3"
+            "type": "integer"
           },
-          "ExclusiveStartStreamArn": {
-            "shape": "S2"
-          }
+          "ExclusiveStartStreamArn": {}
         }
       },
       "output": {
@@ -257,75 +181,24 @@
             "member": {
               "type": "structure",
               "members": {
-                "StreamArn": {
-                  "shape": "S2"
-                },
-                "TableName": {
-                  "shape": "Sb"
-                },
+                "StreamArn": {},
+                "TableName": {},
                 "StreamLabel": {}
               }
             }
           },
-          "LastEvaluatedStreamArn": {
-            "shape": "S2"
-          }
+          "LastEvaluatedStreamArn": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 1024,
-      "min": 37
-    },
-    "S3": {
-      "type": "integer",
-      "min": 1
-    },
-    "S4": {
-      "type": "string",
-      "max": 65,
-      "min": 28
-    },
-    "S9": {
-      "type": "string",
-      "enum": [
-        "NEW_IMAGE",
-        "OLD_IMAGE",
-        "NEW_AND_OLD_IMAGES",
-        "KEYS_ONLY"
-      ]
-    },
-    "Sb": {
-      "type": "string",
-      "max": 255,
-      "min": 3,
-      "pattern": "[a-zA-Z0-9_.-]+"
-    },
-    "Sj": {
-      "type": "string",
-      "max": 40,
-      "min": 21
-    },
-    "Sl": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
     "Sr": {
       "type": "map",
-      "key": {
-        "shape": "Ss"
-      },
+      "key": {},
       "value": {
         "shape": "St"
       }
-    },
-    "Ss": {
-      "type": "string",
-      "max": 65535
     },
     "St": {
       "type": "structure",
@@ -351,9 +224,7 @@
         },
         "M": {
           "type": "map",
-          "key": {
-            "shape": "Ss"
-          },
+          "key": {},
           "value": {
             "shape": "St"
           }

--- a/apis/sts-2011-06-15.min.json
+++ b/apis/sts-2011-06-15.min.json
@@ -21,30 +21,15 @@
           "RoleSessionName"
         ],
         "members": {
-          "RoleArn": {
-            "shape": "S2"
-          },
-          "RoleSessionName": {
-            "shape": "S3"
-          },
-          "Policy": {
-            "shape": "S4"
-          },
+          "RoleArn": {},
+          "RoleSessionName": {},
+          "Policy": {},
           "DurationSeconds": {
-            "shape": "S5"
+            "type": "integer"
           },
-          "ExternalId": {
-            "type": "string",
-            "max": 1224,
-            "min": 2,
-            "pattern": "[\\w+=,.@:\\/-]*"
-          },
-          "SerialNumber": {
-            "shape": "S7"
-          },
-          "TokenCode": {
-            "shape": "S8"
-          }
+          "ExternalId": {},
+          "SerialNumber": {},
+          "TokenCode": {}
         }
       },
       "output": {
@@ -58,7 +43,7 @@
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "shape": "Sh"
+            "type": "integer"
           }
         }
       }
@@ -72,22 +57,12 @@
           "SAMLAssertion"
         ],
         "members": {
-          "RoleArn": {
-            "shape": "S2"
-          },
-          "PrincipalArn": {
-            "shape": "S2"
-          },
-          "SAMLAssertion": {
-            "type": "string",
-            "max": 100000,
-            "min": 4
-          },
-          "Policy": {
-            "shape": "S4"
-          },
+          "RoleArn": {},
+          "PrincipalArn": {},
+          "SAMLAssertion": {},
+          "Policy": {},
           "DurationSeconds": {
-            "shape": "S5"
+            "type": "integer"
           }
         }
       },
@@ -102,7 +77,7 @@
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "shape": "Sh"
+            "type": "integer"
           },
           "Subject": {},
           "SubjectType": {},
@@ -121,27 +96,13 @@
           "WebIdentityToken"
         ],
         "members": {
-          "RoleArn": {
-            "shape": "S2"
-          },
-          "RoleSessionName": {
-            "shape": "S3"
-          },
-          "WebIdentityToken": {
-            "type": "string",
-            "max": 2048,
-            "min": 4
-          },
-          "ProviderId": {
-            "type": "string",
-            "max": 2048,
-            "min": 4
-          },
-          "Policy": {
-            "shape": "S4"
-          },
+          "RoleArn": {},
+          "RoleSessionName": {},
+          "WebIdentityToken": {},
+          "ProviderId": {},
+          "Policy": {},
           "DurationSeconds": {
-            "shape": "S5"
+            "type": "integer"
           }
         }
       },
@@ -152,16 +113,12 @@
           "Credentials": {
             "shape": "Sa"
           },
-          "SubjectFromWebIdentityToken": {
-            "type": "string",
-            "max": 255,
-            "min": 6
-          },
+          "SubjectFromWebIdentityToken": {},
           "AssumedRoleUser": {
             "shape": "Sf"
           },
           "PackedPolicySize": {
-            "shape": "Sh"
+            "type": "integer"
           },
           "Provider": {},
           "Audience": {}
@@ -175,11 +132,7 @@
           "EncodedMessage"
         ],
         "members": {
-          "EncodedMessage": {
-            "type": "string",
-            "max": 10240,
-            "min": 1
-          }
+          "EncodedMessage": {}
         }
       },
       "output": {
@@ -201,9 +154,7 @@
         "members": {
           "UserId": {},
           "Account": {},
-          "Arn": {
-            "shape": "S2"
-          }
+          "Arn": {}
         }
       }
     },
@@ -214,17 +165,10 @@
           "Name"
         ],
         "members": {
-          "Name": {
-            "type": "string",
-            "max": 32,
-            "min": 2,
-            "pattern": "[\\w+=,.@-]*"
-          },
-          "Policy": {
-            "shape": "S4"
-          },
+          "Name": {},
+          "Policy": {},
           "DurationSeconds": {
-            "shape": "S15"
+            "type": "integer"
           }
         }
       },
@@ -242,19 +186,12 @@
               "Arn"
             ],
             "members": {
-              "FederatedUserId": {
-                "type": "string",
-                "max": 193,
-                "min": 2,
-                "pattern": "[\\w+=,.@\\:-]*"
-              },
-              "Arn": {
-                "shape": "S2"
-              }
+              "FederatedUserId": {},
+              "Arn": {}
             }
           },
           "PackedPolicySize": {
-            "shape": "Sh"
+            "type": "integer"
           }
         }
       }
@@ -264,14 +201,10 @@
         "type": "structure",
         "members": {
           "DurationSeconds": {
-            "shape": "S15"
+            "type": "integer"
           },
-          "SerialNumber": {
-            "shape": "S7"
-          },
-          "TokenCode": {
-            "shape": "S8"
-          }
+          "SerialNumber": {},
+          "TokenCode": {}
         }
       },
       "output": {
@@ -286,41 +219,6 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 2048,
-      "min": 20,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u0085\\u00A0-\\uD7FF\\uE000-\\uFFFD\\u10000-\\u10FFFF]+"
-    },
-    "S3": {
-      "type": "string",
-      "max": 64,
-      "min": 2,
-      "pattern": "[\\w+=,.@-]*"
-    },
-    "S4": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "[\\u0009\\u000A\\u000D\\u0020-\\u00FF]+"
-    },
-    "S5": {
-      "type": "integer",
-      "max": 43200,
-      "min": 900
-    },
-    "S7": {
-      "type": "string",
-      "max": 256,
-      "min": 9,
-      "pattern": "[\\w+=/:,.@-]*"
-    },
-    "S8": {
-      "type": "string",
-      "max": 6,
-      "min": 6,
-      "pattern": "[\\d]*"
-    },
     "Sa": {
       "type": "structure",
       "required": [
@@ -330,12 +228,7 @@
         "Expiration"
       ],
       "members": {
-        "AccessKeyId": {
-          "type": "string",
-          "max": 128,
-          "min": 16,
-          "pattern": "[\\w]*"
-        },
+        "AccessKeyId": {},
         "SecretAccessKey": {},
         "SessionToken": {},
         "Expiration": {
@@ -350,25 +243,9 @@
         "Arn"
       ],
       "members": {
-        "AssumedRoleId": {
-          "type": "string",
-          "max": 193,
-          "min": 2,
-          "pattern": "[\\w+=,.@:-]*"
-        },
-        "Arn": {
-          "shape": "S2"
-        }
+        "AssumedRoleId": {},
+        "Arn": {}
       }
-    },
-    "Sh": {
-      "type": "integer",
-      "min": 0
-    },
-    "S15": {
-      "type": "integer",
-      "max": 129600,
-      "min": 900
     }
   }
 }

--- a/apis/support-2013-04-15.min.json
+++ b/apis/support-2013-04-15.min.json
@@ -44,9 +44,7 @@
         ],
         "members": {
           "caseId": {},
-          "communicationBody": {
-            "shape": "Sb"
-          },
+          "communicationBody": {},
           "ccEmailAddresses": {
             "shape": "Sc"
           },
@@ -74,9 +72,7 @@
           "serviceCode": {},
           "severityCode": {},
           "categoryCode": {},
-          "communicationBody": {
-            "shape": "Sb"
-          },
+          "communicationBody": {},
           "ccEmailAddresses": {
             "shape": "Sc"
           },
@@ -117,9 +113,7 @@
         "members": {
           "caseIdList": {
             "type": "list",
-            "member": {},
-            "max": 100,
-            "min": 0
+            "member": {}
           },
           "displayId": {},
           "afterTime": {},
@@ -129,7 +123,7 @@
           },
           "nextToken": {},
           "maxResults": {
-            "shape": "Sy"
+            "type": "integer"
           },
           "language": {},
           "includeCommunications": {
@@ -186,7 +180,7 @@
           "afterTime": {},
           "nextToken": {},
           "maxResults": {
-            "shape": "Sy"
+            "type": "integer"
           }
         }
       },
@@ -206,9 +200,7 @@
         "members": {
           "serviceCodeList": {
             "type": "list",
-            "member": {},
-            "max": 100,
-            "min": 0
+            "member": {}
           },
           "language": {}
         }
@@ -487,21 +479,9 @@
         }
       }
     },
-    "Sb": {
-      "type": "string",
-      "max": 8000,
-      "min": 1
-    },
     "Sc": {
       "type": "list",
-      "member": {},
-      "max": 10,
-      "min": 0
-    },
-    "Sy": {
-      "type": "integer",
-      "max": 100,
-      "min": 10
+      "member": {}
     },
     "S17": {
       "type": "list",
@@ -509,9 +489,7 @@
         "type": "structure",
         "members": {
           "caseId": {},
-          "body": {
-            "shape": "Sb"
-          },
+          "body": {},
           "submittedBy": {},
           "timeCreated": {},
           "attachmentSet": {

--- a/apis/swf-2012-01-25.min.json
+++ b/apis/swf-2012-01-25.min.json
@@ -21,9 +21,7 @@
           "domain"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -56,9 +54,7 @@
           "startTimeFilter"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -85,9 +81,7 @@
           "taskList"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "taskList": {
             "shape": "Sj"
           }
@@ -105,9 +99,7 @@
           "taskList"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "taskList": {
             "shape": "Sj"
           }
@@ -125,9 +117,7 @@
           "activityType"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "activityType": {
             "shape": "Sn"
           }
@@ -141,9 +131,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          }
+          "name": {}
         }
       }
     },
@@ -155,9 +143,7 @@
           "workflowType"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "workflowType": {
             "shape": "Sr"
           }
@@ -172,9 +158,7 @@
           "activityType"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "activityType": {
             "shape": "Sn"
           }
@@ -193,22 +177,14 @@
           "configuration": {
             "type": "structure",
             "members": {
-              "defaultTaskStartToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "defaultTaskHeartbeatTimeout": {
-                "shape": "Sy"
-              },
+              "defaultTaskStartToCloseTimeout": {},
+              "defaultTaskHeartbeatTimeout": {},
               "defaultTaskList": {
                 "shape": "Sj"
               },
               "defaultTaskPriority": {},
-              "defaultTaskScheduleToStartTimeout": {
-                "shape": "Sy"
-              },
-              "defaultTaskScheduleToCloseTimeout": {
-                "shape": "Sy"
-              }
+              "defaultTaskScheduleToStartTimeout": {},
+              "defaultTaskScheduleToCloseTimeout": {}
             }
           }
         }
@@ -221,9 +197,7 @@
           "name"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          }
+          "name": {}
         }
       },
       "output": {
@@ -242,9 +216,7 @@
               "workflowExecutionRetentionPeriodInDays"
             ],
             "members": {
-              "workflowExecutionRetentionPeriodInDays": {
-                "shape": "S14"
-              }
+              "workflowExecutionRetentionPeriodInDays": {}
             }
           }
         }
@@ -258,9 +230,7 @@
           "execution"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "execution": {
             "shape": "S16"
           }
@@ -286,22 +256,14 @@
               "childPolicy"
             ],
             "members": {
-              "taskStartToCloseTimeout": {
-                "shape": "S1e"
-              },
-              "executionStartToCloseTimeout": {
-                "shape": "S1e"
-              },
+              "taskStartToCloseTimeout": {},
+              "executionStartToCloseTimeout": {},
               "taskList": {
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "childPolicy": {
-                "shape": "S1f"
-              },
-              "lambdaRole": {
-                "shape": "S1g"
-              }
+              "childPolicy": {},
+              "lambdaRole": {}
             }
           },
           "openCounts": {
@@ -314,30 +276,26 @@
             ],
             "members": {
               "openActivityTasks": {
-                "shape": "Sf"
+                "type": "integer"
               },
               "openDecisionTasks": {
-                "type": "integer",
-                "max": 1,
-                "min": 0
+                "type": "integer"
               },
               "openTimers": {
-                "shape": "Sf"
+                "type": "integer"
               },
               "openChildWorkflowExecutions": {
-                "shape": "Sf"
+                "type": "integer"
               },
               "openLambdaFunctions": {
-                "shape": "Sf"
+                "type": "integer"
               }
             }
           },
           "latestActivityTaskTimestamp": {
             "type": "timestamp"
           },
-          "latestExecutionContext": {
-            "shape": "S1j"
-          }
+          "latestExecutionContext": {}
         }
       }
     },
@@ -349,9 +307,7 @@
           "workflowType"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "workflowType": {
             "shape": "Sr"
           }
@@ -370,22 +326,14 @@
           "configuration": {
             "type": "structure",
             "members": {
-              "defaultTaskStartToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "defaultExecutionStartToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "defaultTaskStartToCloseTimeout": {},
+              "defaultExecutionStartToCloseTimeout": {},
               "defaultTaskList": {
                 "shape": "Sj"
               },
               "defaultTaskPriority": {},
-              "defaultChildPolicy": {
-                "shape": "S1f"
-              },
-              "defaultLambdaRole": {
-                "shape": "S1g"
-              }
+              "defaultChildPolicy": {},
+              "defaultLambdaRole": {}
             }
           }
         }
@@ -399,17 +347,13 @@
           "execution"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "execution": {
             "shape": "S16"
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -425,9 +369,7 @@
           "events": {
             "shape": "S1t"
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          }
+          "nextPageToken": {}
         }
       }
     },
@@ -439,20 +381,12 @@
           "registrationStatus"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S8"
-          },
-          "registrationStatus": {
-            "shape": "Sv"
-          },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "domain": {},
+          "name": {},
+          "registrationStatus": {},
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -471,9 +405,7 @@
               "shape": "Su"
             }
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          }
+          "nextPageToken": {}
         }
       }
     },
@@ -484,9 +416,7 @@
           "domain"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -505,11 +435,9 @@
           "tagFilter": {
             "shape": "Sa"
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -527,14 +455,10 @@
           "registrationStatus"
         ],
         "members": {
-          "nextPageToken": {
-            "shape": "S1p"
-          },
-          "registrationStatus": {
-            "shape": "Sv"
-          },
+          "nextPageToken": {},
+          "registrationStatus": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -553,9 +477,7 @@
               "shape": "S12"
             }
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          }
+          "nextPageToken": {}
         }
       }
     },
@@ -567,9 +489,7 @@
           "startTimeFilter"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "startTimeFilter": {
             "shape": "S3"
           },
@@ -579,11 +499,9 @@
           "tagFilter": {
             "shape": "Sa"
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -605,20 +523,12 @@
           "registrationStatus"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S8"
-          },
-          "registrationStatus": {
-            "shape": "Sv"
-          },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "domain": {},
+          "name": {},
+          "registrationStatus": {},
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -637,9 +547,7 @@
               "shape": "S1m"
             }
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          }
+          "nextPageToken": {}
         }
       }
     },
@@ -651,15 +559,11 @@
           "taskList"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "taskList": {
             "shape": "Sj"
           },
-          "identity": {
-            "shape": "S2l"
-          }
+          "identity": {}
         }
       },
       "output": {
@@ -672,12 +576,8 @@
           "activityType"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
-          "activityId": {
-            "shape": "S2q"
-          },
+          "taskToken": {},
+          "activityId": {},
           "startedEventId": {
             "type": "long"
           },
@@ -687,9 +587,7 @@
           "activityType": {
             "shape": "Sn"
           },
-          "input": {
-            "shape": "S1j"
-          }
+          "input": {}
         }
       }
     },
@@ -701,20 +599,14 @@
           "taskList"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
+          "domain": {},
           "taskList": {
             "shape": "Sj"
           },
-          "identity": {
-            "shape": "S2l"
-          },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "identity": {},
+          "nextPageToken": {},
           "maximumPageSize": {
-            "shape": "S1q"
+            "type": "integer"
           },
           "reverseOrder": {
             "type": "boolean"
@@ -731,9 +623,7 @@
           "events"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
+          "taskToken": {},
           "startedEventId": {
             "type": "long"
           },
@@ -746,9 +636,7 @@
           "events": {
             "shape": "S1t"
           },
-          "nextPageToken": {
-            "shape": "S1p"
-          },
+          "nextPageToken": {},
           "previousStartedEventId": {
             "type": "long"
           }
@@ -762,12 +650,8 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
-          "details": {
-            "shape": "S2w"
-          }
+          "taskToken": {},
+          "details": {}
         }
       },
       "output": {
@@ -791,34 +675,18 @@
           "version"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S8"
-          },
-          "version": {
-            "shape": "So"
-          },
-          "description": {
-            "shape": "Sw"
-          },
-          "defaultTaskStartToCloseTimeout": {
-            "shape": "Sy"
-          },
-          "defaultTaskHeartbeatTimeout": {
-            "shape": "Sy"
-          },
+          "domain": {},
+          "name": {},
+          "version": {},
+          "description": {},
+          "defaultTaskStartToCloseTimeout": {},
+          "defaultTaskHeartbeatTimeout": {},
           "defaultTaskList": {
             "shape": "Sj"
           },
           "defaultTaskPriority": {},
-          "defaultTaskScheduleToStartTimeout": {
-            "shape": "Sy"
-          },
-          "defaultTaskScheduleToCloseTimeout": {
-            "shape": "Sy"
-          }
+          "defaultTaskScheduleToStartTimeout": {},
+          "defaultTaskScheduleToCloseTimeout": {}
         }
       }
     },
@@ -830,15 +698,9 @@
           "workflowExecutionRetentionPeriodInDays"
         ],
         "members": {
-          "name": {
-            "shape": "S2"
-          },
-          "description": {
-            "shape": "Sw"
-          },
-          "workflowExecutionRetentionPeriodInDays": {
-            "shape": "S14"
-          }
+          "name": {},
+          "description": {},
+          "workflowExecutionRetentionPeriodInDays": {}
         }
       }
     },
@@ -851,34 +713,18 @@
           "version"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "name": {
-            "shape": "S8"
-          },
-          "version": {
-            "shape": "So"
-          },
-          "description": {
-            "shape": "Sw"
-          },
-          "defaultTaskStartToCloseTimeout": {
-            "shape": "Sy"
-          },
-          "defaultExecutionStartToCloseTimeout": {
-            "shape": "Sy"
-          },
+          "domain": {},
+          "name": {},
+          "version": {},
+          "description": {},
+          "defaultTaskStartToCloseTimeout": {},
+          "defaultExecutionStartToCloseTimeout": {},
           "defaultTaskList": {
             "shape": "Sj"
           },
           "defaultTaskPriority": {},
-          "defaultChildPolicy": {
-            "shape": "S1f"
-          },
-          "defaultLambdaRole": {
-            "shape": "S1g"
-          }
+          "defaultChildPolicy": {},
+          "defaultLambdaRole": {}
         }
       }
     },
@@ -890,15 +736,9 @@
           "workflowId"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "workflowId": {
-            "shape": "S6"
-          },
-          "runId": {
-            "shape": "S1y"
-          }
+          "domain": {},
+          "workflowId": {},
+          "runId": {}
         }
       }
     },
@@ -909,12 +749,8 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
-          "details": {
-            "shape": "S1j"
-          }
+          "taskToken": {},
+          "details": {}
         }
       }
     },
@@ -925,12 +761,8 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
-          "result": {
-            "shape": "S1j"
-          }
+          "taskToken": {},
+          "result": {}
         }
       }
     },
@@ -941,15 +773,9 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
-          "reason": {
-            "shape": "S23"
-          },
-          "details": {
-            "shape": "S1j"
-          }
+          "taskToken": {},
+          "reason": {},
+          "details": {}
         }
       }
     },
@@ -960,9 +786,7 @@
           "taskToken"
         ],
         "members": {
-          "taskToken": {
-            "shape": "S4r"
-          },
+          "taskToken": {},
           "decisions": {
             "type": "list",
             "member": {
@@ -971,24 +795,7 @@
                 "decisionType"
               ],
               "members": {
-                "decisionType": {
-                  "type": "string",
-                  "enum": [
-                    "ScheduleActivityTask",
-                    "RequestCancelActivityTask",
-                    "CompleteWorkflowExecution",
-                    "FailWorkflowExecution",
-                    "CancelWorkflowExecution",
-                    "ContinueAsNewWorkflowExecution",
-                    "RecordMarker",
-                    "StartTimer",
-                    "CancelTimer",
-                    "SignalExternalWorkflowExecution",
-                    "RequestCancelExternalWorkflowExecution",
-                    "StartChildWorkflowExecution",
-                    "ScheduleLambdaFunction"
-                  ]
-                },
+                "decisionType": {},
                 "scheduleActivityTaskDecisionAttributes": {
                   "type": "structure",
                   "required": [
@@ -999,31 +806,17 @@
                     "activityType": {
                       "shape": "Sn"
                     },
-                    "activityId": {
-                      "shape": "S2q"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    },
-                    "input": {
-                      "shape": "S1j"
-                    },
-                    "scheduleToCloseTimeout": {
-                      "shape": "Sy"
-                    },
+                    "activityId": {},
+                    "control": {},
+                    "input": {},
+                    "scheduleToCloseTimeout": {},
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "scheduleToStartTimeout": {
-                      "shape": "Sy"
-                    },
-                    "startToCloseTimeout": {
-                      "shape": "Sy"
-                    },
-                    "heartbeatTimeout": {
-                      "shape": "Sy"
-                    }
+                    "scheduleToStartTimeout": {},
+                    "startToCloseTimeout": {},
+                    "heartbeatTimeout": {}
                   }
                 },
                 "requestCancelActivityTaskDecisionAttributes": {
@@ -1032,66 +825,44 @@
                     "activityId"
                   ],
                   "members": {
-                    "activityId": {
-                      "shape": "S2q"
-                    }
+                    "activityId": {}
                   }
                 },
                 "completeWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "result": {
-                      "shape": "S1j"
-                    }
+                    "result": {}
                   }
                 },
                 "failWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "reason": {
-                      "shape": "S23"
-                    },
-                    "details": {
-                      "shape": "S1j"
-                    }
+                    "reason": {},
+                    "details": {}
                   }
                 },
                 "cancelWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "details": {
-                      "shape": "S1j"
-                    }
+                    "details": {}
                   }
                 },
                 "continueAsNewWorkflowExecutionDecisionAttributes": {
                   "type": "structure",
                   "members": {
-                    "input": {
-                      "shape": "S1j"
-                    },
-                    "executionStartToCloseTimeout": {
-                      "shape": "Sy"
-                    },
+                    "input": {},
+                    "executionStartToCloseTimeout": {},
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "taskStartToCloseTimeout": {
-                      "shape": "Sy"
-                    },
-                    "childPolicy": {
-                      "shape": "S1f"
-                    },
+                    "taskStartToCloseTimeout": {},
+                    "childPolicy": {},
                     "tagList": {
                       "shape": "S1b"
                     },
-                    "workflowTypeVersion": {
-                      "shape": "So"
-                    },
-                    "lambdaRole": {
-                      "shape": "S1g"
-                    }
+                    "workflowTypeVersion": {},
+                    "lambdaRole": {}
                   }
                 },
                 "recordMarkerDecisionAttributes": {
@@ -1100,12 +871,8 @@
                     "markerName"
                   ],
                   "members": {
-                    "markerName": {
-                      "shape": "S32"
-                    },
-                    "details": {
-                      "shape": "S1j"
-                    }
+                    "markerName": {},
+                    "details": {}
                   }
                 },
                 "startTimerDecisionAttributes": {
@@ -1115,15 +882,9 @@
                     "startToFireTimeout"
                   ],
                   "members": {
-                    "timerId": {
-                      "shape": "S36"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    },
-                    "startToFireTimeout": {
-                      "shape": "S1e"
-                    }
+                    "timerId": {},
+                    "control": {},
+                    "startToFireTimeout": {}
                   }
                 },
                 "cancelTimerDecisionAttributes": {
@@ -1132,9 +893,7 @@
                     "timerId"
                   ],
                   "members": {
-                    "timerId": {
-                      "shape": "S36"
-                    }
+                    "timerId": {}
                   }
                 },
                 "signalExternalWorkflowExecutionDecisionAttributes": {
@@ -1144,21 +903,11 @@
                     "signalName"
                   ],
                   "members": {
-                    "workflowId": {
-                      "shape": "S6"
-                    },
-                    "runId": {
-                      "shape": "S1y"
-                    },
-                    "signalName": {
-                      "shape": "S30"
-                    },
-                    "input": {
-                      "shape": "S1j"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    }
+                    "workflowId": {},
+                    "runId": {},
+                    "signalName": {},
+                    "input": {},
+                    "control": {}
                   }
                 },
                 "requestCancelExternalWorkflowExecutionDecisionAttributes": {
@@ -1167,15 +916,9 @@
                     "workflowId"
                   ],
                   "members": {
-                    "workflowId": {
-                      "shape": "S6"
-                    },
-                    "runId": {
-                      "shape": "S1y"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    }
+                    "workflowId": {},
+                    "runId": {},
+                    "control": {}
                   }
                 },
                 "startChildWorkflowExecutionDecisionAttributes": {
@@ -1188,34 +931,20 @@
                     "workflowType": {
                       "shape": "Sr"
                     },
-                    "workflowId": {
-                      "shape": "S6"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    },
-                    "input": {
-                      "shape": "S1j"
-                    },
-                    "executionStartToCloseTimeout": {
-                      "shape": "Sy"
-                    },
+                    "workflowId": {},
+                    "control": {},
+                    "input": {},
+                    "executionStartToCloseTimeout": {},
                     "taskList": {
                       "shape": "Sj"
                     },
                     "taskPriority": {},
-                    "taskStartToCloseTimeout": {
-                      "shape": "Sy"
-                    },
-                    "childPolicy": {
-                      "shape": "S1f"
-                    },
+                    "taskStartToCloseTimeout": {},
+                    "childPolicy": {},
                     "tagList": {
                       "shape": "S1b"
                     },
-                    "lambdaRole": {
-                      "shape": "S1g"
-                    }
+                    "lambdaRole": {}
                   }
                 },
                 "scheduleLambdaFunctionDecisionAttributes": {
@@ -1225,29 +954,17 @@
                     "name"
                   ],
                   "members": {
-                    "id": {
-                      "shape": "S3z"
-                    },
-                    "name": {
-                      "shape": "S40"
-                    },
-                    "control": {
-                      "shape": "S1j"
-                    },
-                    "input": {
-                      "shape": "S41"
-                    },
-                    "startToCloseTimeout": {
-                      "shape": "Sy"
-                    }
+                    "id": {},
+                    "name": {},
+                    "control": {},
+                    "input": {},
+                    "startToCloseTimeout": {}
                   }
                 }
               }
             }
           },
-          "executionContext": {
-            "shape": "S1j"
-          }
+          "executionContext": {}
         }
       }
     },
@@ -1260,21 +977,11 @@
           "signalName"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "workflowId": {
-            "shape": "S6"
-          },
-          "runId": {
-            "shape": "S1y"
-          },
-          "signalName": {
-            "shape": "S30"
-          },
-          "input": {
-            "shape": "S1j"
-          }
+          "domain": {},
+          "workflowId": {},
+          "runId": {},
+          "signalName": {},
+          "input": {}
         }
       }
     },
@@ -1287,12 +994,8 @@
           "workflowType"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "workflowId": {
-            "shape": "S6"
-          },
+          "domain": {},
+          "workflowId": {},
           "workflowType": {
             "shape": "Sr"
           },
@@ -1300,32 +1003,20 @@
             "shape": "Sj"
           },
           "taskPriority": {},
-          "input": {
-            "shape": "S1j"
-          },
-          "executionStartToCloseTimeout": {
-            "shape": "Sy"
-          },
+          "input": {},
+          "executionStartToCloseTimeout": {},
           "tagList": {
             "shape": "S1b"
           },
-          "taskStartToCloseTimeout": {
-            "shape": "Sy"
-          },
-          "childPolicy": {
-            "shape": "S1f"
-          },
-          "lambdaRole": {
-            "shape": "S1g"
-          }
+          "taskStartToCloseTimeout": {},
+          "childPolicy": {},
+          "lambdaRole": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "runId": {
-            "shape": "S17"
-          }
+          "runId": {}
         }
       }
     },
@@ -1337,34 +1028,17 @@
           "workflowId"
         ],
         "members": {
-          "domain": {
-            "shape": "S2"
-          },
-          "workflowId": {
-            "shape": "S6"
-          },
-          "runId": {
-            "shape": "S1y"
-          },
-          "reason": {
-            "shape": "S2f"
-          },
-          "details": {
-            "shape": "S1j"
-          },
-          "childPolicy": {
-            "shape": "S1f"
-          }
+          "domain": {},
+          "workflowId": {},
+          "runId": {},
+          "reason": {},
+          "details": {},
+          "childPolicy": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
     "S3": {
       "type": "structure",
       "required": [
@@ -1385,15 +1059,8 @@
         "workflowId"
       ],
       "members": {
-        "workflowId": {
-          "shape": "S6"
-        }
+        "workflowId": {}
       }
-    },
-    "S6": {
-      "type": "string",
-      "max": 256,
-      "min": 1
     },
     "S7": {
       "type": "structure",
@@ -1401,19 +1068,9 @@
         "name"
       ],
       "members": {
-        "name": {
-          "shape": "S8"
-        },
-        "version": {
-          "type": "string",
-          "max": 64
-        }
+        "name": {},
+        "version": {}
       }
-    },
-    "S8": {
-      "type": "string",
-      "max": 256,
-      "min": 1
     },
     "Sa": {
       "type": "structure",
@@ -1421,15 +1078,8 @@
         "tag"
       ],
       "members": {
-        "tag": {
-          "shape": "Sb"
-        }
+        "tag": {}
       }
-    },
-    "Sb": {
-      "type": "string",
-      "max": 256,
-      "min": 0
     },
     "Sc": {
       "type": "structure",
@@ -1437,21 +1087,8 @@
         "status"
       ],
       "members": {
-        "status": {
-          "shape": "Sd"
-        }
+        "status": {}
       }
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "COMPLETED",
-        "FAILED",
-        "CANCELED",
-        "TERMINATED",
-        "CONTINUED_AS_NEW",
-        "TIMED_OUT"
-      ]
     },
     "Se": {
       "type": "structure",
@@ -1460,16 +1097,12 @@
       ],
       "members": {
         "count": {
-          "shape": "Sf"
+          "type": "integer"
         },
         "truncated": {
           "type": "boolean"
         }
       }
-    },
-    "Sf": {
-      "type": "integer",
-      "min": 0
     },
     "Sj": {
       "type": "structure",
@@ -1477,9 +1110,7 @@
         "name"
       ],
       "members": {
-        "name": {
-          "shape": "S8"
-        }
+        "name": {}
       }
     },
     "Sk": {
@@ -1489,7 +1120,7 @@
       ],
       "members": {
         "count": {
-          "shape": "Sf"
+          "type": "integer"
         },
         "truncated": {
           "type": "boolean"
@@ -1503,18 +1134,9 @@
         "version"
       ],
       "members": {
-        "name": {
-          "shape": "S8"
-        },
-        "version": {
-          "shape": "So"
-        }
+        "name": {},
+        "version": {}
       }
-    },
-    "So": {
-      "type": "string",
-      "max": 64,
-      "min": 1
     },
     "Sr": {
       "type": "structure",
@@ -1523,12 +1145,8 @@
         "version"
       ],
       "members": {
-        "name": {
-          "shape": "S8"
-        },
-        "version": {
-          "shape": "So"
-        }
+        "name": {},
+        "version": {}
       }
     },
     "Su": {
@@ -1542,12 +1160,8 @@
         "activityType": {
           "shape": "Sn"
         },
-        "status": {
-          "shape": "Sv"
-        },
-        "description": {
-          "shape": "Sw"
-        },
+        "status": {},
+        "description": {},
         "creationDate": {
           "type": "timestamp"
         },
@@ -1556,21 +1170,6 @@
         }
       }
     },
-    "Sv": {
-      "type": "string",
-      "enum": [
-        "REGISTERED",
-        "DEPRECATED"
-      ]
-    },
-    "Sw": {
-      "type": "string",
-      "max": 1024
-    },
-    "Sy": {
-      "type": "string",
-      "max": 8
-    },
     "S12": {
       "type": "structure",
       "required": [
@@ -1578,21 +1177,10 @@
         "status"
       ],
       "members": {
-        "name": {
-          "shape": "S2"
-        },
-        "status": {
-          "shape": "Sv"
-        },
-        "description": {
-          "shape": "Sw"
-        }
+        "name": {},
+        "status": {},
+        "description": {}
       }
-    },
-    "S14": {
-      "type": "string",
-      "max": 8,
-      "min": 1
     },
     "S16": {
       "type": "structure",
@@ -1601,18 +1189,9 @@
         "runId"
       ],
       "members": {
-        "workflowId": {
-          "shape": "S6"
-        },
-        "runId": {
-          "shape": "S17"
-        }
+        "workflowId": {},
+        "runId": {}
       }
-    },
-    "S17": {
-      "type": "string",
-      "max": 64,
-      "min": 1
     },
     "S19": {
       "type": "structure",
@@ -1635,16 +1214,8 @@
         "closeTimestamp": {
           "type": "timestamp"
         },
-        "executionStatus": {
-          "type": "string",
-          "enum": [
-            "OPEN",
-            "CLOSED"
-          ]
-        },
-        "closeStatus": {
-          "shape": "Sd"
-        },
+        "executionStatus": {},
+        "closeStatus": {},
         "parent": {
           "shape": "S16"
         },
@@ -1658,32 +1229,7 @@
     },
     "S1b": {
       "type": "list",
-      "member": {
-        "shape": "Sb"
-      },
-      "max": 5
-    },
-    "S1e": {
-      "type": "string",
-      "max": 8,
-      "min": 1
-    },
-    "S1f": {
-      "type": "string",
-      "enum": [
-        "TERMINATE",
-        "REQUEST_CANCEL",
-        "ABANDON"
-      ]
-    },
-    "S1g": {
-      "type": "string",
-      "max": 1600,
-      "min": 1
-    },
-    "S1j": {
-      "type": "string",
-      "max": 32768
+      "member": {}
     },
     "S1m": {
       "type": "structure",
@@ -1696,12 +1242,8 @@
         "workflowType": {
           "shape": "Sr"
         },
-        "status": {
-          "shape": "Sv"
-        },
-        "description": {
-          "shape": "Sw"
-        },
+        "status": {},
+        "description": {},
         "creationDate": {
           "type": "timestamp"
         },
@@ -1709,15 +1251,6 @@
           "type": "timestamp"
         }
       }
-    },
-    "S1p": {
-      "type": "string",
-      "max": 2048
-    },
-    "S1q": {
-      "type": "integer",
-      "max": 1000,
-      "min": 0
     },
     "S1t": {
       "type": "list",
@@ -1732,65 +1265,7 @@
           "eventTimestamp": {
             "type": "timestamp"
           },
-          "eventType": {
-            "type": "string",
-            "enum": [
-              "WorkflowExecutionStarted",
-              "WorkflowExecutionCancelRequested",
-              "WorkflowExecutionCompleted",
-              "CompleteWorkflowExecutionFailed",
-              "WorkflowExecutionFailed",
-              "FailWorkflowExecutionFailed",
-              "WorkflowExecutionTimedOut",
-              "WorkflowExecutionCanceled",
-              "CancelWorkflowExecutionFailed",
-              "WorkflowExecutionContinuedAsNew",
-              "ContinueAsNewWorkflowExecutionFailed",
-              "WorkflowExecutionTerminated",
-              "DecisionTaskScheduled",
-              "DecisionTaskStarted",
-              "DecisionTaskCompleted",
-              "DecisionTaskTimedOut",
-              "ActivityTaskScheduled",
-              "ScheduleActivityTaskFailed",
-              "ActivityTaskStarted",
-              "ActivityTaskCompleted",
-              "ActivityTaskFailed",
-              "ActivityTaskTimedOut",
-              "ActivityTaskCanceled",
-              "ActivityTaskCancelRequested",
-              "RequestCancelActivityTaskFailed",
-              "WorkflowExecutionSignaled",
-              "MarkerRecorded",
-              "RecordMarkerFailed",
-              "TimerStarted",
-              "StartTimerFailed",
-              "TimerFired",
-              "TimerCanceled",
-              "CancelTimerFailed",
-              "StartChildWorkflowExecutionInitiated",
-              "StartChildWorkflowExecutionFailed",
-              "ChildWorkflowExecutionStarted",
-              "ChildWorkflowExecutionCompleted",
-              "ChildWorkflowExecutionFailed",
-              "ChildWorkflowExecutionTimedOut",
-              "ChildWorkflowExecutionCanceled",
-              "ChildWorkflowExecutionTerminated",
-              "SignalExternalWorkflowExecutionInitiated",
-              "SignalExternalWorkflowExecutionFailed",
-              "ExternalWorkflowExecutionSignaled",
-              "RequestCancelExternalWorkflowExecutionInitiated",
-              "RequestCancelExternalWorkflowExecutionFailed",
-              "ExternalWorkflowExecutionCancelRequested",
-              "LambdaFunctionScheduled",
-              "LambdaFunctionStarted",
-              "LambdaFunctionCompleted",
-              "LambdaFunctionFailed",
-              "LambdaFunctionTimedOut",
-              "ScheduleLambdaFunctionFailed",
-              "StartLambdaFunctionFailed"
-            ]
-          },
+          "eventType": {},
           "eventId": {
             "type": "long"
           },
@@ -1802,18 +1277,10 @@
               "workflowType"
             ],
             "members": {
-              "input": {
-                "shape": "S1j"
-              },
-              "executionStartToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "taskStartToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "childPolicy": {
-                "shape": "S1f"
-              },
+              "input": {},
+              "executionStartToCloseTimeout": {},
+              "taskStartToCloseTimeout": {},
+              "childPolicy": {},
               "taskList": {
                 "shape": "Sj"
               },
@@ -1824,18 +1291,14 @@
               "tagList": {
                 "shape": "S1b"
               },
-              "continuedExecutionRunId": {
-                "shape": "S1y"
-              },
+              "continuedExecutionRunId": {},
               "parentWorkflowExecution": {
                 "shape": "S16"
               },
               "parentInitiatedEventId": {
                 "type": "long"
               },
-              "lambdaRole": {
-                "shape": "S1g"
-              }
+              "lambdaRole": {}
             }
           },
           "workflowExecutionCompletedEventAttributes": {
@@ -1844,9 +1307,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "result": {
-                "shape": "S1j"
-              },
+              "result": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1859,13 +1320,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNHANDLED_DECISION",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1877,12 +1332,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "reason": {
-                "shape": "S23"
-              },
-              "details": {
-                "shape": "S1j"
-              },
+              "reason": {},
+              "details": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1895,13 +1346,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNHANDLED_DECISION",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1914,12 +1359,8 @@
               "childPolicy"
             ],
             "members": {
-              "timeoutType": {
-                "shape": "S27"
-              },
-              "childPolicy": {
-                "shape": "S1f"
-              }
+              "timeoutType": {},
+              "childPolicy": {}
             }
           },
           "workflowExecutionCanceledEventAttributes": {
@@ -1928,9 +1369,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "details": {
-                "shape": "S1j"
-              },
+              "details": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1943,13 +1382,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNHANDLED_DECISION",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -1965,37 +1398,25 @@
               "workflowType"
             ],
             "members": {
-              "input": {
-                "shape": "S1j"
-              },
+              "input": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "newExecutionRunId": {
-                "shape": "S17"
-              },
-              "executionStartToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "newExecutionRunId": {},
+              "executionStartToCloseTimeout": {},
               "taskList": {
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "taskStartToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "childPolicy": {
-                "shape": "S1f"
-              },
+              "taskStartToCloseTimeout": {},
+              "childPolicy": {},
               "tagList": {
                 "shape": "S1b"
               },
               "workflowType": {
                 "shape": "Sr"
               },
-              "lambdaRole": {
-                "shape": "S1g"
-              }
+              "lambdaRole": {}
             }
           },
           "continueAsNewWorkflowExecutionFailedEventAttributes": {
@@ -2005,20 +1426,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNHANDLED_DECISION",
-                  "WORKFLOW_TYPE_DEPRECATED",
-                  "WORKFLOW_TYPE_DOES_NOT_EXIST",
-                  "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_TASK_LIST_UNDEFINED",
-                  "DEFAULT_CHILD_POLICY_UNDEFINED",
-                  "CONTINUE_AS_NEW_WORKFLOW_EXECUTION_RATE_EXCEEDED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2030,23 +1438,10 @@
               "childPolicy"
             ],
             "members": {
-              "reason": {
-                "shape": "S2f"
-              },
-              "details": {
-                "shape": "S1j"
-              },
-              "childPolicy": {
-                "shape": "S1f"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "CHILD_POLICY_APPLIED",
-                  "EVENT_LIMIT_EXCEEDED",
-                  "OPERATOR_INITIATED"
-                ]
-              }
+              "reason": {},
+              "details": {},
+              "childPolicy": {},
+              "cause": {}
             }
           },
           "workflowExecutionCancelRequestedEventAttributes": {
@@ -2058,12 +1453,7 @@
               "externalInitiatedEventId": {
                 "type": "long"
               },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "CHILD_POLICY_APPLIED"
-                ]
-              }
+              "cause": {}
             }
           },
           "decisionTaskScheduledEventAttributes": {
@@ -2076,9 +1466,7 @@
                 "shape": "Sj"
               },
               "taskPriority": {},
-              "startToCloseTimeout": {
-                "shape": "Sy"
-              }
+              "startToCloseTimeout": {}
             }
           },
           "decisionTaskStartedEventAttributes": {
@@ -2087,9 +1475,7 @@
               "scheduledEventId"
             ],
             "members": {
-              "identity": {
-                "shape": "S2l"
-              },
+              "identity": {},
               "scheduledEventId": {
                 "type": "long"
               }
@@ -2102,9 +1488,7 @@
               "startedEventId"
             ],
             "members": {
-              "executionContext": {
-                "shape": "S1j"
-              },
+              "executionContext": {},
               "scheduledEventId": {
                 "type": "long"
               },
@@ -2121,12 +1505,7 @@
               "startedEventId"
             ],
             "members": {
-              "timeoutType": {
-                "type": "string",
-                "enum": [
-                  "START_TO_CLOSE"
-                ]
-              },
+              "timeoutType": {},
               "scheduledEventId": {
                 "type": "long"
               },
@@ -2147,24 +1526,12 @@
               "activityType": {
                 "shape": "Sn"
               },
-              "activityId": {
-                "shape": "S2q"
-              },
-              "input": {
-                "shape": "S1j"
-              },
-              "control": {
-                "shape": "S1j"
-              },
-              "scheduleToStartTimeout": {
-                "shape": "Sy"
-              },
-              "scheduleToCloseTimeout": {
-                "shape": "Sy"
-              },
-              "startToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "activityId": {},
+              "input": {},
+              "control": {},
+              "scheduleToStartTimeout": {},
+              "scheduleToCloseTimeout": {},
+              "startToCloseTimeout": {},
               "taskList": {
                 "shape": "Sj"
               },
@@ -2172,9 +1539,7 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "heartbeatTimeout": {
-                "shape": "Sy"
-              }
+              "heartbeatTimeout": {}
             }
           },
           "activityTaskStartedEventAttributes": {
@@ -2183,9 +1548,7 @@
               "scheduledEventId"
             ],
             "members": {
-              "identity": {
-                "shape": "S2l"
-              },
+              "identity": {},
               "scheduledEventId": {
                 "type": "long"
               }
@@ -2198,9 +1561,7 @@
               "startedEventId"
             ],
             "members": {
-              "result": {
-                "shape": "S1j"
-              },
+              "result": {},
               "scheduledEventId": {
                 "type": "long"
               },
@@ -2216,12 +1577,8 @@
               "startedEventId"
             ],
             "members": {
-              "reason": {
-                "shape": "S23"
-              },
-              "details": {
-                "shape": "S1j"
-              },
+              "reason": {},
+              "details": {},
               "scheduledEventId": {
                 "type": "long"
               },
@@ -2238,24 +1595,14 @@
               "startedEventId"
             ],
             "members": {
-              "timeoutType": {
-                "type": "string",
-                "enum": [
-                  "START_TO_CLOSE",
-                  "SCHEDULE_TO_START",
-                  "SCHEDULE_TO_CLOSE",
-                  "HEARTBEAT"
-                ]
-              },
+              "timeoutType": {},
               "scheduledEventId": {
                 "type": "long"
               },
               "startedEventId": {
                 "type": "long"
               },
-              "details": {
-                "shape": "S2w"
-              }
+              "details": {}
             }
           },
           "activityTaskCanceledEventAttributes": {
@@ -2265,9 +1612,7 @@
               "startedEventId"
             ],
             "members": {
-              "details": {
-                "shape": "S1j"
-              },
+              "details": {},
               "scheduledEventId": {
                 "type": "long"
               },
@@ -2289,9 +1634,7 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "activityId": {
-                "shape": "S2q"
-              }
+              "activityId": {}
             }
           },
           "workflowExecutionSignaledEventAttributes": {
@@ -2300,12 +1643,8 @@
               "signalName"
             ],
             "members": {
-              "signalName": {
-                "shape": "S30"
-              },
-              "input": {
-                "shape": "S1j"
-              },
+              "signalName": {},
+              "input": {},
               "externalWorkflowExecution": {
                 "shape": "S16"
               },
@@ -2321,12 +1660,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "markerName": {
-                "shape": "S32"
-              },
-              "details": {
-                "shape": "S1j"
-              },
+              "markerName": {},
+              "details": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2340,15 +1675,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "markerName": {
-                "shape": "S32"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "markerName": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2362,15 +1690,9 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {
-                "shape": "S36"
-              },
-              "control": {
-                "shape": "S1j"
-              },
-              "startToFireTimeout": {
-                "shape": "S1e"
-              },
+              "timerId": {},
+              "control": {},
+              "startToFireTimeout": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2383,9 +1705,7 @@
               "startedEventId"
             ],
             "members": {
-              "timerId": {
-                "shape": "S36"
-              },
+              "timerId": {},
               "startedEventId": {
                 "type": "long"
               }
@@ -2399,9 +1719,7 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {
-                "shape": "S36"
-              },
+              "timerId": {},
               "startedEventId": {
                 "type": "long"
               },
@@ -2420,21 +1738,13 @@
               "childPolicy"
             ],
             "members": {
-              "workflowId": {
-                "shape": "S6"
-              },
+              "workflowId": {},
               "workflowType": {
                 "shape": "Sr"
               },
-              "control": {
-                "shape": "S1j"
-              },
-              "input": {
-                "shape": "S1j"
-              },
-              "executionStartToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "control": {},
+              "input": {},
+              "executionStartToCloseTimeout": {},
               "taskList": {
                 "shape": "Sj"
               },
@@ -2442,18 +1752,12 @@
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "childPolicy": {
-                "shape": "S1f"
-              },
-              "taskStartToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "childPolicy": {},
+              "taskStartToCloseTimeout": {},
               "tagList": {
                 "shape": "S1b"
               },
-              "lambdaRole": {
-                "shape": "S1g"
-              }
+              "lambdaRole": {}
             }
           },
           "childWorkflowExecutionStartedEventAttributes": {
@@ -2490,9 +1794,7 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "result": {
-                "shape": "S1j"
-              },
+              "result": {},
               "initiatedEventId": {
                 "type": "long"
               },
@@ -2516,12 +1818,8 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "reason": {
-                "shape": "S23"
-              },
-              "details": {
-                "shape": "S1j"
-              },
+              "reason": {},
+              "details": {},
               "initiatedEventId": {
                 "type": "long"
               },
@@ -2546,9 +1844,7 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "timeoutType": {
-                "shape": "S27"
-              },
+              "timeoutType": {},
               "initiatedEventId": {
                 "type": "long"
               },
@@ -2572,9 +1868,7 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "details": {
-                "shape": "S1j"
-              },
+              "details": {},
               "initiatedEventId": {
                 "type": "long"
               },
@@ -2614,24 +1908,14 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {
-                "shape": "S6"
-              },
-              "runId": {
-                "shape": "S1y"
-              },
-              "signalName": {
-                "shape": "S30"
-              },
-              "input": {
-                "shape": "S1j"
-              },
+              "workflowId": {},
+              "runId": {},
+              "signalName": {},
+              "input": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {
-                "shape": "S1j"
-              }
+              "control": {}
             }
           },
           "externalWorkflowExecutionSignaledEventAttributes": {
@@ -2658,29 +1942,16 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {
-                "shape": "S6"
-              },
-              "runId": {
-                "shape": "S1y"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
-                  "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "workflowId": {},
+              "runId": {},
+              "cause": {},
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {
-                "shape": "S1j"
-              }
+              "control": {}
             }
           },
           "externalWorkflowExecutionCancelRequestedEventAttributes": {
@@ -2705,18 +1976,12 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {
-                "shape": "S6"
-              },
-              "runId": {
-                "shape": "S1y"
-              },
+              "workflowId": {},
+              "runId": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {
-                "shape": "S1j"
-              }
+              "control": {}
             }
           },
           "requestCancelExternalWorkflowExecutionFailedEventAttributes": {
@@ -2728,29 +1993,16 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "workflowId": {
-                "shape": "S6"
-              },
-              "runId": {
-                "shape": "S1y"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
-                  "REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_RATE_EXCEEDED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "workflowId": {},
+              "runId": {},
+              "cause": {},
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {
-                "shape": "S1j"
-              }
+              "control": {}
             }
           },
           "scheduleActivityTaskFailedEventAttributes": {
@@ -2765,25 +2017,8 @@
               "activityType": {
                 "shape": "Sn"
               },
-              "activityId": {
-                "shape": "S2q"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "ACTIVITY_TYPE_DEPRECATED",
-                  "ACTIVITY_TYPE_DOES_NOT_EXIST",
-                  "ACTIVITY_ID_ALREADY_IN_USE",
-                  "OPEN_ACTIVITIES_LIMIT_EXCEEDED",
-                  "ACTIVITY_CREATION_RATE_EXCEEDED",
-                  "DEFAULT_SCHEDULE_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_TASK_LIST_UNDEFINED",
-                  "DEFAULT_SCHEDULE_TO_START_TIMEOUT_UNDEFINED",
-                  "DEFAULT_START_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_HEARTBEAT_TIMEOUT_UNDEFINED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "activityId": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2797,16 +2032,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "activityId": {
-                "shape": "S2q"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "ACTIVITY_ID_UNKNOWN",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "activityId": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2820,18 +2047,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {
-                "shape": "S36"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "TIMER_ID_ALREADY_IN_USE",
-                  "OPEN_TIMERS_LIMIT_EXCEEDED",
-                  "TIMER_CREATION_RATE_EXCEEDED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "timerId": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2845,16 +2062,8 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "timerId": {
-                "shape": "S36"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "TIMER_ID_UNKNOWN",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
+              "timerId": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2873,34 +2082,15 @@
               "workflowType": {
                 "shape": "Sr"
               },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "WORKFLOW_TYPE_DOES_NOT_EXIST",
-                  "WORKFLOW_TYPE_DEPRECATED",
-                  "OPEN_CHILDREN_LIMIT_EXCEEDED",
-                  "OPEN_WORKFLOWS_LIMIT_EXCEEDED",
-                  "CHILD_CREATION_RATE_EXCEEDED",
-                  "WORKFLOW_ALREADY_RUNNING",
-                  "DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_TASK_LIST_UNDEFINED",
-                  "DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_UNDEFINED",
-                  "DEFAULT_CHILD_POLICY_UNDEFINED",
-                  "OPERATION_NOT_PERMITTED"
-                ]
-              },
-              "workflowId": {
-                "shape": "S6"
-              },
+              "cause": {},
+              "workflowId": {},
               "initiatedEventId": {
                 "type": "long"
               },
               "decisionTaskCompletedEventId": {
                 "type": "long"
               },
-              "control": {
-                "shape": "S1j"
-              }
+              "control": {}
             }
           },
           "lambdaFunctionScheduledEventAttributes": {
@@ -2911,21 +2101,11 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "id": {
-                "shape": "S3z"
-              },
-              "name": {
-                "shape": "S40"
-              },
-              "control": {
-                "shape": "S1j"
-              },
-              "input": {
-                "shape": "S41"
-              },
-              "startToCloseTimeout": {
-                "shape": "Sy"
-              },
+              "id": {},
+              "name": {},
+              "control": {},
+              "input": {},
+              "startToCloseTimeout": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -2955,9 +2135,7 @@
               "startedEventId": {
                 "type": "long"
               },
-              "result": {
-                "shape": "S1j"
-              }
+              "result": {}
             }
           },
           "lambdaFunctionFailedEventAttributes": {
@@ -2973,12 +2151,8 @@
               "startedEventId": {
                 "type": "long"
               },
-              "reason": {
-                "shape": "S23"
-              },
-              "details": {
-                "shape": "S1j"
-              }
+              "reason": {},
+              "details": {}
             }
           },
           "lambdaFunctionTimedOutEventAttributes": {
@@ -2994,12 +2168,7 @@
               "startedEventId": {
                 "type": "long"
               },
-              "timeoutType": {
-                "type": "string",
-                "enum": [
-                  "START_TO_CLOSE"
-                ]
-              }
+              "timeoutType": {}
             }
           },
           "scheduleLambdaFunctionFailedEventAttributes": {
@@ -3011,21 +2180,9 @@
               "decisionTaskCompletedEventId"
             ],
             "members": {
-              "id": {
-                "shape": "S3z"
-              },
-              "name": {
-                "shape": "S40"
-              },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "ID_ALREADY_IN_USE",
-                  "OPEN_LAMBDA_FUNCTIONS_LIMIT_EXCEEDED",
-                  "LAMBDA_FUNCTION_CREATION_RATE_EXCEEDED",
-                  "LAMBDA_SERVICE_NOT_AVAILABLE_IN_REGION"
-                ]
-              },
+              "id": {},
+              "name": {},
+              "cause": {},
               "decisionTaskCompletedEventId": {
                 "type": "long"
               }
@@ -3037,81 +2194,12 @@
               "scheduledEventId": {
                 "type": "long"
               },
-              "cause": {
-                "type": "string",
-                "enum": [
-                  "ASSUME_ROLE_FAILED"
-                ]
-              },
-              "message": {
-                "type": "string",
-                "max": 1728
-              }
+              "cause": {},
+              "message": {}
             }
           }
         }
       }
-    },
-    "S1y": {
-      "type": "string",
-      "max": 64
-    },
-    "S23": {
-      "type": "string",
-      "max": 256
-    },
-    "S27": {
-      "type": "string",
-      "enum": [
-        "START_TO_CLOSE"
-      ]
-    },
-    "S2f": {
-      "type": "string",
-      "max": 256
-    },
-    "S2l": {
-      "type": "string",
-      "max": 256
-    },
-    "S2q": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S2w": {
-      "type": "string",
-      "max": 2048
-    },
-    "S30": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S32": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S36": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S3z": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S40": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "S41": {
-      "type": "string",
-      "max": 32768,
-      "min": 0
     },
     "S4g": {
       "type": "structure",
@@ -3125,15 +2213,8 @@
             "shape": "S19"
           }
         },
-        "nextPageToken": {
-          "shape": "S1p"
-        }
+        "nextPageToken": {}
       }
-    },
-    "S4r": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
     }
   }
 }

--- a/apis/transcribe-2017-10-26.min.json
+++ b/apis/transcribe-2017-10-26.min.json
@@ -22,12 +22,8 @@
           "Phrases"
         ],
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
+          "VocabularyName": {},
+          "LanguageCode": {},
           "Phrases": {
             "shape": "S4"
           }
@@ -36,15 +32,9 @@
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
-          "VocabularyState": {
-            "shape": "S7"
-          },
+          "VocabularyName": {},
+          "LanguageCode": {},
+          "VocabularyState": {},
           "LastModifiedTime": {
             "type": "timestamp"
           },
@@ -59,9 +49,7 @@
           "VocabularyName"
         ],
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          }
+          "VocabularyName": {}
         }
       }
     },
@@ -72,9 +60,7 @@
           "TranscriptionJobName"
         ],
         "members": {
-          "TranscriptionJobName": {
-            "shape": "Sc"
-          }
+          "TranscriptionJobName": {}
         }
       },
       "output": {
@@ -93,30 +79,20 @@
           "VocabularyName"
         ],
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          }
+          "VocabularyName": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
-          "VocabularyState": {
-            "shape": "S7"
-          },
+          "VocabularyName": {},
+          "LanguageCode": {},
+          "VocabularyState": {},
           "LastModifiedTime": {
             "type": "timestamp"
           },
           "FailureReason": {},
-          "DownloadUri": {
-            "shape": "Sj"
-          }
+          "DownloadUri": {}
         }
       }
     },
@@ -124,57 +100,35 @@
       "input": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "Sf"
-          },
-          "JobNameContains": {
-            "shape": "Sc"
-          },
-          "NextToken": {
-            "shape": "Sr"
-          },
+          "Status": {},
+          "JobNameContains": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "Ss"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "Sf"
-          },
-          "NextToken": {
-            "shape": "Sr"
-          },
+          "Status": {},
+          "NextToken": {},
           "TranscriptionJobSummaries": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "TranscriptionJobName": {
-                  "shape": "Sc"
-                },
+                "TranscriptionJobName": {},
                 "CreationTime": {
                   "type": "timestamp"
                 },
                 "CompletionTime": {
                   "type": "timestamp"
                 },
-                "LanguageCode": {
-                  "shape": "S3"
-                },
-                "TranscriptionJobStatus": {
-                  "shape": "Sf"
-                },
+                "LanguageCode": {},
+                "TranscriptionJobStatus": {},
                 "FailureReason": {},
-                "OutputLocationType": {
-                  "type": "string",
-                  "enum": [
-                    "CUSTOMER_BUCKET",
-                    "SERVICE_BUCKET"
-                  ]
-                }
+                "OutputLocationType": {}
               }
             }
           }
@@ -185,46 +139,30 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "Sr"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "Ss"
+            "type": "integer"
           },
-          "StateEquals": {
-            "shape": "S7"
-          },
-          "NameContains": {
-            "shape": "S2"
-          }
+          "StateEquals": {},
+          "NameContains": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Status": {
-            "shape": "Sf"
-          },
-          "NextToken": {
-            "shape": "Sr"
-          },
+          "Status": {},
+          "NextToken": {},
           "Vocabularies": {
             "type": "list",
             "member": {
               "type": "structure",
               "members": {
-                "VocabularyName": {
-                  "shape": "S2"
-                },
-                "LanguageCode": {
-                  "shape": "S3"
-                },
+                "VocabularyName": {},
+                "LanguageCode": {},
                 "LastModifiedTime": {
                   "type": "timestamp"
                 },
-                "VocabularyState": {
-                  "shape": "S7"
-                }
+                "VocabularyState": {}
               }
             }
           }
@@ -241,25 +179,16 @@
           "Media"
         ],
         "members": {
-          "TranscriptionJobName": {
-            "shape": "Sc"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
+          "TranscriptionJobName": {},
+          "LanguageCode": {},
           "MediaSampleRateHertz": {
-            "shape": "Sg"
+            "type": "integer"
           },
-          "MediaFormat": {
-            "shape": "Sh"
-          },
+          "MediaFormat": {},
           "Media": {
             "shape": "Si"
           },
-          "OutputBucketName": {
-            "type": "string",
-            "pattern": "[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]"
-          },
+          "OutputBucketName": {},
           "Settings": {
             "shape": "Sl"
           }
@@ -283,12 +212,8 @@
           "Phrases"
         ],
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
+          "VocabularyName": {},
+          "LanguageCode": {},
           "Phrases": {
             "shape": "S4"
           }
@@ -297,85 +222,38 @@
       "output": {
         "type": "structure",
         "members": {
-          "VocabularyName": {
-            "shape": "S2"
-          },
-          "LanguageCode": {
-            "shape": "S3"
-          },
+          "VocabularyName": {},
+          "LanguageCode": {},
           "LastModifiedTime": {
             "type": "timestamp"
           },
-          "VocabularyState": {
-            "shape": "S7"
-          }
+          "VocabularyState": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "^[0-9a-zA-Z._-]+"
-    },
-    "S3": {
-      "type": "string",
-      "enum": [
-        "en-US",
-        "es-US"
-      ]
-    },
     "S4": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 256,
-        "min": 0
-      }
-    },
-    "S7": {
-      "type": "string",
-      "enum": [
-        "PENDING",
-        "READY",
-        "FAILED"
-      ]
-    },
-    "Sc": {
-      "type": "string",
-      "max": 200,
-      "min": 1,
-      "pattern": "^[0-9a-zA-Z._-]+"
+      "member": {}
     },
     "Se": {
       "type": "structure",
       "members": {
-        "TranscriptionJobName": {
-          "shape": "Sc"
-        },
-        "TranscriptionJobStatus": {
-          "shape": "Sf"
-        },
-        "LanguageCode": {
-          "shape": "S3"
-        },
+        "TranscriptionJobName": {},
+        "TranscriptionJobStatus": {},
+        "LanguageCode": {},
         "MediaSampleRateHertz": {
-          "shape": "Sg"
+          "type": "integer"
         },
-        "MediaFormat": {
-          "shape": "Sh"
-        },
+        "MediaFormat": {},
         "Media": {
           "shape": "Si"
         },
         "Transcript": {
           "type": "structure",
           "members": {
-            "TranscriptFileUri": {
-              "shape": "Sj"
-            }
+            "TranscriptFileUri": {}
           }
         },
         "CreationTime": {
@@ -390,68 +268,26 @@
         }
       }
     },
-    "Sf": {
-      "type": "string",
-      "enum": [
-        "IN_PROGRESS",
-        "FAILED",
-        "COMPLETED"
-      ]
-    },
-    "Sg": {
-      "type": "integer",
-      "max": 48000,
-      "min": 8000
-    },
-    "Sh": {
-      "type": "string",
-      "enum": [
-        "mp3",
-        "mp4",
-        "wav",
-        "flac"
-      ]
-    },
     "Si": {
       "type": "structure",
       "members": {
-        "MediaFileUri": {
-          "shape": "Sj"
-        }
+        "MediaFileUri": {}
       }
-    },
-    "Sj": {
-      "type": "string",
-      "max": 2000,
-      "min": 1
     },
     "Sl": {
       "type": "structure",
       "members": {
-        "VocabularyName": {
-          "shape": "S2"
-        },
+        "VocabularyName": {},
         "ShowSpeakerLabels": {
           "type": "boolean"
         },
         "MaxSpeakerLabels": {
-          "type": "integer",
-          "max": 10,
-          "min": 2
+          "type": "integer"
         },
         "ChannelIdentification": {
           "type": "boolean"
         }
       }
-    },
-    "Sr": {
-      "type": "string",
-      "max": 8192
-    },
-    "Ss": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
     }
   }
 }

--- a/apis/translate-2017-07-01.min.json
+++ b/apis/translate-2017-07-01.min.json
@@ -22,17 +22,9 @@
           "TargetLanguageCode"
         ],
         "members": {
-          "Text": {
-            "type": "string",
-            "max": 5000,
-            "min": 1
-          },
-          "SourceLanguageCode": {
-            "shape": "S3"
-          },
-          "TargetLanguageCode": {
-            "shape": "S3"
-          }
+          "Text": {},
+          "SourceLanguageCode": {},
+          "TargetLanguageCode": {}
         }
       },
       "output": {
@@ -43,25 +35,12 @@
           "TargetLanguageCode"
         ],
         "members": {
-          "TranslatedText": {
-            "type": "string",
-            "min": 1
-          },
-          "SourceLanguageCode": {
-            "shape": "S3"
-          },
-          "TargetLanguageCode": {
-            "shape": "S3"
-          }
+          "TranslatedText": {},
+          "SourceLanguageCode": {},
+          "TargetLanguageCode": {}
         }
       }
     }
   },
-  "shapes": {
-    "S3": {
-      "type": "string",
-      "max": 5,
-      "min": 2
-    }
-  }
+  "shapes": {}
 }

--- a/apis/waf-2015-08-24.min.json
+++ b/apis/waf-2015-08-24.min.json
@@ -21,12 +21,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -35,9 +31,7 @@
           "ByteMatchSet": {
             "shape": "S5"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -49,12 +43,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -63,9 +53,7 @@
           "GeoMatchSet": {
             "shape": "Sh"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -77,12 +65,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -91,9 +75,7 @@
           "IPSet": {
             "shape": "So"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -108,19 +90,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "MetricName": {},
-          "RateKey": {
-            "shape": "Sv"
-          },
+          "RateKey": {},
           "RateLimit": {
-            "shape": "Sw"
+            "type": "long"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -129,9 +105,7 @@
           "Rule": {
             "shape": "Sy"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -143,12 +117,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -157,9 +127,7 @@
           "RegexMatchSet": {
             "shape": "S15"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -171,12 +139,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -185,9 +149,7 @@
           "RegexPatternSet": {
             "shape": "S1a"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -200,13 +162,9 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "MetricName": {},
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -215,9 +173,7 @@
           "Rule": {
             "shape": "S1f"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -230,13 +186,9 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "MetricName": {},
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -245,9 +197,7 @@
           "RuleGroup": {
             "shape": "S1i"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -259,12 +209,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -273,9 +219,7 @@
           "SizeConstraintSet": {
             "shape": "S1l"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -287,12 +231,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -301,9 +241,7 @@
           "SqlInjectionMatchSet": {
             "shape": "S1s"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -317,16 +255,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
+          "Name": {},
           "MetricName": {},
           "DefaultAction": {
             "shape": "S1w"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -335,9 +269,7 @@
           "WebACL": {
             "shape": "S1z"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -349,12 +281,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -363,9 +291,7 @@
           "XssMatchSet": {
             "shape": "S28"
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -377,20 +303,14 @@
           "ChangeToken"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ByteMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -402,20 +322,14 @@
           "ChangeToken"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "GeoMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -427,20 +341,14 @@
           "ChangeToken"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "IPSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -451,9 +359,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2i"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -468,9 +374,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2i"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -486,20 +390,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "RuleId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -511,20 +409,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "RegexMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -536,20 +428,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "RegexPatternSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -561,20 +447,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "RuleId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -586,20 +466,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "RuleGroupId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -611,20 +485,14 @@
           "ChangeToken"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "SizeConstraintSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -636,20 +504,14 @@
           "ChangeToken"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "SqlInjectionMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -661,20 +523,14 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "WebACLId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -686,20 +542,14 @@
           "ChangeToken"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "XssMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -710,9 +560,7 @@
           "ByteMatchSetId"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S6"
-          }
+          "ByteMatchSetId": {}
         }
       },
       "output": {
@@ -732,9 +580,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -745,22 +591,13 @@
           "ChangeToken"
         ],
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeTokenStatus": {
-            "type": "string",
-            "enum": [
-              "PROVISIONED",
-              "PENDING",
-              "INSYNC"
-            ]
-          }
+          "ChangeTokenStatus": {}
         }
       }
     },
@@ -771,9 +608,7 @@
           "GeoMatchSetId"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S6"
-          }
+          "GeoMatchSetId": {}
         }
       },
       "output": {
@@ -792,9 +627,7 @@
           "IPSetId"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S6"
-          }
+          "IPSetId": {}
         }
       },
       "output": {
@@ -813,9 +646,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2i"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -834,17 +665,13 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2i"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {
-            "shape": "S3m"
-          }
+          "Policy": {}
         }
       }
     },
@@ -855,9 +682,7 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          }
+          "RuleId": {}
         }
       },
       "output": {
@@ -876,12 +701,8 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "NextMarker": {
-            "shape": "S3q"
-          }
+          "RuleId": {},
+          "NextMarker": {}
         }
       },
       "output": {
@@ -891,9 +712,7 @@
             "type": "list",
             "member": {}
           },
-          "NextMarker": {
-            "shape": "S3q"
-          }
+          "NextMarker": {}
         }
       }
     },
@@ -904,9 +723,7 @@
           "RegexMatchSetId"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S6"
-          }
+          "RegexMatchSetId": {}
         }
       },
       "output": {
@@ -925,9 +742,7 @@
           "RegexPatternSetId"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S6"
-          }
+          "RegexPatternSetId": {}
         }
       },
       "output": {
@@ -946,9 +761,7 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          }
+          "RuleId": {}
         }
       },
       "output": {
@@ -967,9 +780,7 @@
           "RuleGroupId"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S6"
-          }
+          "RuleGroupId": {}
         }
       },
       "output": {
@@ -991,19 +802,13 @@
           "MaxItems"
         ],
         "members": {
-          "WebAclId": {
-            "shape": "S6"
-          },
-          "RuleId": {
-            "shape": "S6"
-          },
+          "WebAclId": {},
+          "RuleId": {},
           "TimeWindow": {
             "shape": "S43"
           },
           "MaxItems": {
-            "type": "long",
-            "max": 500,
-            "min": 1
+            "type": "long"
           }
         }
       },
@@ -1040,16 +845,13 @@
                   }
                 },
                 "Weight": {
-                  "type": "long",
-                  "min": 0
+                  "type": "long"
                 },
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "Action": {},
-                "RuleWithinRuleGroup": {
-                  "shape": "S6"
-                }
+                "RuleWithinRuleGroup": {}
               }
             }
           },
@@ -1069,9 +871,7 @@
           "SizeConstraintSetId"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S6"
-          }
+          "SizeConstraintSetId": {}
         }
       },
       "output": {
@@ -1090,9 +890,7 @@
           "SqlInjectionMatchSetId"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S6"
-          }
+          "SqlInjectionMatchSetId": {}
         }
       },
       "output": {
@@ -1111,9 +909,7 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S6"
-          }
+          "WebACLId": {}
         }
       },
       "output": {
@@ -1132,9 +928,7 @@
           "XssMatchSetId"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S6"
-          }
+          "XssMatchSetId": {}
         }
       },
       "output": {
@@ -1150,23 +944,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "RuleGroupId": {
-            "shape": "S6"
-          },
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "RuleGroupId": {},
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "ActivatedRules": {
             "shape": "S20"
           }
@@ -1177,20 +965,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "ByteMatchSets": {
             "type": "list",
             "member": {
@@ -1200,12 +984,8 @@
                 "Name"
               ],
               "members": {
-                "ByteMatchSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "ByteMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1216,20 +996,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "GeoMatchSets": {
             "type": "list",
             "member": {
@@ -1239,12 +1015,8 @@
                 "Name"
               ],
               "members": {
-                "GeoMatchSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "GeoMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1255,20 +1027,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "IPSets": {
             "type": "list",
             "member": {
@@ -1278,12 +1046,8 @@
                 "Name"
               ],
               "members": {
-                "IPSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "IPSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1294,11 +1058,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
@@ -1311,9 +1073,7 @@
               "shape": "S3h"
             }
           },
-          "NextMarker": {
-            "shape": "S3q"
-          }
+          "NextMarker": {}
         }
       }
     },
@@ -1321,20 +1081,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Rules": {
             "shape": "S5e"
           }
@@ -1345,20 +1101,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "RegexMatchSets": {
             "type": "list",
             "member": {
@@ -1368,12 +1120,8 @@
                 "Name"
               ],
               "members": {
-                "RegexMatchSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "RegexMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1384,20 +1132,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "RegexPatternSets": {
             "type": "list",
             "member": {
@@ -1407,12 +1151,8 @@
                 "Name"
               ],
               "members": {
-                "RegexPatternSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "RegexPatternSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1423,20 +1163,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1446,12 +1182,8 @@
                 "Name"
               ],
               "members": {
-                "RuleGroupId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "RuleGroupId": {},
+                "Name": {}
               }
             }
           }
@@ -1462,20 +1194,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Rules": {
             "shape": "S5e"
           }
@@ -1486,20 +1214,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "SizeConstraintSets": {
             "type": "list",
             "member": {
@@ -1509,12 +1233,8 @@
                 "Name"
               ],
               "members": {
-                "SizeConstraintSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "SizeConstraintSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1525,20 +1245,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "SqlInjectionMatchSets": {
             "type": "list",
             "member": {
@@ -1548,12 +1264,8 @@
                 "Name"
               ],
               "members": {
-                "SqlInjectionMatchSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "SqlInjectionMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1564,20 +1276,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1588,12 +1296,8 @@
                 "MetricName"
               ],
               "members": {
-                "RuleGroupId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                },
+                "RuleGroupId": {},
+                "Name": {},
                 "MetricName": {}
               }
             }
@@ -1605,20 +1309,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "WebACLs": {
             "type": "list",
             "member": {
@@ -1628,12 +1328,8 @@
                 "Name"
               ],
               "members": {
-                "WebACLId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "WebACLId": {},
+                "Name": {}
               }
             }
           }
@@ -1644,20 +1340,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S4v"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3q"
-          },
+          "NextMarker": {},
           "XssMatchSets": {
             "type": "list",
             "member": {
@@ -1667,12 +1359,8 @@
                 "Name"
               ],
               "members": {
-                "XssMatchSetId": {
-                  "shape": "S6"
-                },
-                "Name": {
-                  "shape": "S2"
-                }
+                "XssMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1708,12 +1396,8 @@
           "Policy"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S2i"
-          },
-          "Policy": {
-            "shape": "S3m"
-          }
+          "ResourceArn": {},
+          "Policy": {}
         }
       },
       "output": {
@@ -1730,12 +1414,8 @@
           "Updates"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "ByteMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1745,24 +1425,19 @@
                 "ByteMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "ByteMatchTuple": {
                   "shape": "S8"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1775,12 +1450,8 @@
           "Updates"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "GeoMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1790,24 +1461,19 @@
                 "GeoMatchConstraint"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "GeoMatchConstraint": {
                   "shape": "Sj"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1820,12 +1486,8 @@
           "Updates"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "IPSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1835,24 +1497,19 @@
                 "IPSetDescriptor"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "IPSetDescriptor": {
                   "shape": "Sq"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1866,26 +1523,20 @@
           "RateLimit"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "RuleId": {},
+          "ChangeToken": {},
           "Updates": {
             "shape": "S6w"
           },
           "RateLimit": {
-            "shape": "Sw"
+            "type": "long"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1898,9 +1549,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S6"
-          },
+          "RegexMatchSetId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1910,27 +1559,20 @@
                 "RegexMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "RegexMatchTuple": {
                   "shape": "S17"
                 }
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1943,9 +1585,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S6"
-          },
+          "RegexPatternSetId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1955,27 +1595,18 @@
                 "RegexPatternString"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
-                "RegexPatternString": {
-                  "shape": "S1c"
-                }
+                "Action": {},
+                "RegexPatternString": {}
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1988,12 +1619,8 @@
           "Updates"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "RuleId": {},
+          "ChangeToken": {},
           "Updates": {
             "shape": "S6w"
           }
@@ -2002,9 +1629,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2017,9 +1642,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S6"
-          },
+          "RuleGroupId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2029,27 +1652,20 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "ActivatedRule": {
                   "shape": "S21"
                 }
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2062,12 +1678,8 @@
           "Updates"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "SizeConstraintSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2077,24 +1689,19 @@
                 "SizeConstraint"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "SizeConstraint": {
                   "shape": "S1n"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2107,12 +1714,8 @@
           "Updates"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "SqlInjectionMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2122,24 +1725,19 @@
                 "SqlInjectionMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "SqlInjectionMatchTuple": {
                   "shape": "S1u"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2151,12 +1749,8 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "WebACLId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2166,9 +1760,7 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "ActivatedRule": {
                   "shape": "S21"
                 }
@@ -2183,9 +1775,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2198,12 +1788,8 @@
           "Updates"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S3"
-          },
+          "XssMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2213,38 +1799,24 @@
                 "XssMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6l"
-                },
+                "Action": {},
                 "XssMatchTuple": {
                   "shape": "S2a"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S3"
-          }
+          "ChangeToken": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "min": 1
-    },
     "S5": {
       "type": "structure",
       "required": [
@@ -2252,12 +1824,8 @@
         "ByteMatchTuples"
       ],
       "members": {
-        "ByteMatchSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "ByteMatchSetId": {},
+        "Name": {},
         "ByteMatchTuples": {
           "type": "list",
           "member": {
@@ -2265,11 +1833,6 @@
           }
         }
       }
-    },
-    "S6": {
-      "type": "string",
-      "max": 128,
-      "min": 1
     },
     "S8": {
       "type": "structure",
@@ -2286,19 +1849,8 @@
         "TargetString": {
           "type": "blob"
         },
-        "TextTransformation": {
-          "shape": "Sd"
-        },
-        "PositionalConstraint": {
-          "type": "string",
-          "enum": [
-            "EXACTLY",
-            "STARTS_WITH",
-            "ENDS_WITH",
-            "CONTAINS",
-            "CONTAINS_WORD"
-          ]
-        }
+        "TextTransformation": {},
+        "PositionalConstraint": {}
       }
     },
     "S9": {
@@ -2307,31 +1859,9 @@
         "Type"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "URI",
-            "QUERY_STRING",
-            "HEADER",
-            "METHOD",
-            "BODY",
-            "SINGLE_QUERY_ARG",
-            "ALL_QUERY_ARGS"
-          ]
-        },
+        "Type": {},
         "Data": {}
       }
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "COMPRESS_WHITE_SPACE",
-        "HTML_ENTITY_DECODE",
-        "LOWERCASE",
-        "CMD_LINE",
-        "URL_DECODE"
-      ]
     },
     "Sh": {
       "type": "structure",
@@ -2340,12 +1870,8 @@
         "GeoMatchConstraints"
       ],
       "members": {
-        "GeoMatchSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "GeoMatchSetId": {},
+        "Name": {},
         "GeoMatchConstraints": {
           "type": "list",
           "member": {
@@ -2361,266 +1887,8 @@
         "Value"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "Country"
-          ]
-        },
-        "Value": {
-          "type": "string",
-          "enum": [
-            "AF",
-            "AX",
-            "AL",
-            "DZ",
-            "AS",
-            "AD",
-            "AO",
-            "AI",
-            "AQ",
-            "AG",
-            "AR",
-            "AM",
-            "AW",
-            "AU",
-            "AT",
-            "AZ",
-            "BS",
-            "BH",
-            "BD",
-            "BB",
-            "BY",
-            "BE",
-            "BZ",
-            "BJ",
-            "BM",
-            "BT",
-            "BO",
-            "BQ",
-            "BA",
-            "BW",
-            "BV",
-            "BR",
-            "IO",
-            "BN",
-            "BG",
-            "BF",
-            "BI",
-            "KH",
-            "CM",
-            "CA",
-            "CV",
-            "KY",
-            "CF",
-            "TD",
-            "CL",
-            "CN",
-            "CX",
-            "CC",
-            "CO",
-            "KM",
-            "CG",
-            "CD",
-            "CK",
-            "CR",
-            "CI",
-            "HR",
-            "CU",
-            "CW",
-            "CY",
-            "CZ",
-            "DK",
-            "DJ",
-            "DM",
-            "DO",
-            "EC",
-            "EG",
-            "SV",
-            "GQ",
-            "ER",
-            "EE",
-            "ET",
-            "FK",
-            "FO",
-            "FJ",
-            "FI",
-            "FR",
-            "GF",
-            "PF",
-            "TF",
-            "GA",
-            "GM",
-            "GE",
-            "DE",
-            "GH",
-            "GI",
-            "GR",
-            "GL",
-            "GD",
-            "GP",
-            "GU",
-            "GT",
-            "GG",
-            "GN",
-            "GW",
-            "GY",
-            "HT",
-            "HM",
-            "VA",
-            "HN",
-            "HK",
-            "HU",
-            "IS",
-            "IN",
-            "ID",
-            "IR",
-            "IQ",
-            "IE",
-            "IM",
-            "IL",
-            "IT",
-            "JM",
-            "JP",
-            "JE",
-            "JO",
-            "KZ",
-            "KE",
-            "KI",
-            "KP",
-            "KR",
-            "KW",
-            "KG",
-            "LA",
-            "LV",
-            "LB",
-            "LS",
-            "LR",
-            "LY",
-            "LI",
-            "LT",
-            "LU",
-            "MO",
-            "MK",
-            "MG",
-            "MW",
-            "MY",
-            "MV",
-            "ML",
-            "MT",
-            "MH",
-            "MQ",
-            "MR",
-            "MU",
-            "YT",
-            "MX",
-            "FM",
-            "MD",
-            "MC",
-            "MN",
-            "ME",
-            "MS",
-            "MA",
-            "MZ",
-            "MM",
-            "NA",
-            "NR",
-            "NP",
-            "NL",
-            "NC",
-            "NZ",
-            "NI",
-            "NE",
-            "NG",
-            "NU",
-            "NF",
-            "MP",
-            "NO",
-            "OM",
-            "PK",
-            "PW",
-            "PS",
-            "PA",
-            "PG",
-            "PY",
-            "PE",
-            "PH",
-            "PN",
-            "PL",
-            "PT",
-            "PR",
-            "QA",
-            "RE",
-            "RO",
-            "RU",
-            "RW",
-            "BL",
-            "SH",
-            "KN",
-            "LC",
-            "MF",
-            "PM",
-            "VC",
-            "WS",
-            "SM",
-            "ST",
-            "SA",
-            "SN",
-            "RS",
-            "SC",
-            "SL",
-            "SG",
-            "SX",
-            "SK",
-            "SI",
-            "SB",
-            "SO",
-            "ZA",
-            "GS",
-            "SS",
-            "ES",
-            "LK",
-            "SD",
-            "SR",
-            "SJ",
-            "SZ",
-            "SE",
-            "CH",
-            "SY",
-            "TW",
-            "TJ",
-            "TZ",
-            "TH",
-            "TL",
-            "TG",
-            "TK",
-            "TO",
-            "TT",
-            "TN",
-            "TR",
-            "TM",
-            "TC",
-            "TV",
-            "UG",
-            "UA",
-            "AE",
-            "GB",
-            "US",
-            "UM",
-            "UY",
-            "UZ",
-            "VU",
-            "VE",
-            "VN",
-            "VG",
-            "VI",
-            "WF",
-            "EH",
-            "YE",
-            "ZM",
-            "ZW"
-          ]
-        }
+        "Type": {},
+        "Value": {}
       }
     },
     "So": {
@@ -2630,12 +1898,8 @@
         "IPSetDescriptors"
       ],
       "members": {
-        "IPSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "IPSetId": {},
+        "Name": {},
         "IPSetDescriptors": {
           "type": "list",
           "member": {
@@ -2651,26 +1915,9 @@
         "Value"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "IPV4",
-            "IPV6"
-          ]
-        },
+        "Type": {},
         "Value": {}
       }
-    },
-    "Sv": {
-      "type": "string",
-      "enum": [
-        "IP"
-      ]
-    },
-    "Sw": {
-      "type": "long",
-      "max": 2000000000,
-      "min": 2000
     },
     "Sy": {
       "type": "structure",
@@ -2681,21 +1928,15 @@
         "RateLimit"
       ],
       "members": {
-        "RuleId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "RuleId": {},
+        "Name": {},
         "MetricName": {},
         "MatchPredicates": {
           "shape": "Sz"
         },
-        "RateKey": {
-          "shape": "Sv"
-        },
+        "RateKey": {},
         "RateLimit": {
-          "shape": "Sw"
+          "type": "long"
         }
       }
     },
@@ -2716,32 +1957,15 @@
         "Negated": {
           "type": "boolean"
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "IPMatch",
-            "ByteMatch",
-            "SqlInjectionMatch",
-            "GeoMatch",
-            "SizeConstraint",
-            "XssMatch",
-            "RegexMatch"
-          ]
-        },
-        "DataId": {
-          "shape": "S6"
-        }
+        "Type": {},
+        "DataId": {}
       }
     },
     "S15": {
       "type": "structure",
       "members": {
-        "RegexMatchSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "RegexMatchSetId": {},
+        "Name": {},
         "RegexMatchTuples": {
           "type": "list",
           "member": {
@@ -2761,12 +1985,8 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {
-          "shape": "Sd"
-        },
-        "RegexPatternSetId": {
-          "shape": "S6"
-        }
+        "TextTransformation": {},
+        "RegexPatternSetId": {}
       }
     },
     "S1a": {
@@ -2776,24 +1996,13 @@
         "RegexPatternStrings"
       ],
       "members": {
-        "RegexPatternSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "RegexPatternSetId": {},
+        "Name": {},
         "RegexPatternStrings": {
           "type": "list",
-          "member": {
-            "shape": "S1c"
-          },
-          "max": 10
+          "member": {}
         }
       }
-    },
-    "S1c": {
-      "type": "string",
-      "min": 1
     },
     "S1f": {
       "type": "structure",
@@ -2802,12 +2011,8 @@
         "Predicates"
       ],
       "members": {
-        "RuleId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "RuleId": {},
+        "Name": {},
         "MetricName": {},
         "Predicates": {
           "shape": "Sz"
@@ -2820,12 +2025,8 @@
         "RuleGroupId"
       ],
       "members": {
-        "RuleGroupId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "RuleGroupId": {},
+        "Name": {},
         "MetricName": {}
       }
     },
@@ -2836,12 +2037,8 @@
         "SizeConstraints"
       ],
       "members": {
-        "SizeConstraintSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "SizeConstraintSetId": {},
+        "Name": {},
         "SizeConstraints": {
           "type": "list",
           "member": {
@@ -2862,24 +2059,10 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {
-          "shape": "Sd"
-        },
-        "ComparisonOperator": {
-          "type": "string",
-          "enum": [
-            "EQ",
-            "NE",
-            "LE",
-            "LT",
-            "GE",
-            "GT"
-          ]
-        },
+        "TextTransformation": {},
+        "ComparisonOperator": {},
         "Size": {
-          "type": "long",
-          "max": 21474836480,
-          "min": 0
+          "type": "long"
         }
       }
     },
@@ -2890,12 +2073,8 @@
         "SqlInjectionMatchTuples"
       ],
       "members": {
-        "SqlInjectionMatchSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "SqlInjectionMatchSetId": {},
+        "Name": {},
         "SqlInjectionMatchTuples": {
           "type": "list",
           "member": {
@@ -2914,9 +2093,7 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {
-          "shape": "Sd"
-        }
+        "TextTransformation": {}
       }
     },
     "S1w": {
@@ -2925,14 +2102,7 @@
         "Type"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "BLOCK",
-            "ALLOW",
-            "COUNT"
-          ]
-        }
+        "Type": {}
       }
     },
     "S1z": {
@@ -2943,12 +2113,8 @@
         "Rules"
       ],
       "members": {
-        "WebACLId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "WebACLId": {},
+        "Name": {},
         "MetricName": {},
         "DefaultAction": {
           "shape": "S1w"
@@ -2974,9 +2140,7 @@
         "Priority": {
           "type": "integer"
         },
-        "RuleId": {
-          "shape": "S6"
-        },
+        "RuleId": {},
         "Action": {
           "shape": "S1w"
         },
@@ -2986,23 +2150,10 @@
             "Type"
           ],
           "members": {
-            "Type": {
-              "type": "string",
-              "enum": [
-                "NONE",
-                "COUNT"
-              ]
-            }
+            "Type": {}
           }
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "REGULAR",
-            "RATE_BASED",
-            "GROUP"
-          ]
-        }
+        "Type": {}
       }
     },
     "S28": {
@@ -3012,12 +2163,8 @@
         "XssMatchTuples"
       ],
       "members": {
-        "XssMatchSetId": {
-          "shape": "S6"
-        },
-        "Name": {
-          "shape": "S2"
-        },
+        "XssMatchSetId": {},
+        "Name": {},
         "XssMatchTuples": {
           "type": "list",
           "member": {
@@ -3036,15 +2183,8 @@
         "FieldToMatch": {
           "shape": "S9"
         },
-        "TextTransformation": {
-          "shape": "Sd"
-        }
+        "TextTransformation": {}
       }
-    },
-    "S2i": {
-      "type": "string",
-      "max": 1224,
-      "min": 1
     },
     "S3h": {
       "type": "structure",
@@ -3053,16 +2193,10 @@
         "LogDestinationConfigs"
       ],
       "members": {
-        "ResourceArn": {
-          "shape": "S2i"
-        },
+        "ResourceArn": {},
         "LogDestinationConfigs": {
           "type": "list",
-          "member": {
-            "shape": "S2i"
-          },
-          "max": 1,
-          "min": 1
+          "member": {}
         },
         "RedactedFields": {
           "type": "list",
@@ -3071,14 +2205,6 @@
           }
         }
       }
-    },
-    "S3m": {
-      "type": "string",
-      "min": 1
-    },
-    "S3q": {
-      "type": "string",
-      "min": 1
     },
     "S43": {
       "type": "structure",
@@ -3095,11 +2221,6 @@
         }
       }
     },
-    "S4v": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
-    },
     "S5e": {
       "type": "list",
       "member": {
@@ -3109,21 +2230,10 @@
           "Name"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S6"
-          },
-          "Name": {
-            "shape": "S2"
-          }
+          "RuleId": {},
+          "Name": {}
         }
       }
-    },
-    "S6l": {
-      "type": "string",
-      "enum": [
-        "INSERT",
-        "DELETE"
-      ]
     },
     "S6w": {
       "type": "list",
@@ -3134,9 +2244,7 @@
           "Predicate"
         ],
         "members": {
-          "Action": {
-            "shape": "S6l"
-          },
+          "Action": {},
           "Predicate": {
             "shape": "S10"
           }

--- a/apis/waf-regional-2016-11-28.min.json
+++ b/apis/waf-regional-2016-11-28.min.json
@@ -21,12 +21,8 @@
           "ResourceArn"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S2"
-          },
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "WebACLId": {},
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -42,12 +38,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -56,9 +48,7 @@
           "ByteMatchSet": {
             "shape": "S9"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -70,12 +60,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -84,9 +70,7 @@
           "GeoMatchSet": {
             "shape": "Sk"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -98,12 +82,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -112,9 +92,7 @@
           "IPSet": {
             "shape": "Sr"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -129,19 +107,13 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
+          "Name": {},
           "MetricName": {},
-          "RateKey": {
-            "shape": "Sy"
-          },
+          "RateKey": {},
           "RateLimit": {
-            "shape": "Sz"
+            "type": "long"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -150,9 +122,7 @@
           "Rule": {
             "shape": "S11"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -164,12 +134,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -178,9 +144,7 @@
           "RegexMatchSet": {
             "shape": "S18"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -192,12 +156,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -206,9 +166,7 @@
           "RegexPatternSet": {
             "shape": "S1d"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -221,13 +179,9 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
+          "Name": {},
           "MetricName": {},
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -236,9 +190,7 @@
           "Rule": {
             "shape": "S1i"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -251,13 +203,9 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
+          "Name": {},
           "MetricName": {},
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -266,9 +214,7 @@
           "RuleGroup": {
             "shape": "S1l"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -280,12 +226,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -294,9 +236,7 @@
           "SizeConstraintSet": {
             "shape": "S1o"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -308,12 +248,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -322,9 +258,7 @@
           "SqlInjectionMatchSet": {
             "shape": "S1v"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -338,16 +272,12 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
+          "Name": {},
           "MetricName": {},
           "DefaultAction": {
             "shape": "S1z"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -356,9 +286,7 @@
           "WebACL": {
             "shape": "S22"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -370,12 +298,8 @@
           "ChangeToken"
         ],
         "members": {
-          "Name": {
-            "shape": "S6"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "Name": {},
+          "ChangeToken": {}
         }
       },
       "output": {
@@ -384,9 +308,7 @@
           "XssMatchSet": {
             "shape": "S2b"
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -398,20 +320,14 @@
           "ChangeToken"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ByteMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -423,20 +339,14 @@
           "ChangeToken"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "GeoMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -448,20 +358,14 @@
           "ChangeToken"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "IPSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -472,9 +376,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -489,9 +391,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -507,20 +407,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "RuleId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -532,20 +426,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "RegexMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -557,20 +445,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "RegexPatternSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -582,20 +464,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "RuleId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -607,20 +483,14 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "RuleGroupId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -632,20 +502,14 @@
           "ChangeToken"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "SizeConstraintSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -657,20 +521,14 @@
           "ChangeToken"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "SqlInjectionMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -682,20 +540,14 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "WebACLId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -707,20 +559,14 @@
           "ChangeToken"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "XssMatchSetId": {},
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -731,9 +577,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -748,9 +592,7 @@
           "ByteMatchSetId"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S2"
-          }
+          "ByteMatchSetId": {}
         }
       },
       "output": {
@@ -770,9 +612,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -783,22 +623,13 @@
           "ChangeToken"
         ],
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeTokenStatus": {
-            "type": "string",
-            "enum": [
-              "PROVISIONED",
-              "PENDING",
-              "INSYNC"
-            ]
-          }
+          "ChangeTokenStatus": {}
         }
       }
     },
@@ -809,9 +640,7 @@
           "GeoMatchSetId"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S2"
-          }
+          "GeoMatchSetId": {}
         }
       },
       "output": {
@@ -830,9 +659,7 @@
           "IPSetId"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S2"
-          }
+          "IPSetId": {}
         }
       },
       "output": {
@@ -851,9 +678,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -872,17 +697,13 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "Policy": {
-            "shape": "S3q"
-          }
+          "Policy": {}
         }
       }
     },
@@ -893,9 +714,7 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          }
+          "RuleId": {}
         }
       },
       "output": {
@@ -914,12 +733,8 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "NextMarker": {
-            "shape": "S3u"
-          }
+          "RuleId": {},
+          "NextMarker": {}
         }
       },
       "output": {
@@ -929,9 +744,7 @@
             "type": "list",
             "member": {}
           },
-          "NextMarker": {
-            "shape": "S3u"
-          }
+          "NextMarker": {}
         }
       }
     },
@@ -942,9 +755,7 @@
           "RegexMatchSetId"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S2"
-          }
+          "RegexMatchSetId": {}
         }
       },
       "output": {
@@ -963,9 +774,7 @@
           "RegexPatternSetId"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S2"
-          }
+          "RegexPatternSetId": {}
         }
       },
       "output": {
@@ -984,9 +793,7 @@
           "RuleId"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          }
+          "RuleId": {}
         }
       },
       "output": {
@@ -1005,9 +812,7 @@
           "RuleGroupId"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S2"
-          }
+          "RuleGroupId": {}
         }
       },
       "output": {
@@ -1029,19 +834,13 @@
           "MaxItems"
         ],
         "members": {
-          "WebAclId": {
-            "shape": "S2"
-          },
-          "RuleId": {
-            "shape": "S2"
-          },
+          "WebAclId": {},
+          "RuleId": {},
           "TimeWindow": {
             "shape": "S47"
           },
           "MaxItems": {
-            "type": "long",
-            "max": 500,
-            "min": 1
+            "type": "long"
           }
         }
       },
@@ -1078,16 +877,13 @@
                   }
                 },
                 "Weight": {
-                  "type": "long",
-                  "min": 0
+                  "type": "long"
                 },
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "Action": {},
-                "RuleWithinRuleGroup": {
-                  "shape": "S2"
-                }
+                "RuleWithinRuleGroup": {}
               }
             }
           },
@@ -1107,9 +903,7 @@
           "SizeConstraintSetId"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S2"
-          }
+          "SizeConstraintSetId": {}
         }
       },
       "output": {
@@ -1128,9 +922,7 @@
           "SqlInjectionMatchSetId"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S2"
-          }
+          "SqlInjectionMatchSetId": {}
         }
       },
       "output": {
@@ -1149,9 +941,7 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S2"
-          }
+          "WebACLId": {}
         }
       },
       "output": {
@@ -1170,9 +960,7 @@
           "ResourceArn"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          }
+          "ResourceArn": {}
         }
       },
       "output": {
@@ -1191,9 +979,7 @@
           "XssMatchSetId"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S2"
-          }
+          "XssMatchSetId": {}
         }
       },
       "output": {
@@ -1209,23 +995,17 @@
       "input": {
         "type": "structure",
         "members": {
-          "RuleGroupId": {
-            "shape": "S2"
-          },
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "RuleGroupId": {},
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "ActivatedRules": {
             "shape": "S23"
           }
@@ -1236,20 +1016,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "ByteMatchSets": {
             "type": "list",
             "member": {
@@ -1259,12 +1035,8 @@
                 "Name"
               ],
               "members": {
-                "ByteMatchSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "ByteMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1275,20 +1047,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "GeoMatchSets": {
             "type": "list",
             "member": {
@@ -1298,12 +1066,8 @@
                 "Name"
               ],
               "members": {
-                "GeoMatchSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "GeoMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1314,20 +1078,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "IPSets": {
             "type": "list",
             "member": {
@@ -1337,12 +1097,8 @@
                 "Name"
               ],
               "members": {
-                "IPSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "IPSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1353,11 +1109,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
@@ -1370,9 +1124,7 @@
               "shape": "S3l"
             }
           },
-          "NextMarker": {
-            "shape": "S3u"
-          }
+          "NextMarker": {}
         }
       }
     },
@@ -1380,20 +1132,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Rules": {
             "shape": "S5l"
           }
@@ -1404,20 +1152,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "RegexMatchSets": {
             "type": "list",
             "member": {
@@ -1427,12 +1171,8 @@
                 "Name"
               ],
               "members": {
-                "RegexMatchSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "RegexMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1443,20 +1183,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "RegexPatternSets": {
             "type": "list",
             "member": {
@@ -1466,12 +1202,8 @@
                 "Name"
               ],
               "members": {
-                "RegexPatternSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "RegexPatternSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1485,9 +1217,7 @@
           "WebACLId"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S2"
-          }
+          "WebACLId": {}
         }
       },
       "output": {
@@ -1495,9 +1225,7 @@
         "members": {
           "ResourceArns": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           }
         }
       }
@@ -1506,20 +1234,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1529,12 +1253,8 @@
                 "Name"
               ],
               "members": {
-                "RuleGroupId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "RuleGroupId": {},
+                "Name": {}
               }
             }
           }
@@ -1545,20 +1265,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Rules": {
             "shape": "S5l"
           }
@@ -1569,20 +1285,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "SizeConstraintSets": {
             "type": "list",
             "member": {
@@ -1592,12 +1304,8 @@
                 "Name"
               ],
               "members": {
-                "SizeConstraintSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "SizeConstraintSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1608,20 +1316,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "SqlInjectionMatchSets": {
             "type": "list",
             "member": {
@@ -1631,12 +1335,8 @@
                 "Name"
               ],
               "members": {
-                "SqlInjectionMatchSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "SqlInjectionMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1647,20 +1347,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "RuleGroups": {
             "type": "list",
             "member": {
@@ -1671,12 +1367,8 @@
                 "MetricName"
               ],
               "members": {
-                "RuleGroupId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                },
+                "RuleGroupId": {},
+                "Name": {},
                 "MetricName": {}
               }
             }
@@ -1688,20 +1380,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "WebACLs": {
             "type": "list",
             "member": {
@@ -1715,20 +1403,16 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "Limit": {
-            "shape": "S52"
+            "type": "integer"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "NextMarker": {
-            "shape": "S3u"
-          },
+          "NextMarker": {},
           "XssMatchSets": {
             "type": "list",
             "member": {
@@ -1738,12 +1422,8 @@
                 "Name"
               ],
               "members": {
-                "XssMatchSetId": {
-                  "shape": "S2"
-                },
-                "Name": {
-                  "shape": "S6"
-                }
+                "XssMatchSetId": {},
+                "Name": {}
               }
             }
           }
@@ -1779,12 +1459,8 @@
           "Policy"
         ],
         "members": {
-          "ResourceArn": {
-            "shape": "S3"
-          },
-          "Policy": {
-            "shape": "S3q"
-          }
+          "ResourceArn": {},
+          "Policy": {}
         }
       },
       "output": {
@@ -1801,12 +1477,8 @@
           "Updates"
         ],
         "members": {
-          "ByteMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "ByteMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1816,24 +1488,19 @@
                 "ByteMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "ByteMatchTuple": {
                   "shape": "Sb"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1846,12 +1513,8 @@
           "Updates"
         ],
         "members": {
-          "GeoMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "GeoMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1861,24 +1524,19 @@
                 "GeoMatchConstraint"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "GeoMatchConstraint": {
                   "shape": "Sm"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1891,12 +1549,8 @@
           "Updates"
         ],
         "members": {
-          "IPSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "IPSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1906,24 +1560,19 @@
                 "IPSetDescriptor"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "IPSetDescriptor": {
                   "shape": "St"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1937,26 +1586,20 @@
           "RateLimit"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "RuleId": {},
+          "ChangeToken": {},
           "Updates": {
             "shape": "S75"
           },
           "RateLimit": {
-            "shape": "Sz"
+            "type": "long"
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -1969,9 +1612,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexMatchSetId": {
-            "shape": "S2"
-          },
+          "RegexMatchSetId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -1981,27 +1622,20 @@
                 "RegexMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "RegexMatchTuple": {
                   "shape": "S1a"
                 }
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2014,9 +1648,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RegexPatternSetId": {
-            "shape": "S2"
-          },
+          "RegexPatternSetId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2026,27 +1658,18 @@
                 "RegexPatternString"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
-                "RegexPatternString": {
-                  "shape": "S1f"
-                }
+                "Action": {},
+                "RegexPatternString": {}
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2059,12 +1682,8 @@
           "Updates"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "RuleId": {},
+          "ChangeToken": {},
           "Updates": {
             "shape": "S75"
           }
@@ -2073,9 +1692,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2088,9 +1705,7 @@
           "ChangeToken"
         ],
         "members": {
-          "RuleGroupId": {
-            "shape": "S2"
-          },
+          "RuleGroupId": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2100,27 +1715,20 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "ActivatedRule": {
                   "shape": "S24"
                 }
               }
-            },
-            "min": 1
+            }
           },
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2133,12 +1741,8 @@
           "Updates"
         ],
         "members": {
-          "SizeConstraintSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "SizeConstraintSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2148,24 +1752,19 @@
                 "SizeConstraint"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "SizeConstraint": {
                   "shape": "S1q"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2178,12 +1777,8 @@
           "Updates"
         ],
         "members": {
-          "SqlInjectionMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "SqlInjectionMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2193,24 +1788,19 @@
                 "SqlInjectionMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "SqlInjectionMatchTuple": {
                   "shape": "S1x"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2222,12 +1812,8 @@
           "ChangeToken"
         ],
         "members": {
-          "WebACLId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "WebACLId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2237,9 +1823,7 @@
                 "ActivatedRule"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "ActivatedRule": {
                   "shape": "S24"
                 }
@@ -2254,9 +1838,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     },
@@ -2269,12 +1851,8 @@
           "Updates"
         ],
         "members": {
-          "XssMatchSetId": {
-            "shape": "S2"
-          },
-          "ChangeToken": {
-            "shape": "S7"
-          },
+          "XssMatchSetId": {},
+          "ChangeToken": {},
           "Updates": {
             "type": "list",
             "member": {
@@ -2284,48 +1862,24 @@
                 "XssMatchTuple"
               ],
               "members": {
-                "Action": {
-                  "shape": "S6u"
-                },
+                "Action": {},
                 "XssMatchTuple": {
                   "shape": "S2d"
                 }
               }
-            },
-            "min": 1
+            }
           }
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ChangeToken": {
-            "shape": "S7"
-          }
+          "ChangeToken": {}
         }
       }
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S3": {
-      "type": "string",
-      "max": 1224,
-      "min": 1
-    },
-    "S6": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
-    "S7": {
-      "type": "string",
-      "min": 1
-    },
     "S9": {
       "type": "structure",
       "required": [
@@ -2333,12 +1887,8 @@
         "ByteMatchTuples"
       ],
       "members": {
-        "ByteMatchSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "ByteMatchSetId": {},
+        "Name": {},
         "ByteMatchTuples": {
           "type": "list",
           "member": {
@@ -2362,19 +1912,8 @@
         "TargetString": {
           "type": "blob"
         },
-        "TextTransformation": {
-          "shape": "Sg"
-        },
-        "PositionalConstraint": {
-          "type": "string",
-          "enum": [
-            "EXACTLY",
-            "STARTS_WITH",
-            "ENDS_WITH",
-            "CONTAINS",
-            "CONTAINS_WORD"
-          ]
-        }
+        "TextTransformation": {},
+        "PositionalConstraint": {}
       }
     },
     "Sc": {
@@ -2383,31 +1922,9 @@
         "Type"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "URI",
-            "QUERY_STRING",
-            "HEADER",
-            "METHOD",
-            "BODY",
-            "SINGLE_QUERY_ARG",
-            "ALL_QUERY_ARGS"
-          ]
-        },
+        "Type": {},
         "Data": {}
       }
-    },
-    "Sg": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "COMPRESS_WHITE_SPACE",
-        "HTML_ENTITY_DECODE",
-        "LOWERCASE",
-        "CMD_LINE",
-        "URL_DECODE"
-      ]
     },
     "Sk": {
       "type": "structure",
@@ -2416,12 +1933,8 @@
         "GeoMatchConstraints"
       ],
       "members": {
-        "GeoMatchSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "GeoMatchSetId": {},
+        "Name": {},
         "GeoMatchConstraints": {
           "type": "list",
           "member": {
@@ -2437,266 +1950,8 @@
         "Value"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "Country"
-          ]
-        },
-        "Value": {
-          "type": "string",
-          "enum": [
-            "AF",
-            "AX",
-            "AL",
-            "DZ",
-            "AS",
-            "AD",
-            "AO",
-            "AI",
-            "AQ",
-            "AG",
-            "AR",
-            "AM",
-            "AW",
-            "AU",
-            "AT",
-            "AZ",
-            "BS",
-            "BH",
-            "BD",
-            "BB",
-            "BY",
-            "BE",
-            "BZ",
-            "BJ",
-            "BM",
-            "BT",
-            "BO",
-            "BQ",
-            "BA",
-            "BW",
-            "BV",
-            "BR",
-            "IO",
-            "BN",
-            "BG",
-            "BF",
-            "BI",
-            "KH",
-            "CM",
-            "CA",
-            "CV",
-            "KY",
-            "CF",
-            "TD",
-            "CL",
-            "CN",
-            "CX",
-            "CC",
-            "CO",
-            "KM",
-            "CG",
-            "CD",
-            "CK",
-            "CR",
-            "CI",
-            "HR",
-            "CU",
-            "CW",
-            "CY",
-            "CZ",
-            "DK",
-            "DJ",
-            "DM",
-            "DO",
-            "EC",
-            "EG",
-            "SV",
-            "GQ",
-            "ER",
-            "EE",
-            "ET",
-            "FK",
-            "FO",
-            "FJ",
-            "FI",
-            "FR",
-            "GF",
-            "PF",
-            "TF",
-            "GA",
-            "GM",
-            "GE",
-            "DE",
-            "GH",
-            "GI",
-            "GR",
-            "GL",
-            "GD",
-            "GP",
-            "GU",
-            "GT",
-            "GG",
-            "GN",
-            "GW",
-            "GY",
-            "HT",
-            "HM",
-            "VA",
-            "HN",
-            "HK",
-            "HU",
-            "IS",
-            "IN",
-            "ID",
-            "IR",
-            "IQ",
-            "IE",
-            "IM",
-            "IL",
-            "IT",
-            "JM",
-            "JP",
-            "JE",
-            "JO",
-            "KZ",
-            "KE",
-            "KI",
-            "KP",
-            "KR",
-            "KW",
-            "KG",
-            "LA",
-            "LV",
-            "LB",
-            "LS",
-            "LR",
-            "LY",
-            "LI",
-            "LT",
-            "LU",
-            "MO",
-            "MK",
-            "MG",
-            "MW",
-            "MY",
-            "MV",
-            "ML",
-            "MT",
-            "MH",
-            "MQ",
-            "MR",
-            "MU",
-            "YT",
-            "MX",
-            "FM",
-            "MD",
-            "MC",
-            "MN",
-            "ME",
-            "MS",
-            "MA",
-            "MZ",
-            "MM",
-            "NA",
-            "NR",
-            "NP",
-            "NL",
-            "NC",
-            "NZ",
-            "NI",
-            "NE",
-            "NG",
-            "NU",
-            "NF",
-            "MP",
-            "NO",
-            "OM",
-            "PK",
-            "PW",
-            "PS",
-            "PA",
-            "PG",
-            "PY",
-            "PE",
-            "PH",
-            "PN",
-            "PL",
-            "PT",
-            "PR",
-            "QA",
-            "RE",
-            "RO",
-            "RU",
-            "RW",
-            "BL",
-            "SH",
-            "KN",
-            "LC",
-            "MF",
-            "PM",
-            "VC",
-            "WS",
-            "SM",
-            "ST",
-            "SA",
-            "SN",
-            "RS",
-            "SC",
-            "SL",
-            "SG",
-            "SX",
-            "SK",
-            "SI",
-            "SB",
-            "SO",
-            "ZA",
-            "GS",
-            "SS",
-            "ES",
-            "LK",
-            "SD",
-            "SR",
-            "SJ",
-            "SZ",
-            "SE",
-            "CH",
-            "SY",
-            "TW",
-            "TJ",
-            "TZ",
-            "TH",
-            "TL",
-            "TG",
-            "TK",
-            "TO",
-            "TT",
-            "TN",
-            "TR",
-            "TM",
-            "TC",
-            "TV",
-            "UG",
-            "UA",
-            "AE",
-            "GB",
-            "US",
-            "UM",
-            "UY",
-            "UZ",
-            "VU",
-            "VE",
-            "VN",
-            "VG",
-            "VI",
-            "WF",
-            "EH",
-            "YE",
-            "ZM",
-            "ZW"
-          ]
-        }
+        "Type": {},
+        "Value": {}
       }
     },
     "Sr": {
@@ -2706,12 +1961,8 @@
         "IPSetDescriptors"
       ],
       "members": {
-        "IPSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "IPSetId": {},
+        "Name": {},
         "IPSetDescriptors": {
           "type": "list",
           "member": {
@@ -2727,26 +1978,9 @@
         "Value"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "IPV4",
-            "IPV6"
-          ]
-        },
+        "Type": {},
         "Value": {}
       }
-    },
-    "Sy": {
-      "type": "string",
-      "enum": [
-        "IP"
-      ]
-    },
-    "Sz": {
-      "type": "long",
-      "max": 2000000000,
-      "min": 2000
     },
     "S11": {
       "type": "structure",
@@ -2757,21 +1991,15 @@
         "RateLimit"
       ],
       "members": {
-        "RuleId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "RuleId": {},
+        "Name": {},
         "MetricName": {},
         "MatchPredicates": {
           "shape": "S12"
         },
-        "RateKey": {
-          "shape": "Sy"
-        },
+        "RateKey": {},
         "RateLimit": {
-          "shape": "Sz"
+          "type": "long"
         }
       }
     },
@@ -2792,32 +2020,15 @@
         "Negated": {
           "type": "boolean"
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "IPMatch",
-            "ByteMatch",
-            "SqlInjectionMatch",
-            "GeoMatch",
-            "SizeConstraint",
-            "XssMatch",
-            "RegexMatch"
-          ]
-        },
-        "DataId": {
-          "shape": "S2"
-        }
+        "Type": {},
+        "DataId": {}
       }
     },
     "S18": {
       "type": "structure",
       "members": {
-        "RegexMatchSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "RegexMatchSetId": {},
+        "Name": {},
         "RegexMatchTuples": {
           "type": "list",
           "member": {
@@ -2837,12 +2048,8 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {
-          "shape": "Sg"
-        },
-        "RegexPatternSetId": {
-          "shape": "S2"
-        }
+        "TextTransformation": {},
+        "RegexPatternSetId": {}
       }
     },
     "S1d": {
@@ -2852,24 +2059,13 @@
         "RegexPatternStrings"
       ],
       "members": {
-        "RegexPatternSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "RegexPatternSetId": {},
+        "Name": {},
         "RegexPatternStrings": {
           "type": "list",
-          "member": {
-            "shape": "S1f"
-          },
-          "max": 10
+          "member": {}
         }
       }
-    },
-    "S1f": {
-      "type": "string",
-      "min": 1
     },
     "S1i": {
       "type": "structure",
@@ -2878,12 +2074,8 @@
         "Predicates"
       ],
       "members": {
-        "RuleId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "RuleId": {},
+        "Name": {},
         "MetricName": {},
         "Predicates": {
           "shape": "S12"
@@ -2896,12 +2088,8 @@
         "RuleGroupId"
       ],
       "members": {
-        "RuleGroupId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "RuleGroupId": {},
+        "Name": {},
         "MetricName": {}
       }
     },
@@ -2912,12 +2100,8 @@
         "SizeConstraints"
       ],
       "members": {
-        "SizeConstraintSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "SizeConstraintSetId": {},
+        "Name": {},
         "SizeConstraints": {
           "type": "list",
           "member": {
@@ -2938,24 +2122,10 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {
-          "shape": "Sg"
-        },
-        "ComparisonOperator": {
-          "type": "string",
-          "enum": [
-            "EQ",
-            "NE",
-            "LE",
-            "LT",
-            "GE",
-            "GT"
-          ]
-        },
+        "TextTransformation": {},
+        "ComparisonOperator": {},
         "Size": {
-          "type": "long",
-          "max": 21474836480,
-          "min": 0
+          "type": "long"
         }
       }
     },
@@ -2966,12 +2136,8 @@
         "SqlInjectionMatchTuples"
       ],
       "members": {
-        "SqlInjectionMatchSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "SqlInjectionMatchSetId": {},
+        "Name": {},
         "SqlInjectionMatchTuples": {
           "type": "list",
           "member": {
@@ -2990,9 +2156,7 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {
-          "shape": "Sg"
-        }
+        "TextTransformation": {}
       }
     },
     "S1z": {
@@ -3001,14 +2165,7 @@
         "Type"
       ],
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "BLOCK",
-            "ALLOW",
-            "COUNT"
-          ]
-        }
+        "Type": {}
       }
     },
     "S22": {
@@ -3019,12 +2176,8 @@
         "Rules"
       ],
       "members": {
-        "WebACLId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "WebACLId": {},
+        "Name": {},
         "MetricName": {},
         "DefaultAction": {
           "shape": "S1z"
@@ -3050,9 +2203,7 @@
         "Priority": {
           "type": "integer"
         },
-        "RuleId": {
-          "shape": "S2"
-        },
+        "RuleId": {},
         "Action": {
           "shape": "S1z"
         },
@@ -3062,23 +2213,10 @@
             "Type"
           ],
           "members": {
-            "Type": {
-              "type": "string",
-              "enum": [
-                "NONE",
-                "COUNT"
-              ]
-            }
+            "Type": {}
           }
         },
-        "Type": {
-          "type": "string",
-          "enum": [
-            "REGULAR",
-            "RATE_BASED",
-            "GROUP"
-          ]
-        }
+        "Type": {}
       }
     },
     "S2b": {
@@ -3088,12 +2226,8 @@
         "XssMatchTuples"
       ],
       "members": {
-        "XssMatchSetId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        },
+        "XssMatchSetId": {},
+        "Name": {},
         "XssMatchTuples": {
           "type": "list",
           "member": {
@@ -3112,9 +2246,7 @@
         "FieldToMatch": {
           "shape": "Sc"
         },
-        "TextTransformation": {
-          "shape": "Sg"
-        }
+        "TextTransformation": {}
       }
     },
     "S3l": {
@@ -3124,16 +2256,10 @@
         "LogDestinationConfigs"
       ],
       "members": {
-        "ResourceArn": {
-          "shape": "S3"
-        },
+        "ResourceArn": {},
         "LogDestinationConfigs": {
           "type": "list",
-          "member": {
-            "shape": "S3"
-          },
-          "max": 1,
-          "min": 1
+          "member": {}
         },
         "RedactedFields": {
           "type": "list",
@@ -3142,14 +2268,6 @@
           }
         }
       }
-    },
-    "S3q": {
-      "type": "string",
-      "min": 1
-    },
-    "S3u": {
-      "type": "string",
-      "min": 1
     },
     "S47": {
       "type": "structure",
@@ -3173,18 +2291,9 @@
         "Name"
       ],
       "members": {
-        "WebACLId": {
-          "shape": "S2"
-        },
-        "Name": {
-          "shape": "S6"
-        }
+        "WebACLId": {},
+        "Name": {}
       }
-    },
-    "S52": {
-      "type": "integer",
-      "max": 100,
-      "min": 0
     },
     "S5l": {
       "type": "list",
@@ -3195,21 +2304,10 @@
           "Name"
         ],
         "members": {
-          "RuleId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "S6"
-          }
+          "RuleId": {},
+          "Name": {}
         }
       }
-    },
-    "S6u": {
-      "type": "string",
-      "enum": [
-        "INSERT",
-        "DELETE"
-      ]
     },
     "S75": {
       "type": "list",
@@ -3220,9 +2318,7 @@
           "Predicate"
         ],
         "members": {
-          "Action": {
-            "shape": "S6u"
-          },
+          "Action": {},
           "Predicate": {
             "shape": "S13"
           }

--- a/apis/workdocs-2016-05-01.min.json
+++ b/apis/workdocs-2016-05-01.min.json
@@ -30,12 +30,10 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           }
@@ -54,7 +52,6 @@
         ],
         "members": {
           "UserId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
@@ -92,7 +89,6 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -106,15 +102,9 @@
                 "Role"
               ],
               "members": {
-                "Id": {
-                  "shape": "S6"
-                },
-                "Type": {
-                  "shape": "Sp"
-                },
-                "Role": {
-                  "shape": "Sq"
-                }
+                "Id": {},
+                "Type": {},
+                "Role": {}
               }
             }
           },
@@ -139,22 +129,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "PrincipalId": {
-                  "shape": "S6"
-                },
-                "Role": {
-                  "shape": "Sq"
-                },
-                "Status": {
-                  "type": "string",
-                  "enum": [
-                    "SUCCESS",
-                    "FAILURE"
-                  ]
-                },
-                "ShareId": {
-                  "shape": "S3"
-                },
+                "PrincipalId": {},
+                "Role": {},
+                "Status": {},
+                "ShareId": {},
                 "StatusMessage": {
                   "shape": "St"
                 }
@@ -183,27 +161,19 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
-          "ParentId": {
-            "shape": "Sz"
-          },
-          "ThreadId": {
-            "shape": "Sz"
-          },
+          "ParentId": {},
+          "ThreadId": {},
           "Text": {
             "shape": "S10"
           },
-          "Visibility": {
-            "shape": "S11"
-          },
+          "Visibility": {},
           "NotifyCollaborators": {
             "type": "boolean"
           }
@@ -237,12 +207,10 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "querystring",
             "locationName": "versionid"
           },
@@ -272,12 +240,8 @@
             "location": "header",
             "locationName": "Authentication"
           },
-          "Name": {
-            "shape": "S1b"
-          },
-          "ParentFolderId": {
-            "shape": "S3"
-          }
+          "Name": {},
+          "ParentFolderId": {}
         }
       },
       "output": {
@@ -303,7 +267,6 @@
         ],
         "members": {
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -337,22 +300,12 @@
         ],
         "members": {
           "OrganizationId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           },
-          "Endpoint": {
-            "shape": "S1l"
-          },
-          "Protocol": {
-            "shape": "S1m"
-          },
-          "SubscriptionType": {
-            "type": "string",
-            "enum": [
-              "ALL"
-            ]
-          }
+          "Endpoint": {},
+          "Protocol": {},
+          "SubscriptionType": {}
         }
       },
       "output": {
@@ -378,31 +331,16 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S6"
-          },
-          "Username": {
-            "shape": "S9"
-          },
-          "EmailAddress": {
-            "shape": "Sa"
-          },
-          "GivenName": {
-            "shape": "Sb"
-          },
-          "Surname": {
-            "shape": "Sb"
-          },
+          "OrganizationId": {},
+          "Username": {},
+          "EmailAddress": {},
+          "GivenName": {},
+          "Surname": {},
           "Password": {
             "type": "string",
-            "max": 32,
-            "min": 4,
-            "pattern": "[\\u0020-\\u00FF]+",
             "sensitive": true
           },
-          "TimeZoneId": {
-            "shape": "Sf"
-          },
+          "TimeZoneId": {},
           "StorageRule": {
             "shape": "Sj"
           },
@@ -435,7 +373,6 @@
         ],
         "members": {
           "UserId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
@@ -467,17 +404,14 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "CommentId": {
-            "shape": "Sz",
             "location": "uri",
             "locationName": "CommentId"
           }
@@ -502,12 +436,10 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "querystring",
             "locationName": "versionId"
           },
@@ -515,10 +447,7 @@
             "location": "querystring",
             "locationName": "keys",
             "type": "list",
-            "member": {
-              "shape": "S17"
-            },
-            "max": 8
+            "member": {}
           },
           "DeleteAll": {
             "location": "querystring",
@@ -550,7 +479,6 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           }
@@ -575,7 +503,6 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           }
@@ -600,7 +527,6 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           }
@@ -620,7 +546,6 @@
         ],
         "members": {
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
@@ -660,12 +585,10 @@
         ],
         "members": {
           "SubscriptionId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "SubscriptionId"
           },
           "OrganizationId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           }
@@ -690,7 +613,6 @@
             "locationName": "Authentication"
           },
           "UserId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           }
@@ -722,22 +644,19 @@
             "type": "timestamp"
           },
           "OrganizationId": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "UserId": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "userId"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Marker": {
-            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -751,48 +670,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "Type": {
-                  "type": "string",
-                  "enum": [
-                    "DOCUMENT_CHECKED_IN",
-                    "DOCUMENT_CHECKED_OUT",
-                    "DOCUMENT_RENAMED",
-                    "DOCUMENT_VERSION_UPLOADED",
-                    "DOCUMENT_VERSION_DELETED",
-                    "DOCUMENT_RECYCLED",
-                    "DOCUMENT_RESTORED",
-                    "DOCUMENT_REVERTED",
-                    "DOCUMENT_SHARED",
-                    "DOCUMENT_UNSHARED",
-                    "DOCUMENT_SHARE_PERMISSION_CHANGED",
-                    "DOCUMENT_SHAREABLE_LINK_CREATED",
-                    "DOCUMENT_SHAREABLE_LINK_REMOVED",
-                    "DOCUMENT_SHAREABLE_LINK_PERMISSION_CHANGED",
-                    "DOCUMENT_MOVED",
-                    "DOCUMENT_COMMENT_ADDED",
-                    "DOCUMENT_COMMENT_DELETED",
-                    "DOCUMENT_ANNOTATION_ADDED",
-                    "DOCUMENT_ANNOTATION_DELETED",
-                    "FOLDER_CREATED",
-                    "FOLDER_DELETED",
-                    "FOLDER_RENAMED",
-                    "FOLDER_RECYCLED",
-                    "FOLDER_RESTORED",
-                    "FOLDER_SHARED",
-                    "FOLDER_UNSHARED",
-                    "FOLDER_SHARE_PERMISSION_CHANGED",
-                    "FOLDER_SHAREABLE_LINK_CREATED",
-                    "FOLDER_SHAREABLE_LINK_REMOVED",
-                    "FOLDER_SHAREABLE_LINK_PERMISSION_CHANGED",
-                    "FOLDER_MOVED"
-                  ]
-                },
+                "Type": {},
                 "TimeStamp": {
                   "type": "timestamp"
                 },
-                "OrganizationId": {
-                  "shape": "S6"
-                },
+                "OrganizationId": {},
                 "Initiator": {
                   "shape": "S2c"
                 },
@@ -819,29 +701,21 @@
                 "CommentMetadata": {
                   "type": "structure",
                   "members": {
-                    "CommentId": {
-                      "shape": "Sz"
-                    },
+                    "CommentId": {},
                     "Contributor": {
                       "shape": "S8"
                     },
                     "CreatedTimestamp": {
                       "type": "timestamp"
                     },
-                    "CommentStatus": {
-                      "shape": "S14"
-                    },
-                    "RecipientId": {
-                      "shape": "S6"
-                    }
+                    "CommentStatus": {},
+                    "RecipientId": {}
                   }
                 }
               }
             }
           },
-          "Marker": {
-            "shape": "S27"
-          }
+          "Marker": {}
         }
       }
     },
@@ -864,22 +738,19 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Marker": {
-            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -894,9 +765,7 @@
               "shape": "S13"
             }
           },
-          "Marker": {
-            "shape": "S27"
-          }
+          "Marker": {}
         }
       }
     },
@@ -918,27 +787,23 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Include": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "include"
           },
           "Fields": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           }
@@ -953,9 +818,7 @@
               "shape": "S2t"
             }
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -977,46 +840,31 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
           "Sort": {
             "location": "querystring",
-            "locationName": "sort",
-            "type": "string",
-            "enum": [
-              "DATE",
-              "NAME"
-            ]
+            "locationName": "sort"
           },
           "Order": {
-            "shape": "S33",
             "location": "querystring",
             "locationName": "order"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Type": {
             "location": "querystring",
-            "locationName": "type",
-            "type": "string",
-            "enum": [
-              "ALL",
-              "DOCUMENT",
-              "FOLDER"
-            ]
+            "locationName": "type"
           },
           "Include": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "include"
           }
@@ -1034,9 +882,7 @@
               "shape": "S38"
             }
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1063,20 +909,17 @@
             "locationName": "searchQuery"
           },
           "OrganizationId": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "Marker": {
-            "shape": "S27",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
             "location": "querystring",
             "locationName": "limit",
-            "type": "integer",
-            "min": 1
+            "type": "integer"
           }
         }
       },
@@ -1086,9 +929,7 @@
           "Groups": {
             "shape": "S2f"
           },
-          "Marker": {
-            "shape": "S27"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1105,19 +946,17 @@
         ],
         "members": {
           "OrganizationId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "OrganizationId"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           }
         }
       },
@@ -1128,12 +967,9 @@
             "type": "list",
             "member": {
               "shape": "S1p"
-            },
-            "max": 256
+            }
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1155,22 +991,19 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "PrincipalId": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "principalId"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1184,36 +1017,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S6"
-                },
-                "Type": {
-                  "shape": "Sp"
-                },
+                "Id": {},
+                "Type": {},
                 "Roles": {
                   "type": "list",
                   "member": {
                     "type": "structure",
                     "members": {
-                      "Role": {
-                        "shape": "Sq"
-                      },
-                      "Type": {
-                        "type": "string",
-                        "enum": [
-                          "DIRECT",
-                          "INHERITED"
-                        ]
-                      }
+                      "Role": {},
+                      "Type": {}
                     }
                   }
                 }
               }
             }
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1235,12 +1054,11 @@
             "locationName": "Authentication"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1252,9 +1070,7 @@
           "Folders": {
             "shape": "S36"
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1273,17 +1089,12 @@
             "locationName": "Authentication"
           },
           "OrganizationId": {
-            "shape": "S6",
             "location": "querystring",
             "locationName": "organizationId"
           },
           "UserIds": {
             "location": "querystring",
-            "locationName": "userIds",
-            "type": "string",
-            "max": 2000,
-            "min": 1,
-            "pattern": "[&\\w+-.@, ]+"
+            "locationName": "userIds"
           },
           "Query": {
             "shape": "S3a",
@@ -1292,42 +1103,26 @@
           },
           "Include": {
             "location": "querystring",
-            "locationName": "include",
-            "type": "string",
-            "enum": [
-              "ALL",
-              "ACTIVE_PENDING"
-            ]
+            "locationName": "include"
           },
           "Order": {
-            "shape": "S33",
             "location": "querystring",
             "locationName": "order"
           },
           "Sort": {
             "location": "querystring",
-            "locationName": "sort",
-            "type": "string",
-            "enum": [
-              "USER_NAME",
-              "FULL_NAME",
-              "STORAGE_LIMIT",
-              "USER_STATUS",
-              "STORAGE_USED"
-            ]
+            "locationName": "sort"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Fields": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           }
@@ -1346,9 +1141,7 @@
             "deprecated": true,
             "type": "long"
           },
-          "Marker": {
-            "shape": "S2p"
-          }
+          "Marker": {}
         }
       }
     },
@@ -1398,7 +1191,6 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
@@ -1439,22 +1231,19 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Fields": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1488,17 +1277,14 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
           "Fields": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
@@ -1539,7 +1325,6 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
@@ -1580,22 +1365,19 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "FolderId"
           },
           "Limit": {
-            "shape": "S26",
             "location": "querystring",
-            "locationName": "limit"
+            "locationName": "limit",
+            "type": "integer"
           },
           "Fields": {
-            "shape": "S2q",
             "location": "querystring",
             "locationName": "fields"
           },
           "Marker": {
-            "shape": "S2p",
             "location": "querystring",
             "locationName": "marker"
           }
@@ -1626,27 +1408,19 @@
             "location": "header",
             "locationName": "Authentication"
           },
-          "Id": {
-            "shape": "S3"
-          },
-          "Name": {
-            "shape": "S1b"
-          },
+          "Id": {},
+          "Name": {},
           "ContentCreatedTimestamp": {
             "type": "timestamp"
           },
           "ContentModifiedTimestamp": {
             "type": "timestamp"
           },
-          "ContentType": {
-            "shape": "S2u"
-          },
+          "ContentType": {},
           "DocumentSizeInBytes": {
             "type": "long"
           },
-          "ParentFolderId": {
-            "shape": "S3"
-          }
+          "ParentFolderId": {}
         }
       },
       "output": {
@@ -1663,17 +1437,8 @@
               },
               "SignedHeaders": {
                 "type": "map",
-                "key": {
-                  "type": "string",
-                  "max": 256,
-                  "min": 1,
-                  "pattern": "[\\w-]+"
-                },
-                "value": {
-                  "type": "string",
-                  "max": 1024,
-                  "min": 1
-                }
+                "key": {},
+                "value": {}
               }
             }
           }
@@ -1698,7 +1463,6 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           }
@@ -1724,17 +1488,14 @@
             "locationName": "Authentication"
           },
           "ResourceId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "ResourceId"
           },
           "PrincipalId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "PrincipalId"
           },
           "PrincipalType": {
-            "shape": "Sp",
             "location": "querystring",
             "locationName": "type"
           }
@@ -1759,19 +1520,12 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
-          "Name": {
-            "shape": "S1b"
-          },
-          "ParentFolderId": {
-            "shape": "S3"
-          },
-          "ResourceState": {
-            "shape": "S1e"
-          }
+          "Name": {},
+          "ParentFolderId": {},
+          "ResourceState": {}
         }
       }
     },
@@ -1794,21 +1548,14 @@
             "locationName": "Authentication"
           },
           "DocumentId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "DocumentId"
           },
           "VersionId": {
-            "shape": "S4",
             "location": "uri",
             "locationName": "VersionId"
           },
-          "VersionStatus": {
-            "type": "string",
-            "enum": [
-              "ACTIVE"
-            ]
-          }
+          "VersionStatus": {}
         }
       }
     },
@@ -1830,19 +1577,12 @@
             "locationName": "Authentication"
           },
           "FolderId": {
-            "shape": "S3",
             "location": "uri",
             "locationName": "FolderId"
           },
-          "Name": {
-            "shape": "S1b"
-          },
-          "ParentFolderId": {
-            "shape": "S3"
-          },
-          "ResourceState": {
-            "shape": "S1e"
-          }
+          "Name": {},
+          "ParentFolderId": {},
+          "ResourceState": {}
         }
       }
     },
@@ -1864,35 +1604,18 @@
             "locationName": "Authentication"
           },
           "UserId": {
-            "shape": "S6",
             "location": "uri",
             "locationName": "UserId"
           },
-          "GivenName": {
-            "shape": "Sb"
-          },
-          "Surname": {
-            "shape": "Sb"
-          },
-          "Type": {
-            "shape": "Sd"
-          },
+          "GivenName": {},
+          "Surname": {},
+          "Type": {},
           "StorageRule": {
             "shape": "Sj"
           },
-          "TimeZoneId": {
-            "shape": "Sf"
-          },
-          "Locale": {
-            "shape": "Sg"
-          },
-          "GrantPoweruserPrivileges": {
-            "type": "string",
-            "enum": [
-              "TRUE",
-              "FALSE"
-            ]
-          }
+          "TimeZoneId": {},
+          "Locale": {},
+          "GrantPoweruserPrivileges": {}
         }
       },
       "output": {
@@ -1908,78 +1631,29 @@
   "shapes": {
     "S2": {
       "type": "string",
-      "max": 8199,
-      "min": 1,
       "sensitive": true
-    },
-    "S3": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+-.@]+"
-    },
-    "S4": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+-.@]+"
-    },
-    "S6": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[&\\w+-.@]+"
     },
     "S8": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S6"
-        },
-        "Username": {
-          "shape": "S9"
-        },
-        "EmailAddress": {
-          "shape": "Sa"
-        },
-        "GivenName": {
-          "shape": "Sb"
-        },
-        "Surname": {
-          "shape": "Sb"
-        },
-        "OrganizationId": {
-          "shape": "S6"
-        },
-        "RootFolderId": {
-          "shape": "S3"
-        },
-        "RecycleBinFolderId": {
-          "shape": "S3"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "ACTIVE",
-            "INACTIVE",
-            "PENDING"
-          ]
-        },
-        "Type": {
-          "shape": "Sd"
-        },
+        "Id": {},
+        "Username": {},
+        "EmailAddress": {},
+        "GivenName": {},
+        "Surname": {},
+        "OrganizationId": {},
+        "RootFolderId": {},
+        "RecycleBinFolderId": {},
+        "Status": {},
+        "Type": {},
         "CreatedTimestamp": {
           "type": "timestamp"
         },
         "ModifiedTimestamp": {
           "type": "timestamp"
         },
-        "TimeZoneId": {
-          "shape": "Sf"
-        },
-        "Locale": {
-          "shape": "Sg"
-        },
+        "TimeZoneId": {},
+        "Locale": {},
         "Storage": {
           "type": "structure",
           "members": {
@@ -1993,113 +1667,22 @@
         }
       }
     },
-    "S9": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\w\\-+.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]+)?"
-    },
-    "Sa": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
-    },
-    "Sb": {
-      "type": "string",
-      "max": 64,
-      "min": 1
-    },
-    "Sd": {
-      "type": "string",
-      "enum": [
-        "USER",
-        "ADMIN",
-        "POWERUSER",
-        "MINIMALUSER",
-        "WORKSPACESUSER"
-      ]
-    },
-    "Sf": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "Sg": {
-      "type": "string",
-      "enum": [
-        "en",
-        "fr",
-        "ko",
-        "de",
-        "es",
-        "ja",
-        "ru",
-        "zh_CN",
-        "zh_TW",
-        "pt_BR",
-        "default"
-      ]
-    },
     "Sj": {
       "type": "structure",
       "members": {
         "StorageAllocatedInBytes": {
-          "type": "long",
-          "min": 0
+          "type": "long"
         },
-        "StorageType": {
-          "type": "string",
-          "enum": [
-            "UNLIMITED",
-            "QUOTA"
-          ]
-        }
+        "StorageType": {}
       }
-    },
-    "Sp": {
-      "type": "string",
-      "enum": [
-        "USER",
-        "GROUP",
-        "INVITE",
-        "ANONYMOUS",
-        "ORGANIZATION"
-      ]
-    },
-    "Sq": {
-      "type": "string",
-      "enum": [
-        "VIEWER",
-        "CONTRIBUTOR",
-        "OWNER",
-        "COOWNER"
-      ]
     },
     "St": {
       "type": "string",
-      "max": 2048,
-      "min": 0,
       "sensitive": true
-    },
-    "Sz": {
-      "type": "string",
-      "max": 128,
-      "min": 1,
-      "pattern": "[\\w+-.@]+"
     },
     "S10": {
       "type": "string",
-      "max": 2048,
-      "min": 1,
       "sensitive": true
-    },
-    "S11": {
-      "type": "string",
-      "enum": [
-        "PUBLIC",
-        "PRIVATE"
-      ]
     },
     "S13": {
       "type": "structure",
@@ -2107,15 +1690,9 @@
         "CommentId"
       ],
       "members": {
-        "CommentId": {
-          "shape": "Sz"
-        },
-        "ParentId": {
-          "shape": "Sz"
-        },
-        "ThreadId": {
-          "shape": "Sz"
-        },
+        "CommentId": {},
+        "ParentId": {},
+        "ThreadId": {},
         "Text": {
           "shape": "S10"
         },
@@ -2125,78 +1702,31 @@
         "CreatedTimestamp": {
           "type": "timestamp"
         },
-        "Status": {
-          "shape": "S14"
-        },
-        "Visibility": {
-          "shape": "S11"
-        },
-        "RecipientId": {
-          "shape": "S6"
-        }
+        "Status": {},
+        "Visibility": {},
+        "RecipientId": {}
       }
-    },
-    "S14": {
-      "type": "string",
-      "enum": [
-        "DRAFT",
-        "PUBLISHED",
-        "DELETED"
-      ]
     },
     "S16": {
       "type": "map",
-      "key": {
-        "shape": "S17"
-      },
-      "value": {
-        "type": "string",
-        "max": 256,
-        "min": 1,
-        "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
-      },
-      "max": 8,
-      "min": 1
-    },
-    "S17": {
-      "type": "string",
-      "max": 56,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
-    },
-    "S1b": {
-      "type": "string",
-      "max": 255,
-      "min": 1,
-      "pattern": "[\\u0020-\\u202D\\u202F-\\uFFFF]+"
+      "key": {},
+      "value": {}
     },
     "S1d": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
-        "Name": {
-          "shape": "S1b"
-        },
-        "CreatorId": {
-          "shape": "S6"
-        },
-        "ParentFolderId": {
-          "shape": "S3"
-        },
+        "Id": {},
+        "Name": {},
+        "CreatorId": {},
+        "ParentFolderId": {},
         "CreatedTimestamp": {
           "type": "timestamp"
         },
         "ModifiedTimestamp": {
           "type": "timestamp"
         },
-        "ResourceState": {
-          "shape": "S1e"
-        },
-        "Signature": {
-          "shape": "S1f"
-        },
+        "ResourceState": {},
+        "Signature": {},
         "Labels": {
           "shape": "S1g"
         },
@@ -2208,85 +1738,26 @@
         }
       }
     },
-    "S1e": {
-      "type": "string",
-      "enum": [
-        "ACTIVE",
-        "RESTORING",
-        "RECYCLING",
-        "RECYCLED"
-      ]
-    },
-    "S1f": {
-      "type": "string",
-      "max": 128,
-      "min": 0,
-      "pattern": "[&\\w+-.@]+"
-    },
     "S1g": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "max": 32,
-        "min": 1,
-        "pattern": "[a-zA-Z0-9._+-/=][a-zA-Z0-9 ._+-/=]*"
-      },
-      "max": 20
-    },
-    "S1l": {
-      "type": "string",
-      "max": 256,
-      "min": 1
-    },
-    "S1m": {
-      "type": "string",
-      "enum": [
-        "HTTPS"
-      ]
+      "member": {}
     },
     "S1p": {
       "type": "structure",
       "members": {
-        "SubscriptionId": {
-          "shape": "S6"
-        },
-        "EndPoint": {
-          "shape": "S1l"
-        },
-        "Protocol": {
-          "shape": "S1m"
-        }
+        "SubscriptionId": {},
+        "EndPoint": {},
+        "Protocol": {}
       }
-    },
-    "S26": {
-      "type": "integer",
-      "max": 999,
-      "min": 1
-    },
-    "S27": {
-      "type": "string",
-      "max": 2048,
-      "min": 1,
-      "pattern": "[\\u0000-\\u00FF]+"
     },
     "S2c": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S6"
-        },
-        "Username": {
-          "shape": "S9"
-        },
-        "GivenName": {
-          "shape": "Sb"
-        },
-        "Surname": {
-          "shape": "Sb"
-        },
-        "EmailAddress": {
-          "shape": "Sa"
-        }
+        "Id": {},
+        "Username": {},
+        "GivenName": {},
+        "Surname": {},
+        "EmailAddress": {}
       }
     },
     "S2f": {
@@ -2294,9 +1765,7 @@
       "member": {
         "type": "structure",
         "members": {
-          "Id": {
-            "shape": "S6"
-          },
+          "Id": {},
           "Name": {}
         }
       }
@@ -2304,69 +1773,28 @@
     "S2i": {
       "type": "structure",
       "members": {
-        "Type": {
-          "type": "string",
-          "enum": [
-            "FOLDER",
-            "DOCUMENT"
-          ]
-        },
-        "Name": {
-          "shape": "S1b"
-        },
-        "OriginalName": {
-          "shape": "S1b"
-        },
-        "Id": {
-          "shape": "S3"
-        },
-        "VersionId": {
-          "shape": "S4"
-        },
+        "Type": {},
+        "Name": {},
+        "OriginalName": {},
+        "Id": {},
+        "VersionId": {},
         "Owner": {
           "shape": "S2c"
         },
-        "ParentId": {
-          "shape": "S3"
-        }
+        "ParentId": {}
       }
-    },
-    "S2p": {
-      "type": "string",
-      "max": 2048,
-      "min": 1
-    },
-    "S2q": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\w,]+"
     },
     "S2t": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S4"
-        },
-        "Name": {
-          "shape": "S1b"
-        },
-        "ContentType": {
-          "shape": "S2u"
-        },
+        "Id": {},
+        "Name": {},
+        "ContentType": {},
         "Size": {
           "type": "long"
         },
-        "Signature": {
-          "shape": "S1f"
-        },
-        "Status": {
-          "type": "string",
-          "enum": [
-            "INITIALIZED",
-            "ACTIVE"
-          ]
-        },
+        "Signature": {},
+        "Status": {},
         "CreatedTimestamp": {
           "type": "timestamp"
         },
@@ -2379,55 +1807,26 @@
         "ContentModifiedTimestamp": {
           "type": "timestamp"
         },
-        "CreatorId": {
-          "shape": "S6"
-        },
+        "CreatorId": {},
         "Thumbnail": {
           "type": "map",
-          "key": {
-            "type": "string",
-            "enum": [
-              "SMALL",
-              "SMALL_HQ",
-              "LARGE"
-            ]
-          },
+          "key": {},
           "value": {
             "shape": "S2y"
           }
         },
         "Source": {
           "type": "map",
-          "key": {
-            "type": "string",
-            "enum": [
-              "ORIGINAL",
-              "WITH_COMMENTS"
-            ]
-          },
+          "key": {},
           "value": {
             "shape": "S2y"
           }
         }
       }
     },
-    "S2u": {
-      "type": "string",
-      "max": 128,
-      "min": 1
-    },
     "S2y": {
       "type": "string",
-      "max": 1024,
-      "min": 1,
       "sensitive": true
-    },
-    "S33": {
-      "type": "string",
-      "enum": [
-        "ASCENDING",
-        "DESCENDING"
-      ]
     },
     "S36": {
       "type": "list",
@@ -2438,15 +1837,9 @@
     "S38": {
       "type": "structure",
       "members": {
-        "Id": {
-          "shape": "S3"
-        },
-        "CreatorId": {
-          "shape": "S6"
-        },
-        "ParentFolderId": {
-          "shape": "S3"
-        },
+        "Id": {},
+        "CreatorId": {},
+        "ParentFolderId": {},
         "CreatedTimestamp": {
           "type": "timestamp"
         },
@@ -2456,9 +1849,7 @@
         "LatestVersionMetadata": {
           "shape": "S2t"
         },
-        "ResourceState": {
-          "shape": "S1e"
-        },
+        "ResourceState": {},
         "Labels": {
           "shape": "S1g"
         }
@@ -2466,9 +1857,6 @@
     },
     "S3a": {
       "type": "string",
-      "max": 512,
-      "min": 1,
-      "pattern": "[\\u0020-\\uFFFF]+",
       "sensitive": true
     },
     "S41": {
@@ -2479,12 +1867,8 @@
           "member": {
             "type": "structure",
             "members": {
-              "Id": {
-                "shape": "S6"
-              },
-              "Name": {
-                "shape": "S1b"
-              }
+              "Id": {},
+              "Name": {}
             }
           }
         }

--- a/apis/workmail-2017-10-01.min.json
+++ b/apis/workmail-2017-10-01.min.json
@@ -21,15 +21,9 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S3"
-          },
-          "EntityId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "ResourceId": {},
+          "EntityId": {}
         }
       },
       "output": {
@@ -47,15 +41,9 @@
           "MemberId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "GroupId": {
-            "shape": "S4"
-          },
-          "MemberId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "GroupId": {},
+          "MemberId": {}
         }
       },
       "output": {
@@ -73,15 +61,9 @@
           "Alias"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "Alias": {
-            "shape": "S9"
-          }
+          "OrganizationId": {},
+          "EntityId": {},
+          "Alias": {}
         }
       },
       "output": {
@@ -98,20 +80,14 @@
           "Name"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "Sc"
-          }
+          "OrganizationId": {},
+          "Name": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          }
+          "GroupId": {}
         }
       },
       "idempotent": true
@@ -125,23 +101,15 @@
           "Type"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "Sf"
-          },
-          "Type": {
-            "shape": "Sg"
-          }
+          "OrganizationId": {},
+          "Name": {},
+          "Type": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "S3"
-          }
+          "ResourceId": {}
         }
       },
       "idempotent": true
@@ -156,15 +124,9 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "Name": {
-            "shape": "Sj"
-          },
-          "DisplayName": {
-            "shape": "Sk"
-          },
+          "OrganizationId": {},
+          "Name": {},
+          "DisplayName": {},
           "Password": {
             "shape": "Sl"
           }
@@ -173,9 +135,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "UserId": {
-            "shape": "S4"
-          }
+          "UserId": {}
         }
       },
       "idempotent": true
@@ -189,15 +149,9 @@
           "Alias"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "Alias": {
-            "shape": "S9"
-          }
+          "OrganizationId": {},
+          "EntityId": {},
+          "Alias": {}
         }
       },
       "output": {
@@ -214,12 +168,8 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "GroupId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "GroupId": {}
         }
       },
       "output": {
@@ -237,15 +187,9 @@
           "GranteeId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "GranteeId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "EntityId": {},
+          "GranteeId": {}
         }
       },
       "output": {
@@ -262,12 +206,8 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S3"
-          }
+          "OrganizationId": {},
+          "ResourceId": {}
         }
       },
       "output": {
@@ -284,12 +224,8 @@
           "UserId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "UserId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "UserId": {}
         }
       },
       "output": {
@@ -306,12 +242,8 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "EntityId": {}
         }
       },
       "output": {
@@ -328,29 +260,17 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "GroupId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "GroupId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "Sc"
-          },
-          "Email": {
-            "shape": "S9"
-          },
-          "State": {
-            "shape": "S11"
-          },
+          "GroupId": {},
+          "Name": {},
+          "Email": {},
+          "State": {},
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -368,38 +288,22 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          }
+          "OrganizationId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "Alias": {
-            "shape": "S15"
-          },
-          "State": {
-            "shape": "Sk"
-          },
-          "DirectoryId": {
-            "shape": "Sk"
-          },
-          "DirectoryType": {
-            "shape": "Sk"
-          },
-          "DefaultMailDomain": {
-            "shape": "Sk"
-          },
+          "OrganizationId": {},
+          "Alias": {},
+          "State": {},
+          "DirectoryId": {},
+          "DirectoryType": {},
+          "DefaultMailDomain": {},
           "CompletedDate": {
             "type": "timestamp"
           },
-          "ErrorMessage": {
-            "shape": "Sk"
-          }
+          "ErrorMessage": {}
         }
       },
       "idempotent": true
@@ -412,35 +316,21 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S3"
-          }
+          "OrganizationId": {},
+          "ResourceId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "ResourceId": {
-            "shape": "S3"
-          },
-          "Email": {
-            "shape": "S9"
-          },
-          "Name": {
-            "shape": "Sf"
-          },
-          "Type": {
-            "shape": "Sg"
-          },
+          "ResourceId": {},
+          "Email": {},
+          "Name": {},
+          "Type": {},
           "BookingOptions": {
             "shape": "S18"
           },
-          "State": {
-            "shape": "S11"
-          },
+          "State": {},
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -459,35 +349,19 @@
           "UserId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "UserId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "UserId": {}
         }
       },
       "output": {
         "type": "structure",
         "members": {
-          "UserId": {
-            "shape": "S4"
-          },
-          "Name": {
-            "shape": "Sj"
-          },
-          "Email": {
-            "shape": "S9"
-          },
-          "DisplayName": {
-            "shape": "Sk"
-          },
-          "State": {
-            "shape": "S11"
-          },
-          "UserRole": {
-            "shape": "S1c"
-          },
+          "UserId": {},
+          "Name": {},
+          "Email": {},
+          "DisplayName": {},
+          "State": {},
+          "UserRole": {},
           "EnabledDate": {
             "type": "timestamp"
           },
@@ -507,15 +381,9 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S3"
-          },
-          "EntityId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "ResourceId": {},
+          "EntityId": {}
         }
       },
       "output": {
@@ -533,15 +401,9 @@
           "MemberId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "GroupId": {
-            "shape": "S4"
-          },
-          "MemberId": {
-            "shape": "S4"
-          }
+          "OrganizationId": {},
+          "GroupId": {},
+          "MemberId": {}
         }
       },
       "output": {
@@ -558,17 +420,11 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "EntityId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -577,13 +433,9 @@
         "members": {
           "Aliases": {
             "type": "list",
-            "member": {
-              "shape": "S9"
-            }
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -596,17 +448,11 @@
           "GroupId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "GroupId": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "GroupId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -618,18 +464,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "Sk"
-                },
-                "Name": {
-                  "shape": "Sk"
-                },
-                "Type": {
-                  "shape": "S1q"
-                },
-                "State": {
-                  "shape": "S11"
-                },
+                "Id": {},
+                "Name": {},
+                "Type": {},
+                "State": {},
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -639,9 +477,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -653,14 +489,10 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -672,18 +504,10 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S4"
-                },
-                "Email": {
-                  "shape": "S9"
-                },
-                "Name": {
-                  "shape": "Sc"
-                },
-                "State": {
-                  "shape": "S11"
-                },
+                "Id": {},
+                "Email": {},
+                "Name": {},
+                "State": {},
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -693,9 +517,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -708,17 +530,11 @@
           "EntityId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "EntityId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -735,21 +551,15 @@
                 "PermissionValues"
               ],
               "members": {
-                "GranteeId": {
-                  "shape": "S4"
-                },
-                "GranteeType": {
-                  "shape": "S1q"
-                },
+                "GranteeId": {},
+                "GranteeType": {},
                 "PermissionValues": {
                   "shape": "S1z"
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -758,11 +568,9 @@
       "input": {
         "type": "structure",
         "members": {
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -774,24 +582,14 @@
             "member": {
               "type": "structure",
               "members": {
-                "OrganizationId": {
-                  "shape": "S2"
-                },
-                "Alias": {
-                  "shape": "S15"
-                },
-                "ErrorMessage": {
-                  "shape": "Sk"
-                },
-                "State": {
-                  "shape": "Sk"
-                }
+                "OrganizationId": {},
+                "Alias": {},
+                "ErrorMessage": {},
+                "State": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -804,17 +602,11 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S4"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "ResourceId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -830,18 +622,12 @@
                 "Type"
               ],
               "members": {
-                "Id": {
-                  "shape": "Sk"
-                },
-                "Type": {
-                  "shape": "S1q"
-                }
+                "Id": {},
+                "Type": {}
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -853,14 +639,10 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -872,21 +654,11 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S4"
-                },
-                "Email": {
-                  "shape": "S9"
-                },
-                "Name": {
-                  "shape": "Sf"
-                },
-                "Type": {
-                  "shape": "Sg"
-                },
-                "State": {
-                  "shape": "S11"
-                },
+                "Id": {},
+                "Email": {},
+                "Name": {},
+                "Type": {},
+                "State": {},
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -896,9 +668,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -910,14 +680,10 @@
           "OrganizationId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "NextToken": {
-            "shape": "S1i"
-          },
+          "OrganizationId": {},
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1j"
+            "type": "integer"
           }
         }
       },
@@ -929,24 +695,12 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S4"
-                },
-                "Email": {
-                  "shape": "S9"
-                },
-                "Name": {
-                  "shape": "Sj"
-                },
-                "DisplayName": {
-                  "shape": "Sk"
-                },
-                "State": {
-                  "shape": "S11"
-                },
-                "UserRole": {
-                  "shape": "S1c"
-                },
+                "Id": {},
+                "Email": {},
+                "Name": {},
+                "DisplayName": {},
+                "State": {},
+                "UserRole": {},
                 "EnabledDate": {
                   "type": "timestamp"
                 },
@@ -956,9 +710,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1i"
-          }
+          "NextToken": {}
         }
       },
       "idempotent": true
@@ -973,15 +725,9 @@
           "PermissionValues"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "GranteeId": {
-            "shape": "S4"
-          },
+          "OrganizationId": {},
+          "EntityId": {},
+          "GranteeId": {},
           "PermissionValues": {
             "shape": "S1z"
           }
@@ -1002,15 +748,9 @@
           "Email"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "Email": {
-            "shape": "S9"
-          }
+          "OrganizationId": {},
+          "EntityId": {},
+          "Email": {}
         }
       },
       "output": {
@@ -1028,12 +768,8 @@
           "Password"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "UserId": {
-            "shape": "S4"
-          },
+          "OrganizationId": {},
+          "UserId": {},
           "Password": {
             "shape": "Sl"
           }
@@ -1054,15 +790,9 @@
           "Email"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "EntityId": {
-            "shape": "S4"
-          },
-          "Email": {
-            "shape": "S9"
-          }
+          "OrganizationId": {},
+          "EntityId": {},
+          "Email": {}
         }
       },
       "output": {
@@ -1079,15 +809,9 @@
           "ResourceId"
         ],
         "members": {
-          "OrganizationId": {
-            "shape": "S2"
-          },
-          "ResourceId": {
-            "shape": "S3"
-          },
-          "Name": {
-            "shape": "Sf"
-          },
+          "OrganizationId": {},
+          "ResourceId": {},
+          "Name": {},
           "BookingOptions": {
             "shape": "S18"
           }
@@ -1101,73 +825,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "^m-[0-9a-f]{32}$"
-    },
-    "S3": {
-      "type": "string",
-      "pattern": "^r-[0-9a-f]{32}$"
-    },
-    "S4": {
-      "type": "string",
-      "max": 256,
-      "min": 12
-    },
-    "S9": {
-      "type": "string",
-      "max": 254,
-      "min": 1,
-      "pattern": "[a-zA-Z0-9._%+-]{1,64}@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
-    },
-    "Sc": {
-      "type": "string",
-      "max": 256,
-      "min": 1,
-      "pattern": "[\\u0020-\\u00FF]+"
-    },
-    "Sf": {
-      "type": "string",
-      "max": 20,
-      "min": 1,
-      "pattern": "[\\w\\-.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z0-9]{2,})?"
-    },
-    "Sg": {
-      "type": "string",
-      "enum": [
-        "ROOM",
-        "EQUIPMENT"
-      ]
-    },
-    "Sj": {
-      "type": "string",
-      "max": 64,
-      "min": 1,
-      "pattern": "[\\w\\-.]+(@[a-zA-Z0-9.\\-]+\\.[a-zA-Z0-9]{2,})?"
-    },
-    "Sk": {
-      "type": "string",
-      "max": 256
-    },
     "Sl": {
       "type": "string",
-      "max": 256,
-      "pattern": "[\\u0020-\\u00FF]+",
       "sensitive": true
-    },
-    "S11": {
-      "type": "string",
-      "enum": [
-        "ENABLED",
-        "DISABLED",
-        "DELETED"
-      ]
-    },
-    "S15": {
-      "type": "string",
-      "max": 62,
-      "min": 1,
-      "pattern": "^(?!d-)([\\da-zA-Z]+)([-]*[\\da-zA-Z])*"
     },
     "S18": {
       "type": "structure",
@@ -1183,41 +843,9 @@
         }
       }
     },
-    "S1c": {
-      "type": "string",
-      "enum": [
-        "USER",
-        "RESOURCE",
-        "SYSTEM_USER"
-      ]
-    },
-    "S1i": {
-      "type": "string",
-      "max": 1024,
-      "min": 1
-    },
-    "S1j": {
-      "type": "integer",
-      "max": 100,
-      "min": 1
-    },
-    "S1q": {
-      "type": "string",
-      "enum": [
-        "GROUP",
-        "USER"
-      ]
-    },
     "S1z": {
       "type": "list",
-      "member": {
-        "type": "string",
-        "enum": [
-          "FULL_ACCESS",
-          "SEND_AS",
-          "SEND_ON_BEHALF"
-        ]
-      }
+      "member": {}
     }
   }
 }

--- a/apis/workspaces-2015-04-08.min.json
+++ b/apis/workspaces-2015-04-08.min.json
@@ -20,9 +20,7 @@
           "GroupIds"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "GroupIds": {
             "shape": "S3"
           }
@@ -41,9 +39,7 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          },
+          "GroupId": {},
           "UserRules": {
             "shape": "S7"
           }
@@ -71,9 +67,7 @@
       "output": {
         "type": "structure",
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          }
+          "GroupId": {}
         }
       }
     },
@@ -85,9 +79,7 @@
           "Tags"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sh"
-          },
+          "ResourceId": {},
           "Tags": {
             "shape": "Si"
           }
@@ -109,9 +101,7 @@
             "type": "list",
             "member": {
               "shape": "Sp"
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -144,9 +134,7 @@
           "GroupId"
         ],
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          }
+          "GroupId": {}
         }
       },
       "output": {
@@ -162,14 +150,10 @@
           "TagKeys"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sh"
-          },
+          "ResourceId": {},
           "TagKeys": {
             "type": "list",
-            "member": {
-              "shape": "Sh"
-            }
+            "member": {}
           }
         }
       },
@@ -185,11 +169,9 @@
           "GroupIds": {
             "shape": "S3"
           },
-          "NextToken": {
-            "shape": "S1n"
-          },
+          "NextToken": {},
           "MaxResults": {
-            "shape": "S1o"
+            "type": "integer"
           }
         }
       },
@@ -201,9 +183,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "groupId": {
-                  "shape": "S4"
-                },
+                "groupId": {},
                 "groupName": {},
                 "groupDesc": {},
                 "userRules": {
@@ -212,9 +192,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -225,9 +203,7 @@
           "ResourceId"
         ],
         "members": {
-          "ResourceId": {
-            "shape": "Sh"
-          }
+          "ResourceId": {}
         }
       },
       "output": {
@@ -245,16 +221,10 @@
         "members": {
           "BundleIds": {
             "type": "list",
-            "member": {
-              "shape": "Sr"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           },
           "Owner": {},
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -265,44 +235,32 @@
             "member": {
               "type": "structure",
               "members": {
-                "BundleId": {
-                  "shape": "Sr"
-                },
-                "Name": {
-                  "shape": "Sh"
-                },
+                "BundleId": {},
+                "Name": {},
                 "Owner": {},
                 "Description": {},
                 "RootStorage": {
                   "type": "structure",
                   "members": {
-                    "Capacity": {
-                      "shape": "Sh"
-                    }
+                    "Capacity": {}
                   }
                 },
                 "UserStorage": {
                   "type": "structure",
                   "members": {
-                    "Capacity": {
-                      "shape": "Sh"
-                    }
+                    "Capacity": {}
                   }
                 },
                 "ComputeType": {
                   "type": "structure",
                   "members": {
-                    "Name": {
-                      "shape": "Sz"
-                    }
+                    "Name": {}
                   }
                 }
               }
             }
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -312,15 +270,9 @@
         "members": {
           "DirectoryIds": {
             "type": "list",
-            "member": {
-              "shape": "S2"
-            },
-            "max": 25,
-            "min": 1
+            "member": {}
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -331,53 +283,23 @@
             "member": {
               "type": "structure",
               "members": {
-                "DirectoryId": {
-                  "shape": "S2"
-                },
+                "DirectoryId": {},
                 "Alias": {},
                 "DirectoryName": {},
-                "RegistrationCode": {
-                  "type": "string",
-                  "max": 20,
-                  "min": 1
-                },
+                "RegistrationCode": {},
                 "SubnetIds": {
                   "type": "list",
-                  "member": {
-                    "shape": "S1a"
-                  }
+                  "member": {}
                 },
                 "DnsIpAddresses": {
                   "type": "list",
                   "member": {}
                 },
-                "CustomerUserName": {
-                  "shape": "Sq"
-                },
-                "IamRoleId": {
-                  "type": "string",
-                  "pattern": "^arn:aws:[A-Za-z0-9][A-za-z0-9_/.-]{0,62}:[A-za-z0-9_/.-]{0,63}:[A-za-z0-9_/.-]{0,63}:[A-Za-z0-9][A-za-z0-9_/.-]{0,127}$"
-                },
-                "DirectoryType": {
-                  "type": "string",
-                  "enum": [
-                    "SIMPLE_AD",
-                    "AD_CONNECTOR"
-                  ]
-                },
-                "WorkspaceSecurityGroupId": {
-                  "shape": "S2f"
-                },
-                "State": {
-                  "type": "string",
-                  "enum": [
-                    "REGISTERING",
-                    "REGISTERED",
-                    "DEREGISTERING",
-                    "DEREGISTERED",
-                    "ERROR"
-                  ]
-                },
+                "CustomerUserName": {},
+                "IamRoleId": {},
+                "DirectoryType": {},
+                "WorkspaceSecurityGroupId": {},
+                "State": {},
                 "WorkspaceCreationProperties": {
                   "type": "structure",
                   "members": {
@@ -388,9 +310,7 @@
                       "type": "boolean"
                     },
                     "DefaultOu": {},
-                    "CustomSecurityGroupId": {
-                      "shape": "S2f"
-                    },
+                    "CustomSecurityGroupId": {},
                     "UserEnabledAsLocalAdministrator": {
                       "type": "boolean"
                     }
@@ -402,9 +322,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -415,21 +333,13 @@
           "WorkspaceIds": {
             "shape": "S2k"
           },
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "UserName": {
-            "shape": "Sq"
-          },
-          "BundleId": {
-            "shape": "Sr"
-          },
+          "DirectoryId": {},
+          "UserName": {},
+          "BundleId": {},
           "Limit": {
-            "shape": "S1o"
+            "type": "integer"
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -438,9 +348,7 @@
           "Workspaces": {
             "shape": "S15"
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -451,9 +359,7 @@
           "WorkspaceIds": {
             "shape": "S2k"
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       },
       "output": {
@@ -464,17 +370,8 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                },
-                "ConnectionState": {
-                  "type": "string",
-                  "enum": [
-                    "CONNECTED",
-                    "DISCONNECTED",
-                    "UNKNOWN"
-                  ]
-                },
+                "WorkspaceId": {},
+                "ConnectionState": {},
                 "ConnectionStateCheckTimestamp": {
                   "type": "timestamp"
                 },
@@ -484,9 +381,7 @@
               }
             }
           },
-          "NextToken": {
-            "shape": "S1n"
-          }
+          "NextToken": {}
         }
       }
     },
@@ -498,9 +393,7 @@
           "GroupIds"
         ],
         "members": {
-          "DirectoryId": {
-            "shape": "S2"
-          },
+          "DirectoryId": {},
           "GroupIds": {
             "shape": "S3"
           }
@@ -519,9 +412,7 @@
           "WorkspaceProperties"
         ],
         "members": {
-          "WorkspaceId": {
-            "shape": "S17"
-          },
+          "WorkspaceId": {},
           "WorkspaceProperties": {
             "shape": "Su"
           }
@@ -540,16 +431,8 @@
           "WorkspaceState"
         ],
         "members": {
-          "WorkspaceId": {
-            "shape": "S17"
-          },
-          "WorkspaceState": {
-            "type": "string",
-            "enum": [
-              "AVAILABLE",
-              "ADMIN_MAINTENANCE"
-            ]
-          }
+          "WorkspaceId": {},
+          "WorkspaceState": {}
         }
       },
       "output": {
@@ -572,13 +455,9 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                }
+                "WorkspaceId": {}
               }
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -609,13 +488,9 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                }
+                "WorkspaceId": {}
               }
-            },
-            "max": 1,
-            "min": 1
+            }
           }
         }
       },
@@ -639,9 +514,7 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          },
+          "GroupId": {},
           "UserRules": {
             "type": "list",
             "member": {}
@@ -665,13 +538,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                }
+                "WorkspaceId": {}
               }
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -699,13 +568,9 @@
             "member": {
               "type": "structure",
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                }
+                "WorkspaceId": {}
               }
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -736,13 +601,9 @@
                 "WorkspaceId"
               ],
               "members": {
-                "WorkspaceId": {
-                  "shape": "S17"
-                }
+                "WorkspaceId": {}
               }
-            },
-            "max": 25,
-            "min": 1
+            }
           }
         }
       },
@@ -766,9 +627,7 @@
           "UserRules"
         ],
         "members": {
-          "GroupId": {
-            "shape": "S4"
-          },
+          "GroupId": {},
           "UserRules": {
             "shape": "S7"
           }
@@ -781,19 +640,9 @@
     }
   },
   "shapes": {
-    "S2": {
-      "type": "string",
-      "pattern": "^d-[0-9a-f]{8,63}$"
-    },
     "S3": {
       "type": "list",
-      "member": {
-        "shape": "S4"
-      }
-    },
-    "S4": {
-      "type": "string",
-      "pattern": "wsipg-[0-9a-z]{8,63}$"
+      "member": {}
     },
     "S7": {
       "type": "list",
@@ -805,10 +654,6 @@
         }
       }
     },
-    "Sh": {
-      "type": "string",
-      "min": 1
-    },
     "Si": {
       "type": "list",
       "member": {
@@ -817,15 +662,8 @@
           "Key"
         ],
         "members": {
-          "Key": {
-            "type": "string",
-            "max": 127,
-            "min": 1
-          },
-          "Value": {
-            "type": "string",
-            "max": 255
-          }
+          "Key": {},
+          "Value": {}
         }
       }
     },
@@ -837,15 +675,9 @@
         "BundleId"
       ],
       "members": {
-        "DirectoryId": {
-          "shape": "S2"
-        },
-        "UserName": {
-          "shape": "Sq"
-        },
-        "BundleId": {
-          "shape": "Sr"
-        },
+        "DirectoryId": {},
+        "UserName": {},
+        "BundleId": {},
         "VolumeEncryptionKey": {},
         "UserVolumeEncryptionEnabled": {
           "type": "boolean"
@@ -861,25 +693,10 @@
         }
       }
     },
-    "Sq": {
-      "type": "string",
-      "max": 63,
-      "min": 1
-    },
-    "Sr": {
-      "type": "string",
-      "pattern": "^wsb-[0-9a-z]{8,63}$"
-    },
     "Su": {
       "type": "structure",
       "members": {
-        "RunningMode": {
-          "type": "string",
-          "enum": [
-            "AUTO_STOP",
-            "ALWAYS_ON"
-          ]
-        },
+        "RunningMode": {},
         "RunningModeAutoStopTimeoutInMinutes": {
           "type": "integer"
         },
@@ -889,63 +706,21 @@
         "UserVolumeSizeGib": {
           "type": "integer"
         },
-        "ComputeTypeName": {
-          "shape": "Sz"
-        }
+        "ComputeTypeName": {}
       }
-    },
-    "Sz": {
-      "type": "string",
-      "enum": [
-        "VALUE",
-        "STANDARD",
-        "PERFORMANCE",
-        "POWER",
-        "GRAPHICS"
-      ]
     },
     "S15": {
       "type": "list",
       "member": {
         "type": "structure",
         "members": {
-          "WorkspaceId": {
-            "shape": "S17"
-          },
-          "DirectoryId": {
-            "shape": "S2"
-          },
-          "UserName": {
-            "shape": "Sq"
-          },
+          "WorkspaceId": {},
+          "DirectoryId": {},
+          "UserName": {},
           "IpAddress": {},
-          "State": {
-            "type": "string",
-            "enum": [
-              "PENDING",
-              "AVAILABLE",
-              "IMPAIRED",
-              "UNHEALTHY",
-              "REBOOTING",
-              "STARTING",
-              "REBUILDING",
-              "MAINTENANCE",
-              "ADMIN_MAINTENANCE",
-              "TERMINATING",
-              "TERMINATED",
-              "SUSPENDED",
-              "UPDATING",
-              "STOPPING",
-              "STOPPED",
-              "ERROR"
-            ]
-          },
-          "BundleId": {
-            "shape": "Sr"
-          },
-          "SubnetId": {
-            "shape": "S1a"
-          },
+          "State": {},
+          "BundleId": {},
+          "SubnetId": {},
           "ErrorMessage": {},
           "ErrorCode": {},
           "ComputerName": {},
@@ -964,63 +739,22 @@
             "member": {
               "type": "structure",
               "members": {
-                "Resource": {
-                  "type": "string",
-                  "enum": [
-                    "ROOT_VOLUME",
-                    "USER_VOLUME",
-                    "COMPUTE_TYPE"
-                  ]
-                },
-                "State": {
-                  "type": "string",
-                  "enum": [
-                    "UPDATE_INITIATED",
-                    "UPDATE_IN_PROGRESS"
-                  ]
-                }
+                "Resource": {},
+                "State": {}
               }
             }
           }
         }
       }
     },
-    "S17": {
-      "type": "string",
-      "pattern": "^ws-[0-9a-z]{8,63}$"
-    },
-    "S1a": {
-      "type": "string",
-      "pattern": "^(subnet-[0-9a-f]{8})$"
-    },
-    "S1n": {
-      "type": "string",
-      "max": 63,
-      "min": 1
-    },
-    "S1o": {
-      "type": "integer",
-      "max": 25,
-      "min": 1
-    },
-    "S2f": {
-      "type": "string",
-      "pattern": "^(sg-[0-9a-f]{8})$"
-    },
     "S2k": {
       "type": "list",
-      "member": {
-        "shape": "S17"
-      },
-      "max": 25,
-      "min": 1
+      "member": {}
     },
     "S34": {
       "type": "structure",
       "members": {
-        "WorkspaceId": {
-          "shape": "S17"
-        },
+        "WorkspaceId": {},
         "ErrorCode": {},
         "ErrorMessage": {}
       }

--- a/apis/xray-2016-04-12.min.json
+++ b/apis/xray-2016-04-12.min.json
@@ -34,9 +34,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
+                "Id": {},
                 "Duration": {
                   "type": "double"
                 },
@@ -46,10 +44,7 @@
                     "type": "structure",
                     "members": {
                       "Id": {},
-                      "Document": {
-                        "type": "string",
-                        "min": 1
-                      }
+                      "Document": {}
                     }
                   }
                 }
@@ -58,9 +53,7 @@
           },
           "UnprocessedTraceIds": {
             "type": "list",
-            "member": {
-              "shape": "S3"
-            }
+            "member": {}
           },
           "NextToken": {}
         }
@@ -210,32 +203,22 @@
                 "SampledCount"
               ],
               "members": {
-                "RuleName": {
-                  "shape": "Sg"
-                },
-                "ClientID": {
-                  "type": "string",
-                  "max": 24,
-                  "min": 24
-                },
+                "RuleName": {},
+                "ClientID": {},
                 "Timestamp": {
                   "type": "timestamp"
                 },
                 "RequestCount": {
-                  "type": "integer",
-                  "min": 0
+                  "type": "integer"
                 },
                 "SampledCount": {
-                  "type": "integer",
-                  "min": 0
+                  "type": "integer"
                 },
                 "BorrowCount": {
-                  "type": "integer",
-                  "min": 0
+                  "type": "integer"
                 }
               }
-            },
-            "max": 25
+            }
           }
         }
       },
@@ -362,11 +345,7 @@
           "Sampling": {
             "type": "boolean"
           },
-          "FilterExpression": {
-            "type": "string",
-            "max": 2000,
-            "min": 1
-          },
+          "FilterExpression": {},
           "NextToken": {}
         }
       },
@@ -378,9 +357,7 @@
             "member": {
               "type": "structure",
               "members": {
-                "Id": {
-                  "shape": "S3"
-                },
+                "Id": {},
                 "Duration": {
                   "type": "double"
                 },
@@ -476,14 +453,8 @@
           "Type"
         ],
         "members": {
-          "KeyId": {
-            "type": "string",
-            "max": 3000,
-            "min": 1
-          },
-          "Type": {
-            "shape": "S13"
-          }
+          "KeyId": {},
+          "Type": {}
         }
       },
       "output": {
@@ -554,17 +525,9 @@
               }
             }
           },
-          "EC2InstanceId": {
-            "type": "string",
-            "max": 20
-          },
-          "Hostname": {
-            "type": "string",
-            "max": 255
-          },
-          "ResourceARN": {
-            "shape": "Sh"
-          }
+          "EC2InstanceId": {},
+          "Hostname": {},
+          "ResourceARN": {}
         }
       },
       "output": {
@@ -618,13 +581,9 @@
           "SamplingRuleUpdate": {
             "type": "structure",
             "members": {
-              "RuleName": {
-                "shape": "Sg"
-              },
+              "RuleName": {},
               "RuleARN": {},
-              "ResourceARN": {
-                "shape": "Sh"
-              },
+              "ResourceARN": {},
               "Priority": {
                 "type": "integer"
               },
@@ -634,21 +593,11 @@
               "ReservoirSize": {
                 "type": "integer"
               },
-              "Host": {
-                "shape": "Sn"
-              },
-              "ServiceName": {
-                "shape": "Sl"
-              },
-              "ServiceType": {
-                "shape": "Sm"
-              },
-              "HTTPMethod": {
-                "shape": "So"
-              },
-              "URLPath": {
-                "shape": "Sp"
-              },
+              "Host": {},
+              "ServiceName": {},
+              "ServiceType": {},
+              "HTTPMethod": {},
+              "URLPath": {},
               "Attributes": {
                 "shape": "Sr"
               }
@@ -669,14 +618,7 @@
   "shapes": {
     "S2": {
       "type": "list",
-      "member": {
-        "shape": "S3"
-      }
-    },
-    "S3": {
-      "type": "string",
-      "max": 35,
-      "min": 1
+      "member": {}
     },
     "Sf": {
       "type": "structure",
@@ -693,93 +635,35 @@
         "Version"
       ],
       "members": {
-        "RuleName": {
-          "shape": "Sg"
-        },
+        "RuleName": {},
         "RuleARN": {},
-        "ResourceARN": {
-          "shape": "Sh"
-        },
+        "ResourceARN": {},
         "Priority": {
-          "type": "integer",
-          "max": 9999,
-          "min": 1
+          "type": "integer"
         },
         "FixedRate": {
-          "type": "double",
-          "max": 1,
-          "min": 0
+          "type": "double"
         },
         "ReservoirSize": {
-          "type": "integer",
-          "min": 0
+          "type": "integer"
         },
-        "ServiceName": {
-          "shape": "Sl"
-        },
-        "ServiceType": {
-          "shape": "Sm"
-        },
-        "Host": {
-          "shape": "Sn"
-        },
-        "HTTPMethod": {
-          "shape": "So"
-        },
-        "URLPath": {
-          "shape": "Sp"
-        },
+        "ServiceName": {},
+        "ServiceType": {},
+        "Host": {},
+        "HTTPMethod": {},
+        "URLPath": {},
         "Version": {
-          "type": "integer",
-          "min": 1
+          "type": "integer"
         },
         "Attributes": {
           "shape": "Sr"
         }
       }
     },
-    "Sg": {
-      "type": "string",
-      "max": 32,
-      "min": 1
-    },
-    "Sh": {
-      "type": "string",
-      "max": 500
-    },
-    "Sl": {
-      "type": "string",
-      "max": 64
-    },
-    "Sm": {
-      "type": "string",
-      "max": 64
-    },
-    "Sn": {
-      "type": "string",
-      "max": 64
-    },
-    "So": {
-      "type": "string",
-      "max": 10
-    },
-    "Sp": {
-      "type": "string",
-      "max": 128
-    },
     "Sr": {
       "type": "map",
-      "key": {
-        "type": "string",
-        "max": 32,
-        "min": 1
-      },
-      "value": {
-        "type": "string",
-        "max": 32,
-        "min": 1
-      },
-      "max": 5
+      "key": {},
+      "value": {}
     },
     "Sv": {
       "type": "structure",
@@ -799,24 +683,9 @@
       "type": "structure",
       "members": {
         "KeyId": {},
-        "Status": {
-          "type": "string",
-          "enum": [
-            "UPDATING",
-            "ACTIVE"
-          ]
-        },
-        "Type": {
-          "shape": "S13"
-        }
+        "Status": {},
+        "Type": {}
       }
-    },
-    "S13": {
-      "type": "string",
-      "enum": [
-        "NONE",
-        "KMS"
-      ]
     },
     "S1s": {
       "type": "list",

--- a/scripts/lib/foo-2018-03-30.normal.json
+++ b/scripts/lib/foo-2018-03-30.normal.json
@@ -121,13 +121,7 @@
             "timestampFormat": "rfc822"
         },
         "StringShape": {
-            "type": "string",
-            "min": 1,
-            "max": 100,
-            "enum": [
-                "test"
-            ],
-            "pattern": "\\w+"
+            "type": "string"
         }
     }
 }

--- a/scripts/lib/translate-api.spec.js
+++ b/scripts/lib/translate-api.spec.js
@@ -4,19 +4,6 @@ var Translator = require('./translator');
 var Api = require('../../lib/model/api');
 var fooModel = require('./foo-2018-03-30.normal.json');
 
-describe('Translator', function() {
-    it('does not remove min, max, enum, or pattern traits form shapes', function() {
-        var mockModel = deepCopyObject(fooModel);
-        var modifiedModel = new Translator(mockModel, {documentation: false});
-
-        // shapes are renamed when they are reused
-        expect(modifiedModel.shapes['S2'].min).to.equal(1);
-        expect(modifiedModel.shapes['S2'].max).to.equal(100);
-        expect(modifiedModel.shapes['S2'].enum).to.eql(["test"]);
-        expect(modifiedModel.shapes['S2'].pattern).to.equal("\\w+");
-    });
-});
-
 describe('removeEventStreamOperations', function() {
     describe('removes operations when eventstream', function() {
         it('is on the input shape shape', function() {

--- a/scripts/lib/translator.js
+++ b/scripts/lib/translator.js
@@ -43,6 +43,10 @@ function Translator(api, options) {
       delete obj.documentation;
       delete obj.documentationUrl;
       delete obj.errors;
+      delete obj.min;
+      delete obj.max;
+      delete obj.pattern;
+      delete obj['enum'];
       delete obj.box;
     }
   }


### PR DESCRIPTION
#2279 caused our integration tests to fail due to how we're validating error codes. Reverting the change until we decide how to update the integration tests and/or param validation.