### PR TITLE
show service descriptions in each client document

### DIFF
--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -1,6 +1,12 @@
 require 'ostruct'
 
 module Documentor
+  def service_overview(rules)
+    docs = documentation(rules)
+    docs = docs ? docs.gsub(/<fullname>.+?<\/fullname>/, '') : docs
+    docs
+  end
+
   def documentation(rules)
     docs = rules['documentation'] || ''
     docs = docs.gsub(/<!--.*?-->/m, '')
@@ -37,12 +43,25 @@ class ModelDocumentor
 
   def initialize(klass, api)
     api_version = api['metadata']['apiVersion']
+    service_desc = service_overview(api)
     @lines = []
     @lines << ''
     @lines << <<-DOCS.strip
 Constructs a service interface object. Each API operation is exposed as a
 function on service.
+DOCS
 
+    if service_desc
+      @lines << <<-DOCS.strip
+
+### Service Description
+      
+#{service_desc}
+
+DOCS
+    end
+
+    @lines << <<-DOCS.strip
 ### Sending a Request Using #{klass}
 
 ```javascript

--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -3,8 +3,13 @@ require 'ostruct'
 module Documentor
   def service_overview(rules)
     docs = documentation(rules)
-    docs = docs ? docs.gsub(/<fullname>.+?<\/fullname>/, '') : docs
-    docs
+    docs = docs || '';
+    docs = docs.gsub(/<fullname>.+?<\/fullname>/, '')
+    docs = docs.gsub(/(.*?)\{(\S*?)\}/, '\1[\2]') ## replace {} in format string with []
+    if docs && (docs.include? 'runtime aspects of your deployed APIs')
+      puts docs
+    end
+    docs == '' ? nil : docs
   end
 
   def documentation(rules)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Show description of each service client in the API reference. We used to ignore the service description thus some information is not shown in API reference. For example the [APIGatewayManagementAPI](https://github.com/aws/aws-sdk-js/blob/master/apis/apigatewaymanagementapi-2018-11-29.normal.json#L75) mentions the endpoint should include stage, but currently not shown in the API reference.

/cc @srchase 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
