### PR TITLE
fix: browser sha256 hasher can hash file larger than 512MB

### DIFF
--- a/.changes/next-release/bugfix-Sha256-15ffd471.json
+++ b/.changes/next-release/bugfix-Sha256-15ffd471.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Sha256",
+  "description": "fixed a bug in browser sha256 hasher. The function used to calculate wrong hash when content is larger than 512MB"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,10 @@ sudo: false
 matrix:
   include:
   - node_js: "10"
-    env: TEST_SCRIPT=test
+    env: TEST_SCRIPT=browsertest
+
+cache:
+  npm: false
 
 addons:
   rake: 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,8 @@ module.exports = function(config) {
             },
     singleRun: true,
     browserDisconnectTolerance: 3,
-    browserNoActivityTimeout: 90000,
+    browserDisconnectTimeout: 300000,
+    browserNoActivityTimeout: 300000,
     concurrency: 1
   })
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
             },
     singleRun: true,
     browserDisconnectTolerance: 3,
-    browserNoActivityTimeout: 30000,
+    browserNoActivityTimeout: 90000,
     concurrency: 1
   })
 };

--- a/lib/browserSha256.js
+++ b/lib/browserSha256.js
@@ -1,239 +1,206 @@
 var Buffer = require('buffer/').Buffer;
-var hashUtils = require('./browserHashUtils');
 
 var BLOCK_SIZE = 64;
+var FINAL_SIZE = 56;
 
-var DIGEST_LENGTH = 32;
-
-var KEY = new Uint32Array([
-    0x428a2f98,
-    0x71374491,
-    0xb5c0fbcf,
-    0xe9b5dba5,
-    0x3956c25b,
-    0x59f111f1,
-    0x923f82a4,
-    0xab1c5ed5,
-    0xd807aa98,
-    0x12835b01,
-    0x243185be,
-    0x550c7dc3,
-    0x72be5d74,
-    0x80deb1fe,
-    0x9bdc06a7,
-    0xc19bf174,
-    0xe49b69c1,
-    0xefbe4786,
-    0x0fc19dc6,
-    0x240ca1cc,
-    0x2de92c6f,
-    0x4a7484aa,
-    0x5cb0a9dc,
-    0x76f988da,
-    0x983e5152,
-    0xa831c66d,
-    0xb00327c8,
-    0xbf597fc7,
-    0xc6e00bf3,
-    0xd5a79147,
-    0x06ca6351,
-    0x14292967,
-    0x27b70a85,
-    0x2e1b2138,
-    0x4d2c6dfc,
-    0x53380d13,
-    0x650a7354,
-    0x766a0abb,
-    0x81c2c92e,
-    0x92722c85,
-    0xa2bfe8a1,
-    0xa81a664b,
-    0xc24b8b70,
-    0xc76c51a3,
-    0xd192e819,
-    0xd6990624,
-    0xf40e3585,
-    0x106aa070,
-    0x19a4c116,
-    0x1e376c08,
-    0x2748774c,
-    0x34b0bcb5,
-    0x391c0cb3,
-    0x4ed8aa4a,
-    0x5b9cca4f,
-    0x682e6ff3,
-    0x748f82ee,
-    0x78a5636f,
-    0x84c87814,
-    0x8cc70208,
-    0x90befffa,
-    0xa4506ceb,
-    0xbef9a3f7,
-    0xc67178f2
-]);
-
-var INIT = [
-    0x6a09e667,
-    0xbb67ae85,
-    0x3c6ef372,
-    0xa54ff53a,
-    0x510e527f,
-    0x9b05688c,
-    0x1f83d9ab,
-    0x5be0cd19,
+var KEY = [
+    0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5,
+    0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+    0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3,
+    0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+    0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC,
+    0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+    0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7,
+    0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+    0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13,
+    0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+    0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3,
+    0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+    0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5,
+    0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+    0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208,
+    0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2
 ];
 
-var MAX_HASHABLE_LENGTH = Math.pow(2, 53) - 1;
-
 /**
- * @private
+ * Adopted from: https://github.com/crypto-browserify/sha.js
+ * but removed other un-used hashers.
  */
 function Sha256() {
-    this.state = [
-        0x6a09e667,
-        0xbb67ae85,
-        0x3c6ef372,
-        0xa54ff53a,
-        0x510e527f,
-        0x9b05688c,
-        0x1f83d9ab,
-        0x5be0cd19,
-    ];
-    this.temp = new Int32Array(64);
-    this.buffer = new Uint8Array(64);
-    this.bufferLength = 0;
-    this.bytesHashed = 0;
-    /**
-     * @private
-     */
-    this.finished = false;
-}
+    this.init();
 
-/**
- * @api private
- */
-module.exports = exports = Sha256;
+    this.word = new Array(64);
+    this.block = new Buffer.alloc(BLOCK_SIZE);
+    this.wordLength = 0;
+}
 
 Sha256.BLOCK_SIZE = BLOCK_SIZE;
 
-Sha256.prototype.update = function (data) {
-    if (this.finished) {
-        throw new Error('Attempted to update an already finished hash.');
-    }
-
-    if (hashUtils.isEmptyData(data)) {
-        return this;
-    }
-
-    data = hashUtils.convertToBuffer(data);
-
-    var position = 0;
-    var byteLength = data.byteLength;
-    this.bytesHashed += byteLength;
-    if (this.bytesHashed * 8 > MAX_HASHABLE_LENGTH) {
-        throw new Error('Cannot hash more than 2^53 - 1 bits');
-    }
-
-    while (byteLength > 0) {
-        this.buffer[this.bufferLength++] = data[position++];
-        byteLength--;
-        if (this.bufferLength === BLOCK_SIZE) {
-            this.hashBuffer();
-            this.bufferLength = 0;
-        }
-    }
+Sha256.prototype.init = function () {
+    this._a = 0x6a09e667;
+    this._b = 0xbb67ae85;
+    this._c = 0x3c6ef372;
+    this._d = 0xa54ff53a;
+    this._e = 0x510e527f;
+    this._f = 0x9b05688c;
+    this._g = 0x1f83d9ab;
+    this._h = 0x5be0cd19;
 
     return this;
 };
 
-Sha256.prototype.digest = function (encoding) {
-    if (!this.finished) {
-        var bitsHashed = this.bytesHashed * 8;
-        var bufferView = new DataView(this.buffer.buffer, this.buffer.byteOffset, this.buffer.byteLength);
-        var undecoratedLength = this.bufferLength;
-        bufferView.setUint8(this.bufferLength++, 0x80);
-        // Ensure the final block has enough room for the hashed length
-        if (undecoratedLength % BLOCK_SIZE >= BLOCK_SIZE - 8) {
-            for (var i = this.bufferLength; i < BLOCK_SIZE; i++) {
-                bufferView.setUint8(i, 0);
-            }
-            this.hashBuffer();
-            this.bufferLength = 0;
-        }
-        for (var i = this.bufferLength; i < BLOCK_SIZE - 8; i++) {
-            bufferView.setUint8(i, 0);
-        }
-        bufferView.setUint32(BLOCK_SIZE - 8, Math.floor(bitsHashed / 0x100000000), true);
-        bufferView.setUint32(BLOCK_SIZE - 4, bitsHashed);
-        this.hashBuffer();
-        this.finished = true;
+Sha256.prototype.update = function (data, enc) {
+    if (typeof data === 'string') {
+        enc = enc || 'utf8';
+        data = Buffer.from(data, enc);
     }
-    // The value in state is little-endian rather than big-endian, so flip
-    // each word into a new Uint8Array
-    var out = new Buffer(DIGEST_LENGTH);
-    for (var i = 0; i < 8; i++) {
-        out[i * 4] = (this.state[i] >>> 24) & 0xff;
-        out[i * 4 + 1] = (this.state[i] >>> 16) & 0xff;
-        out[i * 4 + 2] = (this.state[i] >>> 8) & 0xff;
-        out[i * 4 + 3] = (this.state[i] >>> 0) & 0xff;
+
+    var block = this.block;
+    var blockSize = BLOCK_SIZE;
+    var length = data.length;
+    var accum = this.wordLength;
+
+    for (var offset = 0; offset < length;) {
+        var assigned = accum % blockSize;
+        var remainder = Math.min(length - offset, blockSize - assigned);
+
+        for (var i = 0; i < remainder; i++) {
+            block[assigned + i] = data[offset + i];
+        }
+
+        accum += remainder;
+        offset += remainder;
+
+        if (accum % blockSize === 0) {
+            this._update(block);
+        }
     }
-    return encoding ? out.toString(encoding) : out;
+
+    this.wordLength += length;
+    return this;
 };
 
-Sha256.prototype.hashBuffer = function () {
-    var _a = this,
-        buffer = _a.buffer,
-        state = _a.state;
-    var state0 = state[0],
-        state1 = state[1],
-        state2 = state[2],
-        state3 = state[3],
-        state4 = state[4],
-        state5 = state[5],
-        state6 = state[6],
-        state7 = state[7];
-    for (var i = 0; i < BLOCK_SIZE; i++) {
-        if (i < 16) {
-            this.temp[i] = (((buffer[i * 4] & 0xff) << 24) |
-                ((buffer[(i * 4) + 1] & 0xff) << 16) |
-                ((buffer[(i * 4) + 2] & 0xff) << 8) |
-                (buffer[(i * 4) + 3] & 0xff));
-        }
-        else {
-            var u = this.temp[i - 2];
-            var t1_1 = (u >>> 17 | u << 15) ^
-                (u >>> 19 | u << 13) ^
-                (u >>> 10);
-            u = this.temp[i - 15];
-            var t2_1 = (u >>> 7 | u << 25) ^
-                (u >>> 18 | u << 14) ^
-                (u >>> 3);
-            this.temp[i] = (t1_1 + this.temp[i - 7] | 0) +
-                (t2_1 + this.temp[i - 16] | 0);
-        }
-        var t1 = (((((state4 >>> 6 | state4 << 26) ^
-            (state4 >>> 11 | state4 << 21) ^
-            (state4 >>> 25 | state4 << 7))
-            + ((state4 & state5) ^ (~state4 & state6))) | 0)
-            + ((state7 + ((KEY[i] + this.temp[i]) | 0)) | 0)) | 0;
-        var t2 = (((state0 >>> 2 | state0 << 30) ^
-            (state0 >>> 13 | state0 << 19) ^
-            (state0 >>> 22 | state0 << 10)) + ((state0 & state1) ^ (state0 & state2) ^ (state1 & state2))) | 0;
-        state7 = state6;
-        state6 = state5;
-        state5 = state4;
-        state4 = (state3 + t1) | 0;
-        state3 = state2;
-        state2 = state1;
-        state1 = state0;
-        state0 = (t1 + t2) | 0;
+Sha256.prototype._update = function (M) {
+    var W = this.word;
+
+    var a = this._a | 0;
+    var b = this._b | 0;
+    var c = this._c | 0;
+    var d = this._d | 0;
+    var e = this._e | 0;
+    var f = this._f | 0;
+    var g = this._g | 0;
+    var h = this._h | 0;
+
+    for (var i = 0; i < 16; ++i) W[i] = M.readInt32BE(i * 4);
+    for (; i < 64; ++i)
+        W[i] = (gamma1(W[i - 2]) + W[i - 7] + gamma0(W[i - 15]) + W[i - 16]) | 0;
+
+    for (var j = 0; j < 64; ++j) {
+        var T1 = (h + sigma1(e) + ch(e, f, g) + KEY[j] + W[j]) | 0;
+        var T2 = (sigma0(a) + maj(a, b, c)) | 0;
+
+        h = g;
+        g = f;
+        f = e;
+        e = (d + T1) | 0;
+        d = c;
+        c = b;
+        b = a;
+        a = (T1 + T2) | 0;
     }
-    state[0] += state0;
-    state[1] += state1;
-    state[2] += state2;
-    state[3] += state3;
-    state[4] += state4;
-    state[5] += state5;
-    state[6] += state6;
-    state[7] += state7;
+
+    this._a = (a + this._a) | 0;
+    this._b = (b + this._b) | 0;
+    this._c = (c + this._c) | 0;
+    this._d = (d + this._d) | 0;
+    this._e = (e + this._e) | 0;
+    this._f = (f + this._f) | 0;
+    this._g = (g + this._g) | 0;
+    this._h = (h + this._h) | 0;
 };
+
+Sha256.prototype._hash = function () {
+    var H = Buffer.alloc(32);
+
+    H.writeInt32BE(this._a, 0);
+    H.writeInt32BE(this._b, 4);
+    H.writeInt32BE(this._c, 8);
+    H.writeInt32BE(this._d, 12);
+    H.writeInt32BE(this._e, 16);
+    H.writeInt32BE(this._f, 20);
+    H.writeInt32BE(this._g, 24);
+    H.writeInt32BE(this._h, 28);
+
+    return H;
+};
+
+Sha256.prototype.digest = function (enc) {
+    var rem = this.wordLength % BLOCK_SIZE;
+
+    this.block[rem] = 0x80;
+
+    // zero (rem + 1) trailing bits, where (rem + 1) is the smallest
+    // non-negative solution to the equation (length + 1 + (rem + 1)) === finalSize mod blockSize
+    this.block.fill(0, rem + 1);
+
+    if (rem >= FINAL_SIZE) {
+        this._update(this.block);
+        this.block.fill(0);
+    }
+
+    var bits = this.wordLength * 8;
+
+    // uint32
+    if (bits <= 0xffffffff) {
+        this.block.writeUInt32BE(bits, BLOCK_SIZE - 4);
+
+        // uint64
+    } else {
+        var lowBits = (bits & 0xffffffff) >>> 0;
+        var highBits = (bits - lowBits) / 0x100000000;
+
+        this.block.writeUInt32BE(highBits, BLOCK_SIZE - 8);
+        this.block.writeUInt32BE(lowBits, BLOCK_SIZE - 4);
+    }
+
+    this._update(this.block);
+    var hash = this._hash();
+
+    return enc ? hash.toString(enc) : hash;
+};
+
+function ch(x, y, z) {
+    return z ^ (x & (y ^ z));
+}
+
+function maj(x, y, z) {
+    return (x & y) | (z & (x | y));
+}
+
+function sigma0(x) {
+    return (
+        ((x >>> 2) | (x << 30)) ^
+        ((x >>> 13) | (x << 19)) ^
+        ((x >>> 22) | (x << 10))
+    );
+}
+
+function sigma1(x) {
+    return (
+        ((x >>> 6) | (x << 26)) ^ ((x >>> 11) | (x << 21)) ^ ((x >>> 25) | (x << 7))
+    );
+}
+
+function gamma0(x) {
+    return ((x >>> 7) | (x << 25)) ^ ((x >>> 18) | (x << 14)) ^ (x >>> 3);
+}
+
+function gamma1(x) {
+    return ((x >>> 17) | (x << 15)) ^ ((x >>> 19) | (x << 13)) ^ (x >>> 10);
+}
+
+/**
+ * @private
+ */
+module.exports = Sha256;

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -407,6 +407,9 @@
       var input = 'foo';
       var result = '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae';
       var originalTimeout;
+      if (typeof this.timeout === 'function') {
+        this.timeout(90000);
+      }
       beforeEach(function() {
         if (AWS.util.isBrowser() && jasmine) {
           originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -454,13 +457,13 @@
           });
         });
         it('handles large stream', function(done) {
-          var result = 'f64f0c6761baef28012637ac79851debbf212acfa3dd273e25213910e688287a';
+          var result = 'ada8eb6157edeb1eb10346f34c330d8e0ac9c7f889d077de5d0f8dcd97021628';
           var Transform = AWS.util.stream.Transform;
           var tr = new Transform;
           tr._transform = function(data, encoding, callback) {
             return callback(null, data);
           };
-          tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
+          // Send 0.75 GB data in chunk.
           tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
           tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
           tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
@@ -470,7 +473,7 @@
             expect(d).to.equal(result);
             return done();
           });
-        }, 90000);
+        });
       }
       if (AWS.util.isBrowser()) {
         it('handles Blobs (no phantomjs)', function(done) {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -457,14 +457,13 @@
           });
         });
         it('handles large stream', function(done) {
-          var result = 'ada8eb6157edeb1eb10346f34c330d8e0ac9c7f889d077de5d0f8dcd97021628';
+          var result = '86c338dcc928fcc63ac180b5a1f6df6c59f5ac409edd966a146e65702a2b8c10';
           var Transform = AWS.util.stream.Transform;
           var tr = new Transform;
           tr._transform = function(data, encoding, callback) {
             return callback(null, data);
           };
-          // Send 0.75 GB data in chunk.
-          tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
+          // Send 0.5 GB data in chunk.
           tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
           tr.push(AWS.util.buffer.alloc(256 * 1024 * 1024, 0));
           tr.push(AWS.util.buffer.toBuffer([1, 2, 3]));
@@ -485,9 +484,9 @@
           });
         });
         it('handles large buffers', function(done) {
-          var result = 'f64f0c6761baef28012637ac79851debbf212acfa3dd273e25213910e688287a';
-          // 1 gigabyte
-          var buffer = AWS.util.buffer.alloc(1024 * 1024 * 1024 + 3, 0);
+          var result = '86c338dcc928fcc63ac180b5a1f6df6c59f5ac409edd966a146e65702a2b8c10';
+          // 0.5 GB
+          var buffer = AWS.util.buffer.alloc(512 * 1024 * 1024 + 3, 0);
           //set last 3 bytes to [1, 2, 3]
           buffer.fill(Uint8Array.from([1,2,3]), buffer.length - 3);
           util.sha256(new Blob([buffer]), 'hex', function(e, d) {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -470,7 +470,7 @@
             expect(d).to.equal(result);
             return done();
           });
-        });
+        }, 90000);
       }
       if (AWS.util.isBrowser()) {
         it('handles Blobs (no phantomjs)', function(done) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Fixes a bug that browser SHA256 generates incorrect hash when content is larger than (2^32 - 1) bits. The new hasher implementation is adopted from https://github.com/crypto-browserify/sha.js

/cc @seebees

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed
