### PR TITLE
fix: move comprehensive test to CodeBuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ node_js:
   - "8"
   - "10"
 
-sudo: false
-
 addons:
   rake: 
   chrome: stable 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,8 @@ node_js:
   - "6"
   - "8"
   - "10"
-env:
-  - TEST_SCRIPT=coverage
 
 sudo: false
-
-matrix:
-  include:
-  - node_js: "10"
-    env: TEST_SCRIPT=test
 
 addons:
   rake: 
@@ -24,5 +17,4 @@ before script:
   - export CHROME_BIN=/usr/bin/chromium-browser
 
 script:
-  - npm run $TEST_SCRIPT
-  - "if [[ $TEST_SCRIPT == 'coverage' ]]; then node ./node_modules/.bin/codecov || exit 0; fi"
+  - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,5 @@ node_js:
   - "6"
   - "8"
   - "10"
-
-addons:
-  rake: 
-  chrome: stable 
-
-before script:
-  - export CHROME_BIN=/usr/bin/chromium-browser
-
 script:
   - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: node_js
 node_js:
-# - "0.8"
   - "0.10"
   - "0.12"
-  - "4.2"
-  - "4.4"
-  - "5"
+  - "4"
   - "6"
-  - "7"
   - "8"
-  - "9"
   - "10"
 env:
   - TEST_SCRIPT=coverage

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,3 +20,6 @@ phases:
     commands:
       - echo Running Test
       - npm run test
+  post_build:
+    commands:
+      - ./node_modules/.bin/codecov -f coverage/*.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     AWS_REGION: "us-west-2"
+    CHROME_BIN: "/usr/bin/chromium-browser"
 
 phases:
   install:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,16 +3,13 @@ version: 0.2
 env:
   variables:
     AWS_REGION: "us-west-2"
-    NODE_PATH: "/root/.nvm/v8.11.3/lib/node_modules"
-    PATH: "/root/.nvm/versions/node/v8.11.3/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 phases:
+  install:
+    runtime-versions:
+      nodejs: 12
   pre_build:
     commands:
-      - echo use node 8.11.3
-      - export NVM_DIR=~/.nvm && source ~/.nvm/nvm.sh && nvm install 8.11.3
-      - echo use npm 3.10.10
-      - npm install -g npm@3.10.10
       - echo Install npm dependencies
       - npm install
       - gem install rake


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3153

This PR does the following:
* Limits coverage testing to just Node LTS releases ([list](https://nodejs.org/en/download/releases/))
* Runs comprehensive test on Node.js v8 on CodeBuild
* Posts CodeCov results from CodeBuild

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
