### PR TITLE
Fix types for callback argument in get & refresh methods for Credentials to accept error optionally

### DIFF
--- a/.changes/next-release/bugfix-Credentials-08f473f2.json
+++ b/.changes/next-release/bugfix-Credentials-08f473f2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Fix types for callback argument in get & refresh methods for Credentials to accept error optionally"
+}

--- a/lib/credentials.d.ts
+++ b/lib/credentials.d.ts
@@ -21,7 +21,7 @@ export class Credentials {
      *
      * @param {get} callback - Called when the instance metadata service responds. When called with no error, the credentials information has been loaded into the object.
      */
-    get(callback: (err: AWSError) => void): void;
+    get(callback: (err?: AWSError) => void): void;
     /**
      * Gets the existing credentials, refreshing them if necessary, and returns
      * a promise that will be fulfilled immediately (if no refresh is necessary)
@@ -38,7 +38,7 @@ export class Credentials {
      *
      * @param {function} callback - Called when the instance metadata service responds. When called with no error, the credentials information has been loaded into the object.
      */
-    refresh(callback: (err: AWSError) => void): void;
+    refresh(callback: (err?: AWSError) => void): void;
     /**
      * Invokes a credential refresh and returns a promise that will be fulfilled
      * when the refresh has completed or rejected when the refresh has failed.


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] `.d.ts` file is updated
- [X] changelog is added, `npm run add-change`
- [X] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [X] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
