### PR TITLE
Allowing config.signatureVersion to be used when signing requests

### DIFF
--- a/.changes/next-release/bugfix-Request Signing-6a70276c.json
+++ b/.changes/next-release/bugfix-Request Signing-6a70276c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Request Signing",
+  "description": "This change allows requests to a service to be signed if the api.json doesn't specify a signatureVersion or authtype, but the configuration has a signatureVersion specified. Prior to this change, the logic to create a signer would use signatureVersion specified in the config, but the code would never reach it if api.json signatureVersion or authtype weren't defined."
+}

--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -6412,7 +6412,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  Core: new SequentialExecutor().addNamedListeners(function(add, addAsync) {
 	    addAsync('VALIDATE_CREDENTIALS', 'validate',
 	        function VALIDATE_CREDENTIALS(req, done) {
-	      if (!req.service.api.signatureVersion) return done(); // none
+	      if (!req.service.api.signatureVersion && !req.service.config.signatureVersion) return done(); // none
 	      req.service.config.getCredentials(function(err) {
 	        if (err) {
 	          req.response.error = AWS.util.error(err,
@@ -6468,7 +6468,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	      var operation = req.service.api.operations[req.operation];
 	      var authtype = operation ? operation.authtype : '';
-	      if (!req.service.api.signatureVersion && !authtype) return done(); // none
+	      if (!req.service.api.signatureVersion && !authtype && !req.service.config.signatureVersion) return done(); // none
 	      if (req.service.getSignerClass(req) === AWS.Signers.V4) {
 	        var body = req.httpRequest.body || '';
 	        if (authtype.indexOf('unsigned-body') >= 0) {
@@ -6542,7 +6542,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var operations = req.service.api.operations || {};
 	      var operation = operations[req.operation];
 	      var authtype = operation ? operation.authtype : '';
-	      if (!service.api.signatureVersion && !authtype) return done(); // none
+	      if (!service.api.signatureVersion && !authtype && !service.config.signatureVersion) return done(); // none
 
 	      service.config.getCredentials(function (err, credentials) {
 	        if (err) {

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -77,7 +77,7 @@ AWS.EventListeners = {
   Core: new SequentialExecutor().addNamedListeners(function(add, addAsync) {
     addAsync('VALIDATE_CREDENTIALS', 'validate',
         function VALIDATE_CREDENTIALS(req, done) {
-      if (!req.service.api.signatureVersion) return done(); // none
+      if (!req.service.api.signatureVersion && !req.service.config.signatureVersion) return done(); // none
       req.service.config.getCredentials(function(err) {
         if (err) {
           req.response.error = AWS.util.error(err,
@@ -133,7 +133,7 @@ AWS.EventListeners = {
       }
       var operation = req.service.api.operations[req.operation];
       var authtype = operation ? operation.authtype : '';
-      if (!req.service.api.signatureVersion && !authtype) return done(); // none
+      if (!req.service.api.signatureVersion && !authtype && !req.service.config.signatureVersion) return done(); // none
       if (req.service.getSignerClass(req) === AWS.Signers.V4) {
         var body = req.httpRequest.body || '';
         if (authtype.indexOf('unsigned-body') >= 0) {
@@ -207,7 +207,7 @@ AWS.EventListeners = {
       var operations = req.service.api.operations || {};
       var operation = operations[req.operation];
       var authtype = operation ? operation.authtype : '';
-      if (!service.api.signatureVersion && !authtype) return done(); // none
+      if (!service.api.signatureVersion && !authtype && !service.config.signatureVersion) return done(); // none
 
       service.config.getCredentials(function (err, credentials) {
         if (err) {

--- a/test/response.spec.js
+++ b/test/response.spec.js
@@ -15,6 +15,9 @@
     beforeEach(function() {
       service = new AWS.Service({
         apiConfig: new AWS.Model.Api({
+          metadata: {
+            signingName: 'ocean-wave'
+          },
           operations: {
             op: {}
           }


### PR DESCRIPTION
This change allows requests to a service to be signed if the api.json doesn't specify a signatureVersion or authtype, but the configuration has a signatureVersion specified

Prior to this change, the logic to create a signer would use signatureVersion specified in the config, but the code would never reach it if api.json signatureVersion or authtype weren't defined.

This required an update to test data setup in response.spec.js (since the requests are now being signed, but the signing was failing because the service name for the signer was ending up as undefined)

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] `npm run test` passes
