### PR TITLE
chore: lock inactive issues from 2019-03-15 to 2019-06-15

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -5,7 +5,7 @@ daysUntilLock: 7
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
-skipCreatedBefore: 2019-06-15
+skipCreatedBefore: 2019-03-15
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
 exemptLabels: []


### PR DESCRIPTION
##### Checklist

- [x] non-code related change (markdown/git settings etc)
