### PR TITLE
fix: Update comment in s3.getSignatureVersion

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -38,7 +38,7 @@ AWS.util.update(AWS.S3.prototype, {
       1) User defined version specified:
         a) always return user defined version
       2) No user defined version specified:
-        a) default to lowest version the region supports
+        a) If not using presigned urls, default to V4
         b) If using presigned urls, default to lowest version the region supports
     */
     if (userDefinedVersion) {


### PR DESCRIPTION
The comment was removed while making the changes in https://github.com/aws/aws-sdk-js/pull/1085
It wasn't re-introduced in PR https://github.com/aws/aws-sdk-js/pull/1558

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes