### PR TITLE
Cleans up connectTimeout timers when request errors

### DIFF
--- a/.changes/next-release/bugfix-Core-28a9029d.json
+++ b/.changes/next-release/bugfix-Core-28a9029d.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Core",
+  "description": "Fixes issue where connectTimeout timers would not be cleared if a request errored out. Only affects node.js."
+}

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -55,9 +55,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
 
     // connection timeout support
     if (httpOptions.connectTimeout) {
+      var connectTimeoutId;
       stream.on('socket', function(socket) {
         if (socket.connecting) {
-          var timeoutId = setTimeout(function connectTimeout() {
+          connectTimeoutId = setTimeout(function connectTimeout() {
             if (stream.didCallback) return; stream.didCallback = true;
 
             stream.abort();
@@ -66,11 +67,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
               {code: 'TimeoutError'}
             ));
           }, httpOptions.connectTimeout);
-          socket.on('connect', (function(tId) {
-            return function () {
-              clearTimeout(tId);
-            };
-          })(timeoutId));
+          socket.on('connect', function() {
+            clearTimeout(connectTimeoutId);
+            connectTimeoutId = null;
+          });
         }
       });
     }
@@ -85,6 +85,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
     });
 
     stream.on('error', function() {
+      if (connectTimeoutId) {
+        clearTimeout(connectTimeoutId);
+        connectTimeoutId = null;
+      }
       if (stream.didCallback) return; stream.didCallback = true;
       errCallback.apply(stream, arguments);
     });

--- a/test/node_http_client.spec.js
+++ b/test/node_http_client.spec.js
@@ -155,7 +155,8 @@
             global.clearTimeout = oldClearTimeout;
             return httpModule.request = oldRequest;
           });
-          return it('clears timeouts once the connection has been established', function() {
+
+          it('clears timeouts once the connection has been established', function() {
             var mockSocket, req;
             req = new AWS.HttpRequest('http://10.255.255.255');
             http.handleRequest(req, {
@@ -169,8 +170,26 @@
             expect(setTimeoutSpy.calls.length).to.equal(1);
             mockSocket.emit('connect');
             expect(clearTimeoutSpy.calls.length).to.equal(1);
-            return expect(clearTimeoutSpy.calls[0]["arguments"][0]).to.equal(timeoutId);
+            expect(clearTimeoutSpy.calls[0]["arguments"][0]).to.equal(timeoutId);
           });
+
+          it('clears timeouts if an error is encountered', function() {
+            var mockSocket = new EventEmitter();
+            var req = new AWS.HttpRequest('http://10.255.255.255');
+
+            http.handleRequest(req, {
+              connectTimeout: 120000
+            }, null, function() {
+              return {};
+            });
+
+            mockSocket.connecting = true;
+            mockClientRequest.emit('socket', mockSocket);
+            expect(setTimeoutSpy.calls.length).to.equal(1);
+            mockClientRequest.emit('error', new Error('Something happened!'));
+            expect(clearTimeoutSpy.calls.length).to.equal(1);
+            expect(clearTimeoutSpy.calls[0]["arguments"][0]).to.equal(timeoutId);
+          })
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed

Fixes #2322 
