### PR TITLE
Increase in Karma Version to fix Lodash vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jasmine": "^2.5.3",
     "jasmine-core": "^2.5.2",
     "json-loader": "^0.5.4",
-    "karma": "^2.0.0",
+    "karma": "^4.1.0",
     "karma-chrome-launcher": "2.2.0",
     "karma-jasmine": "^1.1.0",
     "mocha": "^3.0.0",


### PR DESCRIPTION
As indicated by issue #2651, versions of karma lower than 4.0.1 can bring in a version of lodash with a security vulnerability. Bumping up the version of karma to fix this problem.

- [X] `npm run test` passes