### PR TITLE
Guard against TypeError

### DIFF
--- a/.changes/next-release/bugfix-stream-d608b740.json
+++ b/.changes/next-release/bugfix-stream-d608b740.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "stream",
+  "description": "Verify instanceof operand"
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -703,7 +703,7 @@ var util = {
     if (util.isNode()) {
       var Stream = util.stream.Stream;
       var fs = require('fs');
-      if (body instanceof Stream) {
+      if (typeof Stream === 'object' && body instanceof Stream) {
         if (typeof body.path === 'string') { // assume file object
           var settings = {};
           if (typeof body.start === 'number') {


### PR DESCRIPTION
There is a race condition whereby util.stream.Stream is sometimes undefined when the `if (body instanceof Stream) {` conditional is run. `instanceof` requires an object constructor as its operand. If the operand is undefined, an error is thrown. This fix guards against that use case.

Issue: https://github.com/aws/aws-sdk-js/issues/2581

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`