### PR TITLE
Update AWS.config.getCredential TypeScript definition

### DIFF
--- a/.changes/next-release/bugfix-Typings-c94abd49.json
+++ b/.changes/next-release/bugfix-Typings-c94abd49.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Typings",
+  "description": "getCredentials now specify that the callback can be called with a null value. Relevant for TypeScript users with strict mode turned"
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -10,7 +10,7 @@ export class ConfigBase extends ConfigurationOptions{
     /**
      * Loads credentials from the configuration object.
      */
-    getCredentials(callback: (err: AWSError) => void): void;
+    getCredentials(callback: (err: AWSError | null) => void): void;
     /**
      * Loads configuration data from a JSON file into this config object.
      * Loading configuration willr eset all existing configuration on the object.

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -80,7 +80,7 @@ AWS.config.update({
 });
 
 //test config methods
-AWS.config.getCredentials(function(err) {});
+AWS.config.getCredentials(function(err) { err = null; });
 // make sure we can get the Promise constructor
 var Promise = AWS.config.getPromisesDependency();
 if (Promise) {


### PR DESCRIPTION
getCredentials now specify that the callback can be called with a null value. Relevant for TypeScript users with strict mode turned

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`

Closes #3184 