### PR TITLE
doc: add commands for getting SDK version in Bug report Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -18,7 +18,7 @@ Paste output of `npx envinfo --browsers` or `node -v`
 
 **SDK version number**
 Example: v2.466.0
-* For browsers, the SDK version number is in the script tag `src=".../aws-sdk-**2.466.0**.min.js"`
+* For browsers, the SDK version number is in the script tag <pre>src=".../aws-sdk-<b>2.466.0</b>.min.js"</pre>
 * For Node.js, get SDK version by running command `npm list aws-sdk` from your root directory
 
 **To Reproduce (observed behavior)**

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -10,14 +10,16 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**SDK version number**
-For example, v2.461.0
-
 **Is the issue in the browser/Node.js?**
 Browser/Node.js
 
 **Details of the browser/Node.js version**
 Paste output of `npx envinfo --browsers` or `node -v`
+
+**SDK version number**
+Example: v2.466.0
+* For browsers, the SDK version number is in the script tag `src=".../aws-sdk-**2.466.0**.min.js"`
+* For Node.js, get SDK version by running command `npm list aws-sdk` from your root directory
 
 **To Reproduce (observed behavior)**
 Steps to reproduce the behavior (please share code or minimal repo)


### PR DESCRIPTION
Two changes:
* Moved SDK version number question after Node.js/browser
* Added hints on how to find SDK version

This change was added after examining issue #2688 where customer shared Node version instead of SDK version in Issue template