### PR TITLE
doc: add lock.yml

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,38 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 7
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: 2019-06-15
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a 
+  [new issue](https://github.com/aws/aws-sdk-js/issues/new/choose) for
+  related bugs and link to relevant comments in this thread.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
We've successfully tested lock bot in v3 for a month ([lock.yml](https://github.com/aws/aws-sdk-js-v3/blob/master/.github/lock.yml)), and would like to introduce it in v2
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
