### PR TITLE
fix: add IAM endpoint for us-isob-*

### DIFF
--- a/.changes/next-release/bugfix-iam-b72f6077.json
+++ b/.changes/next-release/bugfix-iam-b72f6077.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "iam",
+  "description": "add IAM endpoint for us-isob-*"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -3,6 +3,9 @@
     "*/*": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },
+    "us-isob-*/iam": {
+      "endpoint": "iam.{region}.sc2s.sgov.gov"
+    },
     "cn-*/*": {
       "endpoint": "{service}.{region}.amazonaws.com.cn"
     },


### PR DESCRIPTION
Confirmed that region is set for IAM endpoint using AWS REPL
```console
aws-sdk> let client = new AWS.IAM({ "region": "us-isob-east-1" });

aws-sdk> let req = client.listRoles();

aws-sdk> req.httpRequest.region
'us-isob-east-1'
```

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`