### PR TITLE
feat: retry 429 exception by default

### DIFF
--- a/.changes/next-release/feature-Retry-b976dacf.json
+++ b/.changes/next-release/feature-Retry-b976dacf.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Retry",
+  "description": "retry all 429 status code exceptions"
+}

--- a/lib/service.js
+++ b/lib/service.js
@@ -601,7 +601,7 @@ AWS.Service = inherit({
    */
   throttledError: function throttledError(error) {
     // this logic varies between services
-    if (error.statusCode === 429) return true; 
+    if (error.statusCode === 429) return true;
     switch (error.code) {
       case 'ProvisionedThroughputExceededException':
       case 'Throttling':

--- a/lib/service.js
+++ b/lib/service.js
@@ -601,6 +601,7 @@ AWS.Service = inherit({
    */
   throttledError: function throttledError(error) {
     // this logic varies between services
+    if (error.statusCode === 429) return true; 
     switch (error.code) {
       case 'ProvisionedThroughputExceededException':
       case 'Throttling':

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -497,6 +497,10 @@
     describe('retryableError', function() {
       it('should retry on throttle error', function() {
         retryableError({
+          code: 'AnyThrottleError',
+          statusCode: 429
+        }, true);
+        retryableError({
           code: 'ProvisionedThroughputExceededException',
           statusCode: 400
         }, true);


### PR DESCRIPTION
fix #2884 

SDK will retry 429 exception no matter what the error code is: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429

**Note:** The 'Retry-After' header may return from the service side and SDK doesn't respect it because it may interfere the [Exponential Backoff Policy](https://docs.aws.amazon.com/general/latest/gr/api-retries.html) or [custom retry delay options](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#retryDelayOptions-property). So we decide not to make a preference on behalf of users. To handle this header, you can insert a [retry event](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html#retry-event) to the request and update the [retryDelay](https://github.com/aws/aws-sdk-js/blob/34cc60ed5c7b67c9739c4bd9275dac70cde7de40/lib/error.d.ts#L36).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
