### PR TITLE
Allow shortcutting in customBackoff based on error

### DIFF
--- a/.changes/next-release/feature-Config-d8a13181.json
+++ b/.changes/next-release/feature-Config-d8a13181.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Config",
+  "description": "Allow shortcutting in customBackoff based on error"
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -146,7 +146,7 @@ export interface RetryDelayOptions {
      * A custom function that accepts a retry count and error and returns the amount of time to delay in milliseconds. If the result is a non-zero negative value, no further retry attempts will be made.
      * The base option will be ignored if this option is supplied.
      */
-    customBackoff?: (retryCount: number, err: Error) => number
+    customBackoff?: (retryCount: number, err?: Error) => number
 }
 
 export interface APIVersions {

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -143,10 +143,10 @@ export interface RetryDelayOptions {
      */
     base?: number
     /**
-     * A custom function that accepts a retry count and returns the amount of time to delay in milliseconds.
+     * A custom function that accepts a retry count and error and returns the amount of time to delay in milliseconds. If the result is a non-zero negative value, no further retry attempts will be made.
      * The base option will be ignored if this option is supplied.
      */
-    customBackoff?: (retryCount: number) => number
+    customBackoff?: (retryCount: number, err: Error) => number
 }
 
 export interface APIVersions {

--- a/lib/config.js
+++ b/lib/config.js
@@ -93,7 +93,7 @@ var PromisesDependency;
  *     AWS.config.update({retryDelayOptions: {base: 300}});
  *     // Delays with maxRetries = 3: 300, 600, 1200
  *   @example Set a custom backoff function to provide delay values on retries
- *     AWS.config.update({retryDelayOptions: {customBackoff: function(retryCount) {
+ *     AWS.config.update({retryDelayOptions: {customBackoff: function(retryCount, err) {
  *       // returns delay in ms
  *     }}});
  *   @return [map] A set of options to configure the retry delay on retryable errors.
@@ -102,9 +102,12 @@ var PromisesDependency;
  *     * **base** [Integer] &mdash; The base number of milliseconds to use in the
  *       exponential backoff for operation retries. Defaults to 100 ms for all services except
  *       DynamoDB, where it defaults to 50ms.
- *     * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
- *       and returns the amount of time to delay in milliseconds. The `base` option will be
- *       ignored if this option is supplied.
+ *
+ *     * **customBackoff ** [function] &mdash; A custom function that accepts a
+ *       retry count and error and returns the amount of time to delay in
+ *       milliseconds. If the result is a non-zero negative value, no further
+ *       retry attempts will be made. The `base` option will be ignored if this
+ *       option is supplied.
  *
  * @!attribute httpOptions
  *   @return [map] A set of options to pass to the low-level HTTP request.
@@ -242,9 +245,11 @@ AWS.Config = AWS.util.inherit({
    *   * **base** [Integer] &mdash; The base number of milliseconds to use in the
    *     exponential backoff for operation retries. Defaults to 100 ms for all
    *     services except DynamoDB, where it defaults to 50ms.
-   *   * **customBackoff ** [function] &mdash; A custom function that accepts a retry count
-   *     and returns the amount of time to delay in milliseconds. The `base` option will be
-   *     ignored if this option is supplied.
+   *   * **customBackoff ** [function] &mdash; A custom function that accepts a
+   *     retry count and error and returns the amount of time to delay in
+   *     milliseconds. If the result is a non-zero negative value, no further
+   *     retry attempts will be made. The `base` option will be ignored if this
+   *     option is supplied.
    * @option options httpOptions [map] A set of options to pass to the low-level
    *   HTTP request. Currently supported options are:
    *

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -454,7 +454,7 @@ AWS.EventListeners = {
         if (resp.error.redirect && resp.redirectCount < resp.maxRedirects) {
           resp.error.retryDelay = 0;
         } else if (resp.retryCount < resp.maxRetries) {
-          resp.error.retryDelay = this.service.retryDelays(resp.retryCount) || 0;
+          resp.error.retryDelay = this.service.retryDelays(resp.retryCount, resp.error) || 0;
         }
       }
     });
@@ -473,7 +473,8 @@ AWS.EventListeners = {
         }
       }
 
-      if (willRetry) {
+      // delay < 0 is a signal from customBackoff to skip retries
+      if (willRetry && delay >= 0) {
         resp.error = null;
         setTimeout(done, delay);
       } else {

--- a/lib/service.js
+++ b/lib/service.js
@@ -517,8 +517,8 @@ AWS.Service = inherit({
   /**
    * @api private
    */
-  retryDelays: function retryDelays(retryCount) {
-    return AWS.util.calculateRetryDelay(retryCount, this.config.retryDelayOptions);
+  retryDelays: function retryDelays(retryCount, err) {
+    return AWS.util.calculateRetryDelay(retryCount, this.config.retryDelayOptions, err);
   },
 
   /**

--- a/lib/services/dynamodb.js
+++ b/lib/services/dynamodb.js
@@ -46,13 +46,13 @@ AWS.util.update(AWS.DynamoDB.prototype, {
   /**
    * @api private
    */
-  retryDelays: function retryDelays(retryCount) {
+  retryDelays: function retryDelays(retryCount, err) {
     var retryDelayOptions = AWS.util.copy(this.config.retryDelayOptions);
 
     if (typeof retryDelayOptions.base !== 'number') {
         retryDelayOptions.base = 50; // default for dynamodb
     }
-    var delay = AWS.util.calculateRetryDelay(retryCount, retryDelayOptions);
+    var delay = AWS.util.calculateRetryDelay(retryCount, retryDelayOptions, err);
     return delay;
   }
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -850,11 +850,11 @@ var util = {
   /**
    * @api private
    */
-  calculateRetryDelay: function calculateRetryDelay(retryCount, retryDelayOptions) {
+  calculateRetryDelay: function calculateRetryDelay(retryCount, retryDelayOptions, err) {
     if (!retryDelayOptions) retryDelayOptions = {};
     var customBackoff = retryDelayOptions.customBackoff || null;
     if (typeof customBackoff === 'function') {
-      return customBackoff(retryCount);
+      return customBackoff(retryCount, err);
     }
     var base = typeof retryDelayOptions.base === 'number' ? retryDelayOptions.base : 100;
     var delay = Math.random() * (Math.pow(2, retryCount) * base);
@@ -873,9 +873,9 @@ var util = {
     var errCallback = function(err) {
       var maxRetries = options.maxRetries || 0;
       if (err && err.code === 'TimeoutError') err.retryable = true;
-      if (err && err.retryable && retryCount < maxRetries) {
+      var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions, err);
+      if (err && err.retryable && retryCount < maxRetries && delay >= 0) {
         retryCount++;
-        var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions);
         setTimeout(sendRequest, delay + (err.retryAfter || 0));
       } else {
         cb(err);

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -2,7 +2,7 @@ var whitelist = {
     '/config.js': [
         24,
         25,
-        184
+        187
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -665,6 +665,25 @@
         makeRequest(function() {});
         return expect(delays).to.eql([0, 2, 4]);
       });
+      it('skips retries if custom backoff returns negative delay', function() {
+        service.config.update({
+          retryDelayOptions: {
+            customBackoff: function(retryCount, err) {
+              if (err.code === 'NetworkingError') {
+                return -1;
+              } else {
+                return 2 * retryCount;
+              }
+            }
+          }
+        });
+        helpers.mockHttpResponse({
+          code: 'NetworkingError',
+          message: 'Cannot connect'
+        });
+        makeRequest(function() {});
+        return expect(delays).to.eql([]);
+      });
       it('uses retry from error.retryDelay property', function() {
         var request, response;
         helpers.mockHttpResponse({

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -607,6 +607,26 @@
         })();
         return expect(actualDelays).to.eql(expectedDelays);
       });
+      it('can pass error through to user-defined custom backoff', function() {
+        var customBackoff = function(retryCount, err) {
+          if (err.code === 'NetworkingError') {
+            return -1;
+          } else {
+            return 100 * retryCount;
+          }
+        };
+        var client = new AWS.Service({
+          retryDelayOptions: {
+            customBackoff: customBackoff
+          }
+        });
+        var err = {
+          code: 'NetworkingError',
+          message: 'Invalid character',
+        };
+        var delays = client.retryDelays(1, err);
+        return expect(delays).to.eql(-1);
+      });
       return it('can accept a user-defined custom backoff', function() {
         var actualDelays, client, customBackoff, expectedDelays, i;
         customBackoff = function(retryCount) {

--- a/test/services/dynamodb.spec.js
+++ b/test/services/dynamodb.spec.js
@@ -68,6 +68,26 @@ describe('AWS.DynamoDB', function() {
       })();
       return expect(actualDelays).to.eql(expectedDelays);
     });
+    it('can pass error through to user-defined custom backoff', function() {
+      var customBackoff = function(retryCount, err) {
+        if (err.code === 'NetworkingError') {
+          return -1;
+        } else {
+          return 100 * retryCount;
+        }
+      };
+      var service = ddb({
+        retryDelayOptions: {
+          customBackoff: customBackoff
+        }
+      });
+      var err = {
+        code: 'NetworkingError',
+        message: 'Invalid character',
+      };
+      var delays = service.retryDelays(1, err);
+      return expect(delays).to.eql(-1);
+    });
     return it('can accept a user-defined custom backoff', function() {
       var actualDelays, customBackoff, expectedDelays, i, service;
       customBackoff = function(retryCount) {


### PR DESCRIPTION
Adds the error as a parameter to the `customBackoff` function. This should be a non-breaking change for all clients.

If the result of the custom backoff is negative, then use that as a signal to shortcut remaining retries. This would make explicit a previously undefined behavior if clients returned a negative value from `customBackoff`.

Previously stated in issue https://github.com/aws/aws-sdk-js/issues/2896 (cc @ajredniwja):

> **Is your feature request related to a problem? Please describe.**
> It is frustrating when I add a custom backoff function and must wait for all retry attempts for errors I know will repeat if retried. Specifically, if I receive a `NetworkingError: Invalid character in header content ["x-amz-copy-source"]` error, I know this will be the same error for each request, there's no need for me to wait for all backoff attempts.
> 
> **Describe the solution you'd like**
> Pass the error through to the [customBackoff function](https://github.com/aws/aws-sdk-js/blob/a203c0e23010e256c88092a0be1e66a7a392eedf/lib/util.js#L857) and [allow some return value to signal shortcutting the retry attempts](https://github.com/aws/aws-sdk-js/blob/a203c0e23010e256c88092a0be1e66a7a392eedf/lib/util.js#L878-L879), eg, returning negative value or throwing an Error. [Example logic change](https://github.com/nullren/aws-sdk-js/commit/a7375492b74f414c4d87bdb727a8dac5d82e2515), happy to open PR with remaining repo changes.
> 
> **Describe alternatives you've considered**
> Not using built-in retry logic and handling it all ourselves.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed