### PR TITLE
Changed deprecated usage of Buffer

### DIFF
--- a/dist/xml2js.js
+++ b/dist/xml2js.js
@@ -4968,7 +4968,7 @@ module.exports =
 	  } else {
 	    // Fallback: Return an object instance of the Buffer class
 	    if (that === null) {
-	      that = new Buffer(length)
+	      that = Buffer.from(length)
 	    }
 	    that.length = length
 	  }
@@ -4988,7 +4988,7 @@ module.exports =
 
 	function Buffer (arg, encodingOrOffset, length) {
 	  if (!Buffer.TYPED_ARRAY_SUPPORT && !(this instanceof Buffer)) {
-	    return new Buffer(arg, encodingOrOffset, length)
+	    return Buffer.from(arg, encodingOrOffset, length)
 	  }
 
 	  // Common case.


### PR DESCRIPTION
I was getting errors in my Lambda logs:

```
ERROR (node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

I did some digging and traced the issue to this file.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
