### PR TITLE
Retry on RDSDataService Communications link failure

### DIFF
--- a/.changes/next-release/feature-RDSDataService-a799b536.json
+++ b/.changes/next-release/feature-RDSDataService-a799b536.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "RDSDataService",
+  "description": "Retry on Serverless Aurora \"Communications link failure\""
+}

--- a/clients/rdsdataservice.js
+++ b/clients/rdsdataservice.js
@@ -5,6 +5,7 @@ var apiLoader = AWS.apiLoader;
 
 apiLoader.services['rdsdataservice'] = {};
 AWS.RDSDataService = Service.defineService('rdsdataservice', ['2018-08-01']);
+require('../lib/services/rdsdataservice');
 Object.defineProperty(apiLoader.services['rdsdataservice'], '2018-08-01', {
   get: function get() {
     var model = require('../apis/rds-data-2018-08-01.min.json');

--- a/lib/services/rdsdataservice.js
+++ b/lib/services/rdsdataservice.js
@@ -1,0 +1,19 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.RDSDataService.prototype, {
+  /**
+   * @return [Boolean] whether the error can be retried
+   * @api private
+   */
+  retryableError: function retryableError(error) {
+    if (error.code === 'BadRequestException' &&
+      error.message &&
+      error.message.match(/^Communications link failure/) &&
+      error.statusCode === 400) {
+      return true;
+    } else {
+      var _super = AWS.Service.prototype.retryableError;
+      return _super.call(this, error);
+    }
+  }
+});

--- a/test/services/rdsdataservice.spec.js
+++ b/test/services/rdsdataservice.spec.js
@@ -1,0 +1,33 @@
+var AWS, helpers;
+
+helpers = require('../helpers');
+
+AWS = helpers.AWS;
+
+describe('AWS.RDSDataService', function() {
+  var service;
+  beforeEach(function() {
+    service = new AWS.RDSDataService();
+  });
+  return describe('retryableError', function() {
+    it('retryableError returns true for Communications link failure errors', function() {
+      var err;
+      err = {
+        message: 'Communications link failure\n' +
+          '\n' +
+          'The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.',
+        code: 'BadRequestException',
+        statusCode: 400
+      };
+      return expect(service.retryableError(err)).to.be['true'];
+    });
+    return it('retryableError returns false for other 400 errors', function() {
+      var err;
+      err = {
+        code: 'SomeErrorCode',
+        statusCode: 400
+      };
+      return expect(service.retryableError(err)).to.be['false'];
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Closes #2914

Running AWS.RDSDataService.executeStatement against an auto-paused Serverless Aurora in a paused state results in `400 - BadRequestException: Communications link failure`.

I have limited making retryable to the following conditions:
 * Status code is `400`
 * Error code is `BadRequestException`
 * Error message starts with `Communications link failure`

I included the error message condition because the service documentation is not clear that "BadRequestException" is limited to this condition.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] ~`.d.ts` file is updated~
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] ~run `npm run integration` if integration test is changed~
- [ ] ~non-code related change (markdown/git settings etc)~
