### PR TITLE
doc: add TokenFileWebIdentityCredentials to CredentialProviderChain

### DIFF
--- a/lib/credentials/credential_provider_chain.js
+++ b/lib/credentials/credential_provider_chain.js
@@ -155,6 +155,7 @@ AWS.CredentialProviderChain = AWS.util.inherit(AWS.Credentials, {
  *   function () { return new AWS.SharedIniFileCredentials(); },
  *   function () { return new AWS.ECSCredentials(); },
  *   function () { return new AWS.ProcessCredentials(); },
+ *   function () { return new AWS.TokenFileWebIdentityCredentials(); },
  *   function () { return new AWS.EC2MetadataCredentials() }
  * ]
  * ```


### PR DESCRIPTION
This update was missed in :
* node_loader.js calls TokenFileWebIdentityCredentials:
https://github.com/aws/aws-sdk-js/blob/5d8a5ead33431b1303cf63bf01db26c52c28ce69/lib/node_loader.js#L61-L69
* It's not documented in CredentialProviderChain:
https://github.com/aws/aws-sdk-js/blob/03a2070ee70cc75c3326a7e0545907f386021b19/lib/credentials/credential_provider_chain.js#L152-L159

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
