### PR TITLE
Pass across the protocol when using the proxy-from-env library to dynamically retrieve proxy information (Fixes #2815)

### DIFF
--- a/.changes/next-release/bugfix-networking-98f24eb6.json
+++ b/.changes/next-release/bugfix-networking-98f24eb6.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "networking",
+  "description": "Pass across the protocol when using the proxy-from-env library to dynamically retrieve proxy information (Fixes #2815)"
+}

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -25,6 +25,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
     var useSSL = endpoint.protocol === 'https:';
     var http = useSSL ? require('https') : require('http');
     var options = {
+      protocol: endpoint.protocol,
       host: endpoint.hostname,
       port: endpoint.port,
       method: httpRequest.method,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Pass across the protocol when using the proxy-from-env library to dynamically retrieve proxy information (Fixes #2815)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
