### PR TITLE
Added serviceIdentifier to service instance

### DIFF
--- a/.changes/next-release/feature-Service-969e3343.json
+++ b/.changes/next-release/feature-Service-969e3343.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Service",
+  "description": "Expose service identifier on service instances."
+}

--- a/lib/service.d.ts
+++ b/lib/service.d.ts
@@ -23,7 +23,7 @@ export class Service {
 
     /**
      * Defines a new Service class using a service identifier and list of versions including an optional set of features (functions) to apply to the class prototype.
-     * 
+     *
      * @param {string} serviceIdentifier - the identifier for the service.
      * @param {string[]} versions - a list of versions that work with this service.
      * @param {Object} features - an object to attach to the prototype.
@@ -31,16 +31,16 @@ export class Service {
     defineService(serviceIdentifier: string, versions: string[], features?: any): typeof Service;
     /**
      * Calls an operation on a service with the given input parameters.
-     * 
+     *
      * @param {string} operation - the name of the operation to call on the service.
-     * @param {map} params - a map of input options for the operation. 
+     * @param {map} params - a map of input options for the operation.
      */
     makeRequest(operation: string, params?: {[key: string]: any}, callback?: (err: AWSError, data: any) => void): Request<any, AWSError>;
     /**
      * Calls an operation on a service with the given input parameters, without any authentication data.
-     * 
+     *
      * @param {string} operation - the name of the operation to call on the service.
-     * @param {map} params - a map of input options for the operation. 
+     * @param {map} params - a map of input options for the operation.
      */
     makeUnauthenticatedRequest(operation: string, params?: {[key: string]: any}, callback?: (err: AWSError, data: any) => void): Request<any, AWSError>;
     /**
@@ -64,20 +64,24 @@ export class Service {
      * An Endpoint object representing the endpoint URL for service requests.
      */
     endpoint: Endpoint;
+
+    /**
+     * The internal identifier of the service.
+     */
+    serviceIdentifier: string;
 }
 
 export interface ServiceConfigurationOptions extends ConfigurationOptions {
     /**
-     * The endpoint URI to send requests to. The default endpoint is built from the configured region. 
+     * The endpoint URI to send requests to. The default endpoint is built from the configured region.
      * The endpoint should be a string like 'https://{service}.{region}.amazonaws.com'.
      */
     endpoint?: string;
     /**
-     * An optional map of parameters to bind to every request sent by this service object. 
+     * An optional map of parameters to bind to every request sent by this service object.
      * For more information on bound parameters, see "Working with Services" in the Getting Started Guide.
      */
     params?: {
         [key: string]: any;
     }
 }
-

--- a/lib/service.js
+++ b/lib/service.js
@@ -35,6 +35,7 @@ AWS.Service = inherit({
         configurable: true
       });
       svc._clientId = ++clientCount;
+      svc.serviceIdentifier = this.serviceIdentifier;
       return svc;
     }
     this.initialize(config);
@@ -700,6 +701,7 @@ AWS.util.update(AWS.Service, {
 
       var identifier = svc.serviceIdentifier || serviceIdentifier;
       svc.serviceIdentifier = identifier;
+      svc.prototype.serviceIdentifier = identifier;
     } else { // defineService called with an API
       svc.prototype.api = serviceIdentifier;
       AWS.Service.defineMethods(svc);

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -260,6 +260,11 @@
         return expect(service.config.endpoint).to.equal('http://mockservice.mock-region.domain.tld');
       });
 
+      it('copies the service identifier onto the constructed instance', function() {
+        var service = new MockService();
+        expect(service.serviceIdentifier).to.equal('mock');
+      });
+
       describe('will work with', function() {
         var allServices, className, ctor, obsoleteVersions, results, serviceIdentifier, version;
         allServices = require('../clients/all');


### PR DESCRIPTION
This exposes the `serviceIdentifier` on the `Service` instances. This is useful for instrumenting the `aws-sdk` by giving a pathway to look up the `apiLoader` metadata for the service and thus getting the appropriate human readable name for the service (e.g. "Amazon S3").

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
