### PR TITLE
Update travic node runtime to 10.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ sudo: false
 
 matrix:
   include:
-  - node_js: "8"
+  - node_js: "10"
     env: TEST_SCRIPT=test
 
 addons:


### PR DESCRIPTION
Node 10.X is now LTS. We should probably switch.