### PR TITLE
Revert "chore: use ^ to allow relaxed versions (#2933)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
     "webpack": "^1.15.0"
   },
   "dependencies": {
-    "buffer": "^4.9.1",
-    "events": "^1.1.1",
-    "ieee754": "^1.1.13",
-    "jmespath": "^0.15.0",
-    "querystring": "^0.2.0",
-    "sax": "^1.2.1",
-    "url": "^0.10.3",
-    "uuid": "^3.3.2",
-    "xml2js": "^0.4.19"
+    "buffer": "4.9.1",
+    "events": "1.1.1",
+    "ieee754": "1.1.13",
+    "jmespath": "0.15.0",
+    "querystring": "0.2.0",
+    "sax": "1.2.1",
+    "url": "0.10.3",
+    "uuid": "3.3.2",
+    "xml2js": "0.4.19"
   },
   "main": "lib/aws.js",
   "browser": {


### PR DESCRIPTION
This reverts commit ff22c9505eb89e21a6c6ffbe771f54478c0f193a.

xml2js version currently breaks CI on Node 0.10 for my other PR: #2987 Revert the commit all together because other dependencies may break the CI in the future

