### PR TITLE
Correctly remove whitespace from custom policy

### DIFF
--- a/.changes/next-release/bugfix-cloudfront-89d630df.json
+++ b/.changes/next-release/bugfix-cloudfront-89d630df.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "cloudfront",
+  "description": "Fix whitespace removal on custom policy"
+}

--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -39,7 +39,7 @@ var signWithCannedPolicy = function (url, expires, keyPairId, privateKey) {
 };
 
 var signWithCustomPolicy = function (policy, keyPairId, privateKey) {
-    policy = policy.replace(/\s/mg, policy);
+    policy = policy.replace(/\s/mg, '');
 
     return {
         Policy: queryEncode(base64Encode(policy)),


### PR DESCRIPTION
Currently it incorrectly replaces whitespace characters with policy itself, making it invalid json.

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
