### PR TITLE
feat: adds support for credential_source

### DIFF
--- a/.changes/next-release/feature-Configuration-ed504276.json
+++ b/.changes/next-release/feature-Configuration-ed504276.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Configuration",
+  "description": "Adds support for \"credential_source\" in when loading credentials from the shared ini files. Closes #1916 and #2071."
+}

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -190,30 +190,62 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     var externalId = roleProfile['external_id'];
     var mfaSerial = roleProfile['mfa_serial'];
     var sourceProfileName = roleProfile['source_profile'];
+    var credentialSource = roleProfile['credential_source'];
 
-    if (!sourceProfileName) {
+    if (!sourceProfileName && !credentialSource) {
       throw AWS.util.error(
-        new Error('source_profile is not set using profile ' + this.profile),
+        new Error('source_profile or credential_source are not set '
+        + 'using profile ' + this.profile),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
 
-    var sourceProfileExistanceTest = creds[sourceProfileName];
-
-    if (typeof sourceProfileExistanceTest !== 'object') {
+    if (sourceProfileName && credentialSource) {
       throw AWS.util.error(
-        new Error('source_profile ' + sourceProfileName + ' using profile '
-          + this.profile + ' does not exist'),
+        new Error('source_profile and credential_source are set '
+        + 'using profile ' + this.profile),
         { code: 'SharedIniFileCredentialsProviderFailure' }
       );
     }
 
-    var sourceCredentials = new AWS.SharedIniFileCredentials(
-      AWS.util.merge(this.options || {}, {
-        profile: sourceProfileName,
-        preferStaticCredentials: true
-      })
-    );
+    var sourceCredentials;
+
+    if (sourceProfileName) {
+      var sourceProfileExistanceTest = creds[sourceProfileName];
+
+      if (typeof sourceProfileExistanceTest !== 'object') {
+        throw AWS.util.error(
+          new Error('source_profile ' + sourceProfileName + ' using profile '
+            + this.profile + ' does not exist'),
+          { code: 'SharedIniFileCredentialsProviderFailure' }
+        );
+      }
+
+      sourceCredentials = new AWS.SharedIniFileCredentials(
+        AWS.util.merge(this.options || {}, {
+          profile: sourceProfileName,
+          preferStaticCredentials: true
+        })
+      );
+    } else {
+      switch (credentialSource) {
+        case 'Environment':
+          sourceCredentials = new AWS.EnvironmentCredentials('AWS');
+          break;
+        case 'Ec2InstanceMetadata':
+          sourceCredentials = new AWS.EC2MetadataCredentials();
+          break;
+        case 'EcsContainer':
+          sourceCredentials = new AWS.ECSCredentials();
+          break;
+        default:
+          throw AWS.util.error(
+            new Error('credential_source ' + credentialSource
+            + ' using profile ' + this.profile + ' is not valid'),
+            { code: 'SharedIniFileCredentialsProviderFailure' }
+          );
+      }
+    }
 
     this.roleArn = roleArn;
     var sts = new STS({


### PR DESCRIPTION
Updates SharedIniFileCredentials to use "credential_source" as well as "source_profile", in combination with "role_arn", as specified in the AWS CLI configuration [1].

Attempting to use both "credential_source" and "source_profile" results in an error, and failure to provide at least one of them produces an updated error.

Test suite has been updated to cover these scenarios, valid and invalid values for "credential_source", as well as one "end to end" test case, using EnvironmentCredentials. I was not able to find a simple way to add similar "end to end" test cases for Ec2MetadataCredentials or ECSCredentials, but would love to do so if provided some guidance.

I did, however, manually verify that using Ec2MetadataCredentials works, by trying this configuration from inside an actual EC2 instance.

Closes #1916
Closes #2071

[1] https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#using-aws-iam-roles

##### Checklist

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`