### PR TITLE
Fix for #3041 - Access point arn check error with s3

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -448,7 +448,7 @@ AWS.util.update(AWS.S3.prototype, {
    * @api private
    */
   populateUriFromAccessPoint: function populateUriFromAccessPoint(req) {
-    if (req.service._originalConfig.endpoint) {
+    if (req.service._originalConfig.endpoint && req.service._originalConfig.endpoint !== 's3.amazonaws.com') {
       throw AWS.util.error(new Error(), {
         code: 'InvalidConfiguration',
         message: 'Custom endpoint is not compatible with access point ARN'


### PR DESCRIPTION
The check throws an error with a default config when using an access point uri to upload.  Possibly this is due to something else that should be handled separately but the check above makes the sdk work for me as expected.

I am sure there is a more official way of referencing the default endpoint value but figure I'd illustrate the fix for quick and easy testing.

fixes #3041

##### Checklist

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)

I just edited using github quick in all honesty :-P 