### PR TITLE
Allocate new buffer when parsing sensitive blob

### DIFF
--- a/.changes/next-release/bugfix-Parser-f872d831.json
+++ b/.changes/next-release/bugfix-Parser-f872d831.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Parser",
+  "description": "Alloc new buffers from 0 offset when parsing the sensitive blob data and zero out the node shared buffer pool."
+}

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -357,7 +357,13 @@ function BinaryShape() {
   this.toType = function(value) {
     var buf = util.base64.decode(value);
     if (this.isSensitive && util.isNode() && typeof util.Buffer.alloc === 'function') {
-      //for Node 5.10+ which has Buffer.alloc, zero out the sensitive data in shared buffer
+  /* Node.js can create a Buffer that is not isolated.
+   * i.e. buf.byteLength !== buf.buffer.byteLength
+   * This means that the sensitive data is accessible to anyone with access to buf.buffer.
+   * If this is the node shared Buffer, then other code within this process _could_ find this secret.
+   * Copy sensitive data to an isolated Buffer and zero the sensitive data.
+   * While this is safe to do here, copying this code somewhere else may produce unexpected results.
+   */
       var secureBuf = util.Buffer.alloc(buf.length, buf);
       buf.fill(0);
       buf = secureBuf;

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -356,14 +356,14 @@ function BinaryShape() {
   Shape.apply(this, arguments);
   this.toType = function(value) {
     var buf = util.base64.decode(value);
-    if (this.isSensitive && typeof util.Buffer.alloc === 'function') {
+    if (this.isSensitive && util.isNode() && typeof util.Buffer.alloc === 'function') {
       //for Node 5.10+ which has Buffer.alloc, zero out the sensitive data in shared buffer
       var secureBuf = util.Buffer.alloc(buf.length, buf);
       buf.fill(0);
       buf = secureBuf;
     }
     return buf;
-  }
+  };
   this.toWireFormat = util.base64.encode;
 }
 

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -354,7 +354,16 @@ function IntegerShape() {
 
 function BinaryShape() {
   Shape.apply(this, arguments);
-  this.toType = util.base64.decode;
+  this.toType = function(value) {
+    var buf = util.base64.decode(value);
+    if (this.isSensitive && typeof util.Buffer.alloc === 'function') {
+      //for Node 5.10+ which has Buffer.alloc, zero out the sensitive data in shared buffer
+      var secureBuf = util.Buffer.alloc(buf.length, buf);
+      buf.fill(0);
+      buf = secureBuf;
+    }
+    return buf;
+  }
   this.toWireFormat = util.base64.encode;
 }
 

--- a/test/model/shape.spec.js
+++ b/test/model/shape.spec.js
@@ -54,7 +54,7 @@
 
     if (AWS.util.isNode() && AWS.util.Buffer.alloc) {
       describe('Sensitive binary data', function() {
-        it('should not use Buffer.from() for sensitive data', function() {
+        it('should not use Buffer.from() for decoding sensitive data', function() {
           var binaryTypes = ['blob', 'binary', 'base64'];
           for (var i = 0; i < binaryTypes.length; i++) {
               api = new AWS.Model.Api({
@@ -72,7 +72,7 @@
               expect(bufferSpace[buf.byteOffset]).to.not.eql(0x11);
               expect(bufferSpace[buf.byteOffset+1]).to.not.eql(0x12);
           };
-        })
+        });
       });
     }
 

--- a/test/model/shape.spec.js
+++ b/test/model/shape.spec.js
@@ -51,6 +51,31 @@
         return expect(shape.members.body.isStreaming).to.eql(true);
       });
     });
+
+    if (AWS.util.isNode() && AWS.util.Buffer.alloc) {
+      describe('Sensitive binary data', function() {
+        it('should not use Buffer.from() for sensitive data', function() {
+          var binaryTypes = ['blob', 'binary', 'base64'];
+          for (var i = 0; i < binaryTypes.length; i++) {
+              api = new AWS.Model.Api({
+                shapes: {
+                  S2: {
+                    'type': binaryTypes[i],
+                    'sensitive': true
+                  }
+                }
+              });
+              var buf = api.shapes.S2.toType([0x11, 0x12]);
+              // The shared buffer space in NodeJS. Response sensitive data should not lay in here
+              // see: https://nodejs.org/docs/latest/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
+              var bufferSpace = new Uint8Array(AWS.util.Buffer.from('foo').buffer);
+              expect(bufferSpace[buf.byteOffset]).to.not.eql(0x11);
+              expect(bufferSpace[buf.byteOffset+1]).to.not.eql(0x12);
+          };
+        })
+      });
+    }
+
     return describe('TimestampShape', function() {
       describe('timestampFormat', function() {
         it('can be inherited', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Use `Buffer.alloc` instead of `Buffer.from` to avoid sensitive data being left in the Node share buffer pool.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`