### PR TITLE
doc: add checkbox for Questions/Help template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---questions---help.md
+++ b/.github/ISSUE_TEMPLATE/---questions---help.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Confirm by changing [ ] to [x]
+Confirm by changing [ ] to [x] below:
 - [ ] I've gone though [Developer Guide](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/welcome.html) and [API reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/)
 - [ ] I've checked [AWS Forums](https://forums.aws.amazon.com) and [StackOverflow](https://stackoverflow.com/questions/tagged/aws-sdk-js) for answers
 

--- a/.github/ISSUE_TEMPLATE/---questions---help.md
+++ b/.github/ISSUE_TEMPLATE/---questions---help.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-Confirm by changing [] to [x]
-[] I've gone though [Developer Guide](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/welcome.html) and [API reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/)
-[] I've checked [AWS Forums](https://forums.aws.amazon.com) and [StackOverflow](https://stackoverflow.com/questions/tagged/aws-sdk-js) for answers
+Confirm by changing [ ] to [x]
+- [ ] I've gone though [Developer Guide](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/welcome.html) and [API reference](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/)
+- [ ] I've checked [AWS Forums](https://forums.aws.amazon.com) and [StackOverflow](https://stackoverflow.com/questions/tagged/aws-sdk-js) for answers
 
 **Describe the question**


### PR DESCRIPTION
Checkboxes were not shown in the Questions/Help template in original PR #2684
This one adds those checkboxes as shown in the screenshot:
![image](https://user-images.githubusercontent.com/16024985/58276364-1b44f000-7d4c-11e9-8f89-57e7d12b08b8.png)
