### PR TITLE
Revert "skip s3 and elastictranscoder smoke test (#2881)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --reporter=lcovonly -- test test/json test/model test/protocol test/query test/services test/signers test/xml test/s3 test/cloudfront test/dynamodb test/polly test/rds test/publisher test/event-stream",
     "browsertest": "rake browser:test && karma start",
     "buildertest": "mocha --require coffeescript/register -s 1000 -t 10000 dist-tools/test/*.coffee",
-    "integration": "cucumber.js --tags ~@s3 --tags ~@elastictranscoder",
+    "integration": "cucumber.js",
     "lint": "eslint lib test dist-tools/*.js",
     "console": "./scripts/console",
     "testfiles": "istanbul `[ $COVERAGE ] && echo 'cover _mocha' || echo 'test mocha'`",


### PR DESCRIPTION
This reverts commit 29fe1bebf62bb9dd8769f4aed1ff16a6dd937f17. This is reverted because the S3 issue is resolved

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] non-code related change (markdown/git settings etc)
