### PR TITLE
Have presigner preserve accesssKeyIds with colons in them

### DIFF
--- a/.changes/next-release/bugfix-Signers.Presign-6cf33bd5.json
+++ b/.changes/next-release/bugfix-Signers.Presign-6cf33bd5.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Request Signing",
+  "description": "Better handle colons in accessKeyIds when presigning URLs."
+}

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -52,8 +52,8 @@ function signedUrlSigner(request) {
   var auth = request.httpRequest.headers['Authorization'].split(' ');
   if (auth[0] === 'AWS') {
     auth = auth[1].split(':');
-    queryParams['AWSAccessKeyId'] = auth[0];
-    queryParams['Signature'] = auth[1];
+    queryParams['Signature'] = auth.pop();
+    queryParams['AWSAccessKeyId'] = auth.join(':');
 
     AWS.util.each(request.httpRequest.headers, function (key, value) {
       if (key === expiresHeader) key = 'Expires';


### PR DESCRIPTION
If a user supplies an accessKeyId like `test:tester`, the v2 signer will (correctly) craft an Authorization header like

    Authorization: AWS test:tester:<signature>

When creating a presigned URL, however, we previously would generate a query string like

    ?AWSAccessKeyId=test&Expires=<expiry>&Signature=tester

which changes the accessKeyId used and completely ignores the calculated signature. Now, have the presigner generate a query string like

    ?AWSAccessKeyId=test%3Atester&Expires=<expiry>&Signature=<signature>

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
