### PR TITLE
EC2MetadataCredentials should fail to refresh when loaded credentials are expired

### DIFF
--- a/.changes/next-release/feature-EC2MetadataCredentials-bebc1355.json
+++ b/.changes/next-release/feature-EC2MetadataCredentials-bebc1355.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EC2MetadataCredentials",
+  "description": "refresh now passes an error to callback if metadata service responds with expired credentials"
+}

--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -72,14 +72,23 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
    */
   load: function load(callback) {
     var self = this;
-    self.metadataService.loadCredentials(function (err, creds) {
+    self.metadataService.loadCredentials(function(err, creds) {
       if (!err) {
-        self.expired = false;
-        self.metadata = creds;
-        self.accessKeyId = creds.AccessKeyId;
-        self.secretAccessKey = creds.SecretAccessKey;
-        self.sessionToken = creds.Token;
-        self.expireTime = new Date(creds.Expiration);
+        var currentTime = AWS.util.date.getDate();
+        var expireTime = new Date(creds.Expiration);
+        if (expireTime < currentTime) {
+          err = AWS.util.error(
+            new Error('EC2 Instance Metadata Serivce provided expired credentials'),
+            { code: 'EC2MetadataCredentialsProviderFailure' }
+          );
+        } else {
+          self.expired = false;
+          self.metadata = creds;
+          self.accessKeyId = creds.AccessKeyId;
+          self.secretAccessKey = creds.SecretAccessKey;
+          self.sessionToken = creds.Token;
+          self.expireTime = expireTime;
+        }
       }
       callback(err);
     });


### PR DESCRIPTION
resolves #2440 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] changelog is added
