### PR TITLE
Correct examples in api reference

### DIFF
--- a/.changes/next-release/feature-docs-45c289fa.json
+++ b/.changes/next-release/feature-docs-45c289fa.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "docs",
+  "description": "update doc operation example to use 'NUMBER_VALUE' instead of 0 in input"
+}

--- a/doc-src/templates/api-versions/model_documentor.rb
+++ b/doc-src/templates/api-versions/model_documentor.rb
@@ -591,12 +591,12 @@ class ExampleShapeVisitor
   end
 
   def visit_integer(node, required = false)
-    "0"
+    "'NUMBER_VALUE'"
   end
   alias visit_long visit_integer
 
   def visit_float(node, required = false)
-    "0.0"
+    "'NUMBER_VALUE'"
   end
   alias visit_double visit_float
   alias visit_bigdecimal visit_float


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
The examples in api reference used to use 0 or 0.0 for number type input. Sometimes these dummy values are not valid for given API. This PR change them to 'NUMBER_VALUE' to avoid confusion.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`
- [X] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
