### PR TITLE
Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_…

### DIFF
--- a/.changes/next-release/bugfix-AWS.EventListeners.Core-878c8ff0.json
+++ b/.changes/next-release/bugfix-AWS.EventListeners.Core-878c8ff0.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "AWS.EventListeners.Core",
+  "description": "add error message"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -81,7 +81,7 @@ AWS.EventListeners = {
       req.service.config.getCredentials(function(err) {
         if (err) {
           req.response.error = AWS.util.error(err,
-            {code: 'CredentialsError', message: 'Missing credentials in config'});
+            {code: 'CredentialsError', message: 'Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1'});
         }
         done();
       });


### PR DESCRIPTION
Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
