### PR TITLE
Fix for s3.createBucket mutates args

### DIFF
--- a/.changes/next-release/bugfix-s3-a752bb97.json
+++ b/.changes/next-release/bugfix-s3-a752bb97.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "createBucket mutates params argument when endpoint is configured by appending CreateBucketConfigurationon key, this side effect is now fixed"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -1314,10 +1314,14 @@ AWS.util.update(AWS.S3.prototype, {
       params = {};
     }
     var hostname = this.endpoint.hostname;
+    // copy params so that appending keys does not unintentioinallly
+    // mutate params object argument passed in by user
+    var copiedParams = AWS.util.copy(params);
+
     if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
-      params.CreateBucketConfiguration = { LocationConstraint: this.config.region };
+      copiedParams.CreateBucketConfiguration = { LocationConstraint: this.config.region };
     }
-    return this.makeRequest('createBucket', params, callback);
+    return this.makeRequest('createBucket', copiedParams, callback);
   },
 
   /**

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2415,10 +2415,10 @@ describe('AWS.S3', function() {
       helpers.mockHttpResponse(200, {}, '');
       s3.createBucket(params, function() {
         expect(params.CreateBucketConfiguration).to.not.exist;
-        expect(loc).to.be.a.string
+        expect(loc).to.be.a.string;
         done();
       });
-    })
+    });
   });
 
   describe('deleteBucket', function() {

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -2391,6 +2391,34 @@ describe('AWS.S3', function() {
         done();
       });
     });
+
+    it('appends CreateBucketConfiguration key to copy of params, not original, when endpoint is configured', function(done) {
+      var loc = null;
+      var params = {
+        Bucket: 'name'
+      };
+
+      s3 = new AWS.S3({
+        region: 'eu-west-1',
+        Bucket: 'name',
+        endpoint: 'https://foo.bar.baz:555/prefix'
+      });
+
+      s3.makeRequest = function(op, copiedParams, cb) {
+        expect(copiedParams).to['be'].a('object');
+        loc = copiedParams.CreateBucketConfiguration.LocationConstraint;
+        if (typeof cb === 'function') {
+          return cb();
+        }
+      };
+
+      helpers.mockHttpResponse(200, {}, '');
+      s3.createBucket(params, function() {
+        expect(params.CreateBucketConfiguration).to.not.exist;
+        expect(loc).to.be.a.string
+        done();
+      });
+    })
   });
 
   describe('deleteBucket', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This PR fixes [Open Issue 3112](https://github.com/aws/aws-sdk-js/issues/3112) as well as the previously reported https://github.com/aws/aws-sdk-js/issues/3013 , which both describe how `s3.createBucket()` unintentionally mutates the object passed in as the `params` argument when the s3 `endpoint` has been configured to be different than the global settings. This side-effect is not intended and will cause successive calls to `s3.createBucket()` which leverage the same base params object to fail the validation step of the request. Details of the bug can be found in the open issue.

This PR resolves the bug by making a copy of the `params` within `s3.createBucket()` using the `AWS.util.copy()` utility. This way, any additional settings can be appended to the copy of the `params` object, which then is passed into `makeRequest`, without mutating the user's original parameters.

First time contributing here and I tried to adhere to all the relevant contribution guidelines, and was asked to make a pull request by @ajredniwja , but certainly let me know if anything is missing here or incorrect and happy to adjust as needed.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
