### PR TITLE
fix putObject with Stream <1mb, set 100-continue when Body is a Stream

### DIFF
--- a/.changes/next-release/bugfix-S3-3de7228f.json
+++ b/.changes/next-release/bugfix-S3-3de7228f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "fix putObject using stream <1mb"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -259,7 +259,7 @@ AWS.util.update(AWS.S3.prototype, {
    */
   addExpect100Continue: function addExpect100Continue(req) {
     var len = req.httpRequest.headers['Content-Length'];
-    if (AWS.util.isNode() && len >= 1024 * 1024) {
+    if (AWS.util.isNode() && (len >= 1024 * 1024 || req.params.Body instanceof AWS.util.stream.Stream)) {
       req.httpRequest.headers['Expect'] = '100-continue';
     }
   },


### PR DESCRIPTION
fix for https://github.com/aws/aws-sdk-js/issues/2434

- [x] `npm run test` passes
- [x] changelog is added
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
