### PR TITLE
doc: not to use object stream in managed upload

### DIFF
--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -41,6 +41,8 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
    * Creates a managed upload object with a set of configuration options.
    *
    * @note A "Body" parameter is required to be set prior to calling {send}.
+   * @note In Node.js, sending "Body" as {https://nodejs.org/dist/latest/docs/api/stream.html#stream_object_mode object-mode stream}
+   *   may result in upload hangs. Using buffer stream is preferable.
    * @option options params [map] a map of parameters to pass to the upload
    *   requests. The "Body" parameter is required to be specified either on
    *   the service or in the params option.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
#2615 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)
