### PR TITLE
doc: fix typo in TokenFileWebIdentityCredentials

### DIFF
--- a/lib/credentials/token_file_web_identity_credentials.js
+++ b/lib/credentials/token_file_web_identity_credentials.js
@@ -22,7 +22,7 @@ var iniLoader = AWS.util.iniLoader;
  * This class will read filename from AWS_WEB_IDENTITY_TOKEN_FILE
  * environment variable or web_identity_token_file shared config variable,
  * and get the OIDC token from filename.
- * It will also read IAM role to be assumed from AWS_IAM_ROLE_ARN
+ * It will also read IAM role to be assumed from AWS_ROLE_ARN
  * environment variable or role_arn shared config variable.
  * This provider gets credetials using the {AWS.STS.assumeRoleWithWebIdentity}
  * service operation


### PR DESCRIPTION
Correct the typo in documentation
* Documentation mentions `AWS_IAM_ROLE_ARN`
https://github.com/aws/aws-sdk-js/blob/86d4500a10c3bd123fc010645cf80bddd9669159/lib/credentials/token_file_web_identity_credentials.js#L25
* The environment variable name is `AWS_ROLE_ARN `
https://github.com/aws/aws-sdk-js/blob/86d4500a10c3bd123fc010645cf80bddd9669159/lib/credentials/token_file_web_identity_credentials.js#L60

##### Checklist

- [x] `npm run test` passes
- [x] non-code related change (markdown/git settings etc)
