### PR TITLE
allow sending body for GET request of REST services

### DIFF
--- a/.changes/next-release/bugfix-Paginator-b5c4816c.json
+++ b/.changes/next-release/bugfix-Paginator-b5c4816c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "fix the issue where paginator keys are ignored in GET requests"
+}

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -24,7 +24,10 @@ function populateBody(req) {
       }
     }
   } else {
-    req.httpRequest.body = builder.build(req.params, input);
+    var body = builder.build(req.params, input);
+    if (body !== '{}') { //don't send empty object
+      req.httpRequest.body = body;
+    }
     applyContentTypeHeader(req);
   }
 }

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -42,8 +42,8 @@ function applyContentTypeHeader(req, isBinary) {
 function buildRequest(req) {
   Rest.buildRequest(req);
 
-  // never send body payload on GET/HEAD/DELETE
-  if (['GET', 'HEAD', 'DELETE'].indexOf(req.httpRequest.method) < 0) {
+  // never send body payload on HEAD/DELETE
+  if (['HEAD', 'DELETE'].indexOf(req.httpRequest.method) < 0) {
     populateBody(req);
   }
 }

--- a/test/protocol/rest_json.spec.js
+++ b/test/protocol/rest_json.spec.js
@@ -318,6 +318,21 @@
           });
         });
 
+        it('does not send empty object string', function() {
+          request.params = {};
+          defop({
+            input: {
+              payload: 'Data',
+              members: {
+                Data: {
+                  type: 'string'
+                }
+              }
+            }
+          });
+          expect(build().httpRequest.body).to.eql('');
+        });
+
         it('builds root element if rules contains root', function() {
           request.params = {
             Config: {

--- a/test/protocol/rest_json.spec.js
+++ b/test/protocol/rest_json.spec.js
@@ -296,7 +296,7 @@
       });
 
       describe('body', function() {
-        ['GET', 'HEAD', 'DELETE'].forEach(function(method) {
+        ['HEAD', 'DELETE'].forEach(function(method) {
           it('does not populate a body on a ' + method + ' request', function() {
             request.params = {
               Data: 'abc'

--- a/test/services/cloudsearchdomain.spec.js
+++ b/test/services/cloudsearchdomain.spec.js
@@ -110,7 +110,6 @@
         req = build('suggest', params);
         expect(req.method).to.equal('GET');
         expect(req.path.split('?')[1]).to.equal('format=sdk&pretty=true&q=foo&suggester=bar');
-        return expect(!!req.body).to.be['false'];
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This PR fixes the issue where paginator keys are ignored in GET requests for REST services


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`
- [X] integration test passes
