### PR TITLE
Prefer AWS_DEFAULT_REGION to other ENV vars

### DIFF
--- a/.changes/next-release/bugfix-Config-e8ec7f6e.json
+++ b/.changes/next-release/bugfix-Config-e8ec7f6e.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Config",
+  "description": "Prefer AWS_DEFAULT_REGION environment variable to AWS_REGION or AMAZON_REGION, as indicated by the AWS CLI documentation."
+}

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -89,7 +89,7 @@ AWS.util.update(AWS.Config.prototype.keys, {
   },
   region: function() {
     var env = process.env;
-    var region = env.AWS_REGION || env.AMAZON_REGION;
+    var region = env.AWS_DEFAULT_REGION || env.AWS_REGION || env.AMAZON_REGION;
     if (env[AWS.util.configOptInEnv]) {
       var toCheck = [
         {filename: env[AWS.util.sharedCredentialsFileEnv]},

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -49,6 +49,12 @@ describe('AWS.Config', function() {
     });
 
     if (AWS.util.isNode()) {
+      it('grabs AWS_DEFAULT_REGION from the env', function() {
+        process.env.AWS_DEFAULT_REGION = 'us-east-2';
+        var config = new AWS.Config();
+        expect(config.region).to.equal('us-east-2');
+      });
+
       it('grabs AWS_REGION from the env', function() {
         process.env.AWS_REGION = 'us-west-2';
         var config = new AWS.Config();
@@ -59,6 +65,14 @@ describe('AWS.Config', function() {
         process.env.AMAZON_REGION = 'us-west-1';
         var config = new AWS.Config();
         expect(config.region).to.equal('us-west-1');
+      });
+
+      it('prefers AWS_DEFAULT_REGION to AWS_REGION and AMAZON_REGION', function() {
+        process.env.AWS_DEFAULT_REGION = 'us-east-2';
+        process.env.AWS_REGION = 'us-west-2';
+        process.env.AMAZON_REGION = 'us-west-1';
+        var config = new AWS.Config();
+        expect(config.region).to.equal('us-east-2');
       });
 
       it('prefers AWS_REGION to AMAZON_REGION', function() {


### PR DESCRIPTION
Fixes #2929
Prefer AWS_DEFAULT_REGION to AWS_REGION and AMAZON_REGION as indicated by the AWS CLI docs

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
