### PR TITLE
Revert "chore: npmignore dist-tools folder (#3167)"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,7 +18,6 @@ configuration
 configuration.sample
 codecov.yml
 coverage
-dist-tools
 doc
 doc-src
 eslint-rules


### PR DESCRIPTION
This reverts commit 98c40e64cb7d60927c6a0cec49592fc1fcaa59d7.

<!--
Thank you for your pull request. Please provide a description below.
-->
It turnes out the `dist-tools` folder is consumed by external customers, espatially when they are using `browserify`: https://github.com/aws/aws-sdk-js/blob/2f5261f46eb95a33ddb72ba27a6f7304e4f9ded9/package.json#L62

Revert the change to add `dist-tools` folder back to released artifacts

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
