### PR TITLE
Set connection reusing by default from environmental variable in Node

### DIFF
--- a/.changes/next-release/feature-Core-f5c6ebe9.json
+++ b/.changes/next-release/feature-Core-f5c6ebe9.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Core",
+  "description": "set environmental variable AWS_NODEJS_CONNECTION_REUSE_ENABLED to 1 to make SDK reuse connections by default if users don't supply custom agents."
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -112,8 +112,7 @@ var PromisesDependency;
  *
  *     * **proxy** [String] &mdash; the URL to proxy requests through
  *     * **agent** [http.Agent, https.Agent] &mdash; the Agent object to perform
- *       HTTP requests with. Used for connection pooling. Defaults to the global
- *       agent (`http.globalAgent`) for non-SSL connections. Note that for
+ *       HTTP requests with. Used for connection pooling. Note that for
  *       SSL connections, a special Agent object is used in order to enable
  *       peer certificate verification. This feature is only supported in the
  *       Node.js environment.

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -3,6 +3,7 @@ var Stream = AWS.util.stream.Stream;
 var TransformStream = AWS.util.stream.Transform;
 var ReadableStream = AWS.util.stream.Readable;
 require('../http');
+var CONNECTION_REUSE_ENV_NAME = 'AWS_NODEJS_CONNECTION_REUSE_ENABLED';
 
 /**
  * @api private
@@ -142,7 +143,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
     var https = require('https');
 
     if (!AWS.NodeHttpClient.sslAgent) {
-      AWS.NodeHttpClient.sslAgent = new https.Agent({rejectUnauthorized: true});
+      AWS.NodeHttpClient.sslAgent = new https.Agent({
+        rejectUnauthorized: true,
+        keepAlive: process.env[CONNECTION_REUSE_ENV_NAME] === '1' ? true : false
+      });
       AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
 
       // delegate maxSockets to globalAgent, set a default limit of 50 if current value is Infinity.

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -32,8 +32,10 @@ AWS.NodeHttpClient = AWS.util.inherit({
       path: pathPrefix + httpRequest.path
     };
 
-    if (useSSL && !httpOptions.agent) {
-      options.agent = this.sslAgent();
+    if (!httpOptions.agent) {
+      options.agent = this.getAgent(useSSL, {
+        keepAlive: process.env[CONNECTION_REUSE_ENV_NAME] === '1' ? true : false
+      });
     }
 
     AWS.util.update(options, httpOptions);
@@ -139,31 +141,39 @@ AWS.NodeHttpClient = AWS.util.inherit({
     }
   },
 
-  sslAgent: function sslAgent() {
-    var https = require('https');
+  /**
+   * Create the https.Agent or http.Agent according to the request schema.
+   */
+  getAgent: function getAgent(useSSL, agentOptions) {
+    var http = useSSL ? require('https') : require('http');
+    if (useSSL) {
+      if (!AWS.NodeHttpClient.sslAgent) {
+        AWS.NodeHttpClient.sslAgent = new http.Agent(AWS.util.merge({
+          rejectUnauthorized: true
+        }, agentOptions || {}));
+        AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
 
-    if (!AWS.NodeHttpClient.sslAgent) {
-      AWS.NodeHttpClient.sslAgent = new https.Agent({
-        rejectUnauthorized: true,
-        keepAlive: process.env[CONNECTION_REUSE_ENV_NAME] === '1' ? true : false
-      });
-      AWS.NodeHttpClient.sslAgent.setMaxListeners(0);
-
-      // delegate maxSockets to globalAgent, set a default limit of 50 if current value is Infinity.
-      // Users can bypass this default by supplying their own Agent as part of SDK configuration.
-      Object.defineProperty(AWS.NodeHttpClient.sslAgent, 'maxSockets', {
-        enumerable: true,
-        get: function() {
-          var defaultMaxSockets = 50;
-          var globalAgent = https.globalAgent;
-          if (globalAgent && globalAgent.maxSockets !== Infinity && typeof globalAgent.maxSockets === 'number') {
-            return globalAgent.maxSockets;
+        // delegate maxSockets to globalAgent, set a default limit of 50 if current value is Infinity.
+        // Users can bypass this default by supplying their own Agent as part of SDK configuration.
+        Object.defineProperty(AWS.NodeHttpClient.sslAgent, 'maxSockets', {
+          enumerable: true,
+          get: function() {
+            var defaultMaxSockets = 50;
+            var globalAgent = http.globalAgent;
+            if (globalAgent && globalAgent.maxSockets !== Infinity && typeof globalAgent.maxSockets === 'number') {
+              return globalAgent.maxSockets;
+            }
+            return defaultMaxSockets;
           }
-          return defaultMaxSockets;
-        }
-      });
+        });
+      }
+      return AWS.NodeHttpClient.sslAgent;
+    } else {
+      if (!AWS.NodeHttpClient.agent) {
+        AWS.NodeHttpClient.agent = new http.Agent(agentOptions);
+      }
+      return AWS.NodeHttpClient.agent;
     }
-    return AWS.NodeHttpClient.sslAgent;
   },
 
   progressStream: function progressStream(stream, totalBytes) {

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -2,7 +2,7 @@ var whitelist = {
     '/config.js': [
         24,
         25,
-        180
+        179
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,

--- a/test/node_http_client.spec.js
+++ b/test/node_http_client.spec.js
@@ -18,7 +18,7 @@
         it('delegates maxSockets from agent to globalAgent', function() {
           var agent, https;
           https = require('https');
-          agent = http.sslAgent();
+          agent = http.getAgent(true);
           https.globalAgent.maxSockets = 5;
           expect(https.globalAgent.maxSockets).to.equal(agent.maxSockets);
           https.globalAgent.maxSockets += 1;
@@ -27,7 +27,7 @@
         it('overrides globalAgent value if global is set to Infinity', function() {
           var agent, https;
           https = require('https');
-          agent = http.sslAgent();
+          agent = http.getAgent(true);
           https.globalAgent.maxSockets = 2e308;
           return expect(agent.maxSockets).to.equal(50);
         });
@@ -36,11 +36,50 @@
           https = require('https');
           oldGlobal = https.globalAgent;
           https.globalAgent = false;
-          agent = http.sslAgent();
+          agent = http.getAgent(true);
           expect(agent.maxSockets).to.equal(50);
           return https.globalAgent = oldGlobal;
         });
       });
+
+      describe('default agent', function() {
+        beforeEach(function() {
+          AWS.NodeHttpClient.agent = undefined;
+          AWS.NodeHttpClient.sslAgent = undefined;
+        });
+        it('should conform connection reuse opt-in environment variable', function(done) {
+          process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = '1';
+          var req;
+          req = new AWS.HttpRequest('http://invalid');
+          return http.handleRequest(req, {timeout: 1}, null, function(err) {
+            expect(AWS.NodeHttpClient.agent).not.to.be.undefined;
+            expect(AWS.NodeHttpClient.sslAgent).to.be.undefined;
+            if (httpModule.globalAgent && httpModule.globalAgent.keepAlive !== undefined) {
+              //keepAlive is introduced only after v0.12
+              expect(AWS.NodeHttpClient.agent.keepAlive).to.equal(true);
+            }
+            delete process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED;
+            return done();
+          });
+        });
+
+        it('should conform connection reuse opt-in environment variable when using https', function(done) {
+          process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED = 1;
+          var req;
+          req = new AWS.HttpRequest('https://invalid');
+          return http.handleRequest(req, {timeout: 1}, null, function(err) {
+            expect(AWS.NodeHttpClient.agent).to.be.undefined;
+            expect(AWS.NodeHttpClient.sslAgent).not.to.be.undefined;
+            if (httpModule.globalAgent && httpModule.globalAgent.keepAlive !== undefined) {
+              //keepAlive is introduced only after v0.12
+              expect(AWS.NodeHttpClient.sslAgent.keepAlive).to.equal(true);
+            }
+            delete process.env.AWS_NODEJS_CONNECTION_REUSE_ENABLED;
+            return done();
+          });
+        });
+      });
+
       return describe('handleRequest', function() {
         it('emits error event', function(done) {
           var req;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Users can set environmental variable `AWS_NODEJS_CONNECTION_REUSE_ENABLED` to '1' to make SDK reuses connections by default. This will only change the default value, users can still override time by supply custom `agent`, [see API reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#httpOptions-property).
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`
- [X] run `npm run integration` if integration test is changed
