### PR TITLE
Abort ManagedUpload with body smaller than 5MB

### DIFF
--- a/.changes/next-release/bugfix-ManageUpload-a7d3d6b9.json
+++ b/.changes/next-release/bugfix-ManageUpload-a7d3d6b9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ManageUpload",
+  "description": "abort request stream when body is smaller than 5MB"
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -246,9 +246,15 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    *   setTimeout(upload.abort.bind(upload), 1000);
    */
   abort: function() {
-    this.cleanup(AWS.util.error(new Error('Request aborted by user'), {
-      code: 'RequestAbortedError', retryable: false
-    }));
+    var self = this;
+    //abort putObject request
+    if (self.isDoneChunking === true && self.totalPartNumbers === 1 && self.singlePart) {
+      self.singlePart.abort();
+    } else {
+      self.cleanup(AWS.util.error(new Error('Request aborted by user'), {
+        code: 'RequestAbortedError', retryable: false
+      }));
+    }
   },
 
   /**
@@ -471,6 +477,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       var req = self.service.putObject(params);
       req._managedUpload = self;
       req.on('httpUploadProgress', self.progress).send(self.finishSinglePart);
+      self.singlePart = req; //save the single part request
       return null;
     } else if (self.service.config.params.ContentMD5) {
       var err = AWS.util.error(new Error('The Content-MD5 you specified is invalid for multi-part uploads.'), {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Currently, when calling `abort()` on S3 managed upload, the upload will be aborted only when multi-part upload is used. If the body is less than 5MB, the upload will opt to use `putObject` operation and the request is not able to be aborted. This change fixes the issue.

/cc @srchase 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`