### PR TITLE
ignore linting temporary test config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist/*
 test/browser/**/*
+test/configuration.js


### PR DESCRIPTION
Don't bother linting test/configuration.js.  It should be a temporary file, but may persist if test run doesn't succeed.

- [x] `npm run test` passes
