### PR TITLE
Add DDB transactions to document client

### DIFF
--- a/.changes/next-release/feature-DynamoDB-c9c594a6.json
+++ b/.changes/next-release/feature-DynamoDB-c9c594a6.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "DynamoDB",
+  "description": "Add DynamoDB document client support for transaction operations"
+}

--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -54,6 +54,16 @@ export class DocumentClient {
      * Edits an existing item's attributes, or adds a new item to the table if it does not already exist by delegating to AWS.DynamoDB.updateItem().
      */
     update(params: DocumentClient.UpdateItemInput, callback?: (err: AWSError, data: DocumentClient.UpdateItemOutput) => void): Request<DocumentClient.UpdateItemOutput, AWSError>;
+
+    /**
+     * Atomically retrieves multiple items from one or more tables (but not from indexes) in a single account and region.
+     */
+    transactGet(params: DynamoDB.TransactGetItemsInput, callback?: (err: AWSError, data: DynamoDB.TransactGetItemsOutput) => void): Request<DynamoDB.TransactGetItemsOutput, AWSError>;
+
+    /**
+     * Synchronous write operation that groups up to 10 action requests
+     */
+    transactWrite(params: DynamoDB.TransactWriteItemsInput, callback?: (err: AWSError, data: DynamoDB.TransactWriteItemsOutput) => void): Request<DynamoDB.TransactWriteItemsOutput, AWSError>;
 }
 
 export namespace DocumentClient {

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -92,7 +92,7 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
   /**
    * @api private
    */
-  makeSerivceRequest: function(operation, params, callback) {
+  makeServiceRequest: function(operation, params, callback) {
     var self = this;
     var request = self.service[operation](params);
     self.setupRequest(request);

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -41,20 +41,6 @@ var DynamoDBSet = require('./set');
 AWS.DynamoDB.DocumentClient = AWS.util.inherit({
 
   /**
-   * @api private
-   */
-  operations: {
-    batchGetItem: 'batchGet',
-    batchWriteItem: 'batchWrite',
-    putItem: 'put',
-    getItem: 'get',
-    deleteItem: 'delete',
-    updateItem: 'update',
-    scan: 'scan',
-    query: 'query'
-  },
-
-  /**
    * Creates a DynamoDB document client with a set of configuration options.
    *
    * @option options params [map] An optional map of parameters to bind to every
@@ -104,6 +90,36 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
   },
 
   /**
+   * @api private
+   */
+  makeSerivceRequest: function(operation, params, callback) {
+    var self = this;
+    var request = self.service[operation](params);
+    self.setupRequest(request);
+    self.setupResponse(request);
+    if (typeof callback === 'function') {
+      request.send(callback);
+    }
+    return request;
+  },
+
+  /**
+   * @api private
+   */
+  serviceClientOperationsMap: {
+    batchGet: 'batchGetItem',
+    batchWrite: 'batchWriteItem',
+    delete: 'deleteItem',
+    get: 'getItem',
+    put: 'putItem',
+    query: 'query',
+    scan: 'scan',
+    update: 'updateItem',
+    transactGet: 'transactGetItems',
+    transactWrite: 'transactWriteItems'
+  },
+
+  /**
    * Returns the attributes of one or more items from one or more tables
    * by delegating to `AWS.DynamoDB.batchGetItem()`.
    *
@@ -140,13 +156,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   batchGet: function(params, callback) {
     var self = this;
-    var request = self.service.batchGetItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['batchGet'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -191,13 +202,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   batchWrite: function(params, callback) {
     var self = this;
-    var request = self.service.batchWriteItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['batchWrite'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -227,13 +233,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   delete: function(params, callback) {
     var self = this;
-    var request = self.service.deleteItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['delete'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -262,13 +263,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   get: function(params, callback) {
     var self = this;
-    var request = self.service.getItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['get'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -300,15 +296,10 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *  });
    *
    */
-  put: function put(params, callback) {
+  put: function(params, callback) {
     var self = this;
-    var request = self.service.putItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['put'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -343,13 +334,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   update: function(params, callback) {
     var self = this;
-    var request = self.service.updateItem(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['update'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -377,13 +363,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    */
   scan: function(params, callback) {
     var self = this;
-    var request = self.service.scan(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['scan'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
    /**
@@ -414,13 +395,94 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
     */
   query: function(params, callback) {
     var self = this;
-    var request = self.service.query(params);
-    self.setupRequest(request);
-    self.setupResponse(request);
-    if (typeof callback === 'function') {
-      request.send(callback);
-    }
-    return request;
+    var operation = self.serviceClientOperationsMap['query'];
+    return self.makeServiceRequest(operation, params, callback);
+  },
+
+  /**
+   * Synchronous write operation that groups up to 10 action requests
+   * 
+   * Supply the same parameters as {AWS.DynamoDB.transactWriteItems} with
+   * `AttributeValue`s substituted by native JavaScript types.
+   * 
+   * @see AWS.DynamoDB.transactWriteItems
+   * @example Get items from multiple tables
+   *  var params = {
+   *    TransactItems: [{
+   *      Put: {
+   *        TableName : 'Table0',
+   *        Item: {
+   *          HashKey: 'haskey',
+   *          NumAttribute: 1,
+   *          BoolAttribute: true,
+   *          ListAttribute: [1, 'two', false],
+   *          MapAttribute: { foo: 'bar'},
+   *          NullAttribute: null
+   *        }
+   *      }
+   *    }, {
+   *      Update: {
+   *        TableName: 'Table1',
+   *        Key: { HashKey : 'hashkey' },
+   *        UpdateExpression: 'set #a = :x + :y',
+   *        ConditionExpression: '#a < :MAX',
+   *        ExpressionAttributeNames: {'#a' : 'Sum'},
+   *        ExpressionAttributeValues: {
+   *          ':x' : 20,
+   *          ':y' : 45,
+   *          ':MAX' : 100,
+   *        }
+   *      }
+   *    }]
+   *  };
+   *  
+   *  documentClient.transactWrite(params, function(err, data) {
+   *    if (err) console.log(err);
+   *    else console.log(data);
+   *  });
+   */
+  transactWrite: function(params, callback) {
+    var self = this;
+    var operation = self.serviceClientOperationsMap['transactWrite'];
+    return self.makeServiceRequest(operation, params, callback);
+  },
+
+  /**
+   * Atomically retrieves multiple items from one or more tables (but not from indexes)
+   * in a single account and region.
+   * 
+   * Supply the same parameters as {AWS.DynamoDB.transactGetItems} with
+   * `AttributeValue`s substituted by native JavaScript types.
+   * 
+   * @see AWS.DynamoDB.transactGetItems
+   * @example Get items from multiple tables
+   *  var params = {
+   *    TransactItems: [{
+   *      Get: {
+   *        TableName : 'Table0',
+   *        Key: {
+   *          HashKey: 'hashkey0'
+   *        }
+   *      }
+   *    }, {
+   *      Get: {
+   *        TableName : 'Table1',
+   *        Key: {
+   *          HashKey: 'hashkey1'
+   *        }
+   *      }
+   *    }]
+   *  };
+   *  
+   *  documentClient.transactGet(params, function(err, data) {
+   *    if (err) console.log(err);
+   *    else console.log(data);
+   *  });
+   */
+  transactGet: function(params, callback) {
+    var self = this;
+    var operation = self.serviceClientOperationsMap['transactGet'];
+    return self.makeServiceRequest(operation, params, callback);
   },
 
   /**

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -155,9 +155,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   batchGet: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['batchGet'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['batchGet'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -201,9 +200,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   batchWrite: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['batchWrite'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['batchWrite'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -232,9 +230,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   delete: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['delete'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['delete'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -262,9 +259,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   get: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['get'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['get'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -297,9 +293,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   put: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['put'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['put'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -333,9 +328,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   update: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['update'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['update'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
@@ -362,9 +356,8 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *
    */
   scan: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['scan'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['scan'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
    /**
@@ -394,17 +387,16 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
     *
     */
   query: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['query'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['query'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
    * Synchronous write operation that groups up to 10 action requests
-   * 
+   *
    * Supply the same parameters as {AWS.DynamoDB.transactWriteItems} with
    * `AttributeValue`s substituted by native JavaScript types.
-   * 
+   *
    * @see AWS.DynamoDB.transactWriteItems
    * @example Get items from multiple tables
    *  var params = {
@@ -435,25 +427,24 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *      }
    *    }]
    *  };
-   *  
+   *
    *  documentClient.transactWrite(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
    */
   transactWrite: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['transactWrite'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['transactWrite'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**
    * Atomically retrieves multiple items from one or more tables (but not from indexes)
    * in a single account and region.
-   * 
+   *
    * Supply the same parameters as {AWS.DynamoDB.transactGetItems} with
    * `AttributeValue`s substituted by native JavaScript types.
-   * 
+   *
    * @see AWS.DynamoDB.transactGetItems
    * @example Get items from multiple tables
    *  var params = {
@@ -473,16 +464,15 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *      }
    *    }]
    *  };
-   *  
+   *
    *  documentClient.transactGet(params, function(err, data) {
    *    if (err) console.log(err);
    *    else console.log(data);
    *  });
    */
   transactGet: function(params, callback) {
-    var self = this;
-    var operation = self.serviceClientOperationsMap['transactGet'];
-    return self.makeServiceRequest(operation, params, callback);
+    var operation = this.serviceClientOperationsMap['transactGet'];
+    return this.makeServiceRequest(operation, params, callback);
   },
 
   /**

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -1658,7 +1658,26 @@
   });
 
   describe('validate supported operations', function() {
-
+    var serviceClientOperationsMap = {
+      batchGet: 'batchGetItem',
+      batchWrite: 'batchWriteItem',
+      delete: 'deleteItem',
+      get: 'getItem',
+      put: 'putItem',
+      query: 'query',
+      scan: 'scan',
+      update: 'updateItem',
+      transactGet: 'transactGetItems',
+      transactWrite: 'transactWriteItems'
+    };
+    var client = new AWS.DynamoDB.DocumentClient({paramValidation: false});
+    AWS.util.arrayEach(Object.keys(serviceClientOperationsMap), function(operation) {
+      var request = client[operation]({});
+      it('operation' + operation + ' is available', function() {
+        request.emit('validate', [request]);
+        expect(request.operation).to.eql(serviceClientOperationsMap[operation]);
+      });
+    });
   });
 
 }).call(this);

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -1657,4 +1657,8 @@
     });
   });
 
+  describe('validate supported operations', function() {
+
+  });
+
 }).call(this);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Add support for `transactGetItems()` and `transactWriteItems()` in DDB document client. Corresponding operations are `transactGet()` and `transactWrite()`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
