### PR TITLE
chore: npmignore dist-tools folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@ configuration
 configuration.sample
 codecov.yml
 coverage
+dist-tools
 doc
 doc-src
 eslint-rules


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Adding `dist-tools` folder to `.npmignore` per discussion in #3159

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->