### PR TITLE
fix: supporte moving default lists for xml parser

### DIFF
--- a/.changes/next-release/bugfix-parser-5e14f8ef.json
+++ b/.changes/next-release/bugfix-parser-5e14f8ef.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "parser",
+  "description": "Now we can disable inserting empty array in xml parser if the member doesn't exist in response."
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -360,7 +360,8 @@
   },
   "s3control": {
     "name": "S3Control",
-    "dualstackAvailable": true
+    "dualstackAvailable": true,
+    "xmlNoDefaultLists": true
   },
   "servicecatalog": {
     "name": "ServiceCatalog",

--- a/lib/model/api.js
+++ b/lib/model/api.js
@@ -3,7 +3,7 @@ var Operation = require('./operation');
 var Shape = require('./shape');
 var Paginator = require('./paginator');
 var ResourceWaiter = require('./resource_waiter');
-var Metadata = require('../../apis/metadata.json');
+var metadata = require('../../apis/metadata.json');
 
 var util = require('../util');
 var property = util.property;
@@ -35,7 +35,7 @@ function Api(api, options) {
   property(this, 'fullName', api.metadata.serviceFullName);
   property(this, 'serviceId', api.metadata.serviceId);
   if (serviceIdentifier) {
-      property(this, 'xmlNoDefaultLists', Metadata[serviceIdentifier].xmlNoDefaultLists, false);
+      property(this, 'xmlNoDefaultLists', metadata[serviceIdentifier].xmlNoDefaultLists, false);
   }
 
   memoizedProperty(this, 'className', function() {

--- a/lib/model/api.js
+++ b/lib/model/api.js
@@ -3,6 +3,7 @@ var Operation = require('./operation');
 var Shape = require('./shape');
 var Paginator = require('./paginator');
 var ResourceWaiter = require('./resource_waiter');
+var Metadata = require('../../apis/metadata.json');
 
 var util = require('../util');
 var property = util.property;
@@ -15,6 +16,9 @@ function Api(api, options) {
   options.api = this;
 
   api.metadata = api.metadata || {};
+
+  var serviceIdentifier = options.serviceIdentifier;
+  delete options.serviceIdentifier;
 
   property(this, 'isApi', true, false);
   property(this, 'apiVersion', api.metadata.apiVersion);
@@ -30,6 +34,9 @@ function Api(api, options) {
   property(this, 'abbreviation', api.metadata.serviceAbbreviation);
   property(this, 'fullName', api.metadata.serviceFullName);
   property(this, 'serviceId', api.metadata.serviceId);
+  if (serviceIdentifier) {
+      property(this, 'xmlNoDefaultLists', Metadata[serviceIdentifier].xmlNoDefaultLists, false);
+  }
 
   memoizedProperty(this, 'className', function() {
     var name = api.metadata.serviceAbbreviation || api.metadata.serviceFullName;

--- a/lib/service.js
+++ b/lib/service.js
@@ -751,7 +751,9 @@ AWS.util.update(AWS.Service, {
       if (api.isApi) {
         svc.prototype.api = api;
       } else {
-        svc.prototype.api = new Api(api);
+        svc.prototype.api = new Api(api, {
+          serviceIdentifier: superclass.serviceIdentifier
+        });
       }
     }
 

--- a/lib/xml/browser_parser.js
+++ b/lib/xml/browser_parser.js
@@ -108,7 +108,10 @@ function parseStructure(xml, shape) {
         getElementByTagName(xml, memberShape.name);
       if (xmlChild) {
         data[memberName] = parseXml(xmlChild, memberShape);
-      } else if (!memberShape.flattened && memberShape.type === 'list') {
+      } else if (
+        !memberShape.flattened &&
+        memberShape.type === 'list' &&
+        !shape.api.xmlNoDefaultLists) {
         data[memberName] = memberShape.defaultValue;
       }
     }

--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -70,7 +70,7 @@ function parseStructure(xml, shape) {
     } else if (memberShape.isXmlAttribute &&
                xml.$ && Object.prototype.hasOwnProperty.call(xml.$, xmlName)) {
       data[memberName] = parseScalar(xml.$[xmlName], memberShape);
-    } else if (memberShape.type === 'list') {
+    } else if (memberShape.type === 'list' && !shape.api.xmlNoDefaultLists) {
       data[memberName] = memberShape.defaultValue;
     }
   });

--- a/test/xml/parser.spec.js
+++ b/test/xml/parser.spec.js
@@ -213,6 +213,28 @@
           });
         });
       });
+      it('return empty string for missing list hen xmlNoDefaultLists is set', function() {
+        xml = '<xml></xml>';
+        rules = {
+          type: 'structure',
+          members: {
+            items: {
+              type: 'list',
+              member: {
+                type: 'string'
+              }
+            }
+          }
+        };
+        var shape = AWS.Model.Shape.create(rules, {
+          api: {
+            protocol: 'rest-xml',
+            xmlNoDefaultLists: true
+          }
+        });
+        var data = new AWS.XML.Parser().parse(xml, shape);
+        expect(data).to.eql({});
+      });
       it('Converts xml lists of strings into arrays of strings', function() {
         var rules, xml;
         xml = '<xml>\n  <items>\n    <member>abc</member>\n    <member>xyz</member>\n  </items>\n</xml>';

--- a/test/xml/parser.spec.js
+++ b/test/xml/parser.spec.js
@@ -213,7 +213,7 @@
           });
         });
       });
-      it('return empty string for missing list hen xmlNoDefaultLists is set', function() {
+      it('return empty string for missing list when xmlNoDefaultLists is set', function() {
         xml = '<xml></xml>';
         rules = {
           type: 'structure',


### PR DESCRIPTION
Currently for all xml service, the parser inserts empty
array [] when a list member doesn't exist in xml string.
It was introduced long ago: https://github.com/aws/aws-sdk-js/commit/eae5b320102bb5cd97bcc9feeb7cba8e9ae05dd5
This change introduce a new key in metadata called
`xmlNoDefaultLists`. If set to true, xml parser will not
try to insert default empty array if the member doesn't
exist. This key is only applicable to rest-xml, query
protocol services.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`