### PR TITLE
implement credential_process on ProcessCredentials provider

### DIFF
--- a/.changes/next-release/feature-Credentials-1a22eb00.json
+++ b/.changes/next-release/feature-Credentials-1a22eb00.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Credentials",
+  "description": "enables use of credentials_process for sourcing credentials from an external process https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes"
+}

--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -10,6 +10,7 @@ export {EnvironmentCredentials} from './credentials/environment_credentials';
 export {FileSystemCredentials} from './credentials/file_system_credentials';
 export {SAMLCredentials} from './credentials/saml_credentials';
 export {SharedIniFileCredentials} from './credentials/shared_ini_file_credentials';
+export {ProcessCredentials} from './credentials/process_credentials';
 export {TemporaryCredentials} from './credentials/temporary_credentials';
 export {ChainableTemporaryCredentials} from './credentials/chainable_temporary_credentials';
 export {WebIdentityCredentials} from './credentials/web_identity_credentials';

--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -153,12 +153,9 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
  *   function () { return new AWS.EnvironmentCredentials('AWS'); },
  *   function () { return new AWS.EnvironmentCredentials('AMAZON'); },
  *   function () { return new AWS.SharedIniFileCredentials(); },
- *   function () {
- *     // if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is set
- *       return new AWS.ECSCredentials();
- *     // else
- *       return new AWS.EC2MetadataCredentials();
- *   }
+ *   function () { return new AWS.ECSCredentials(); },
+ *   function () { return new AWS.ProcessCredentials(); },
+ *   function () { return new AWS.EC2MetadataCredentials() }
  * ]
  * ```
  */

--- a/lib/credentials/process_credentials.d.ts
+++ b/lib/credentials/process_credentials.d.ts
@@ -10,7 +10,5 @@ export class ProcessCredentials extends Credentials {
 interface ProcessCredentialsOptions {
     profile?: string
     filename?: string
-    disableAssumeRole?: boolean
-    tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
     httpOptions?: HTTPOptions
 }

--- a/lib/credentials/process_credentials.d.ts
+++ b/lib/credentials/process_credentials.d.ts
@@ -1,0 +1,16 @@
+import {Credentials} from '../credentials';
+import {HTTPOptions} from '../config';
+export class ProcessCredentials extends Credentials {
+    /**
+     * Creates a new ProcessCredentials object.
+     */
+    constructor(options?: ProcessCredentialsOptions);
+}
+
+interface ProcessCredentialsOptions {
+    profile?: string
+    filename?: string
+    disableAssumeRole?: boolean
+    tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
+    httpOptions?: HTTPOptions
+}

--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -71,12 +71,6 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
    *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
    *     milliseconds of inactivity on the socket. Defaults to two minutes
    *     (120000).
-   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
-   *     HTTP requests. Used in the browser environment only. Set to false to
-   *     send requests synchronously. Defaults to true (async on).
-   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
-   *     property of an XMLHttpRequest object. Used in the browser environment
-   *     only. Defaults to false.
    */
   constructor: function ProcessCredentials(options) {
     AWS.Credentials.call(this);
@@ -144,10 +138,6 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
           { code: 'ProcessCredentialsProviderFailure' }
         );
       }
-      this.expired = false;
-      if (this.accessKeyId && this.secretAccessKey) {
-        callback(null);
-      }
     } catch (err) {
       callback(err);
     }
@@ -158,33 +148,39 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
   * credentials from the output
   * @api private
   * @param profile [map] credentials profile
-  * @throws SharedIniFileCredentialsProviderFailure
+  * @throws ProcessCredentialsProviderFailure
   */
   loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
-    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
-      try {
-        var credData = JSON.parse(stdOut);
-        if (credData.Expiration) {
-          var currentTime = AWS.util.date.getDate();
-          var expireTime = new Date(credData.Expiration);
-          if (expireTime < currentTime) {
-            err = AWS.util.error(
-              new Error('credential_process returned expired credentials'),
-              { code: 'ProcessCredentialsProviderFailure' }
+    proc.exec(profile['credential_process'], function(err, stdOut, stdErr) {
+      if (err) {
+        callback(AWS.util.error(
+          new Error('credential_process returned error'),
+          { code: 'ProcessCredentialsPRoviderFailure'}
+        ), null);
+      } else {
+        try {
+          var credData = JSON.parse(stdOut);
+          if (credData.Expiration) {
+            var currentTime = AWS.util.date.getDate();
+            var expireTime = new Date(credData.Expiration);
+            if (expireTime < currentTime) {
+              throw AWS.util.error(
+                new Error('credential_process returned expired credentials'),
+                { code: 'ProcessCredentialsProviderFailure' }
+              );
+            }
+          }
+
+          if (credData.Version !== 1) {
+            throw AWS.util.error(
+              new Error('credential_process does not return Version == 1'),
+            { code: 'ProcessCredentialsProviderFailure' }
             );
           }
-        } else if (credData.Version !== 1) {
-          err = AWS.util.error(
-            new Error('credential_process does not return Version == 1'),
-          { code: 'ProcessCredentialsProviderFailure' }
-          );
-        }
-        if (err) {
+          callback(null, credData);
+        } catch (err) {
           callback(err, null);
         }
-        callback(null, credData);
-      } catch (err) {
-        callback(err, null);
       }
     });
   },

--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -155,7 +155,7 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
       if (err) {
         callback(AWS.util.error(
           new Error('credential_process returned error'),
-          { code: 'ProcessCredentialsPRoviderFailure'}
+          { code: 'ProcessCredentialsProviderFailure'}
         ), null);
       } else {
         try {
@@ -179,7 +179,10 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
           }
           callback(null, credData);
         } catch (err) {
-          callback(err, null);
+          callback(AWS.util.error(
+            new Error(err.message),
+            { code: 'ProcessCredentialsProviderFailure'}
+          ), null);
         }
       }
     });

--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -1,0 +1,206 @@
+var AWS = require('../core');
+var proc = require('child_process');
+var iniLoader = AWS.util.iniLoader;
+
+/**
+ * Represents credentials loaded from shared credentials file
+ * (defaulting to ~/.aws/credentials or defined by the
+ * `AWS_SHARED_CREDENTIALS_FILE` environment variable).
+ *
+ * ## Using process credentials
+ *
+ * The credentials file can specify a credential provider that executes
+ * a given process and attempts to read its stdout to recieve a JSON payload
+ * containing the credentials:
+ *
+ *     [default]
+ *     credential_process = /usr/bin/credential_proc
+ *
+ * Automatically handles refreshing credentials if an Expiration time is
+ * provided in the credentials payload. Credentials supplied in the same profile
+ * will take precedence over the credential_process.
+ *
+ * Sourcing credentials from an external process can potentially be dangerous,
+ * so proceed with caution. Other credential providers should be preferred if
+ * at all possible. If using this option, you should make sure that the shared
+ * credentials file is as locked down as possible using security best practices
+ * for your operating system.
+ *
+ * ## Using custom profiles
+ *
+ * The SDK supports loading credentials for separate profiles. This can be done
+ * in two ways:
+ *
+ * 1. Set the `AWS_PROFILE` environment variable in your process prior to
+ *    loading the SDK.
+ * 2. Directly load the AWS.ProcessCredentials provider:
+ *
+ * ```javascript
+ * var creds = new AWS.ProcessCredentials({profile: 'myprofile'});
+ * AWS.config.credentials = creds;
+ * ```
+ *
+ * @!macro nobrowser
+ */
+AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
+  /**
+   * Creates a new ProcessCredentials object.
+   *
+   * @param options [map] a set of options
+   * @option options profile [String] (AWS_PROFILE env var or 'default')
+   *   the name of the profile to load.
+   * @option options filename [String] ('~/.aws/credentials' or defined by
+   *   AWS_SHARED_CREDENTIALS_FILE process env var)
+   *   the filename to use when loading credentials.
+   * @option options callback [Function] (err) Credentials are eagerly loaded
+   *   by the constructor. When the callback is called with no error, the
+   *   credentials have been loaded successfully.
+   * @option options httpOptions [map] A set of options to pass to the low-level
+   *   HTTP request. Currently supported options are:
+   *   * **proxy** [String] &mdash; the URL to proxy requests through
+   *   * **agent** [http.Agent, https.Agent] &mdash; the Agent object to perform
+   *     HTTP requests with. Used for connection pooling. Defaults to the global
+   *     agent (`http.globalAgent`) for non-SSL connections. Note that for
+   *     SSL connections, a special Agent object is used in order to enable
+   *     peer certificate verification. This feature is only available in the
+   *     Node.js environment.
+   *   * **connectTimeout** [Integer] &mdash; Sets the socket to timeout after
+   *     failing to establish a connection with the server after
+   *     `connectTimeout` milliseconds. This timeout has no effect once a socket
+   *     connection has been established.
+   *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
+   *     milliseconds of inactivity on the socket. Defaults to two minutes
+   *     (120000).
+   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
+   *     HTTP requests. Used in the browser environment only. Set to false to
+   *     send requests synchronously. Defaults to true (async on).
+   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
+   *     property of an XMLHttpRequest object. Used in the browser environment
+   *     only. Defaults to false.
+   */
+  constructor: function ProcessCredentials(options) {
+    AWS.Credentials.call(this);
+
+    options = options || {};
+
+    this.filename = options.filename;
+    this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
+    this.httpOptions = options.httpOptions || null;
+    this.get(options.callback || AWS.util.fn.noop);
+  },
+
+  /**
+   * @api private
+   */
+  load: function load(callback) {
+    var self = this;
+    try {
+      var profiles = {};
+      var profilesFromConfig = {};
+      if (process.env[AWS.util.configOptInEnv]) {
+        var profilesFromConfig = iniLoader.loadFrom({
+          isConfig: true,
+          filename: process.env[AWS.util.sharedConfigFileEnv]
+        });
+      }
+      var profilesFromCreds = iniLoader.loadFrom({
+        filename: this.filename ||
+          (process.env[AWS.util.configOptInEnv] && process.env[AWS.util.sharedCredentialsFileEnv])
+      });
+      for (var i = 0, profileNames = Object.keys(profilesFromCreds); i < profileNames.length; i++) {
+        profiles[profileNames[i]] = profilesFromCreds[profileNames[i]];
+      }
+      // load after profilesFromCreds to prefer profilesFromConfig
+      for (var i = 0, profileNames = Object.keys(profilesFromConfig); i < profileNames.length; i++) {
+        profiles[profileNames[i]] = profilesFromConfig[profileNames[i]];
+      }
+      var profile = profiles[this.profile] || {};
+
+      if (Object.keys(profile).length === 0) {
+        throw AWS.util.error(
+          new Error('Profile ' + this.profile + ' not found'),
+          { code: 'ProcessCredentialsProviderFailure' }
+        );
+      }
+
+      if (profile['credential_process']) {
+        this.loadViaCredentialProcess(profile, function(err, data) {
+          if (err) {
+            callback(err, null);
+          } else {
+            self.expired = false;
+            self.accessKeyId = data.AccessKeyId;
+            self.secretAccessKey = data.SecretAccessKey;
+            self.sessionToken = data.SessionToken;
+            if (data.Expiration) {
+              self.expireTime = new Date(data.Expiration);
+            }
+            callback(null);
+          }
+        });
+      } else {
+        throw AWS.util.error(
+          new Error('Profile ' + this.profile + ' did not include credential process'),
+          { code: 'ProcessCredentialsProviderFailure' }
+        );
+      }
+      this.expired = false;
+      if (this.accessKeyId && this.secretAccessKey) {
+        callback(null);
+      }
+    } catch (err) {
+      callback(err);
+    }
+  },
+
+  /**
+  * Executes the credential_process and retrieves
+  * credentials from the output
+  * @api private
+  * @param profile [map] credentials profile
+  * @throws SharedIniFileCredentialsProviderFailure
+  */
+  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
+    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
+      try {
+        var credData = JSON.parse(stdOut);
+        if (credData.Expiration) {
+          var currentTime = AWS.util.date.getDate();
+          var expireTime = new Date(credData.Expiration);
+          if (expireTime < currentTime) {
+            err = AWS.util.error(
+              new Error('credential_process returned expired credentials'),
+              { code: 'ProcessCredentialsProviderFailure' }
+            );
+          }
+        } else if (credData.Version !== 1) {
+          err = AWS.util.error(
+            new Error('credential_process does not return Version == 1'),
+          { code: 'ProcessCredentialsProviderFailure' }
+          );
+        }
+        if (err) {
+          callback(err, null);
+        }
+        callback(null, credData);
+      } catch (err) {
+        callback(err, null);
+      }
+    });
+  },
+
+  /**
+   * Loads the credentials from the credential process
+   *
+   * @callback callback function(err)
+   *   Called after the credential process has been executed. When this
+   *   callback is called with no error, it means that the credentials
+   *   information has been loaded into the object (as the `accessKeyId`,
+   *   `secretAccessKey`, and `sessionToken` properties).
+   *   @param err [Error] if an error occurred, this value will be filled
+   * @see get
+   */
+  refresh: function refresh(callback) {
+    this.coalesceRefresh(callback || AWS.util.fn.callback);
+  }
+});

--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -55,22 +55,6 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
    * @option options callback [Function] (err) Credentials are eagerly loaded
    *   by the constructor. When the callback is called with no error, the
    *   credentials have been loaded successfully.
-   * @option options httpOptions [map] A set of options to pass to the low-level
-   *   HTTP request. Currently supported options are:
-   *   * **proxy** [String] &mdash; the URL to proxy requests through
-   *   * **agent** [http.Agent, https.Agent] &mdash; the Agent object to perform
-   *     HTTP requests with. Used for connection pooling. Defaults to the global
-   *     agent (`http.globalAgent`) for non-SSL connections. Note that for
-   *     SSL connections, a special Agent object is used in order to enable
-   *     peer certificate verification. This feature is only available in the
-   *     Node.js environment.
-   *   * **connectTimeout** [Integer] &mdash; Sets the socket to timeout after
-   *     failing to establish a connection with the server after
-   *     `connectTimeout` milliseconds. This timeout has no effect once a socket
-   *     connection has been established.
-   *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
-   *     milliseconds of inactivity on the socket. Defaults to two minutes
-   *     (120000).
    */
   constructor: function ProcessCredentials(options) {
     AWS.Credentials.call(this);
@@ -79,7 +63,6 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
 
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
-    this.httpOptions = options.httpOptions || null;
     this.get(options.callback || AWS.util.fn.noop);
   },
 

--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -164,18 +164,12 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
             var currentTime = AWS.util.date.getDate();
             var expireTime = new Date(credData.Expiration);
             if (expireTime < currentTime) {
-              throw AWS.util.error(
-                new Error('credential_process returned expired credentials'),
-                { code: 'ProcessCredentialsProviderFailure' }
-              );
+              throw Error('credential_process returned expired credentials');
             }
           }
 
           if (credData.Version !== 1) {
-            throw AWS.util.error(
-              new Error('credential_process does not return Version == 1'),
-            { code: 'ProcessCredentialsProviderFailure' }
-            );
+            throw Error('credential_process does not return Version == 1');
           }
           callback(null, credData);
         } catch (err) {

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -72,12 +72,6 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   * **timeout** [Integer] &mdash; Sets the socket to timeout after timeout
    *     milliseconds of inactivity on the socket. Defaults to two minutes
    *     (120000).
-   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
-   *     HTTP requests. Used in the browser environment only. Set to false to
-   *     send requests synchronously. Defaults to true (async on).
-   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
-   *     property of an XMLHttpRequest object. Used in the browser environment
-   *     only. Defaults to false.
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -164,7 +164,21 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         this.secretAccessKey = profile['aws_secret_access_key'];
         this.sessionToken = profile['aws_session_token'];
       } else if (profile['credential_process']) {
-        this.loadViaCredentialProcess(profile, callback);
+        this.loadViaCredentialProcess(profile, function(err, data) {
+          if (err) {
+            callback(err);
+          } else {
+            self.expired = false;
+            self.accessKeyId = data.AccessKeyId;
+            self.secretAccessKey = data.SecretAccessKey;
+            self.sessionToken = data.SessionToken;
+            if(data.Expiration) {
+              self.expireTime = new Date(data.Expiration);
+            }
+            callback(null);
+          }
+        });
+        return;
       }
 
       if (!this.accessKeyId || !this.secretAccessKey) {
@@ -187,24 +201,22 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   * @param profile [map] credentials profile
   * @throws SharedIniFileCredentialsProviderFailure
   */
-  loadViaCredentialProcess: function loadCredentialProcess(profile, callback) {
-    try {
-      var output = proc.execSync(profile['credential_process']);
-      var credData = JSON.parse(output);
-      if (parseInt(credData.Version) !== 1) {
-        throw AWS.util.error(
-          Error('credential_process does not return Version == 1 for profile ' + this.profile),
-          { code: 'SharedIniFileCredentialsProviderFailure'}
+  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
+    var self = this;
+    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
+      var credData = JSON.parse(stdOut);
+      if(parseInt(credData.Version) !== 1) {
+        callback(
+          AWS.util.error(
+            new Error('credential_process does not return Version == 1 for profile ' + this.profile),
+            { code: 'SharedIniFileCredentialsProviderFailure' }
+          )
         );
-      } else {
-        this.accessKeyId = credData.AccessKeyId;
-        this.secretAccessKey = credData.SecretAccessKey;
-        this.sessionToken = credData.SessionToken;
+        return self;
       }
-      callback(null);
-    } catch (err) {
-      callback(err);
-    }
+      callback(null, credData);
+      return;
+    });
   },
 
   /**

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -180,14 +180,16 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         });
       }
 
-      if (!this.accessKeyId || !this.secretAccessKey) {
+      if ((!this.accessKeyId || !this.secretAccessKey) && !profile['credential_process']) {
         throw AWS.util.error(
           new Error('Credentials not set for profile ' + this.profile),
           { code: 'SharedIniFileCredentialsProviderFailure' }
         );
       }
       this.expired = false;
-      callback(null);
+      if (this.accessKeyId || this.secretAccessKey) {
+        callback(null);
+      }
     } catch (err) {
       callback(err);
     }
@@ -204,8 +206,6 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
     if (err) {
       callback(err, null);
-    } else if (stdErr) {
-      callback(stdErr, null);
     } else {
       var credData = JSON.parse(stdOut);
       if (credData.Expiration) {
@@ -217,7 +217,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
             { code: 'SharedIniFileCredentialsProviderFailure' }
           );
         }
-      } else if (parseInt(credData.Version) !== 1) {
+      } else if (credData.Version !== 1) {
         err = AWS.util.error(
           new Error('credential_process does not return Version == 1'),
         { code: 'SharedIniFileCredentialsProviderFailure' }

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,5 +1,6 @@
 var AWS = require('../core');
 var STS = require('../../clients/sts');
+var proc = require('child_process');
 var iniLoader = AWS.util.iniLoader;
 
 /**
@@ -158,9 +159,13 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         return;
       }
 
-      this.accessKeyId = profile['aws_access_key_id'];
-      this.secretAccessKey = profile['aws_secret_access_key'];
-      this.sessionToken = profile['aws_session_token'];
+      if (profile['aws_access_key_id'] || profile['aws_secret_access_key']) {
+        this.accessKeyId = profile['aws_access_key_id'];
+        this.secretAccessKey = profile['aws_secret_access_key'];
+        this.sessionToken = profile['aws_session_token'];
+      } else if (profile['credential_process']) {
+        this.loadViaCredentialProcess(profile, callback);
+      }
 
       if (!this.accessKeyId || !this.secretAccessKey) {
         throw AWS.util.error(
@@ -169,6 +174,33 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         );
       }
       this.expired = false;
+      callback(null);
+    } catch (err) {
+      callback(err);
+    }
+  },
+
+  /**
+  * Executes the credential_process and retrieves
+  * credentials from the output
+  * @api private
+  * @param profile [map] credentials profile
+  * @throws SharedIniFileCredentialsProviderFailure
+  */
+  loadViaCredentialProcess: function loadCredentialProcess(profile, callback) {
+    try {
+      var output = proc.execSync(profile['credential_process']);
+      var credData = JSON.parse(output);
+      if (parseInt(credData.Version) !== 1) {
+        throw AWS.util.error(
+          Error('credential_process does not return Version == 1 for profile ' + this.profile),
+          { code: 'SharedIniFileCredentialsProviderFailure'}
+        );
+      } else {
+        this.accessKeyId = credData.AccessKeyId;
+        this.secretAccessKey = credData.SecretAccessKey;
+        this.sessionToken = credData.SessionToken;
+      }
       callback(null);
     } catch (err) {
       callback(err);

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,6 +1,5 @@
 var AWS = require('../core');
 var STS = require('../../clients/sts');
-var proc = require('child_process');
 var iniLoader = AWS.util.iniLoader;
 
 /**
@@ -17,23 +16,6 @@ var iniLoader = AWS.util.iniLoader;
  *     [default]
  *     aws_access_key_id = AKID...
  *     aws_secret_access_key = YOUR_SECRET_KEY
- *
- * The crednetials file can also specify a credential provider that executes
- * a given process and attempts to read its stdout to recieve a JSON payload
- * containing the credentials:
- *
- *     [default]
- *     credential_process = /usr/bin/credential_proc
- *
- * Automatically handles refreshing credentials if an Expiration time is
- * provided in the credentials payload. Credentials supplied in the same profile
- * will take precedence over the credential_process.
- *
- * Sourcing credentials from an external process can potentially be dangerous,
- * so proceed with caution. Other credential providers should be preferred if
- * at all possible. If using this option, you should make sure that the shared
- * credentials file is as locked down as possible using security best practices
- * for your operating system.
  *
  * ## Using custom profiles
  *
@@ -176,76 +158,21 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         return;
       }
 
-      if (profile['aws_access_key_id'] || profile['aws_secret_access_key']) {
-        this.accessKeyId = profile['aws_access_key_id'];
-        this.secretAccessKey = profile['aws_secret_access_key'];
-        this.sessionToken = profile['aws_session_token'];
-      } else if (profile['credential_process']) {
-        this.loadViaCredentialProcess(profile, function(err, data) {
-          if (err) {
-            callback(err);
-          } else {
-            self.expired = false;
-            self.accessKeyId = data.AccessKeyId;
-            self.secretAccessKey = data.SecretAccessKey;
-            self.sessionToken = data.SessionToken;
-            if (data.Expiration) {
-              self.expireTime = new Date(data.Expiration);
-            }
-            callback(null);
-          }
-        });
-      }
+      this.accessKeyId = profile['aws_access_key_id'];
+      this.secretAccessKey = profile['aws_secret_access_key'];
+      this.sessionToken = profile['aws_session_token'];
 
-      if ((!this.accessKeyId || !this.secretAccessKey) && !profile['credential_process']) {
+      if (!this.accessKeyId || !this.secretAccessKey) {
         throw AWS.util.error(
           new Error('Credentials not set for profile ' + this.profile),
           { code: 'SharedIniFileCredentialsProviderFailure' }
         );
       }
       this.expired = false;
-      if (this.accessKeyId && this.secretAccessKey) {
-        callback(null);
-      }
+      callback(null);
     } catch (err) {
       callback(err);
     }
-  },
-
-  /**
-  * Executes the credential_process and retrieves
-  * credentials from the output
-  * @api private
-  * @param profile [map] credentials profile
-  * @throws SharedIniFileCredentialsProviderFailure
-  */
-  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
-    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
-      try {
-        var credData = JSON.parse(stdOut);
-        if (credData.Expiration) {
-          var currentTime = AWS.util.date.getDate();
-          var expireTime = new Date(credData.Expiration);
-          if (expireTime < currentTime) {
-            err = AWS.util.error(
-              new Error('credential_process returned expired credentials'),
-              { code: 'SharedIniFileCredentialsProviderFailure' }
-            );
-          }
-        } else if (credData.Version !== 1) {
-          err = AWS.util.error(
-            new Error('credential_process does not return Version == 1'),
-          { code: 'SharedIniFileCredentialsProviderFailure' }
-          );
-        }
-        if (err) {
-          callback(err, null);
-        }
-        callback(null, credData);
-      } catch (err) {
-        callback(err, null);
-      }
-    });
   },
 
   /**

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -172,13 +172,12 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
             self.accessKeyId = data.AccessKeyId;
             self.secretAccessKey = data.SecretAccessKey;
             self.sessionToken = data.SessionToken;
-            if(data.Expiration) {
+            if (data.Expiration) {
               self.expireTime = new Date(data.Expiration);
             }
             callback(null);
           }
         });
-        return;
       }
 
       if (!this.accessKeyId || !this.secretAccessKey) {
@@ -201,23 +200,29 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   * @param profile [map] credentials profile
   * @throws SharedIniFileCredentialsProviderFailure
   */
-  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
-    var self = this;
-    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
-      var credData = JSON.parse(stdOut);
-      if(parseInt(credData.Version) !== 1) {
-        callback(
-          AWS.util.error(
-            new Error('credential_process does not return Version == 1 for profile ' + this.profile),
+ loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
+  proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
+    var credData = JSON.parse(stdOut);
+    if (!err) {
+      if (credData.Expiration) {
+        var currentTime = AWS.util.date.getDate();
+        var expireTime = new Date(credData.Expiration);
+        if (expireTime < currentTime) {
+          err = AWS.util.error(
+          new Error('credential_process returned expired credentials'),
             { code: 'SharedIniFileCredentialsProviderFailure' }
-          )
+          );
+        }
+      } else if (parseInt(credData.Version) !== 1) {
+        err = AWS.util.error(
+          new Error('credential_process does not return Version == 1'),
+        { code: 'SharedIniFileCredentialsProviderFailure' }
         );
-        return self;
       }
-      callback(null, credData);
-      return;
-    });
-  },
+    }
+    callback(err, credData);
+  });
+},
 
   /**
    * Loads the credentials from the shared credentials file

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -18,6 +18,23 @@ var iniLoader = AWS.util.iniLoader;
  *     aws_access_key_id = AKID...
  *     aws_secret_access_key = YOUR_SECRET_KEY
  *
+ * The crednetials file can also specify a credential provider that executes
+ * a given process and attempts to read its stdout to recieve a JSON payload
+ * containing the credentials:
+ *
+ *     [default]
+ *     credential_process = /usr/bin/credential_proc
+ *
+ * Automatically handles refreshing credentials if an Expiration time is
+ * provided in the credentials payload. Credentials supplied in the same profile
+ * will take precedence over the credential_process.
+ *
+ * Sourcing credentials from an external process can potentially be dangerous,
+ * so proceed with caution. Other credential providers should be preferred if
+ * at all possible. If using this option, you should make sure that the shared
+ * credentials file is as locked down as possible using security best practices
+ * for your operating system.
+ *
  * ## Using custom profiles
  *
  * The SDK supports loading credentials for separate profiles. This can be done
@@ -187,7 +204,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         );
       }
       this.expired = false;
-      if (this.accessKeyId || this.secretAccessKey) {
+      if (this.accessKeyId && this.secretAccessKey) {
         callback(null);
       }
     } catch (err) {
@@ -202,31 +219,34 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   * @param profile [map] credentials profile
   * @throws SharedIniFileCredentialsProviderFailure
   */
- loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
-  proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
-    if (err) {
-      callback(err, null);
-    } else {
-      var credData = JSON.parse(stdOut);
-      if (credData.Expiration) {
-        var currentTime = AWS.util.date.getDate();
-        var expireTime = new Date(credData.Expiration);
-        if (expireTime < currentTime) {
+  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
+    proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
+      try {
+        var credData = JSON.parse(stdOut);
+        if (credData.Expiration) {
+          var currentTime = AWS.util.date.getDate();
+          var expireTime = new Date(credData.Expiration);
+          if (expireTime < currentTime) {
+            err = AWS.util.error(
+              new Error('credential_process returned expired credentials'),
+              { code: 'SharedIniFileCredentialsProviderFailure' }
+            );
+          }
+        } else if (credData.Version !== 1) {
           err = AWS.util.error(
-          new Error('credential_process returned expired credentials'),
-            { code: 'SharedIniFileCredentialsProviderFailure' }
+            new Error('credential_process does not return Version == 1'),
+          { code: 'SharedIniFileCredentialsProviderFailure' }
           );
         }
-      } else if (credData.Version !== 1) {
-        err = AWS.util.error(
-          new Error('credential_process does not return Version == 1'),
-        { code: 'SharedIniFileCredentialsProviderFailure' }
-        );
+        if (err) {
+          callback(err, null);
+        }
+        callback(null, credData);
+      } catch (err) {
+        callback(err, null);
       }
-      callback(err, credData);
-    }
-  });
-},
+    });
+  },
 
   /**
    * Loads the credentials from the shared credentials file

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -202,8 +202,12 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   */
  loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
   proc.exec(profile['credential_process'], function(err,stdOut, stdErr) {
-    var credData = JSON.parse(stdOut);
-    if (!err) {
+    if (err) {
+      callback(err, null);
+    } else if (stdErr) {
+      callback(stdErr, null);
+    } else {
+      var credData = JSON.parse(stdOut);
       if (credData.Expiration) {
         var currentTime = AWS.util.date.getDate();
         var expireTime = new Date(credData.Expiration);
@@ -219,8 +223,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
         { code: 'SharedIniFileCredentialsProviderFailure' }
         );
       }
+      callback(err, credData);
     }
-    callback(err, credData);
   });
 },
 

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -34,6 +34,7 @@ require('./credentials/chainable_temporary_credentials');
 require('./credentials/web_identity_credentials');
 require('./credentials/cognito_identity_credentials');
 require('./credentials/saml_credentials');
+require('./credentials/process_credentials');
 
 // Load the xml2js XML parser
 AWS.XML.Parser = require('./xml/node_parser');
@@ -50,6 +51,7 @@ require('./credentials/ecs_credentials');
 require('./credentials/environment_credentials');
 require('./credentials/file_system_credentials');
 require('./credentials/shared_ini_file_credentials');
+require('./credentials/process_credentials');
 
 // Setup default chain providers
 // If this changes, please update documentation for
@@ -59,12 +61,9 @@ AWS.CredentialProviderChain.defaultProviders = [
   function () { return new AWS.EnvironmentCredentials('AWS'); },
   function () { return new AWS.EnvironmentCredentials('AMAZON'); },
   function () { return new AWS.SharedIniFileCredentials(); },
-  function () {
-    if (AWS.ECSCredentials.prototype.isConfiguredForEcsCredentials()) {
-      return new AWS.ECSCredentials();
-    }
-    return new AWS.EC2MetadataCredentials();
-  }
+  function () { return new AWS.ECSCredentials(); },
+  function () { return new AWS.ProcessCredentials(); },
+  function () { return new AWS.EC2MetadataCredentials(); }
 ];
 
 // Update configuration keys

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -460,12 +460,12 @@
           helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
           var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
           creds.refresh(function(e) {
-            if(e) {
+            if (e) {
               expect(e.message).to.eql('credential_process does not return Version == 1 for profile foo');
               done();
             }
-          })
-        })
+          });
+        });
         it('prefers static INI credentials over credentials process', function() {
           var mockProcess, mockConfig, creds;
           mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": ""}';

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -624,9 +624,9 @@
           helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
             cb(mockErr, undefined, undefined);
           });
-          var creds = new AWS.ProcessCredentials({ profile: 'foo' });
+          var creds = new AWS.ProcessCredentials();
           creds.refresh(function(err) {
-            expect(err).to.not.be.null;
+            expect(err.message).to.eql('credential_process returned error');
             expect(creds.accessKeyId).to.be.undefined;
             done();
           });

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -489,6 +489,38 @@
             done();
           });
         });
+        it('thorws error if credential_process returns err', function(done) {
+          var mockErr, mockConfig, creds;
+          mockErr = 'foo Error';
+          mockConfig = '[foo]\ncredential_process=federated_cli_mock';
+          var child_process = require('child_process');
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(mockErr, undefined, undefined);
+          });
+          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
+          var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
+          creds.refresh(function(err) {
+            expect(err).to.not.be.null;
+            expect(creds.accessKeyId).to.be.undefined;
+            done();
+          });
+        });
+        it('thorws error if credential_process returns stdErr', function(done) {
+          var mockStdErr, mockConfig, creds;
+          mockStdErr = 'foo stdErr';
+          mockConfig = '[foo]\ncredential_process=federated_cli_mock';
+          var child_process = require('child_process');
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(undefined, undefined, mockStdErr);
+          });
+          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
+          var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
+          creds.refresh(function(err) {
+            expect(err).to.not.be.null;
+            expect(creds.accessKeyId).to.be.undefined;
+            done();
+          });
+        });
         it('prefers static INI credentials over credentials process', function(done) {
           var mockProcess, mockConfig, creds;
           mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": ""}';

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -475,7 +475,7 @@
         it('throws error if credential_process returns expired credentials', function(done) {
           var mockProcess, mockConfig, creds, expired;
           expired = AWS.util.date.iso8601(new Date(0));
-          mockProcess = `{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": "${expired}"}`;
+          mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": "' + expired +'"}';
           mockConfig = '[foo]\ncredential_process=federated_cli_mock';
           var child_process = require('child_process');
           helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
@@ -496,22 +496,6 @@
           var child_process = require('child_process');
           helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
             cb(mockErr, undefined, undefined);
-          });
-          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
-          var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-          creds.refresh(function(err) {
-            expect(err).to.not.be.null;
-            expect(creds.accessKeyId).to.be.undefined;
-            done();
-          });
-        });
-        it('thorws error if credential_process returns stdErr', function(done) {
-          var mockStdErr, mockConfig, creds;
-          mockStdErr = 'foo stdErr';
-          mockConfig = '[foo]\ncredential_process=federated_cli_mock';
-          var child_process = require('child_process');
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-            cb(undefined, undefined, mockStdErr);
           });
           helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
           var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
@@ -543,7 +527,7 @@
           var mockProcess, mockConfig, creds, futureExpiration;
           futureExpiration = AWS.util.date.unixTimestamp() + 900;
           futureExpiration = AWS.util.date.iso8601(new Date(futureExpiration * 1000));
-          mockProcess = `{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": "${futureExpiration}"}`;
+          mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": "' + futureExpiration + '"}';
           mockConfig = '[foo]\ncredential_process=federated_cli_mock';
           var child_process = require('child_process');
           helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -124,6 +124,7 @@
         'RemoteCredentials',
         'SAMLCredentials',
         'SharedIniFileCredentials',
+        'ProcessCredentials',
         'WebIdentityCredentials'
       ],
       function(credClass) {
@@ -427,7 +428,7 @@
           creds.get();
           return validateCredentials(creds);
         });
-        it('accepts a loads config profiles from name parameter', function() {
+        return it('accepts a loads config profiles from name parameter', function() {
           var creds, mock;
           process.env.AWS_SDK_LOAD_CONFIG = '1';
           mock = '[profile foo]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session';
@@ -437,106 +438,6 @@
           });
           creds.get();
           return validateCredentials(creds);
-        });
-        describe('credential_process', function() {
-          beforeEach(function() {
-            var child_process = require('child_process');
-            var mockConfig, mockProcess, creds;
-            mockConfig = '[foo]\ncredential_process=federated_cli_mock';
-            helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
-            mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": ""}';
-            helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-              cb(undefined, mockProcess, undefined);
-            });
-          });
-          it('loads successfully', function(done) {
-            creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(creds.accessKeyId).to.equal('akid');
-              expect(creds.secretAccessKey).to.equal('secret');
-              expect(creds.sessionToken).to.equal('session');
-              expect(creds.expireTime).to.be.null;
-              done();
-            });
-          });
-          it('throws error if version is not 1', function(done) {
-            var child_process = require('child_process');
-            mockProcess = '{"Version": 2,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": ""}';
-            helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-              cb(undefined, mockProcess, undefined);
-            });
-            var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(err).to.exist;
-              expect(err.message).to.match(/^credential_process does not return Version == 1/);
-              done();
-            });
-          });
-          it('throws error if credentials are expired', function(done) {
-            var child_process = require('child_process');
-            var expired;
-            expired = AWS.util.date.iso8601(new Date(0));
-            mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": "' + expired +'"}';
-            helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-              cb(undefined, mockProcess, undefined);
-            });
-            var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(err.message).to.eql('credential_process returned expired credentials');
-              expect(err).to.not.be.null;
-              done();
-            });
-          });
-          it('thorws error if an error is returned', function(done) {
-            var child_process = require('child_process');
-            var mockErr;
-            mockErr = 'foo Error';
-            helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-              cb(mockErr, undefined, undefined);
-            });
-            var creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(err).to.not.be.null;
-              expect(creds.accessKeyId).to.be.undefined;
-              done();
-            });
-          });
-          it('prefers static INI credentials', function(done) {
-            mockConfig = '[foo]\ncredential_process=federated_cli_mock\naws_access_key_id = xxx\naws_secret_access_key = yyy\naws_session_token = zzz';
-            helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
-            creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(creds.accessKeyId).to.equal('xxx');
-              expect(creds.secretAccessKey).to.equal('yyy');
-              expect(creds.sessionToken).to.equal('zzz');
-              expect(creds.expireTime).to.be.null;
-              done();
-            });
-          });
-          it('sets expireTime if an expiration is included', function(done) {
-            var child_process = require('child_process');
-            var futureExpiration;
-            futureExpiration = AWS.util.date.unixTimestamp() + 900;
-            futureExpiration = AWS.util.date.iso8601(new Date(futureExpiration * 1000));
-            mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": "' + futureExpiration + '"}';
-            helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
-              cb(undefined, mockProcess, undefined);
-            });
-            creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.refresh(function(err) {
-              expect(creds.expireTime).to.eql(AWS.util.date.from(futureExpiration));
-              done();
-            });
-          });
-          return it('does not set expireTime if expiration is empty', function(done) {
-            var child_process = require('child_process');
-            creds = new AWS.SharedIniFileCredentials({ profile: 'foo' });
-            creds.get();
-            creds.refresh(function(err) {
-              expect(creds.expireTime).to.be.null;
-              done();
-            });
-          });
         });
       });
       describe('refresh', function() {
@@ -562,6 +463,213 @@
           process.env.HOME = '/home/user';
           helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
           new AWS.SharedIniFileCredentials().refresh(function(err) {
+            expect(err.message).to.match(/^Profile default not found/);
+            done();
+          });
+        });
+      });
+    });
+    describe('AWS.ProcessCredentials', function() {
+      var os = require('os');
+      var homedir = os.homedir;
+      var env;
+      afterEach(function() {
+        process.env = env;
+      });
+      beforeEach(function() {
+        env = process.env;
+        process.env = {};
+        delete os.homedir;
+      });
+      afterEach(function() {
+        iniLoader.clearCachedFiles();
+        os.homedir = homedir;
+      });
+      describe('constructor', function() {
+        beforeEach(function() {
+          var mock;
+          mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session';
+          return helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+        });
+        it('should use os.homedir if available', function() {
+          helpers.spyOn(os, 'homedir').andReturn('/foo/bar/baz');
+          new AWS.ProcessCredentials();
+          expect(os.homedir.calls.length).to.equal(1);
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/[\/\\]foo[\/\\]bar[\/\\]baz[\/\\].aws[\/\\]credentials/);
+        });
+        it('should prefer $HOME to os.homedir', function() {
+          process.env.HOME = '/home/user';
+          helpers.spyOn(os, 'homedir').andReturn(process.env.HOME + '/foo/bar');
+
+          new AWS.ProcessCredentials();
+          expect(os.homedir.calls.length).to.equal(0);
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0].arguments[0]).to
+            .match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/);
+        });
+        it('passes an error to callback if HOME/HOMEPATH/USERPROFILE are not set', function(done) {
+          new AWS.ProcessCredentials({
+            callback: function (err) {
+              expect(err).to.be.instanceof(Error);
+              expect(err.message).to.equal('Cannot load credentials, HOME path not set');
+              done();
+            }
+          });
+        });
+        it('uses HOMEDRIVE\\HOMEPATH if HOME and USERPROFILE are not set', function() {
+          var creds;
+          process.env.HOMEDRIVE = 'd:/';
+          process.env.HOMEPATH = 'homepath';
+          creds = new AWS.ProcessCredentials();
+          creds.get();
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/d:[\/\\]homepath[\/\\].aws[\/\\]credentials/);
+        });
+        it('uses default HOMEDRIVE of C:/', function() {
+          var creds;
+          process.env.HOMEPATH = 'homepath';
+          creds = new AWS.ProcessCredentials();
+          creds.get();
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/C:[\/\\]homepath[\/\\].aws[\/\\]credentials/);
+        });
+        it('uses USERPROFILE if HOME is not set', function() {
+          var creds;
+          process.env.USERPROFILE = '/userprofile';
+          creds = new AWS.ProcessCredentials();
+          creds.get();
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/[\/\\]userprofile[\/\\].aws[\/\\]credentials/);
+        });
+        return it('can override filename as a constructor argument', function() {
+          var creds;
+          creds = new AWS.ProcessCredentials({
+            filename: '/etc/creds'
+          });
+          creds.get();
+          expect(AWS.util.readFileSync.calls.length).to.equal(1);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.equal('/etc/creds');
+        });
+      });
+      describe('loading', function() {
+        beforeEach(function() {
+          process.env.HOME = '/home/user';
+          var child_process = require('child_process');
+          var mockConfig, mockProcess, creds;
+          mockConfig = '[default]\ncredential_process=federated_cli_mock';
+          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
+          mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": ""}';
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(undefined, mockProcess, undefined);
+          });
+        });
+        afterEach(function() {
+          iniLoader.clearCachedFiles();
+        });
+        it('loads successfully using default profile', function(done) {
+          creds = new AWS.ProcessCredentials();
+          creds.refresh(function(err) {
+            expect(creds.accessKeyId).to.equal('akid');
+            expect(creds.secretAccessKey).to.equal('secret');
+            expect(creds.sessionToken).to.equal('session');
+            expect(creds.expireTime).to.be.null;
+            done();
+          });
+        });
+        it('loads successfully using named profile', function(done) {
+          mockConfig = '[foo]\ncredential_process=federated_cli_mock';
+          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
+          creds = new AWS.ProcessCredentials({profile: 'foo'});
+          creds.refresh(function(err) {
+            expect(creds.accessKeyId).to.equal('akid');
+            expect(creds.secretAccessKey).to.equal('secret');
+            expect(creds.sessionToken).to.equal('session');
+            expect(creds.expireTime).to.be.null;
+            done();
+          });
+        });
+        it('throws error if version is not 1', function(done) {
+          var child_process = require('child_process');
+          mockProcess = '{"Version": 2,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": ""}';
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(undefined, mockProcess, undefined);
+          });
+          var creds = new AWS.ProcessCredentials();
+          creds.refresh(function(err) {
+            expect(err).to.exist;
+            expect(err.message).to.match(/^credential_process does not return Version == 1/);
+            done();
+          });
+        });
+        it('throws error if credentials are expired', function(done) {
+          var child_process = require('child_process');
+          var expired;
+          expired = AWS.util.date.iso8601(new Date(0));
+          mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": "' + expired +'"}';
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(undefined, mockProcess, undefined);
+          });
+          var creds = new AWS.ProcessCredentials();
+          creds.refresh(function(err) {
+            expect(err.message).to.eql('credential_process returned expired credentials');
+            expect(err).to.not.be.null;
+            done();
+          });
+        });
+        it('thorws error if an error is returned', function(done) {
+          var child_process = require('child_process');
+          var mockErr;
+          mockErr = 'foo Error';
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(mockErr, undefined, undefined);
+          });
+          var creds = new AWS.ProcessCredentials({ profile: 'foo' });
+          creds.refresh(function(err) {
+            expect(err).to.not.be.null;
+            expect(creds.accessKeyId).to.be.undefined;
+            done();
+          });
+        });
+        it('sets expireTime if an expiration is included', function(done) {
+          var child_process = require('child_process');
+          var futureExpiration;
+          futureExpiration = AWS.util.date.unixTimestamp() + 900;
+          futureExpiration = AWS.util.date.iso8601(new Date(futureExpiration * 1000));
+          mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": "' + futureExpiration + '"}';
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+            cb(undefined, mockProcess, undefined);
+          });
+          creds = new AWS.ProcessCredentials();
+          creds.refresh(function(err) {
+            expect(creds.expireTime).to.eql(AWS.util.date.from(futureExpiration));
+            done();
+          });
+        });
+        return it('does not set expireTime if expiration is empty', function(done) {
+          var child_process = require('child_process');
+          creds = new AWS.ProcessCredentials({ profile: 'foo' });
+          creds.get();
+          creds.refresh(function(err) {
+            expect(creds.expireTime).to.be.null;
+            done();
+          });
+        });
+      });
+      describe('refresh', function() {
+        var origEnv = process.env;
+        beforeEach(function() {
+          process.env = {};
+        });
+        afterEach(function() {
+          process.env = origEnv;
+          iniLoader.clearCachedFiles();
+        });
+        return it('fails if credentials are not in the file', function(done) {
+          var mock = '';
+          process.env.HOME = '/home/user';
+          helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+          new AWS.ProcessCredentials().refresh(function(err) {
             expect(err.message).to.match(/^Profile default not found/);
             done();
           });


### PR DESCRIPTION
reworked from https://github.com/aws/aws-sdk-js/pull/1923 to get tests passing

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
