### PR TITLE
chore: npmignore eslintignore and vscode

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,12 +1,14 @@
 .changes
 .yard*
 .eslintrc
+.eslintignore
 .travis.yml
 .github
 .gitignore
 .jshintrc
 .npmignore
 .tesselinclude
+.vscode/
 apis/*.normal.json
 appveyor.yml
 bower.json


### PR DESCRIPTION
These files don't need to be published.

I also question if `scripts`, and `dist-tools` also need to be published - on disk `scripts` is about 100kb alone.
