### PR TITLE
make resolvedProfile cached inenumerable

### DIFF
--- a/.changes/next-release/feature-credentials-8088d9bc.json
+++ b/.changes/next-release/feature-credentials-8088d9bc.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "credentials",
+  "description": "make resolvedProfile cached inenumerable"
+}

--- a/lib/shared-ini/ini-loader.js
+++ b/lib/shared-ini/ini-loader.js
@@ -3,17 +3,17 @@ var os = require('os');
 var path = require('path');
 
 function parseFile(filename, isConfig) {
-  if (!isConfig) {
-    return AWS.util.ini.parse(AWS.util.readFileSync(filename));
-  } else {
     var content = AWS.util.ini.parse(AWS.util.readFileSync(filename));
     var tmpContent = {};
     Object.keys(content).forEach(function(profileName) {
       var profileContent = content[profileName];
-      tmpContent[profileName.replace(/^profile\s/, '')] = profileContent;
-    })
+      profileName = isConfig ? profileName.replace(/^profile\s/, '') : profileName;
+      Object.defineProperty(tmpContent, profileName, {
+        value: profileContent,
+        enumerable: true
+      })
+    });
     return tmpContent;
-  }
 }
 
 /**
@@ -53,7 +53,8 @@ AWS.IniLoader = AWS.util.inherit({
     var isConfig = options.isConfig === true;
     var filename = options.filename || this.getDefaultFilePath(isConfig);
     if (!this.resolvedProfiles[filename]) {
-      this.resolvedProfiles[filename] = this.parseFile(filename, isConfig);
+      var fileContent = this.parseFile(filename, isConfig);
+      Object.defineProperty(this.resolvedProfiles, filename, { value: fileContent });
     }
     return this.resolvedProfiles[filename];
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This change make shared ini credentials cached unconfigurable once loaded. The only way to update the cache is to clear the cache and call `loadFrom` again.

#2181 has been addressed previously, this is a feature update.

@rix0rrr @srchase 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`