### PR TITLE
 Guard against undefined util.stream.Stream

### DIFF
--- a/.changes/next-release/bugfix-utility-e9e3614f.json
+++ b/.changes/next-release/bugfix-utility-e9e3614f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "utility",
+  "description": "Guard against undefined util.stream.Stream"
+}

--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -879,7 +879,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	   */
 	  computeSha256: function computeSha256(body, done) {
 	    if (util.isNode()) {
-	      var Stream = util.stream.Stream;
+	      var Stream = util.stream.Stream || {};
 	      var fs = __webpack_require__(6);
 	      if (body instanceof Stream) {
 	        if (typeof body.path === 'string') { // assume file object

--- a/lib/util.js
+++ b/lib/util.js
@@ -701,7 +701,7 @@ var util = {
    */
   computeSha256: function computeSha256(body, done) {
     if (util.isNode()) {
-      var Stream = util.stream.Stream;
+      var Stream = util.stream.Stream || {};
       var fs = require('fs');
       if (body instanceof Stream) {
         if (typeof body.path === 'string') { // assume file object


### PR DESCRIPTION
There is a race condition whereby util.stream.Stream is sometimes undefined when the `if (body instanceof Stream) {` conditional is run. instanceof requires an object constructor as its operand. If the operand is undefined, an error is thrown. This fix guards against that use case.

Issue: https://github.com/aws/aws-sdk-js/issues/2581

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
