### PR TITLE
Support Personalize APIs in Browser SDK

### DIFF
--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -716,15 +716,18 @@
     "name": "IoTEventsData"
   },
   "personalize": {
-    "name": "Personalize"
+    "name": "Personalize",
+    "cors": true
   },
   "personalizeevents": {
     "prefix": "personalize-events",
-    "name": "PersonalizeEvents"
+    "name": "PersonalizeEvents",
+    "cors": true
   },
   "personalizeruntime": {
     "prefix": "personalize-runtime",
-    "name": "PersonalizeRuntime"
+    "name": "PersonalizeRuntime",
+    "cors": true
   },
   "applicationinsights": {
     "prefix": "application-insights",


### PR DESCRIPTION
I have validated that the 3 services: `Personalize`, `PersonalizeEvents`, `PersonalizeRunTime` supports CORS. This change will make the 3 APIs bundled in our browser SDK.

<!--
Thank you for your pull request. Please provide a description below.
-->