### PR TITLE
Fix to define AWSError as interface, not class

### DIFF
--- a/.changes/next-release/bugfix-typings-60c8932c.json
+++ b/.changes/next-release/bugfix-typings-60c8932c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "typings",
+  "description": "Fix to define AWSError as interface, not class"
+}

--- a/lib/error.d.ts
+++ b/lib/error.d.ts
@@ -1,7 +1,7 @@
 /**
  * A structure containing information about a service or networking error.
  */
-export class AWSError extends Error {
+export interface AWSError extends Error {
     /**
      * A unique short code representing the error that was emitted.
      */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
In a d.ts file, `AWSError` was defined as class. 
However, there is no class or function named `AWSError` in javascript.
So I fix to define it as interface.

This will protect typescript users from mistekenly treating it as class like
```typescript
const result = await this.ses.sendRawEmail(request).promise();
if (result.$response.error instanceof AWSError) {  // AWSError is not an object, so `instaceof` fails!!
    console.error("Error!");
}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
