### PR TITLE
Throw InvalidBucket when Bucket starts with a forward slash

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -163,7 +163,7 @@ AWS.util.update(AWS.S3.prototype, {
     var key = req.params && req.params.Key;
     var slashIndex = bucket && bucket.indexOf('/');
     if (bucket && slashIndex >= 0) {
-      if (typeof key === 'string') {
+      if (typeof key === 'string' && slashIndex > 0) {
         req.params = AWS.util.copy(req.params);
         // Need to include trailing slash to match sigv2 behavior
         var prefix = bucket.substr(slashIndex + 1) || '';

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -282,6 +282,14 @@ describe('AWS.S3', function() {
     });
 
     describe('will throw an error when', function() {
+      it('using sigv4 and the "Bucket" parameter starts with a forward slash', function(done) {
+        var s3 = new AWS.S3({signatureVersion: 'v4'});
+        s3.createBucket({Bucket: '/foo'}, function(err, data) {
+          expect(err.code).to.eql('InvalidBucket');
+          done();
+        });
+      });
+
       it('using sigv4 and the "Bucket" parameter contains forward slashes and "Key" is not defined', function(done) {
         var s3 = new AWS.S3({signatureVersion: 'v4'});
         s3.createBucket({Bucket: 'foo/bar'}, function(err, data) {


### PR DESCRIPTION
Currently, if you pass a bucket name that starts with a forward slash, you end up with this:

```
Error: Expected uri parameter to have length >= 1, but found "" for params.Bucket
```

[This line](https://github.com/cadejscroggins/aws-sdk-js/blob/05537c6dd518ad7ccc4dab96993c1598b0e3a5b2/lib/services/s3.js#L171) assumes that the first forward slash isn't at the beginning of the string, and nukes our poor bucket. To ensure a proper error message, this PR makes sure that `slashIndex` is not 0 before proceeding with that block.

##### Checklist

- [x] `npm run test` passes
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed