### PR TITLE
Dynamodb translator to ignore unknown values - DocumentClient

### DIFF
--- a/.changes/next-release/bugfix-dynamodb-documentClient-translator-9d00ba98.json
+++ b/.changes/next-release/bugfix-dynamodb-documentClient-translator-9d00ba98.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "dynamodb-documentClient-translator",
+  "description": "Fixes runtime exception in the documentClient translator when a native javascript input object contains a top-level property with a non-serializable value (eg, when the input object was created after Object.prototype was modified to include a property whose value is a function) -- see Issue #1236"
+}

--- a/lib/dynamodb/translator.js
+++ b/lib/dynamodb/translator.js
@@ -6,7 +6,6 @@ var Translator = function(options) {
   this.attrValue = options.attrValue;
   this.convertEmptyValues = Boolean(options.convertEmptyValues);
   this.wrapNumbers = Boolean(options.wrapNumbers);
-  this.excludeUnknownInputTypes = Boolean(options.excludeUnknownInputTypes);
 };
 
 Translator.prototype.translateInput = function(value, shape) {
@@ -84,13 +83,7 @@ Translator.prototype.translateScalar = function(value, shape) {
 };
 
 Translator.prototype.translateUnknown = function(unknown, unknownShape) {
-  var self = this;
-  var toTypeDefault = function(value) { return value; };
-
-  if (self.excludeUnknownInputTypes) return undefined;
-  else if (unknownShape.toType) return unknownShape.toType(value);
-  else return toTypeDefault(unknown);
-
+  return undefined;
 };
 
 /**

--- a/lib/dynamodb/translator.js
+++ b/lib/dynamodb/translator.js
@@ -6,6 +6,7 @@ var Translator = function(options) {
   this.attrValue = options.attrValue;
   this.convertEmptyValues = Boolean(options.convertEmptyValues);
   this.wrapNumbers = Boolean(options.wrapNumbers);
+  this.excludeUnknownInputTypes = Boolean(options.excludeUnknownInputTypes);
 };
 
 Translator.prototype.translateInput = function(value, shape) {
@@ -32,6 +33,7 @@ Translator.prototype.translate = function(value, shape) {
     case 'structure': return self.translateStructure(value, shape);
     case 'map': return self.translateMap(value, shape);
     case 'list': return self.translateList(value, shape);
+    case undefined: return self.translateUnknown(value, shape);
     default: return self.translateScalar(value, shape);
   }
 };
@@ -79,6 +81,16 @@ Translator.prototype.translateMap = function(map, shape) {
 
 Translator.prototype.translateScalar = function(value, shape) {
   return shape.toType(value);
+};
+
+Translator.prototype.translateUnknown = function(unknown, unknownShape) {
+  var self = this;
+  var toTypeDefault = function(value) { return value; };
+
+  if (self.excludeUnknownInputTypes) return undefined;
+  else if (unknownShape.toType) return unknownShape.toType(value);
+  else return toTypeDefault(unknown);
+
 };
 
 /**

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -972,7 +972,8 @@
       });
 
       it('translates values containing unknown shape type by excluding when excludeUnknownInputTypes option set', function() {
-        var unknown, bar, baz, fizz, buzz, bang, mapIn, quux, qaax, qiix, input, params, request, client;
+        var unknown, bar, baz, fizz, buzz, bang, mapIn, quux, qaax, qiix, outputIfUnknown, input, params, request, client;
+        outputIfUnknown = null;
         unknown = function() { };
         bar = 'bar';
         baz = 3;
@@ -981,7 +982,7 @@
         quux = docClient.createSet([bar]);
         qaax = docClient.createSet([baz]);
         qiix = docClient.createSet([fizz]);
-        mapIn = {alpha: bar, beta: baz, gamma: fizz, delta: bang};
+        mapIn = {alpha: bar, beta: baz, gamma: fizz, delta: bang, epsilon: unknown};
         input = {
           Item: {
             foo: unknown,
@@ -997,7 +998,7 @@
         };
         params = {
           Item: {
-            foo: null,
+            foo: outputIfUnknown,
             bar: {
               S: 'bar'
             },
@@ -1023,7 +1024,8 @@
                 },
                 delta: {
                   NULL: true
-                }
+                } //,
+                //epsilon: outputIfUnknown
               }
             },
             quux: {

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -1021,10 +1021,16 @@
         client = new AWS.DynamoDB.DocumentClient({
           excludeUnknownInputTypes: true
         });
+        Object.prototype.newProp = unknown;
         request = client.put(input);
         request.emit('validate', [request]);
+        delete Object.prototype.newProp;
 
-        expect( function() { translateInput(input); } ).to.not.throw('shape.toType is not a function');
+        expect( function() {
+            Object.prototype.newProp = unknownn;
+            translateInput(input);
+            delete Object.prototype.newProp;
+        }).to.not.throw('shape.toType is not a function');
         expect(request.params).to.eql(params);
       });
     });

--- a/test/dynamodb/document_client.spec.js
+++ b/test/dynamodb/document_client.spec.js
@@ -951,27 +951,6 @@
       });
 
       it('translates unserializable values of unknown shape type', function() {
-        var input, params, unknownValue;
-        unknownValue = function() { };
-        input = {
-          Item: {
-            foo: 'bar',
-            bar: unknownValue
-          }
-        };
-        params = {
-          Item: {
-            foo: {
-              S: 'bar'
-            },
-            bar: null
-          }
-        };
-        expect( function() { translateInput(input); } ).to.not.throw('shape.toType is not a function');
-        expect(translateInput(input)).to.eql(params);
-      });
-
-      it('translates values containing unknown shape type by excluding when excludeUnknownInputTypes option set', function() {
         var unknown, bar, baz, fizz, buzz, bang, mapIn, quux, qaax, qiix, outputIfUnknown, input, params, request, client;
         outputIfUnknown = null;
         unknown = function() { };
@@ -1044,6 +1023,8 @@
         });
         request = client.put(input);
         request.emit('validate', [request]);
+
+        expect( function() { translateInput(input); } ).to.not.throw('shape.toType is not a function');
         expect(request.params).to.eql(params);
       });
     });


### PR DESCRIPTION
Addresses [Issue #1236](https://github.com/aws/aws-sdk-js/issues/1236) where an error occurs in the DocumentClient's translator module when the input native javascript object contains an unserializable property immediately under a top level property of the input object.

Example scenario:
```
const dynamoDBDocumentClient = new require('aws-sdk').DynamoDB.DocumentClient();
Object.prototype.newProp = function() { };
const paramNewJsObject = { TableName: 't',  Key: { tableKey: 'keyValueJsString' }};
// ? behavior due to "paramNewJsObject.Key.newProp" ?
// without fix: throws TypeError 'shape.toType is not a function'
// with fix: dynamodb request is successful despite "newProp"
dynamoDBDocumentClient.get(paramNewJsObject);
```

Without fix, this results in a runtime exception in the dynamodb document client translator.  The proposed solution is to ensure these input values are treated similar as in other parts of the translator logic -- they are ignored from output and/or emitted as javascript/json null in the output of the DocumentClient translator.

Typical use case shown in example above: dynamodb document client user has modified Object.prototype to include a function property before creating and passing a javascript object to a dynamodb DocumentClient API method.  Without the fix, the request will fail during input translation to the native API request parameter object.  With the fix, the dynamodb request proceeds as expected.


##### Checklist
- [x] `npm run test` passes (npm run unit)
- [x] changelog is added, `npm run add-change`

