### PR TITLE
Before running instanceof, verify that the operand is a function

### DIFF
--- a/.changes/next-release/bugfix-computeSha256-3ba0c8a0.json
+++ b/.changes/next-release/bugfix-computeSha256-3ba0c8a0.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "computeSha256",
+  "description": "Before running instanceof, verify that the operand is a function"
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -703,7 +703,7 @@ var util = {
     if (util.isNode()) {
       var Stream = util.stream.Stream;
       var fs = require('fs');
-      if (body instanceof Stream) {
+      if (typeof Stream === 'function' && body instanceof Stream) {
         if (typeof body.path === 'string') { // assume file object
           var settings = {};
           if (typeof body.start === 'number') {


### PR DESCRIPTION
There is a race condition whereby util.stream.Stream is sometimes undefined when the `if (body instanceof Stream) {` conditional is run. `instanceof` requires a constructor function as its operand. If the operand is not a function, an error is thrown. This fix guards against that use case.

Issue: https://github.com/aws/aws-sdk-js/issues/2581

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`