### PR TITLE
Fix variable assignment

### DIFF
--- a/lib/browser_loader.js
+++ b/lib/browser_loader.js
@@ -33,7 +33,7 @@ AWS.XML.Parser = require('./xml/browser_parser');
 require('./http/xhr');
 
 if (typeof process === 'undefined') {
-  process = {
+  var process = {
     browser: true
   };
 }


### PR DESCRIPTION
This fixes an improper variable assignment in `browser_loader.js`. Prior to this change, a final bundle including this library could throw `ReferenceError: assignment to undeclared variable process` if running in strict mode.

##### Checklist
- [x] `npm run test` passes
