### PR TITLE
fix stsConfig typing on chainable_temporary_credentials

### DIFF
--- a/.changes/next-release/bugfix-Credentials-afac1e37.json
+++ b/.changes/next-release/bugfix-Credentials-afac1e37.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "fix stsConfig typing on chainable_temporary_credentials"
+}

--- a/lib/credentials/chainable_temporary_credentials.d.ts
+++ b/lib/credentials/chainable_temporary_credentials.d.ts
@@ -24,7 +24,7 @@ declare namespace ChainableTemporaryCredentials {
     export type ChainableTemporaryCredentialsOptions = {
         params?: STS.Types.AssumeRoleRequest|STS.Types.GetSessionTokenRequest,
         masterCredentials?: Credentials,
-        stsConfig: STS.Types.ClientConfiguration,
+        stsConfig?: STS.Types.ClientConfiguration,
         tokenCodeFn?: (serialNumber: string, callback: (err?: Error, token?: string) => void) => void
     }
 }


### PR DESCRIPTION
Fixes optional typing for https://github.com/aws/aws-sdk-js/pull/2803 (fix for https://github.com/aws/aws-sdk-js/issues/2673)

##### Checklist
- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
