### PR TITLE
tweak CSM config to be able to enabled by only environment or config

### DIFF
--- a/.changes/next-release/feature-client side monitoring-f83de457.json
+++ b/.changes/next-release/feature-client side monitoring-f83de457.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "client side monitoring",
+  "description": "CSM now can be enabled globally only from environment without code change"
+}

--- a/lib/service.js
+++ b/lib/service.js
@@ -57,7 +57,7 @@ AWS.Service = inherit({
     //enable attaching listeners to service client
     AWS.SequentialExecutor.call(this);
     AWS.Service.addDefaultMonitoringListeners(this);
-    if (this.config.clientSideMonitoring && this.publisher) {
+    if ((this.config.clientSideMonitoring || AWS.Service._clientSideMonitoring) && this.publisher) {
       var publisher = this.publisher;
       this.addNamedListener('PUBLISH_API_CALL', 'apiCall', function PUBLISH_API_CALL(event) {
         process.nextTick(function() {publisher.eventHandler(event);});
@@ -709,7 +709,12 @@ AWS.util.update(AWS.Service, {
     if (!this.prototype.publisher && AWS.util.clientSideMonitoring) {
       var Publisher = AWS.util.clientSideMonitoring.Publisher;
       var configProvider = AWS.util.clientSideMonitoring.configProvider;
-      this.prototype.publisher = new Publisher(configProvider());
+      var publisherConfig = configProvider();
+      this.prototype.publisher = new Publisher(publisherConfig);
+      if (publisherConfig.enabled) {
+        //if csm is enabled in environment, SDK should send all metrics
+        AWS.Service._clientSideMonitoring = true;
+      }
     }
     AWS.SequentialExecutor.call(svc.prototype);
     AWS.Service.addDefaultMonitoringListeners(svc.prototype);

--- a/test/publisher/functional_test/runner.spec.js
+++ b/test/publisher/functional_test/runner.spec.js
@@ -14,7 +14,6 @@ describe('run functional test', () => {
   let defaultConfiguration;
   let processEnvBackup;
   before(() => {
-    AWS.config.clientSideMonitoring = true;
     processEnvBackup = Object.assign({}, process.env);
   });
 

--- a/test/publisher/functional_test/runner.spec.js
+++ b/test/publisher/functional_test/runner.spec.js
@@ -24,6 +24,7 @@ describe('run functional test', () => {
 
   afterEach(async () => {
     process.env = processEnvBackup;
+    AWS.Service.prototype.publisher = undefined;
   });
 
   for (const scenario of schemes.cases) {
@@ -39,7 +40,6 @@ describe('run functional test', () => {
       process.env = Object.assign({}, process.env, scenarioConfiguration.environmentVariables);
 
       const resolvedCSMConfig = csmConfigProvider();
-      AWS.Service.prototype.publisher = new Publisher(resolvedCSMConfig);
 
       //start a subprocess to echo back the udp datagrams
       let fakeAgent = await agentStart(resolvedCSMConfig.port || 31000);

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -990,28 +990,6 @@
         done();
       });
     });
-
-    if(AWS.util.isNode()) {
-      it('should enable client-side monitoring globally if corresponding environment is set', function(done) {
-          var originEnv = process.env.AWS_CSM_ENABLED;
-          process.env.AWS_CSM_ENABLED = true;
-          AWS.Service.prototype.publisher = undefined;
-          AWS.Service.defineService('acm', ['2015-12-08']);
-          expect(AWS.Service.prototype.publisher).not.equal(undefined);
-          var publisherInvoked = false
-          AWS.Service.prototype.publisher = {
-            eventHandler: function(event){
-              if (!publisherInvoked) {
-                publisherInvoked = true;
-                done() //make sure publisher is invoked
-              }
-            }
-          }
-          var client = new MockService({});
-          client.makeRequest('operationName', function(err, data) {});
-          process.env.AWS_CSM_ENABLED = originEnv;
-      });
-    }
   });
 
 }).call(this);

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -988,8 +988,30 @@
         expect(events[0].Type).to.equal('ApiCallAttempt');
         expect(events[1].Type).to.equal('ApiCall');
         done();
-      })
-    })
+      });
+    });
+
+    if(AWS.util.isNode()) {
+      it('should enable client-side monitoring globally if corresponding environment is set', function(done) {
+          var originEnv = process.env.AWS_CSM_ENABLED;
+          process.env.AWS_CSM_ENABLED = true;
+          AWS.Service.prototype.publisher = undefined;
+          AWS.Service.defineService('acm', ['2015-12-08']);
+          expect(AWS.Service.prototype.publisher).not.equal(undefined);
+          var publisherInvoked = false
+          AWS.Service.prototype.publisher = {
+            eventHandler: function(event){
+              if (!publisherInvoked) {
+                publisherInvoked = true;
+                done() //make sure publisher is invoked
+              }
+            }
+          }
+          var client = new MockService({});
+          client.makeRequest('operationName', function(err, data) {});
+          process.env.AWS_CSM_ENABLED = originEnv;
+      });
+    }
   });
 
 }).call(this);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Currently SDK requires user to add client config `clientSideMonitoring` to enable client side monitoring feature. This indicates code change. This change makes SDK sends metrics for all the clients if corresponding environment is setup.

This change is made in order to keep consistency with other SDK.

/cc @srchase 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`