### PR TITLE
improved documentation for #2308

### DIFF
--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -157,7 +157,7 @@ AWS.CloudFront.Signer = inherit({
      *
      * @param options [Object]          The options to create a signed URL.
      * @option options url [String]     The URL to which the signature will grant
-     *                                  access. Any query params included with 
+     *                                  access. Any query params included with
      *                                  the URL should be encoded. Required.
      * @option options expires [Number] A Unix UTC timestamp indicating when the
      *                                  signature should expire. Required unless you

--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -157,7 +157,8 @@ AWS.CloudFront.Signer = inherit({
      *
      * @param options [Object]          The options to create a signed URL.
      * @option options url [String]     The URL to which the signature will grant
-     *                                  access. Required.
+     *                                  access. Any query params included with 
+     *                                  the URL should be encoded. Required.
      * @option options expires [Number] A Unix UTC timestamp indicating when the
      *                                  signature should expire. Required unless you
      *                                  pass in a full policy.


### PR DESCRIPTION
note that query params must be encoded.