### PR TITLE
Support 'requiresLength' Trait

### DIFF
--- a/.changes/next-release/feature-core-531a7bef.json
+++ b/.changes/next-release/feature-core-531a7bef.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "core",
+  "description": "Add support for requiresLength trait for streaming payload and send chunked transfer encode when allowed"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -156,17 +156,25 @@ AWS.EventListeners = {
 
     add('SET_CONTENT_LENGTH', 'afterBuild', function SET_CONTENT_LENGTH(req) {
       var authtype = getOperationAuthtype(req);
+      var payloadMember = AWS.util.getRequestPayloadShape(req);
       if (req.httpRequest.headers['Content-Length'] === undefined) {
         try {
           var length = AWS.util.string.byteLength(req.httpRequest.body);
           req.httpRequest.headers['Content-Length'] = length;
         } catch (err) {
-          if (authtype.indexOf('unsigned-body') === -1) {
-            throw err;
-          } else {
-            // Body isn't signed and may not need content length (lex)
-            return;
+          if (payloadMember && payloadMember.isStreaming) {
+            if (payloadMember.requiresLength) {
+              //streaming payload requires length(s3, glacier)
+              throw err;
+            } else if (authtype.indexOf('unsigned-body') >= 0) {
+              //unbounded streaming payload(lex, mediastore)
+              req.httpRequest.headers['Transfer-Encoding'] = 'chunked';
+              return;
+            } else {
+              throw err;
+            }
           }
+          throw err;
         }
       }
     });

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -28,6 +28,7 @@ function Shape(shape, options, memberName) {
   property(this, 'name', this.name || shape.xmlName || shape.queryName ||
     shape.locationName || memberName);
   property(this, 'isStreaming', shape.streaming || this.isStreaming || false);
+  property(this, 'requiresLength', shape.requiresLength, false);
   property(this, 'isComposite', shape.isComposite || false);
   property(this, 'isShape', true, false);
   property(this, 'isQueryName', Boolean(shape.queryName), false);

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -195,8 +195,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     'user-agent',
     expiresHeader,
     'expect',
-    'x-amzn-trace-id',
-    'transfer-encoding'
+    'x-amzn-trace-id'
   ],
 
   isSignableHeader: function isSignableHeader(key) {

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -195,7 +195,8 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     'user-agent',
     expiresHeader,
     'expect',
-    'x-amzn-trace-id'
+    'x-amzn-trace-id',
+    'transfer-encoding'
   ],
 
   isSignableHeader: function isSignableHeader(key) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -912,6 +912,17 @@ var util = {
   /**
    * @api private
    */
+  getRequestPayloadShape: function getRequestPayloadShape(req) {
+    var operations = req.service.api.operations;
+    if (!operations) return undefined;
+    var operation = (operations || {})[req.operation];
+    if (!operation || !operation.input || !operation.input.payload) return undefined;
+    return operation.input.members[operation.input.payload];
+  },
+
+  /**
+   * @api private
+   */
   defaultProfile: 'default',
 
   /**

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -267,6 +267,7 @@
 
         describe ('when has requiresLength trait exists', function() {
           var oldByteLength = AWS.util.string.byteLength;
+          var service = new FooService();
           beforeEach(function() {
             helpers.spyOn(AWS.util.string, 'byteLength').andCallFake(function(chunk) {
               throw new Error('Cannot determine length of ' + chunk);
@@ -277,7 +278,6 @@
           });
 
           it('throws error when content length is required in payload shape but length is not available', function(done) {
-            var service = new FooService();
             var req = service.putBoundedStream({
               Body: 'NoLengthBody'
             });
@@ -290,7 +290,6 @@
           });
 
           it('throws error when content length is required in unsigned payload shape but length is not available', function(done) {
-            var service = new FooService();
             var req = service.putUnsignedBoundedStream({
               Body: 'NoLengthBody'
             });
@@ -298,6 +297,22 @@
               expect(err.message).to.contain('Cannot determine length of');
               done();
             });
+          });
+        });
+
+        it('throws error when non-streaming body has no length', function(done) {
+          var oldByteLength = AWS.util.string.byteLength;
+          var service = new FooService();
+          helpers.spyOn(AWS.util.string, 'byteLength').andCallFake(function(chunk) {
+            throw new Error('Cannot determine length of ' + chunk);
+          });
+          var req = service.putNonStream({
+            Body: 'NoLengthBody'
+          });
+          req.runTo('sign', function(err) {
+            AWS.util.string.byteLength = oldByteLength;
+            expect(err.message).to.contain('Cannot determine length of');
+            done();
           });
         });
 

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -171,6 +171,26 @@
         }
       };
 
+      describe('add Transfer-Encoding header', function() {
+        it('when streaming payload is unsigned payload if content length is not available', function(done) {
+          var oldByteLength = AWS.util.string.byteLength;
+          helpers.spyOn(AWS.util.string, 'byteLength').andCallFake(function(chunk) {
+            throw new Error('Cannot determine length of ' + chunk);
+          });
+          var service = new FooService();
+          var req = service.putStream({
+            Body: 'NoLengthBody'
+          });
+
+          req.runTo('sign', function(err) {
+            expect(req.httpRequest.headers['Transfer-Encoding']).to.equal('chunked');
+            expect(!err).to.equal(true);
+            AWS.util.string.byteLength = oldByteLength;
+            done();
+          });
+        });
+      });
+
       describe('adds Content-Length header', function() {
         var contentLength;
         contentLength = function(body) {
@@ -243,6 +263,42 @@
 
         it('builds Content-Length for buffer body', function() {
           return expect(contentLength(new AWS.util.Buffer('tï№'))).to.equal(6);
+        });
+
+        describe ('when has requiresLength trait exists', function() {
+          var oldByteLength = AWS.util.string.byteLength;
+          beforeEach(function() {
+            helpers.spyOn(AWS.util.string, 'byteLength').andCallFake(function(chunk) {
+              throw new Error('Cannot determine length of ' + chunk);
+            });
+          });
+          afterEach(function() {
+            AWS.util.string.byteLength = oldByteLength;
+          });
+
+          it('throws error when content length is required in payload shape but length is not available', function(done) {
+            var service = new FooService();
+            var req = service.putBoundedStream({
+              Body: 'NoLengthBody'
+            });
+            //this event listener will raise error even before setting content length
+            req.removeListener('afterBuild', AWS.EventListeners.Core.COMPUTE_SHA256);
+            req.runTo('sign', function(err) {
+              expect(err.message).to.contain('Cannot determine length of');
+              done();
+            });
+          });
+
+          it('throws error when content length is required in unsigned payload shape but length is not available', function(done) {
+            var service = new FooService();
+            var req = service.putUnsignedBoundedStream({
+              Body: 'NoLengthBody'
+            });
+            req.runTo('sign', function(err) {
+              expect(err.message).to.contain('Cannot determine length of');
+              done();
+            });
+          });
         });
 
         if (AWS.util.isNode()) {

--- a/test/foo-service.fixture.js
+++ b/test/foo-service.fixture.js
@@ -80,6 +80,20 @@ var model = {
       },
       'authtype': 'v4-unsigned-body'
     },
+    'PutNonStream': {
+      'http': {
+        'method': 'PUT',
+        'requestUri': '/'
+      },
+      'input': {
+        'type': 'structure',
+        'members': {
+          'Body': {
+            'shape': 'StringShape'
+          }
+        },
+      },
+    },
   },
   'shapes': {
     'StreamingBody': {
@@ -90,7 +104,8 @@ var model = {
       'type': 'blob',
       'streaming': true,
       'requiresLength': true
-    }
+    },
+    'StringShape': {'type': 'string'}
   }
 };
 

--- a/test/foo-service.fixture.js
+++ b/test/foo-service.fixture.js
@@ -33,12 +33,63 @@ var model = {
         'payload': 'Body'
       },
       'authtype': 'v4-unsigned-body'
-    }
+    },
+    'PutSignedStream': {
+      'http': {
+        'method': 'PUT',
+        'requestUri': '/'
+      },
+      'input': {
+        'type': 'structure',
+        'members': {
+          'Body': {
+            'shape': 'StreamingBody'
+          }
+        },
+        'payload': 'Body'
+      },
+    },
+    'PutBoundedStream': {
+      'http': {
+        'method': 'PUT',
+        'requestUri': '/'
+      },
+      'input': {
+        'type': 'structure',
+        'members': {
+          'Body': {
+            'shape': 'BoundedStreamingBody'
+          }
+        },
+        'payload': 'Body'
+      },
+    },
+    'PutUnsignedBoundedStream': {
+      'http': {
+        'method': 'PUT',
+        'requestUri': '/'
+      },
+      'input': {
+        'type': 'structure',
+        'members': {
+          'Body': {
+            'shape': 'BoundedStreamingBody'
+          }
+        },
+        'payload': 'Body'
+      },
+      'authtype': 'v4-unsigned-body'
+    },
   },
   'shapes': {
     'StreamingBody': {
       'type': 'blob',
       'streaming': true
+    },
+    'BoundedStreamingBody': {
+      'type': 'blob',
+      'streaming': true,
+      'requiresLength': true
     }
   }
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Add support for `requiresLength` trait. This trait exists in streaming payload member. If this trait is set true, then `content-length` header is required, and SDK will throw an error if content length cannot be determined by SDK. 

For streaming payload with `v4-unsigned-body` trait, since SDK doesn't sign them, then content length is not required. So if the `requiresLength` trait is falsy, SDK should allow to send stream without knowing the length(mediastore, lex). In this case the `Transfer-Encoding` header should be set to `chunked`.

This change doesn't change current behavior other than allowing sending stream in unsigned payload and stream length cannot be determined;

I have manually checked with S3, Glacier, Lambda, CloudwatchDomain, Lex, and MediaStore services

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`
- [X] run `npm run integration` if integration test is changed
