### PR TITLE
httpOptions on STS assume role in SharedIniFileCredentials

### DIFF
--- a/.changes/next-release/feature-Credentials-5e168daf.json
+++ b/.changes/next-release/feature-Credentials-5e168daf.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Credentials",
+  "description": "httpsOptions for STS in SharedIniFileCredentials"
+}

--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -1,4 +1,5 @@
 import {Credentials} from '../credentials';
+import {HTTPOptions} from '../config';
 export class SharedIniFileCredentials extends Credentials {
     /**
      * Creates a new SharedIniFileCredentials object.
@@ -11,4 +12,5 @@ interface SharedIniFileCredentialsOptions {
     filename?: string
     disableAssumeRole?: boolean
     tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
+    httpOptions?: HTTPOptions
 }

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -53,6 +53,28 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   file. Function is called with value of mfa_serial and callback, and
    *   should provide the TokenCode or an error to the callback in the format
    *   callback(err, token)
+   * @option options httpOptions [map] A set of options to pass to the low-level
+   *   HTTP request. Currently supported options are:
+   *   * **proxy** [String] &mdash; the URL to proxy requests through
+   *   * **agent** [http.Agent, https.Agent] &mdash; the Agent object to perform
+   *     HTTP requests with. Used for connection pooling. Defaults to the global
+   *     agent (`http.globalAgent`) for non-SSL connections. Note that for
+   *     SSL connections, a special Agent object is used in order to enable
+   *     peer certificate verification. This feature is only available in the
+   *     Node.js environment.
+   *   * **connectTimeout** [Integer] &mdash; Sets the socket to timeout after
+   *     failing to establish a connection with the server after
+   *     `connectTimeout` milliseconds. This timeout has no effect once a socket
+   *     connection has been established.
+   *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
+   *     milliseconds of inactivity on the socket. Defaults to two minutes
+   *     (120000).
+   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
+   *     HTTP requests. Used in the browser environment only. Set to false to
+   *     send requests synchronously. Defaults to true (async on).
+   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
+   *     property of an XMLHttpRequest object. Used in the browser environment
+   *     only. Defaults to false.
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
@@ -65,6 +87,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.disableAssumeRole = Boolean(options.disableAssumeRole);
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
     this.tokenCodeFn = options.tokenCodeFn || null;
+    this.httpOptions = options.httpOptions || null;
     this.get(function() {});
   },
 
@@ -206,7 +229,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
     this.roleArn = roleArn;
     var sts = new STS({
-      credentials: sourceCredentials
+      credentials: sourceCredentials,
+      httpOptions: this.httpOptions
     });
 
     var roleParams = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
