### PR TITLE
Sending DurationSeconds in assumeRole request in SharedIniFileCredentials

### DIFF
--- a/.changes/next-release/bugfix-SharedIniFileCredentials-889ac8dc.json
+++ b/.changes/next-release/bugfix-SharedIniFileCredentials-889ac8dc.json
@@ -1,5 +1,0 @@
-{
-  "type": "bugfix",
-  "category": "SharedIniFileCredentials",
-  "description": "Pass duration_seconds to assumeRole request when defined"
-}

--- a/.changes/next-release/bugfix-SharedIniFileCredentials-889ac8dc.json
+++ b/.changes/next-release/bugfix-SharedIniFileCredentials-889ac8dc.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SharedIniFileCredentials",
+  "description": "Pass duration_seconds to assumeRole request when defined"
+}

--- a/.changes/next-release/feature-SharedIniFileCredentials-a7143a9b.json
+++ b/.changes/next-release/feature-SharedIniFileCredentials-a7143a9b.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "SharedIniFileCredentials",
+  "description": "Make duration_seconds work for chained profiles"
+}

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -190,6 +190,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     var externalId = roleProfile['external_id'];
     var mfaSerial = roleProfile['mfa_serial'];
     var sourceProfileName = roleProfile['source_profile'];
+    var durationSeconds = parseInt(roleProfile['duration_seconds'], 10) || undefined;
 
     if (!sourceProfileName) {
       throw AWS.util.error(
@@ -222,6 +223,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     });
 
     var roleParams = {
+      DurationSeconds: durationSeconds,
       RoleArn: roleArn,
       RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
     };

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -910,6 +910,21 @@
           return done();
         });
       });
+      it('will use duration_seconds for assume role when provided', function(done) {
+        var creds, mock, assumeRoleSpy;
+        mock = '[default]\nrole_arn = arn\nsource_profile = foo_base\nduration_seconds = 7200\n'
+          + '[foo_base]\naws_access_key_id = baseKey\naws_secret_access_key = baseSecret\n';
+        helpers.spyOn(AWS.util, 'readFileSync').andReturn(mock);
+        helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
+        var STSPrototype = (new STS()).constructor.prototype;
+        creds = new AWS.SharedIniFileCredentials();
+        assumeRoleSpy = helpers.spyOn(STSPrototype, 'assumeRole').andCallThrough();
+        return creds.refresh(function(err) {
+          expect(assumeRoleSpy.calls.length).to.equal(1);
+          expect(assumeRoleSpy.calls[0].arguments[0].DurationSeconds).to.equal(7200);
+          return done();
+        });
+      });
 
       describe('mfa serial callback', function() {
 


### PR DESCRIPTION
*tldr;* as in title, respect `duration_seconds` of a chained profile if any (by passing it to the assume role request in `SharedIniFileCredentials`)

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run bundle exec rake docs:api and inspect doc/latest/index.html if documentation is changed

--

The unit test should hopefully reflect the use case; but for more context, we're running into the situation where a chained profile's `duration_seconds` doesn't get picked up by `aws-sdk-js` and therefore ends up having the 1h limit by default 

```
[base-profile]
aws_access_key_id = access
aws_secret_access_key = secret

[default]
source_profile = base-profile
duration_seconds = 7200

// And this below credentials would last for just 1h instead of 2h as expected
new AWS.SharedIniFileCredentials({
  profile: 'default'
  disableAssumeRole: false,
});

// The workaround that we do now is to manually craft that Credentials
// (ie. create `baseProfile` credentials, assumeRole `default` with the
// correct `durationSeconds`, etc. literally what we have inside
// `SharedIniFileCredentials#loadRoleProfile()`), which is a bit cumbersome
```