### PR TITLE
fix: add endpoint for us-iso-*

### DIFF
--- a/.changes/next-release/bugfix-endpoint-0203a5c4.json
+++ b/.changes/next-release/bugfix-endpoint-0203a5c4.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "endpoint",
+  "description": "add endpoint for us-iso-*"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -6,6 +6,9 @@
     "cn-*/*": {
       "endpoint": "{service}.{region}.amazonaws.com.cn"
     },
+    "us-iso-*/*": {
+      "endpoint": "{service}.{region}.c2s.ic.gov"
+    },
     "us-isob-*/*": {
       "endpoint": "{service}.{region}.sc2s.sgov.gov"
     },


### PR DESCRIPTION
Similar to: https://github.com/aws/aws-sdk-js/pull/3064

Verified using AWS REPL:
```console
aws-sdk> new AWS.S3({region: "us-iso-east-1"}).endpoint
Endpoint {
  protocol: 'https:',
  host: 's3.us-iso-east-1.c2s.ic.gov',
  port: 443,
  hostname: 's3.us-iso-east-1.c2s.ic.gov',
  pathname: '/',
  path: '/',
  href: 'https://s3.us-iso-east-1.c2s.ic.gov/'
}
```

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`