### PR TITLE
Fix useDualstack typing

### DIFF
--- a/.changes/next-release/bugfix-Config-633c1fbe.json
+++ b/.changes/next-release/bugfix-Config-633c1fbe.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Config",
+  "description": "fix useDualstack typing"
+}

--- a/lib/config_use_dualstack.d.ts
+++ b/lib/config_use_dualstack.d.ts
@@ -4,5 +4,5 @@ export interface UseDualstackConfigOptions {
      * In most cases the network stack in the client environment will automatically prefer the AAAA record and make a connection using the IPv6 address. 
      * Note, however, that currently on Windows, the IPv4 address will be preferred.
      */
-    useDualStack?: boolean;
+    useDualstack?: boolean;
 }


### PR DESCRIPTION
fix for casing on useDualStack typing

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added
