### PR TITLE
doc: brew cask install phantomjs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Please be aware of the following notes prior to opening a pull request:
 To run the tests locally, install `phantomjs`. You can do so using [Homebrew][homebrew]:
 
 ```
-brew install phantomjs
+brew cask install phantomjs
 ```
 
 Then, to run all tests:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
`brew install phantomjs` gives the following error:
```
Error: No available formula with the name "phantomjs" 
Found a cask named "phantomjs" instead.
```

Updating markdown to run `brew cask install phantomjs`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] updated markdown file