### PR TITLE
Support services not specified in metadata.json

### DIFF
--- a/lib/model/api.js
+++ b/lib/model/api.js
@@ -34,7 +34,7 @@ function Api(api, options) {
   property(this, 'abbreviation', api.metadata.serviceAbbreviation);
   property(this, 'fullName', api.metadata.serviceFullName);
   property(this, 'serviceId', api.metadata.serviceId);
-  if (serviceIdentifier) {
+  if (serviceIdentifier && metadata[serviceIdentifier]) {
       property(this, 'xmlNoDefaultLists', metadata[serviceIdentifier].xmlNoDefaultLists, false);
   }
 

--- a/test/model/api.spec.js
+++ b/test/model/api.spec.js
@@ -46,6 +46,12 @@
       });
     });
 
+    describe('serviceIdentifier', function() {
+      it('creates an API with passed serviceIdentifier', function() {
+        return expect(make({}, { serviceIdentifier: 'asdf' }).isApi).to.equal(true);
+      });
+    });
+
     describe('className', function() {
       it('generates the correct class name from fullName', function() {
         var api;


### PR DESCRIPTION
The commit https://github.com/aws/aws-sdk-js/pull/3087 introduced
passing a `serviceIdentifier` to the constructor which needs to be
present in the `metadata.json`. For private models thats not the case
and checking for `xmlNoDefaultLists` fails.


##### Checklist

- [ ] `npm run test` passes
- [ ] changelog is added, `npm run add-change`
