### PR TITLE
fix using accesspoint in ManagedUpload

### DIFF
--- a/.changes/next-release/bugfix-Access Point-5e44acab.json
+++ b/.changes/next-release/bugfix-Access Point-5e44acab.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Access Point",
+  "description": "Avoid mixing up S3 client config set by ManagedUpload with user-set client config"
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -284,7 +284,7 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
       self.service = new AWS.S3({params: params});
     } else {
       var service = self.service;
-      var config = AWS.util.copy(service.config);
+      var config = AWS.util.copy(service._originalConfig || {});
       config.signatureVersion = service.getSignatureVersion();
       self.service = new service.constructor.__super__(config);
       self.service.config.params =

--- a/test/s3/managed_upload.spec.js
+++ b/test/s3/managed_upload.spec.js
@@ -1176,7 +1176,7 @@
           });
         });
       }
-      return describe('tagging', function() {
+      describe('tagging', function() {
         it('should embed tags in PutObject request for single part uploads', function(done) {
           var reqs;
           reqs = helpers.mockResponses([
@@ -1366,6 +1366,52 @@
             e = error;
             return done();
           }
+        });
+      });
+
+      describe('accesspoint', function() {
+        it('should make subsequent calls with accesspoint', function(done) {
+          var reqs = helpers.mockResponses([
+            {
+              data: {
+                UploadId: 'uploadId'
+              }
+            }, {
+              data: {
+                ETag: 'ETAG1'
+              }
+            }, {
+              data: {
+                ETag: 'ETAG2'
+              }
+            }, {
+              data: {
+                ETag: 'FINAL_ETAG',
+                Location: 'FINAL_LOCATION'
+              }
+            }
+          ]);
+          var size = 18;
+          var opts = {
+            partSize: size,
+            queueSize: 1,
+            service: s3,
+            params: {
+              Body: bigbody,
+              Bucket: 'arn:aws:s3:us-west-2:123456789012:accesspoint/myendpoint'
+            }
+          };
+          var endpoint = 'myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com';
+          upload = new AWS.S3.ManagedUpload(opts);
+          return send({}, function() {
+            expect(helpers.operationsForRequests(reqs)).to.eql(['s3.createMultipartUpload', 's3.uploadPart', 's3.uploadPart', 's3.completeMultipartUpload']);
+            expect(err).not.to.exist;
+            expect(reqs[0].httpRequest.endpoint.hostname).to.equal(endpoint);
+            expect(reqs[1].httpRequest.endpoint.hostname).to.equal(endpoint);
+            expect(reqs[2].httpRequest.endpoint.hostname).to.equal(endpoint);
+            expect(reqs[3].httpRequest.endpoint.hostname).to.equal(endpoint);
+            return done();
+          });
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Fixes: #3041 
Replaces: #3042 

Root cause of the issue is that `ManagedUpload` tries to create its internal S3 client with all the original client's resolved config, including `s3.config.endpoint`. So the newly created client treats its `endpoint` config as user-specified instead of interred from user. According to the access point feature spec, users are not allowed to specify an client's endpoint and using access point at the same time. So the mentioned exception is thrown. 

https://github.com/aws/aws-sdk-js/blob/70106adc70b148e61e3dbbbcd63086676b6d0a22/lib/s3/managed_upload.js#L286-L289

This change fixes the very old issue by creating the `ManagedUpload` internal S3 client with only the user-specified config, same to original client.

/cc @bradennapier

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
