### PR TITLE
Fix yard doc build fails for ChainableTemporaryCredentials class

### DIFF
--- a/lib/credentials/chainable_temporary_credentials.js
+++ b/lib/credentials/chainable_temporary_credentials.js
@@ -79,10 +79,9 @@ AWS.ChainableTemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
    *   If a `RoleArn` parameter is passed in, credentials will be based on the
    *   IAM role. If a `SerialNumber` parameter is passed in, {tokenCodeFn} must
    *   also be passed in or an error will be thrown.
-   * @option options masterCredentials [AWS.Credentials] (null) the master
-   *   (source) credentials used to get and refresh temporary credentials from
-   *   AWS STS. By default, {AWS.config.credentials} or
-   *   {AWS.config.credentialProvider} will be used.
+   * @option options masterCredentials [AWS.Credentials] the master credentials
+   *   used to get and refresh temporary credentials from AWS STS. By default,
+   *   AWS.config.credentials or AWS.config.credentialProvider will be used.
    * @option options tokenCodeFn [Function] (null) Function to provide
    *   `TokenCode`, if `SerialNumber` is provided for profile in {params}. Function
    *   is called with value of `SerialNumber` and `callback`, and should provide
@@ -137,7 +136,7 @@ AWS.ChainableTemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
    *   information has been loaded into the object (as the `accessKeyId`,
    *   `secretAccessKey`, and `sessionToken` properties).
    *   @param err [Error] if an error occurred, this value will be filled
-   * @see get
+   * @see AWS.Credentials.get
    */
   refresh: function refresh(callback) {
     this.coalesceRefresh(callback || AWS.util.fn.callback);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This is fix for [ChainableTemporaryCredentials class doc unavailable](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ChainableTempararyCredentials.html). You can run `bundle exec rake docs:api` locally to build the doc and validate corresponding docs exist in `./doc`. 

/cc @jstewmon 
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
