### PR TITLE
Fix host header in endpoint discovery

### DIFF
--- a/.changes/next-release/bugfix-EndpointDiscovery-76fcc017.json
+++ b/.changes/next-release/bugfix-EndpointDiscovery-76fcc017.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "EndpointDiscovery",
+  "description": "Update host header in requests when new endpoint is found; Throw error when endpoint discovery is required but not enabled"
+}

--- a/lib/discover_endpoint.js
+++ b/lib/discover_endpoint.js
@@ -273,7 +273,7 @@ function isFalsy(value) {
  * @param [object] request request object.
  * @api private
  */
-function isEndpointDiscoveryApplicable(request) {
+function isEndpointDiscoveryEnabled(request) {
   var service = request.service || {};
   if (service.config.endpointDiscoveryEnabled === true) return true;
 
@@ -325,13 +325,23 @@ function discoverEndpoint(request, done) {
   var service = request.service || {};
   if (hasCustomEndpoint(service) || request.isPresigned()) return done();
 
-  if (!isEndpointDiscoveryApplicable(request)) return done();
-
-  request.httpRequest.appendToUserAgent('endpoint-discovery');
-
   var operations = service.api.operations || {};
   var operationModel = operations[request.operation];
   var isEndpointDiscoveryRequired = operationModel ? operationModel.endpointDiscoveryRequired : 'NULL';
+  var isEnabled = isEndpointDiscoveryEnabled(request);
+
+  if (!isEnabled) {
+    // Unless endpoint discovery is required, SDK will fallback to normal regional endpoints.
+    if (isEndpointDiscoveryRequired === 'REQUIRED') {
+      throw util.error(new Error(), {
+        code: 'ConfigurationException',
+        message: 'Endpoint Discovery is not enabled but this operation requires it.'
+      });
+    }
+    return done();
+  }
+
+  request.httpRequest.appendToUserAgent('endpoint-discovery');
   switch (isEndpointDiscoveryRequired) {
     case 'OPTIONAL':
       optionalDiscoverEndpoint(request);

--- a/lib/http.js
+++ b/lib/http.js
@@ -161,6 +161,9 @@ AWS.HttpRequest = inherit({
     var newEndpoint = new AWS.Endpoint(endpointStr);
     this.endpoint = newEndpoint;
     this.path = newEndpoint.path || '/';
+    if (this.headers['Host']) {
+      this.headers['Host'] = newEndpoint.host;
+    }
   }
 });
 

--- a/test/discover_endpoint.spec.js
+++ b/test/discover_endpoint.spec.js
@@ -454,6 +454,19 @@ describe('endpoint discovery', function() {
       expect(spy.calls[0].arguments[0].httpRequest.headers['x-amz-api-version']).to.eql('2018-09-19');
     });
 
+    it('update "Host" header with newly discovered endpoint', function() {
+      var client = new AWS.Service({
+        endpointDiscoveryEnabled: true,
+        apiConfig: new AWS.Model.Api(api),
+      });
+      var https = require('https');
+      helpers.spyOn(https, 'request').andCallThrough();
+      var request = client.makeRequest('requiredEDOperation', {Query: 'query', Record: 'record'});
+      helpers.mockHttpResponse(200, {}, '{"Endpoints": [{"Address": "https://cell1.fakeservice.amazonaws.com/fakeregion", "CachePeriodInMinutes": 1}]}');
+      request.send();
+      expect(request.httpRequest.headers.Host).to.eql('cell1.fakeservice.amazonaws.com');
+    });
+
     if (AWS.util.isNode()) {
       describe('not make more endpoint operation requests if there is an in-flight request', function() {
         var port;
@@ -664,7 +677,7 @@ describe('endpoint discovery', function() {
       expect(getFromCacheSpy.calls.length).to.eql(0);
     });
 
-    it('if endpoint specified in global config, custom endpoint should be preferred', function() {
+    it('if endpoint specified in global config, custom endpoint should be preferred(1)', function() {
       AWS.config.update({endpoint: 'custom-endpoint.amazonaws.com/fake-region'});
       client = new AWS.Service({
         apiConfig: new AWS.Model.Api(api),
@@ -675,7 +688,7 @@ describe('endpoint discovery', function() {
       delete AWS.config.endpoint;
     });
 
-    it('if endpoint specified in global config, custom endpoint should be preferred', function() {
+    it('if endpoint specified in global config, custom endpoint should be preferred(2)', function() {
       AWS.config.update({mock: {endpoint: 'custom-endpoint.amazonaws.com/fake-region'}});
       var MockService = helpers.MockServiceFromApi(api);
       var client = new MockService({});
@@ -733,12 +746,20 @@ describe('endpoint discovery', function() {
       });
       helpers.mockHttpResponse(200, {}, '{"Endpoints": [{"Address": "https://cell1.fakeservice.amazonaws.com/fakeregion", "CachePeriodInMinutes": 1}]}');
       client.makeRequest('optionalEDOperation', {Query: 'query'}).send();
-      client.makeRequest('requiredEDOperation',  {Query: 'query', Record: 'record'}).send();
-      expect(spy.calls.length).to.eql(0);
+      var request = client.makeRequest('requiredEDOperation',  {Query: 'query', Record: 'record'});
+      var error;
+      try {
+        request.send();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).not.to.eql(undefined);
+      expect(error.name).to.eql('ConfigurationException');
+      expect(error.message).to.eql('Endpoint Discovery is not enabled but this operation requires it.');
+
     });
 
     it('turn on endpoint discovery in client config', function() {
-
       client = new AWS.Service({
         endpointDiscoveryEnabled: true,
         apiConfig: new AWS.Model.Api(api),


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
2 bugs are fixed for endpoint discovery:
1. When request's endpoint is updated with the one from endpoint discovery, the `Host` header should be also be updated. Otherwise, `ERR_TLS_CERT_ALTNAME_INVALID` error will be thrown
2. When given operation requires endpoint discovery, SDK will throw if endpoint discovery feature is not enabled

2 unit tests are removed from the suite because they are not needed anymore

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
