### PR TITLE
enable keep alive

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -142,7 +142,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
     var https = require('https');
 
     if (!AWS.NodeHttpClient.sslAgent) {
-      AWS.NodeHttpClient.sslAgent = new https.Agent({rejectUnauthorized: true});
+      AWS.NodeHttpClient.sslAgent = new https.Agent({rejectUnauthorized: true, keepAlive: true});
       AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
 
       // delegate maxSockets to globalAgent, set a default limit of 50 if current value is Infinity.


### PR DESCRIPTION
Keep alive flag in the http agent, keeps sockets around even when there are no outstanding requests, so they can be used for future requests without having to reestablish a TCP connection. Without this flag, every request to Dynamo will be on a separate connection. I have overriden the default http agent in my application code as per below , and the impact in terms of latency/execution time is considerable.

const https = require('https');
const keepAliveAgent = new https.Agent({ keepAlive: true});
const ddb = new AWS.DynamoDB({apiVersion: '2012-10-08', httpOptions: {agent: keepAliveAgent}});

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
