### PR TITLE
Update the shared_ini_file_creds typedef

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -13,4 +13,5 @@ interface SharedIniFileCredentialsOptions {
     disableAssumeRole?: boolean
     tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
     httpOptions?: HTTPOptions
+    callback?: (err?: Error) => void
 }


### PR DESCRIPTION
Add type def for callback definition as described here:
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SharedIniFileCredentials.html

##### Checklist

- [X] `npm run test` passes
