### PR TITLE
elasticbeanstalk getInstancesHealth is a paginated endpoint.

### DIFF
--- a/.changes/next-release/bugfix-Paginator-ff3cb8e9.json
+++ b/.changes/next-release/bugfix-Paginator-ff3cb8e9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "When invoking describeInstancesHealth on ElasticBeanstalk the Response object is now correctly paginated."
+}

--- a/apis/elasticbeanstalk-2010-12-01.paginators.json
+++ b/apis/elasticbeanstalk-2010-12-01.paginators.json
@@ -20,6 +20,11 @@
     },
     "ListAvailableSolutionStacks": {
       "result_key": "SolutionStacks"
+    },
+    "DescribeInstancesHealth": {
+      "result_key": "InstanceHealthList",
+      "input_token": "NextToken",
+      "output_token": "NextToken"
     }
   }
 }

--- a/dist/aws-sdk-react-native.js
+++ b/dist/aws-sdk-react-native.js
@@ -32840,7 +32840,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 203 */
 /***/ (function(module, exports) {
 
-	module.exports = {"pagination":{"DescribeApplicationVersions":{"result_key":"ApplicationVersions"},"DescribeApplications":{"result_key":"Applications"},"DescribeConfigurationOptions":{"result_key":"Options"},"DescribeEnvironments":{"result_key":"Environments"},"DescribeEvents":{"input_token":"NextToken","limit_key":"MaxRecords","output_token":"NextToken","result_key":"Events"},"ListAvailableSolutionStacks":{"result_key":"SolutionStacks"}}}
+	module.exports = {"pagination":{"DescribeApplicationVersions":{"result_key":"ApplicationVersions"},"DescribeApplications":{"result_key":"Applications"},"DescribeConfigurationOptions":{"result_key":"Options"},"DescribeEnvironments":{"result_key":"Environments"},"DescribeEvents":{"input_token":"NextToken","limit_key":"MaxRecords","output_token":"NextToken","result_key":"Events"},"ListAvailableSolutionStacks":{"result_key":"SolutionStacks"},"DescribeInstancesHealth":{"result_key":"InstanceHealthList","input_token":"NextToken","output_token":"NextToken"}}}
 
 /***/ }),
 /* 204 */
@@ -36820,7 +36820,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	        });
 	      }
 	      if (err) return self.cleanup(err);
-
+	      //prevent sending part being returned twice (https://github.com/aws/aws-sdk-js/issues/2304)
+	      if (self.completeInfo[partNumber] && self.completeInfo[partNumber].ETag !== null) return null;
 	      partInfo.ETag = data.ETag;
 	      self.doneParts++;
 	      if (self.isDoneChunking && self.doneParts === self.numParts) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

elasticbeanstalk `describeInstancesHealth` is paginated, which was not reflected in the api config. This PR fixes that issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
