### PR TITLE
improved documentation on S3 getSignedUrl operation

### DIFF
--- a/.changes/next-release/feature-s3-8b0c0656.json
+++ b/.changes/next-release/feature-s3-8b0c0656.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "s3",
+  "description": "Improved sigv4 documentation on getSignedUrl operation"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -744,6 +744,9 @@ AWS.util.update(AWS.S3.prototype, {
    *   `ContentLength`, or `Tagging` must be provided as headers when sending a
    *   request. If you are using pre-signed URLs to upload from a browser and
    *   need to use these fields, see {createPresignedPost}.
+   * @note signatureVersion v4 is required for Range to be included as a signed
+   *   header. You must use signatureVersion v4 to enforce the inclusion and
+   *   exact matching of header and signed URL for the Range operation parameter.
    * @param operation [String] the name of the operation to call
    * @param params [map] parameters to pass to the operation. See the given
    *   operation for the expected operation parameters. In addition, you can

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -744,9 +744,11 @@ AWS.util.update(AWS.S3.prototype, {
    *   `ContentLength`, or `Tagging` must be provided as headers when sending a
    *   request. If you are using pre-signed URLs to upload from a browser and
    *   need to use these fields, see {createPresignedPost}.
-   * @note signatureVersion v4 is required for Range to be included as a signed
-   *   header. You must use signatureVersion v4 to enforce the inclusion and
-   *   exact matching of header and signed URL for the Range operation parameter.
+   * @note The default signer allows altering the request by adding corresponding
+   *   headers to set some parameters (e.g. Range) and these added parameters
+   *   won't be signed. You must use signatureVersion v4 to to include these
+   *   parameters in the signed portion of the URL and enforce exact matching
+   *   between headers and signed params in the URL.
    * @param operation [String] the name of the operation to call
    * @param params [map] parameters to pass to the operation. See the given
    *   operation for the expected operation parameters. In addition, you can


### PR DESCRIPTION
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
