### PR TITLE
feat: S3 add an option to enable/disable "Expect: 100-continue" headers

### DIFF
--- a/.changes/next-release/feature-S3-7c5b7c23.json
+++ b/.changes/next-release/feature-S3-7c5b7c23.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "S3",
+  "description": "Add an option to enable/disable \"Expect: 100-continue\" headers for large payloads."
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -281,7 +281,7 @@ export abstract class ConfigurationOptions {
      */
     dynamoDbCrc32?: boolean;
     /**
-     * Whether to enable endpoint discovery for operations that allow optionally using an endpoint returned by 
+     * Whether to enable endpoint discovery for operations that allow optionally using an endpoint returned by
      * the service.
      */
     endpointDiscoveryEnabled?: boolean;

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -247,6 +247,10 @@ export abstract class ConfigurationOptions {
      */
     s3DisableBodySigning?: boolean
     /**
+     * Whether to add "Expect: 100-Continue" HTTP headers when sending large payloads.
+     */
+    s3AddExpect100ContinueHeaders?: boolean
+    /**
      * Whether to force path style URLs for S3 objects.
      */
     s3ForcePathStyle?: boolean

--- a/lib/config.js
+++ b/lib/config.js
@@ -82,6 +82,10 @@ var PromisesDependency;
  *   @return [Boolean] whether to disable S3 body signing when using signature version `v4`.
  *     Body signing can only be disabled when using https. Defaults to `true`.
  *
+ * @!attribute s3AddExpect100ContinueHeaders
+ *  @return [Boolean] whether to add "Expect: 100-Continue" HTTP headers when sending large payloads.
+ *     Defaults to `true`.
+ *
  * @!attribute useAccelerateEndpoint
  *   @note This configuration option is only compatible with S3 while accessing
  *     dns-compatible buckets.
@@ -235,7 +239,9 @@ AWS.Config = AWS.util.inherit({
    * @option options s3DisableBodySigning [Boolean] whether S3 body signing
    *   should be disabled when using signature version `v4`. Body signing
    *   can only be disabled when using https. Defaults to `true`.
-   *
+   * @option options s3AddExpect100ContinueHeaders [Boolean] whether
+   *   to add "Expect: 100-Continue" HTTP headers when sending large payloads.
+   *   Defaults to `true`.
    * @option options retryDelayOptions [map] A set of options to configure
    *   the retry delay on retryable errors. Currently supported options are:
    *
@@ -518,6 +524,7 @@ AWS.Config = AWS.util.inherit({
     s3ForcePathStyle: false,
     s3BucketEndpoint: false,
     s3DisableBodySigning: true,
+    s3AddExpect100ContinueHeaders: true,
     computeChecksums: true,
     convertResponseTypes: true,
     correctClockSkew: false,

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -99,6 +99,13 @@ AWS.util.update(AWS.S3.prototype, {
   /**
    * @api private
    */
+  shouldAddExpect100ContinueHeaders: function shouldAddExpect100ContinueHeaders() {
+      return this.config.s3AddExpect100ContinueHeaders === true;
+  },
+
+  /**
+   * @api private
+   */
   setupRequestListeners: function setupRequestListeners(request) {
     var prependListener = true;
     request.addListener('validate', this.validateScheme);
@@ -110,7 +117,10 @@ AWS.util.update(AWS.S3.prototype, {
     request.addListener('build', this.populateURI);
     request.addListener('build', this.computeContentMd5);
     request.addListener('build', this.computeSseCustomerKeyMd5);
-    request.addListener('afterBuild', this.addExpect100Continue);
+    if (this.shouldAddExpect100ContinueHeaders())
+    {
+        request.addListener('afterBuild', this.addExpect100Continue);
+    }
     request.removeListener('validate',
       AWS.EventListeners.Core.VALIDATE_REGION);
     request.addListener('extractError', this.extractError);

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -2,7 +2,7 @@ var whitelist = {
     '/config.js': [
         24,
         25,
-        184
+        188
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,
@@ -27,14 +27,14 @@ var whitelist = {
     '/services/s3.js': [
         68,
         69,
-        515,
-        517,
-        516,
-        636,
-        647,
-        648,
-        649,
-        654
+        525,
+        527,
+        526,
+        646,
+        657,
+        658,
+        659,
+        664
     ]
 };
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -287,6 +287,12 @@ describe('AWS.Config', function() {
     });
   });
 
+  describe('s3AddExpect100ContinueHeaders', function() {
+    it('defaults to true', function() {
+      expect(configure().s3AddExpect100ContinueHeaders).to.equal(true);
+    });
+  });
+
   describe('set', function() {
     it('should set a default value for a key', function() {
       var config = new AWS.Config();

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -758,9 +758,13 @@ describe('AWS.S3', function() {
       });
     });
 
-    describe('adding Expect: 100-continue', function() {
+    describe('with s3AddExpect100ContinueHeaders set to true', function() {
       if (AWS.util.isNode()) {
         it('does not add expect header to payloads less than 1MB', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: true,
+            signatureVersion: 'v4'
+          });
           var req = build('putObject', {
             Bucket: 'bucket',
             Key: 'key',
@@ -770,6 +774,10 @@ describe('AWS.S3', function() {
         });
 
         it('adds expect header to payloads greater than 1MB', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: true,
+            signatureVersion: 'v4'
+          });
           var req = build('putObject', {
             Bucket: 'bucket',
             Key: 'key',
@@ -785,6 +793,10 @@ describe('AWS.S3', function() {
         });
 
         it('does not add expect header in the browser', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: true,
+            signatureVersion: 'v4'
+          });
           var req = build('putObject', {
             Bucket: 'bucket',
             Key: 'key',
@@ -794,7 +806,54 @@ describe('AWS.S3', function() {
         });
       }
     });
+    describe('with s3AddExpect100ContinueHeaders set to false', function() {
+      if (AWS.util.isNode()) {
+        it('does not add expect header to payloads less than 1MB', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: false,
+            signatureVersion: 'v4'
+          });
+          var req = build('putObject', {
+            Bucket: 'bucket',
+            Key: 'key',
+            Body: new Buffer(1024 * 1024 - 1)
+          });
+          expect(req.headers['Expect']).not.to.exist;
+        });
 
+        it('does not add expect header to payloads greater than 1MB', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: false,
+            signatureVersion: 'v4'
+          });
+          var req = build('putObject', {
+            Bucket: 'bucket',
+            Key: 'key',
+            Body: new Buffer(1024 * 1024 + 1)
+          });
+          expect(req.headers['Expect']).not.to.exist;
+        });
+      }
+
+      if (AWS.util.isBrowser()) {
+        beforeEach(function() {
+          helpers.spyOn(AWS.util, 'isBrowser').andReturn(true);
+        });
+
+        it('does not add expect header in the browser', function() {
+          s3 = new AWS.S3({
+            s3AddExpect100ContinueHeaders: false,
+            signatureVersion: 'v4'
+          });
+          var req = build('putObject', {
+              Bucket: 'bucket',
+              Key: 'key',
+              Body: new Buffer(1024 * 1024 + 1)
+          });
+          expect(req.headers['Expect']).not.to.exist;
+        });
+      }
+    });
     describe('with s3DisableBodySigning set to true', function() {
       it('will disable body signing when using signature version 4 and the endpoint uses https', function() {
         s3 = new AWS.S3({

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -71,6 +71,7 @@ AWS.config.update({
     },
     s3BucketEndpoint: false,
     s3DisableBodySigning: false,
+    s3AddExpect100ContinueHeaders: true,
     s3ForcePathStyle: true,
     signatureCache: false,
     signatureVersion: 'v4',

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -93,7 +93,7 @@ var config = AWS.config.loadFromPath('/to/path');
 
 // test update allowing unknown keys
 AWS.config.update({
-   fake: 'fake' 
+   fake: 'fake'
 }, true);
 
 //Test httpOption interface


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Since https://github.com/aws/aws-sdk-js/pull/437, when using Riak-CS v2.1.1 as backend, uploading files larger than 1MB using streams on NodeJS leads to corrupted data stored in Riak-CS.

This PR adds an option to prevent the `Expect: 100-continue` header from being added to the content of the file when uploading a large file.

Fixes https://github.com/basho/riak_cs/issues/1327.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`