### PR TITLE
enable cors on MediaStoreData - fix for #1827

### DIFF
--- a/.changes/next-release/feature-MediaStoreData-c635fcae.json
+++ b/.changes/next-release/feature-MediaStoreData-c635fcae.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "MediaStoreData",
+  "description": "enable cors to make MediaStoreData available in default browser build"
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -486,7 +486,8 @@
   },
   "mediastoredata": {
     "prefix": "mediastore-data",
-    "name": "MediaStoreData"
+    "name": "MediaStoreData",
+    "cors": true
   },
   "appsync": {
     "name": "AppSync"


### PR DESCRIPTION
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed