### PR TITLE
Fix `name.endsWith is not a function` exception when inspecting some errors produced by the aws sdk with some versions of nodejs

### DIFF
--- a/.changes/next-release/bugfix-util-358e56d3.json
+++ b/.changes/next-release/bugfix-util-358e56d3.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "util",
+  "description": "Fix `name.endsWith is not a function` exception when inspecting some generated errors with some versions of nodejs"
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -594,7 +594,7 @@ var util = {
       Object.defineProperty(err, 'message', {enumerable: true});
     }
 
-    err.name = options && options.name || err.name || err.code || 'Error';
+    err.name = String(options && options.name || err.name || err.code || 'Error');
     err.time = new Date();
 
     if (originalError) err.originalError = originalError;


### PR DESCRIPTION
In some situations, the aws sdk sometimes sets the `name` property on errors it generates to a non-string value. For example, extractError in query.js, when given a bare (bodyless) response, will pass the (numeric) httpResponse statusCode as the `code` option to `util.error`. `util.error` then sets the `name` propertyof the Error from this.

The result is that property ends up as a number. But it is required to be a string; in particular [recent versions of nodejs assume it's a string and calls endsWith() on it](https://github.com/nodejs/node/blob/e5d3c8121dd0bcc4dbf52c7b3a0521e359363a05/lib/internal/util/inspect.js#L922), and throw an exception if an Error with a non-string name is ever inspected.

This pr coerces the `name` to a string.

##### Checklist

- [x] `npm run test` passes (test/services/sts.spec.js:197 fails, but does so even without the change, so unrelated)
- [x] changelog is added, `npm run add-change`
