### PR TITLE
Added support for "waitFor" functionality in MediaConvert client

### DIFF
--- a/.changes/next-release/feature-Waiter-3a1694e2.json
+++ b/.changes/next-release/feature-Waiter-3a1694e2.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "MediaConvert",
+  "description": "Added support for \"waitFor\" functionality in MediaConvert client"
+}

--- a/apis/mediaconvert-2017-08-29.waiters2.json
+++ b/apis/mediaconvert-2017-08-29.waiters2.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "waiters": {
+    "jobComplete": {
+      "delay": 30,
+      "operation": "GetJob",
+      "maxAttempts": 120,
+      "acceptors": [
+        {
+          "expected": "COMPLETE",
+          "matcher": "path",
+          "state": "success",
+          "argument": "Job.Status"
+        },
+        {
+          "expected": "CANCELED",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "Job.Status"
+        },
+        {
+          "expected": "ERROR",
+          "matcher": "path",
+          "state": "failure",
+          "argument": "Job.Status"
+        }
+      ]
+    }
+  }
+}

--- a/clients/mediaconvert.d.ts
+++ b/clients/mediaconvert.d.ts
@@ -2,6 +2,7 @@ import {Request} from '../lib/request';
 import {Response} from '../lib/response';
 import {AWSError} from '../lib/error';
 import {Service} from '../lib/service';
+import {WaiterConfiguration} from '../lib/service';
 import {ServiceConfigurationOptions} from '../lib/service';
 import {ConfigBase as Config} from '../lib/config';
 interface Blob {}
@@ -211,6 +212,18 @@ declare class MediaConvert extends Service {
    * Modify one of your existing queues.
    */
   updateQueue(callback?: (err: AWSError, data: MediaConvert.Types.UpdateQueueResponse) => void): Request<MediaConvert.Types.UpdateQueueResponse, AWSError>;
+  /**
+   * Modify one of your existing queues.
+   */
+  updateQueue(callback?: (err: AWSError, data: MediaConvert.Types.UpdateQueueResponse) => void): Request<MediaConvert.Types.UpdateQueueResponse, AWSError>;
+  /**
+   * Waits for the jobComplete state by periodically calling the underlying MediaConvert.getJob operation every 30 seconds (at most 120 times).
+   */
+  waitFor(state: "jobComplete", params: MediaConvert.Types.GetJobRequest & {$waiter?: WaiterConfiguration}, callback?: (err: AWSError, data: MediaConvert.Types.GetJobRequest) => void): Request<MediaConvert.Types.GetJobRequest, AWSError>;
+  /**
+   * Waits for the jobComplete state by periodically calling the underlying MediaConvert.getJob operation every 30 seconds (at most 120 times).
+   */
+  waitFor(state: "jobComplete", callback?: (err: AWSError, data: MediaConvert.Types.GetJobRequest) => void): Request<MediaConvert.Types.GetJobRequest, AWSError>;
 }
 declare namespace MediaConvert {
   export type AacAudioDescriptionBroadcasterMix = "BROADCASTER_MIXED_AD"|"NORMAL"|string;

--- a/clients/mediaconvert.js
+++ b/clients/mediaconvert.js
@@ -9,6 +9,7 @@ Object.defineProperty(apiLoader.services['mediaconvert'], '2017-08-29', {
   get: function get() {
     var model = require('../apis/mediaconvert-2017-08-29.min.json');
     model.paginators = require('../apis/mediaconvert-2017-08-29.paginators.json').pagination;
+    model.waiters = require('../apis/mediaconvert-2017-08-29.waiters2.json').waiters;
     return model;
   },
   enumerable: true,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
waitFor functionality exist on MediaConvert but wasn't functional because of missing dependency i.e., waiters. Added that waiters in mediaConvert client.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
