### PR TITLE
chore: lock all inactive closed issues and PRs

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -5,7 +5,7 @@ daysUntilLock: 7
 
 # Skip issues and pull requests created before a given timestamp. Timestamp must
 # follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
-skipCreatedBefore: 2019-01-01
+skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
 exemptLabels: []


### PR DESCRIPTION
We introduced lockbot on Jun 26 in #2744
Moving back skipCreatedBefore date in stages is time consuming #2866
We'll create an issue instructing watchers to pause watching over a weekend where lockbot can be done loacking all inactive issues/PRs

##### Checklist

- [x] non-code related change (markdown/git settings etc)
