### PR TITLE
doc: update bug report issue template to ask AWS Lambda question

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -13,6 +13,9 @@ A clear and concise description of what the bug is.
 **Is the issue in the browser/Node.js?**
 Browser/Node.js
 
+**If on Node.js, are you running this on AWS Lambda?**
+AWS Lambda uses previous versions of SDK as documented in their [runtimes documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
+
 **Details of the browser/Node.js version**
 Paste output of `npx envinfo --browsers` or `node -v`
 

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -14,7 +14,7 @@ A clear and concise description of what the bug is.
 Browser/Node.js
 
 **If on Node.js, are you running this on AWS Lambda?**
-AWS Lambda uses previous versions of SDK as documented in their [runtimes documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
+AWS Lambda uses older version of SDK as documented in their [runtimes documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). You can include latest version of SDK by following [these guidelines](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-create-deployment-pkg.html#nodejs-package-dependencies)
 
 **Details of the browser/Node.js version**
 Paste output of `npx envinfo --browsers` or `node -v`


### PR DESCRIPTION
There are several issues in the past where users are unaware that they're using older versions of SDK in AWS lambda. Here are some recent ones:
* #2659
* #2646
* #2671
* #2680
* #2704

This question will hopefully help users to realize they're using older versions of SDK in AWS Lambda.
This template will be updated in future with instructions to fix it by using custom version of SDK and how to follow up on Lambda SDK update timelines.