### PR TITLE
send empty object in body for requests other than GET

### DIFF
--- a/.changes/next-release/bugfix-Paginator-cdfd161d.json
+++ b/.changes/next-release/bugfix-Paginator-cdfd161d.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "still send '{}' in body for requests other than GET"
+}

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -25,7 +25,7 @@ function populateBody(req) {
     }
   } else {
     var body = builder.build(req.params, input);
-    if (body !== '{}') { //don't send empty object
+    if (body !== '{}' || req.httpRequest.method !== 'GET') { //don't send empty body for GET method
       req.httpRequest.body = body;
     }
     applyContentTypeHeader(req);

--- a/test/protocol/rest_json.spec.js
+++ b/test/protocol/rest_json.spec.js
@@ -318,11 +318,13 @@
           });
         });
 
-        it('does not send empty object string', function() {
+        it('does not send empty for GET methods', function() {
           request.params = {};
           defop({
+            http: {
+              method: 'GET'
+            },
             input: {
-              payload: 'Data',
               members: {
                 Data: {
                   type: 'string'
@@ -331,6 +333,22 @@
             }
           });
           expect(build().httpRequest.body).to.eql('');
+
+          ['POST', 'PUT'].forEach(function(method) {
+            defop({
+              http: {
+                method: method
+              },
+              input: {
+                members: {
+                  Data: {
+                    type: 'string'
+                  }
+                }
+              }
+            });
+            expect(build().httpRequest.body).to.eql('{}');
+          });
         });
 
         it('builds root element if rules contains root', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
The previous change #2574 breaks the SDK when request the method is 'PUT' or 'POST' and request body is '{}'. SDK used to send the body but later ignored the body after the change. This PR fix the bug reported here #2588 . 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`