### PR TITLE
Null check for profile

### DIFF
--- a/lib/services/sts.js
+++ b/lib/services/sts.js
@@ -89,7 +89,7 @@ AWS.util.update(AWS.STS.prototype, {
       var profiles = AWS.util.getProfilesFromSharedConfig(AWS.util.iniLoader);
       profile = profiles[process.env.AWS_PROFILE || AWS.util.defaultProfile];
     } catch (e) {};
-    if (Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
+    if (profile && Object.prototype.hasOwnProperty.call(profile, CONFIG_REGIONAL_ENDPOINT_ENABLED)) {
       var fileFlag = profile[CONFIG_REGIONAL_ENDPOINT_ENABLED];
       this.validateRegionalEndpointsFlagValue(fileFlag, {
         code: 'InvalidConfiguration',


### PR DESCRIPTION
Fix for #2839 

On [this line](https://github.com/alexdebrie/aws-sdk-js/blob/f29e3901d2aa8476c785b8c854d0fe880854618c/lib/services/sts.js#L90), the value for `profile` could be `undefined`. This causes an error on line 92 when we try to use `hasOwnProperty` on an undefined variable.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
