### PR TITLE
Add AWS.Endpoint to ServiceConfigurationOptions.endpoint type

### DIFF
--- a/.changes/next-release/feature-TypeScript-5295dcc6.json
+++ b/.changes/next-release/feature-TypeScript-5295dcc6.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "TypeScript",
+  "description": "Add AWS.Endpoint to ServiceConfigurationOptions.endpoint type."
+}

--- a/doc-src/templates/api-versions/plugin.rb
+++ b/doc-src/templates/api-versions/plugin.rb
@@ -146,9 +146,10 @@ API operation.
 @option options [map] params An optional map of parameters to bind to every
   request sent by this service object. For more information on bound parameters,
   see ["Working with Services" in the Getting Started Guide](/AWSJavaScriptSDK/guide/node-services.html#Bound_Parameters).
-@option options [String] endpoint The endpoint URI to send requests
+@option options [String|AWS.Endpoint] endpoint The endpoint URI to send requests
   to.  The default endpoint is built from the configured `region`.
-  The endpoint should be a string like `'https://{service}.{region}.amazonaws.com'`.
+  The endpoint should be a string like `'https://{service}.{region}.amazonaws.com'` or an
+  Endpoint object.
 @option (see AWS.Config.constructor)
 #{dualstack ? "@option options [Boolean] useDualstack Enables IPv6/IPv4 dualstack endpoint.
   When a DNS lookup is performed on an endpoint of this type, it returns an “A” record with

--- a/lib/service.d.ts
+++ b/lib/service.d.ts
@@ -69,9 +69,9 @@ export class Service {
 export interface ServiceConfigurationOptions extends ConfigurationOptions {
     /**
      * The endpoint URI to send requests to. The default endpoint is built from the configured region. 
-     * The endpoint should be a string like 'https://{service}.{region}.amazonaws.com'.
+     * The endpoint should be a string like 'https://{service}.{region}.amazonaws.com' or an Endpoint object.
      */
-    endpoint?: string;
+    endpoint?: string | Endpoint;
     /**
      * An optional map of parameters to bind to every request sent by this service object. 
      * For more information on bound parameters, see "Working with Services" in the Getting Started Guide.

--- a/ts/s3.ts
+++ b/ts/s3.ts
@@ -10,6 +10,11 @@ new S3({
     credentials: null
 });
 
+// Instantiate S3 with an Endpoint object
+new S3({
+    endpoint: new Endpoint('awsproxy.example.com')
+});
+
 // test waiters
 s3.waitFor('bucketExists', {
     Bucket: 'test',

--- a/ts/service.ts
+++ b/ts/service.ts
@@ -1,6 +1,11 @@
 import {AWSError} from '../lib/error';
 import {DescribeTableOutput} from '../clients/dynamodb';
 import {Service} from '../lib/service';
+import {Endpoint} from '../lib/endpoint';
+
+new Service({
+    endpoint: new Endpoint('http://localhost:3000')
+});
 
 const service: Service = new Service({
     endpoint: 'http://localhost:3000',


### PR DESCRIPTION
Fixes #2822, adding `AWS.Endpoint` to the `ServiceConfigurationOptions.endpoint` type (as a feature request per https://github.com/aws/aws-sdk-js/issues/2822#issuecomment-545165116).

##### Checklist

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
