### PR TITLE
Fix DynamoDB DocumentClient set unmarshalling

### DIFF
--- a/.changes/next-release/bugfix-DocumentClient-318ee4e7.json
+++ b/.changes/next-release/bugfix-DocumentClient-318ee4e7.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "DocumentClient",
+  "description": "Fixes issue stringifying sets by only including values."
+}

--- a/lib/dynamodb/set.js
+++ b/lib/dynamodb/set.js
@@ -53,6 +53,14 @@ var DynamoDBSet = util.inherit({
         });
       }
     }
+  },
+
+  /**
+   * Render the underlying values only when converting to JSON.
+   */
+  toJSON: function() {
+    var self = this;
+    return self.values;
   }
 
 });

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -1327,6 +1327,9 @@
           }
         });
         outputString = '{"Item":{"foo":[{"type":"Buffer","data":[98,97,114]},{"type":"Buffer","data":[98,97,122]},{"type":"Buffer","data":[113,117,117,120]}]}}';
+        if (process.version < 'v0.12') {
+          outputString = '{"Item":{"foo":[[98,97,114],[98,97,122],[113,117,117,120]]}}'
+        }
         helpers.mockHttpResponse(200, {}, wire);
         docClient.get({
           Key: {

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -4,6 +4,7 @@
   var AWS = helpers.AWS;
   var Buffer = AWS.util.Buffer;
   var encode = AWS.util.base64.encode;
+  var isBrowser = AWS.util.isBrowser;
   var docClient = null;
   var NumberValue = require('../../lib/dynamodb/numberValue');
 
@@ -1327,8 +1328,8 @@
           }
         });
         outputString = '{"Item":{"foo":[{"type":"Buffer","data":[98,97,114]},{"type":"Buffer","data":[98,97,122]},{"type":"Buffer","data":[113,117,117,120]}]}}';
-        if (process.version < 'v0.12') {
-          outputString = '{"Item":{"foo":[[98,97,114],[98,97,122],[113,117,117,120]]}}'
+        if (process.version < 'v0.12' && !isBrowser()) {
+          outputString = '{"Item":{"foo":[[98,97,114],[98,97,122],[113,117,117,120]]}}';
         }
         helpers.mockHttpResponse(200, {}, wire);
         docClient.get({

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -1272,6 +1272,72 @@
         });
       });
 
+      it('stringifies string sets', function(done) {
+        var outputString, wire;
+        wire = JSON.stringify({
+          Item: {
+            foo: {
+              'SS': ['bar', 'baz', 'quux']
+            }
+          }
+        });
+        outputString = '{"Item":{"foo":["bar","baz","quux"]}}';
+        helpers.mockHttpResponse(200, {}, wire);
+        docClient.get({
+          Key: {
+            foo: 1
+          }
+        }, function(err, data) {
+          expect(JSON.stringify(data)).to.eql(outputString);
+          done();
+        });
+      });
+
+      it('stringifies number sets', function(done) {
+        var outputString, wire;
+        wire = JSON.stringify({
+          Item: {
+            foo: {
+              'NS': ['1', '2', '3']
+            }
+          }
+        });
+        outputString = '{"Item":{"foo":[1,2,3]}}';
+        helpers.mockHttpResponse(200, {}, wire);
+        docClient.get({
+          Key: {
+            foo: 1
+          }
+        }, function(err, data) {
+          expect(JSON.stringify(data)).to.eql(outputString);
+          done();
+        });
+      });
+
+      it('stringifies binary sets', function(done) {
+        var bar, baz, outputString, quux, wire;
+        bar = new Buffer('bar');
+        baz = new Buffer('baz');
+        quux = new Buffer('quux');
+        wire = JSON.stringify({
+          Item: {
+            foo: {
+              'BS': [encode(bar), encode(baz), encode(quux)]
+            }
+          }
+        });
+        outputString = '{"Item":{"foo":[{"type":"Buffer","data":[98,97,114]},{"type":"Buffer","data":[98,97,122]},{"type":"Buffer","data":[113,117,117,120]}]}}';
+        helpers.mockHttpResponse(200, {}, wire);
+        docClient.get({
+          Key: {
+            foo: 1
+          }
+        }, function(err, data) {
+          expect(JSON.stringify(data)).to.eql(outputString);
+          done();
+        });
+      });
+
       it('translates recursive maps', function(done) {
         var output, wire;
         wire = JSON.stringify({


### PR DESCRIPTION
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`

Using the DynamoDB [DocumentClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html), a set within an item will get stringified improperly:

```
const AWS = require('aws-sdk');
const client = new AWS.DynamoDB.DoclumentClient();
const params = {
  TableName: 'myTable',
  Key: {
    id: 1
  }
}
client.get(params, function(err,data) {
  if (!err) {
    console.log(JSON.stringify(data)); // {"Item":{"id":1,"list1":{"wrapperName":"Set","values":[1,5,9],"type":"Number"}}}
  }
}
```
Instead, only the values of the set should be returned: 
```
console.log(JSON.stringify(data)); // {"Item":{"id":55,"list1":[1,5,9]}}
```


