### PR TITLE
fix for existing property matching  `profileName`.

### DIFF
--- a/lib/shared-ini/ini-loader.js
+++ b/lib/shared-ini/ini-loader.js
@@ -8,6 +8,9 @@ function parseFile(filename, isConfig) {
     Object.keys(content).forEach(function(profileName) {
       var profileContent = content[profileName];
       profileName = isConfig ? profileName.replace(/^profile\s/, '') : profileName;
+      if (tmpContent.hasOwnProperty(profileName)) {
+        return;
+      }
       Object.defineProperty(tmpContent, profileName, {
         value: profileContent,
         enumerable: true

--- a/lib/shared-ini/ini-loader.js
+++ b/lib/shared-ini/ini-loader.js
@@ -8,9 +8,7 @@ function parseFile(filename, isConfig) {
     Object.keys(content).forEach(function(profileName) {
       var profileContent = content[profileName];
       profileName = isConfig ? profileName.replace(/^profile\s/, '') : profileName;
-      if (tmpContent.hasOwnProperty(profileName)) {
-        return;
-      }
+      if (profileName in tmpContent) return;
       Object.defineProperty(tmpContent, profileName, {
         value: profileContent,
         enumerable: true


### PR DESCRIPTION
Avoids crash when `~/.aws/config` has profiles that match when ignoring `profile ` prefix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
