### PR TITLE
document promises on getSignedUrl

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -749,6 +749,8 @@ AWS.util.update(AWS.S3.prototype, {
    *   won't be signed. You must use signatureVersion v4 to to include these
    *   parameters in the signed portion of the URL and enforce exact matching
    *   between headers and signed params in the URL.
+   * @note This operation cannot be used with a promise. See note above regarding
+   *   asynchronous credentials and use with a callback.
    * @param operation [String] the name of the operation to call
    * @param params [map] parameters to pass to the operation. See the given
    *   operation for the expected operation parameters. In addition, you can


### PR DESCRIPTION
Add note regarding use of promsie on getSignedUrl

- [x] `npm run test` passes
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed

change to clarify https://github.com/aws/aws-sdk-js/issues/1943