### PR TITLE
Add support opt-in regional STS endpoints

### DIFF
--- a/.changes/next-release/feature-Endpoints-5d7d9e4e.json
+++ b/.changes/next-release/feature-Endpoints-5d7d9e4e.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Endpoints",
+  "description": "Sts client now supports sending requests to regional endpoints. You can opt in by setting stsRegionalEndpoints client config or AWS_STS_REGIONAL_ENDPOINTS environment or sts_regional_endpoints config file entry to 'regional'"
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -291,4 +291,9 @@ export abstract class ConfigurationOptions {
      *  whether to marshal request parameters to the prefix of hostname.
      */
     hostPrefixEnabled?: boolean;
+    /**
+     * whether to send sts request to global endpoints or
+     * regional endpoints. 
+     */
+    stsRegionalEndpoints?: "legacy"|"regional";
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -164,10 +164,10 @@ var PromisesDependency;
  * @!attribute hostPrefixEnabled
  *   @return [Boolean] whether to marshal request parameters to the prefix of
  *     hostname. Defaults to `true`.
- * 
+ *
  * @!attribute stsRegionalEndpoints
  *   @return ['legacy'|'regional'] whether to send sts request to global endpoints or
- *     regional endpoints. 
+ *     regional endpoints.
  *     Defaults to 'legacy'
  */
 AWS.Config = AWS.util.inherit({
@@ -309,7 +309,7 @@ AWS.Config = AWS.util.inherit({
    *   parameters to the prefix of hostname.
    *   Defaults to `true`.
    * @option options stsRegionalEndpoints ['legacy'|'regional'] whether to send sts request
-   *   to global endpoints or regional endpoints. 
+   *   to global endpoints or regional endpoints.
    *   Defaults to 'legacy'.
    */
   constructor: function Config(options) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -164,6 +164,11 @@ var PromisesDependency;
  * @!attribute hostPrefixEnabled
  *   @return [Boolean] whether to marshal request parameters to the prefix of
  *     hostname. Defaults to `true`.
+ * 
+ * @!attribute stsRegionalEndpoints
+ *   @return ['legacy'|'regional'] whether to send sts request to global endpoints or
+ *     regional endpoints. 
+ *     Defaults to 'legacy'
  */
 AWS.Config = AWS.util.inherit({
   /**
@@ -303,6 +308,9 @@ AWS.Config = AWS.util.inherit({
    * @option options hostPrefixEnabled [Boolean] whether to marshal request
    *   parameters to the prefix of hostname.
    *   Defaults to `true`.
+   * @option options stsRegionalEndpoints ['legacy'|'regional'] whether to send sts request
+   *   to global endpoints or regional endpoints. 
+   *   Defaults to 'legacy'.
    */
   constructor: function Config(options) {
     if (options === undefined) options = {};
@@ -523,7 +531,8 @@ AWS.Config = AWS.util.inherit({
     clientSideMonitoring: false,
     endpointDiscoveryEnabled: false,
     endpointCacheSize: 1000,
-    hostPrefixEnabled: true
+    hostPrefixEnabled: true,
+    stsRegionalEndpoints: null
   },
 
   /**

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -1,4 +1,5 @@
 var AWS = require('../core');
+var regionConfig = require('../region_config');
 var ENV_REGIONAL_ENDPOINT_ENABLED = 'AWS_STS_REGIONAL_ENDPOINTS';
 var CONFIG_REGIONAL_ENDPOINT_ENABLED = 'sts_regional_endpoints';
 
@@ -53,24 +54,32 @@ AWS.util.update(AWS.STS.prototype, {
   validateRegionalEndpointsFlag: function validateRegionalEndpointsFlag() {
     //validate config value
     var config = this.config;
-    if (['legacy', 'regional'].indexOf(config.stsRegionalEndpoints) >= 0) return;
+    if (
+      typeof config.stsRegionalEndpoints === 'string' &&
+      ['legacy', 'regional'].indexOf(config.stsRegionalEndpoints.toLowerCase()) >= 0
+    ) {
+      config.stsRegionalEndpoints = config.stsRegionalEndpoints.toLowerCase();
+      return;
+    }
     if (config.stsRegionalEndpoints) {
-      throw AWS.util.error(new Error('InvalidConfiguration'), {
-        message: "invalid 'stsRegionalEndpoints' configuration. Expect 'legacy' " +
-        " or 'regional'. Got '" + config.stsRegionalEndpoints + "'."
-      })
+      throw AWS.util.error(new Error(), {
+        code: 'InvalidConfiguration',
+        message: 'invalid "stsRegionalEndpoints" configuration. Expect "legacy" ' +
+        ' or "regional". Got "' + config.stsRegionalEndpoints + '".'
+      });
     }
     if (!AWS.util.isNode()) return;
     //validate environmental variable
     if (Object.prototype.hasOwnProperty.call(process.env, ENV_REGIONAL_ENDPOINT_ENABLED)) {
       var envFlag = process.env[ENV_REGIONAL_ENDPOINT_ENABLED];
-      if (typeof envFlag === "string" && ['legacy', 'regional'].indexOf(envFlag.toLowerCase()) >= 0) {
+      if (typeof envFlag === 'string' && ['legacy', 'regional'].indexOf(envFlag.toLowerCase()) >= 0) {
         config.stsRegionalEndpoints = envFlag.toLowerCase();
         return;
       } else {
-        throw AWS.util.error(new Error('InvalidEnvironmentalVariable'), {
-          message: "invalid " + ENV_REGIONAL_ENDPOINT_ENABLED + " environmental variable. Expect 'legacy' " +
-          " or 'regional'. Got '" + process.env[ENV_REGIONAL_ENDPOINT_ENABLED] + "'."
+        throw AWS.util.error(new Error(), {
+          code: 'InvalidEnvironmentalVariable',
+          message: 'invalid ' + ENV_REGIONAL_ENDPOINT_ENABLED + ' environmental variable. Expect "legacy" ' +
+          ' or "regional". Got "' + process.env[ENV_REGIONAL_ENDPOINT_ENABLED] + '".'
         });
       }
     }
@@ -79,13 +88,14 @@ AWS.util.update(AWS.STS.prototype, {
     var profile = profiles[process.env.AWS_PROFILE || AWS.util.defaultProfile];
     if (Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
       var fileFlag = profile[CONFIG_REGIONAL_ENDPOINT_ENABLED];
-      if (typeof fileFlag === "string" && ['legacy', 'regional'].indexOf(fileFlag.toLowerCase()) >= 0) {
+      if (typeof fileFlag === 'string' && ['legacy', 'regional'].indexOf(fileFlag.toLowerCase()) >= 0) {
         config.stsRegionalEndpoints = fileFlag.toLowerCase();
         return;
       } else {
-        throw AWS.util.error(new Error('InvalidConfiguration'), {
-          message: "invalid "+CONFIG_REGIONAL_ENDPOINT_ENABLED+" profile config. Expect 'legacy' " +
-          " or 'regional'. Got '" + profile[CONFIG_REGIONAL_ENDPOINT_ENABLED] + "'."
+        throw AWS.util.error(new Error(), {
+          code: 'InvalidConfiguration',
+          message: 'invalid '+CONFIG_REGIONAL_ENDPOINT_ENABLED+' profile config. Expect "legacy" ' +
+          ' or "regional". Got "' + profile[CONFIG_REGIONAL_ENDPOINT_ENABLED] + '".'
         });
       };
     }
@@ -98,18 +108,22 @@ AWS.util.update(AWS.STS.prototype, {
     this.validateRegionalEndpointsFlag();
     var config = this.config;
     if (config.stsRegionalEndpoints === 'regional') {
+      regionConfig(this);
+      if (!this.isGlobalEndpoint) return;
       this.isGlobalEndpoint = false;
       //client will throw if region is not supplied; request will be signed with specified region
       if (!config.region) {
         throw AWS.util.error(new Error(),
           {code: 'ConfigError', message: 'Missing region in config'});
       }
-      config.endpoint = 'sts.' + config.region + '.amazonaws.com';
+      var insertPoint = config.endpoint.indexOf('.amazonaws.com');
+      config.endpoint = config.endpoint.substring(0, insertPoint) +
+        '.' + config.region + config.endpoint.substring(insertPoint);
     }
   },
 
   validateService: function validateService() {
     this.optInRegionalEndpoint();
   }
-  
+
 });

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -1,4 +1,6 @@
 var AWS = require('../core');
+var ENV_REGIONAL_ENDPOINT_ENABLED = 'AWS_STS_REGIONAL_ENDPOINTS';
+var CONFIG_REGIONAL_ENDPOINT_ENABLED = 'sts_regional_endpoints';
 
 AWS.util.update(AWS.STS.prototype, {
   /**
@@ -43,5 +45,71 @@ AWS.util.update(AWS.STS.prototype, {
 
   assumeRoleWithSAML: function assumeRoleWithSAML(params, callback) {
     return this.makeUnauthenticatedRequest('assumeRoleWithSAML', params, callback);
+  },
+
+  /**
+   * @api private
+   */
+  validateRegionalEndpointsFlag: function validateRegionalEndpointsFlag() {
+    //validate config value
+    var config = this.config;
+    if (['legacy', 'regional'].indexOf(config.stsRegionalEndpoints) >= 0) return;
+    if (config.stsRegionalEndpoints) {
+      throw AWS.util.error(new Error('InvalidConfiguration'), {
+        message: "invalid 'stsRegionalEndpoints' configuration. Expect 'legacy' " +
+        " or 'regional'. Got '" + config.stsRegionalEndpoints + "'."
+      })
+    }
+    if (!AWS.util.isNode()) return;
+    //validate environmental variable
+    if (Object.prototype.hasOwnProperty.call(process.env, ENV_REGIONAL_ENDPOINT_ENABLED)) {
+      var envFlag = process.env[ENV_REGIONAL_ENDPOINT_ENABLED];
+      if (typeof envFlag === "string" && ['legacy', 'regional'].indexOf(envFlag.toLowerCase()) >= 0) {
+        config.stsRegionalEndpoints = envFlag.toLowerCase();
+        return;
+      } else {
+        throw AWS.util.error(new Error('InvalidEnvironmentalVariable'), {
+          message: "invalid " + ENV_REGIONAL_ENDPOINT_ENABLED + " environmental variable. Expect 'legacy' " +
+          " or 'regional'. Got '" + process.env[ENV_REGIONAL_ENDPOINT_ENABLED] + "'."
+        });
+      }
+    }
+    //validate shared config file
+    var profiles = AWS.util.getProfilesFromSharedConfig(AWS.util.iniLoader);
+    var profile = profiles[process.env.AWS_PROFILE || AWS.util.defaultProfile];
+    if (Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
+      var fileFlag = profile[CONFIG_REGIONAL_ENDPOINT_ENABLED];
+      if (typeof fileFlag === "string" && ['legacy', 'regional'].indexOf(fileFlag.toLowerCase()) >= 0) {
+        config.stsRegionalEndpoints = fileFlag.toLowerCase();
+        return;
+      } else {
+        throw AWS.util.error(new Error('InvalidConfiguration'), {
+          message: "invalid "+CONFIG_REGIONAL_ENDPOINT_ENABLED+" profile config. Expect 'legacy' " +
+          " or 'regional'. Got '" + profile[CONFIG_REGIONAL_ENDPOINT_ENABLED] + "'."
+        });
+      };
+    }
+  },
+
+  /**
+   * @api private
+   */
+  optInRegionalEndpoint: function optInRegionalEndpoint() {
+    this.validateRegionalEndpointsFlag();
+    var config = this.config;
+    if (config.stsRegionalEndpoints === 'regional') {
+      this.isGlobalEndpoint = false;
+      //client will throw if region is not supplied; request will be signed with specified region
+      if (!config.region) {
+        throw AWS.util.error(new Error(),
+          {code: 'ConfigError', message: 'Missing region in config'});
+      }
+      config.endpoint = 'sts.' + config.region + '.amazonaws.com';
+    }
+  },
+
+  validateService: function validateService() {
+    this.optInRegionalEndpoint();
   }
+  
 });

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -87,8 +87,11 @@ AWS.util.update(AWS.STS.prototype, {
       }
     }
     //validate shared config file
-    var profiles = AWS.util.getProfilesFromSharedConfig(AWS.util.iniLoader);
-    var profile = profiles[process.env.AWS_PROFILE || AWS.util.defaultProfile];
+    var profile = {};
+    try {
+      var profiles = AWS.util.getProfilesFromSharedConfig(AWS.util.iniLoader);
+      profile = profiles[process.env.AWS_PROFILE || AWS.util.defaultProfile];
+    } catch (e) {};
     if (Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
       var fileFlag = profile[CONFIG_REGIONAL_ENDPOINT_ENABLED];
       if (typeof fileFlag === 'string' && ['legacy', 'regional'].indexOf(fileFlag.toLowerCase()) >= 0) {

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -51,18 +51,23 @@ AWS.util.update(AWS.STS.prototype, {
   /**
    * @api private
    */
+  validateRegionalEndpointsFlagValue: function validateRegionalEndpointsFlagValue(configValue, errorOptions) {
+    if (typeof configValue === 'string' && ['legacy', 'regional'].indexOf(configValue.toLowerCase()) >= 0) {
+      this.config.stsRegionalEndpoints = configValue.toLowerCase();
+      return;
+    } else {
+      throw AWS.util.error(new Error(), errorOptions);
+    }
+  },
+
+  /**
+   * @api private
+   */
   validateRegionalEndpointsFlag: function validateRegionalEndpointsFlag() {
     //validate config value
     var config = this.config;
-    if (
-      typeof config.stsRegionalEndpoints === 'string' &&
-      ['legacy', 'regional'].indexOf(config.stsRegionalEndpoints.toLowerCase()) >= 0
-    ) {
-      config.stsRegionalEndpoints = config.stsRegionalEndpoints.toLowerCase();
-      return;
-    }
     if (config.stsRegionalEndpoints) {
-      throw AWS.util.error(new Error(), {
+      this.validateRegionalEndpointsFlagValue(config.stsRegionalEndpoints, {
         code: 'InvalidConfiguration',
         message: 'invalid "stsRegionalEndpoints" configuration. Expect "legacy" ' +
         ' or "regional". Got "' + config.stsRegionalEndpoints + '".'
@@ -72,16 +77,11 @@ AWS.util.update(AWS.STS.prototype, {
     //validate environmental variable
     if (Object.prototype.hasOwnProperty.call(process.env, ENV_REGIONAL_ENDPOINT_ENABLED)) {
       var envFlag = process.env[ENV_REGIONAL_ENDPOINT_ENABLED];
-      if (typeof envFlag === 'string' && ['legacy', 'regional'].indexOf(envFlag.toLowerCase()) >= 0) {
-        config.stsRegionalEndpoints = envFlag.toLowerCase();
-        return;
-      } else {
-        throw AWS.util.error(new Error(), {
-          code: 'InvalidEnvironmentalVariable',
-          message: 'invalid ' + ENV_REGIONAL_ENDPOINT_ENABLED + ' environmental variable. Expect "legacy" ' +
-          ' or "regional". Got "' + process.env[ENV_REGIONAL_ENDPOINT_ENABLED] + '".'
-        });
-      }
+      this.validateRegionalEndpointsFlagValue(envFlag, {
+        code: 'InvalidEnvironmentalVariable',
+        message: 'invalid ' + ENV_REGIONAL_ENDPOINT_ENABLED + ' environmental variable. Expect "legacy" ' +
+        ' or "regional". Got "' + process.env[ENV_REGIONAL_ENDPOINT_ENABLED] + '".'
+      });
     }
     //validate shared config file
     var profile = {};
@@ -91,16 +91,11 @@ AWS.util.update(AWS.STS.prototype, {
     } catch (e) {};
     if (Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
       var fileFlag = profile[CONFIG_REGIONAL_ENDPOINT_ENABLED];
-      if (typeof fileFlag === 'string' && ['legacy', 'regional'].indexOf(fileFlag.toLowerCase()) >= 0) {
-        config.stsRegionalEndpoints = fileFlag.toLowerCase();
-        return;
-      } else {
-        throw AWS.util.error(new Error(), {
-          code: 'InvalidConfiguration',
-          message: 'invalid '+CONFIG_REGIONAL_ENDPOINT_ENABLED+' profile config. Expect "legacy" ' +
-          ' or "regional". Got "' + profile[CONFIG_REGIONAL_ENDPOINT_ENABLED] + '".'
-        });
-      };
+      this.validateRegionalEndpointsFlagValue(fileFlag, {
+        code: 'InvalidConfiguration',
+        message: 'invalid '+CONFIG_REGIONAL_ENDPOINT_ENABLED+' profile config. Expect "legacy" ' +
+        ' or "regional". Got "' + profile[CONFIG_REGIONAL_ENDPOINT_ENABLED] + '".'
+      });
     }
   },
 

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -68,7 +68,10 @@ AWS.util.update(AWS.STS.prototype, {
         ' or "regional". Got "' + config.stsRegionalEndpoints + '".'
       });
     }
-    if (!AWS.util.isNode()) return;
+    if (!AWS.util.isNode()) {
+      config.stsRegionalEndpoints = 'legacy'; //set default value so not to load env and files later
+      return;
+    }
     //validate environmental variable
     if (Object.prototype.hasOwnProperty.call(process.env, ENV_REGIONAL_ENDPOINT_ENABLED)) {
       var envFlag = process.env[ENV_REGIONAL_ENDPOINT_ENABLED];
@@ -99,6 +102,7 @@ AWS.util.update(AWS.STS.prototype, {
         });
       };
     }
+    config.stsRegionalEndpoints = 'legacy';
   },
 
   /**

--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -68,10 +68,7 @@ AWS.util.update(AWS.STS.prototype, {
         ' or "regional". Got "' + config.stsRegionalEndpoints + '".'
       });
     }
-    if (!AWS.util.isNode()) {
-      config.stsRegionalEndpoints = 'legacy'; //set default value so not to load env and files later
-      return;
-    }
+    if (!AWS.util.isNode()) return;
     //validate environmental variable
     if (Object.prototype.hasOwnProperty.call(process.env, ENV_REGIONAL_ENDPOINT_ENABLED)) {
       var envFlag = process.env[ENV_REGIONAL_ENDPOINT_ENABLED];
@@ -105,7 +102,6 @@ AWS.util.update(AWS.STS.prototype, {
         });
       };
     }
-    config.stsRegionalEndpoints = 'legacy';
   },
 
   /**

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -2,7 +2,7 @@ var whitelist = {
     '/config.js': [
         24,
         25,
-        179
+        184
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,

--- a/test/services/sts.spec.js
+++ b/test/services/sts.spec.js
@@ -125,7 +125,7 @@
     describe('regional endpoints', function() {
       describe('stsRegionalConfig client config', function() {
         it ('should set the service client stsRegionalConfig config', function() {
-          var values = ['regional', 'RegionaL', 'legacy', 'LegacY', undefined, void 0];
+          var values = ['regional', 'RegionaL', 'legacy', 'LegacY'];
           for (var i = 0; i < values.length; i++) {
             var sts = new AWS.STS({stsRegionalEndpoints: values[i]});
             expect(['regional', 'legacy'].indexOf(sts.config.stsRegionalEndpoints) >= 0).to.equal(true);
@@ -226,6 +226,14 @@
         });
       }
       describe('service client stsRegionalConfig config', function() {
+        var originalRegion;
+        beforeEach(function() {
+          originalRegion = AWS.config.region;
+          AWS.config.region = undefined;
+        });
+        afterEach(function() {
+          AWS.config.region = originalRegion;
+        });
         it('should use global endpoints for when config is undefined', function() {
           var regions = ['us-west-2', 'ap-east-1'];
           for (var i = 0; i < regions.length; i++) {
@@ -252,6 +260,16 @@
           }
           var sts = new AWS.STS({region: 'cn-north-1', stsRegionalEndpoints: 'regional'});
           expect(sts.config.endpoint).to.contain('sts.cn-north-1.amazonaws.com.cn');
+        });
+        it('should ask for region if stsRegionalEndpoints is set', function() {
+          var error;
+          try {
+            var sts = new AWS.STS({stsRegionalEndpoints: 'regional'});
+          } catch (e) {
+            error = e;
+          }
+          expect(error.code).to.equal('ConfigError');
+          expect(error.message).to.equal('Missing region in config');
         });
       });
     });

--- a/test/services/sts.spec.js
+++ b/test/services/sts.spec.js
@@ -125,7 +125,7 @@
     describe('regional endpoints', function() {
       describe('stsRegionalConfig client config', function() {
         it ('should set the service client stsRegionalConfig config', function() {
-          var values = ['regional', 'RegionaL', 'legacy', 'LegacY'];
+          var values = ['regional', 'RegionaL', 'legacy', 'LegacY', undefined, void 0];
           for (var i = 0; i < values.length; i++) {
             var sts = new AWS.STS({stsRegionalEndpoints: values[i]});
             expect(['regional', 'legacy'].indexOf(sts.config.stsRegionalEndpoints) >= 0).to.equal(true);

--- a/test/services/sts.spec.js
+++ b/test/services/sts.spec.js
@@ -227,12 +227,21 @@
       }
       describe('service client stsRegionalConfig config', function() {
         var originalRegion;
+        var originalEnv;
         beforeEach(function() {
           originalRegion = AWS.config.region;
           AWS.config.region = undefined;
+          //fix CodeBuild test because it comes with AWS_REGION in environment
+          if (AWS.util.isNode()) {
+            originalEnv = process.env;
+            process.env = originalEnv;
+          }
         });
         afterEach(function() {
           AWS.config.region = originalRegion;
+          if (AWS.util.isNode()) {
+            process.env = {};
+          }
         });
         it('should use global endpoints for when config is undefined', function() {
           var regions = ['us-west-2', 'ap-east-1'];
@@ -264,7 +273,7 @@
         it('should ask for region if stsRegionalEndpoints is set', function() {
           var error;
           try {
-            var sts = new AWS.STS({stsRegionalEndpoints: 'regional'});
+            new AWS.STS({stsRegionalEndpoints: 'regional'});
           } catch (e) {
             error = e;
           }

--- a/test/services/sts.spec.js
+++ b/test/services/sts.spec.js
@@ -13,9 +13,11 @@
       return sts = new AWS.STS();
     });
     describe('credentialsFrom', function() {
+
       it('returns null if no data is provided', function() {
         return expect(sts.credentialsFrom(null)).to.equal(null);
       });
+
       it('creates a TemporaryCredentials object with hydrated data', function() {
         var creds;
         creds = sts.credentialsFrom({
@@ -33,7 +35,8 @@
         expect(creds.expireTime).to.eql(new Date(0));
         return expect(creds.expired).to.equal(false);
       });
-      return it('updates an existing Credentials object with hydrated data', function() {
+
+      it('updates an existing Credentials object with hydrated data', function() {
         var creds, data;
         data = {
           Credentials: {
@@ -53,6 +56,7 @@
         return expect(creds.expired).to.equal(false);
       });
     });
+
     describe('assumeRoleWithWebIdentity', function() {
       var service;
       service = new AWS.STS;
@@ -74,7 +78,8 @@
           return expect(hr.path).to.equal('/');
         });
       });
-      return it('can build a post request on a mounted path (custom endpoint)', function() {
+
+      it('can build a post request on a mounted path (custom endpoint)', function() {
         var params;
         helpers.mockHttpResponse(200, {}, '{}');
         service = new AWS.STS({
@@ -93,7 +98,8 @@
         });
       });
     });
-    return describe('assumeRoleWithSAML', function() {
+
+    describe('assumeRoleWithSAML', function() {
       var service;
       service = new AWS.STS;
       return it('sends an unsigned POST request', function() {
@@ -112,6 +118,140 @@
           expect(hr.headers['Authorization']).to.equal(void 0);
           expect(hr.headers['Content-Type']).to.equal('application/x-www-form-urlencoded; charset=utf-8');
           return expect(hr.path).to.equal('/');
+        });
+      });
+    });
+
+    describe('regional endpoints', function() {
+      describe('stsRegionalConfig client config', function() {
+        it ('should set the service client stsRegionalConfig config', function() {
+          var values = ['regional', 'RegionaL', 'legacy', 'LegacY'];
+          for (var i = 0; i < values.length; i++) {
+            var sts = new AWS.STS({stsRegionalEndpoints: values[i]});
+            expect(['regional', 'legacy'].indexOf(sts.config.stsRegionalEndpoints) >= 0).to.equal(true);
+          }
+        });
+
+        it('should throw if the config is set to invalid values', function() {
+          var values = ['foo', 'bar', 'region'];
+          var errors = [];
+          for (var i = 0; i < values.length; i++) {
+            try {
+              new AWS.STS({stsRegionalEndpoints: values[i]});
+            } catch (e) {
+              errors.push(e);
+            }
+          }
+          expect(errors.length).to.equal(values.length);
+          for (var i = 0; i < errors.length; i++) {
+            expect(errors[i].code).to.equal('InvalidConfiguration');
+          }
+        });
+      });
+
+      if (AWS.util.isNode()) {
+        describe('AWS_STS_REGIONAL_ENDPOINTS environmental variable', function() {
+          var originalEnv;
+          beforeEach(function() {
+            originalEnv = process.env;
+            process.env = {};
+          });
+          afterEach(function() {
+            process.env = originalEnv;
+          });
+          it('should be used if client config is not set', function() {
+            process.env.AWS_STS_REGIONAL_ENDPOINTS = 'Regional';
+            var sts = new AWS.STS();
+            expect(sts.config.stsRegionalEndpoints).to.equal('regional');
+            process.env.AWS_STS_REGIONAL_ENDPOINTS = 'LegacY';
+            sts = new AWS.STS();
+            expect(sts.config.stsRegionalEndpoints).to.equal('legacy');
+          });
+
+          it('should throw if the config is set to invalid values', function() {
+            var values = ['foo', 'bar', 'region'];
+            var errors = [];
+            for (var i = 0; i < values.length; i++) {
+              try {
+                process.env.AWS_STS_REGIONAL_ENDPOINTS = values[i];
+                new AWS.STS();
+              } catch (e) {
+                errors.push(e);
+              }
+            }
+            expect(errors.length).to.equal(values.length);
+            for (var i = 0; i < errors.length; i++) {
+              expect(errors[i].code).to.equal('InvalidEnvironmentalVariable');
+            }
+          });
+        });
+
+        describe('sts_regional_endpoints config file entry', function() {
+          it('should be used if environmental variable is not set', function() {
+            helpers.spyOn(AWS.util, 'getProfilesFromSharedConfig').andReturn({
+              default: {
+                sts_regional_endpoints: 'RegionaL'
+              }
+            });
+            var sts = new AWS.STS();
+            expect(sts.config.stsRegionalEndpoints).to.equal('regional');
+            helpers.spyOn(AWS.util, 'getProfilesFromSharedConfig').andReturn({
+              default: {
+                sts_regional_endpoints: 'LegaCy'
+              }
+            });
+            var sts = new AWS.STS();
+            expect(sts.config.stsRegionalEndpoints).to.equal('legacy');
+          });
+          it('should throw if the config is set to invalid values', function() {
+            var values = ['foo', 'bar', 'region'];
+            var errors = [];
+            for (var i = 0; i < values.length; i++) {
+              helpers.spyOn(AWS.util, 'getProfilesFromSharedConfig').andReturn({
+                default: {
+                  sts_regional_endpoints: values[i]
+                }
+              });
+              try {
+                new AWS.STS();
+              } catch (e) {
+                errors.push(e);
+              }
+            }
+            expect(errors.length).to.equal(values.length);
+            for (var i = 0; i < errors.length; i++) {
+              expect(errors[i].code).to.equal('InvalidConfiguration');
+            }
+          });
+        });
+      }
+      describe('service client stsRegionalConfig config', function() {
+        it('should use global endpoints for when config is undefined', function() {
+          var regions = ['us-west-2', 'ap-east-1'];
+          for (var i = 0; i < regions.length; i++) {
+            var sts = new AWS.STS({region: regions[i]});
+            expect(sts.config.endpoint).to.contain('sts.amazonaws.com');
+          }
+          var sts = new AWS.STS({region: 'cn-north-1'});
+          expect(sts.config.endpoint).to.contain('sts.cn-north-1.amazonaws.com.cn');
+        });
+        it('should use global endpoints for when config is set to legacy', function() {
+          var regions = ['us-west-2', 'ap-east-1'];
+          for (var i = 0; i < regions.length; i++) {
+            var sts = new AWS.STS({region: regions[i], stsRegionalEndpoints: 'legacy'});
+            expect(sts.config.endpoint).to.contain('sts.amazonaws.com');
+          }
+          var sts = new AWS.STS({region: 'cn-north-1', stsRegionalEndpoints: 'legacy'});
+          expect(sts.config.endpoint).to.contain('sts.cn-north-1.amazonaws.com.cn');
+        });
+        it('should use regional endpoints for when config is set to regional', function() {
+          var regions = ['us-west-2', 'ap-east-1'];
+          for (var i = 0; i < regions.length; i++) {
+            var sts = new AWS.STS({region: regions[i], stsRegionalEndpoints: 'regional'});
+            expect(sts.config.endpoint).to.contain('sts.' + regions[i] + '.amazonaws.com');
+          }
+          var sts = new AWS.STS({region: 'cn-north-1', stsRegionalEndpoints: 'regional'});
+          expect(sts.config.endpoint).to.contain('sts.cn-north-1.amazonaws.com.cn');
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This PR makes STS client supports sending requests to regional endpoints(e.g. sts.us-west-2.amazonaws.com). You can opt in by setting `stsRegionalEndpoints` client config or `AWS_STS_REGIONAL_ENDPOINTS` environment or `sts_regional_endpoints` config file entry to 'regional'. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
