### PR TITLE
remove Config service integration test

### DIFF
--- a/features/configservice/configservice.feature
+++ b/features/configservice/configservice.feature
@@ -8,10 +8,3 @@ Feature: AWS Config
     Given I run the "describeDeliveryChannels" operation
     Then the request should be successful
     And the value at "DeliveryChannels" should be a list
-
-  Scenario: Error handling
-    Given I run the "putDeliveryChannel" operation with params:
-    """
-    { "DeliveryChannel": { "name": "" } }
-    """
-    Then the error code should be "ValidationException"


### PR DESCRIPTION
Config service is going to change the error code for operation that we use for smoke tesk. Remove it to prevent the release being blocked.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
