### PR TITLE
fix: declare config var to avoid unintended global

### DIFF
--- a/lib/credentials/chainable_temporary_credentials.js
+++ b/lib/credentials/chainable_temporary_credentials.js
@@ -119,7 +119,7 @@ AWS.ChainableTemporaryCredentials = AWS.util.inherit(AWS.Credentials, {
         this.tokenCodeFn = options.tokenCodeFn;
       }
     }
-    config = AWS.util.merge(
+    var config = AWS.util.merge(
       {
         params: params,
         credentials: options.masterCredentials || AWS.config.credentials


### PR DESCRIPTION
This was introduced in #2803 

I didn't see that PR until it was merged and later locked for comment, but the options interface for ChainableTemporaryCredentials is convoluted now b/c the top-level `params` and `masterCredentials` options can also be specified in the `stsConfig` option.

The fault is mine - I should have considered that someone would want full access to the client options.

I just wanted to mention it in case this interface had any bearing on the v3 interface, so that we can clean it up there.