### PR TITLE
chore: add Node.js v12 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
   - "8"
   - "9"
   - "10"
+  - "12"
 env:
   - TEST_SCRIPT=coverage
 


### PR DESCRIPTION
Node.js v12 is LTS https://medium.com/@nodejs/e28d6a4a2bd

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes