### PR TITLE
chore: fix no default export issue with TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ import AWS from 'aws-sdk/global';
 import S3 from 'aws-sdk/clients/s3';
 ```
 
+**NOTE:** You need to add `"esModuleInterop": true` to compilerOptions of your `tsconfig.json`. If not possible, use like `import * as AWS from 'aws-sdk'`.
+
 In a JavaScript file:
 
 ```javascript


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

```typescript
// import entire SDK
import AWS from 'aws-sdk';
// import AWS object without services
import AWS from 'aws-sdk/global';
// import individual service
import S3 from 'aws-sdk/clients/s3';
```

I have noticed that configuring module loading according to current guidelines will fail. [This issue](https://github.com/aws/aws-sdk-js/issues/2654) mentions a same issue. This PR adds a hint to the README that you must set the esModuleInterop option.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
