### PR TITLE
Multpart tag encoding

### DIFF
--- a/.changes/next-release/bugfix-S3 managed uploader-4f745837.json
+++ b/.changes/next-release/bugfix-S3 managed uploader-4f745837.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3 managed uploader",
+  "description": "S3 managed uploader will not uriEscape tags when doing a multi-part upload."
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -637,7 +637,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
 
       if (Array.isArray(self.tags)) {
         for (var i = 0; i < self.tags.length; i++) {
-          self.tags[i].Value = AWS.util.uriEscape(self.tags[i].Value);
+          self.tags[i].Value = String(self.tags[i].Value);
         }
         self.service.putObjectTagging(
           {Tagging: {TagSet: self.tags}},

--- a/test/s3/managed_upload.spec.js
+++ b/test/s3/managed_upload.spec.js
@@ -1231,6 +1231,9 @@
               }, {
                 Key: 'étiquette',
                 Value: 'valeur à être encodé'
+              }, {
+                Key: 'number',
+                Value: 100
               }
             ]
           });
@@ -1248,7 +1251,10 @@
                   Value: 'value2'
                 }, {
                   Key: 'étiquette',
-                  Value: 'valeur%20%C3%A0%20%C3%AAtre%20encod%C3%A9'
+                  Value: 'valeur à être encodé'
+                }, {
+                  Key: 'number',
+                  Value: '100'
                 }
               ]
             });


### PR DESCRIPTION
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
