### PR TITLE
fix: add endpoint for us-isob-*

### DIFF
--- a/.changes/next-release/bugfix-endpoint-bbe41106.json
+++ b/.changes/next-release/bugfix-endpoint-bbe41106.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "endpoint",
+  "description": "add endpoint for us-isob-*"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -3,11 +3,11 @@
     "*/*": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },
-    "us-isob-*/iam": {
-      "endpoint": "iam.{region}.sc2s.sgov.gov"
-    },
     "cn-*/*": {
       "endpoint": "{service}.{region}.amazonaws.com.cn"
+    },
+    "us-isob-*/*": {
+      "endpoint": "{service}.{region}.sc2s.sgov.gov"
     },
     "*/budgets": "globalSSL",
     "*/cloudfront": "globalSSL",


### PR DESCRIPTION
add endpoint for us-isob-*
An update to IAM endpoint as done in https://github.com/aws/aws-sdk-js/pull/3056

Confirmed that region is set for IAM endpoint using AWS REPL
```console
aws-sdk> let client = new AWS.S3({ "region": "us-isob-east-1" });

aws-sdk> let req = client.listBuckets();

aws-sdk> req.httpRequest.region
'us-isob-east-1'
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`