### PR TITLE
Set MaxRetriesExceeded on monitoring event only when the final retry fails

### DIFF
--- a/.changes/next-release/bugfix-Monitoring-dee8cfcd.json
+++ b/.changes/next-release/bugfix-Monitoring-dee8cfcd.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Monitoring",
+  "description": "Set MaxRetriesExceeded on monitoring event only when the final retry fails"
+}

--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -4626,6 +4626,8 @@ return /******/ (function(modules) { // webpackBootstrap
 	      apiCallEvent.Latency = latency >= 0 ? latency : 0;
 	      var response = request.response;
 	      if (
+	        response.error &&
+	        response.error.retryable &&
 	        typeof response.retryCount === 'number' &&
 	        typeof response.maxRetries === 'number' &&
 	        (response.retryCount >= response.maxRetries)

--- a/lib/service.js
+++ b/lib/service.js
@@ -433,6 +433,8 @@ AWS.Service = inherit({
       apiCallEvent.Latency = latency >= 0 ? latency : 0;
       var response = request.response;
       if (
+        response.error &&
+        response.error.retryable &&
         typeof response.retryCount === 'number' &&
         typeof response.maxRetries === 'number' &&
         (response.retryCount >= response.maxRetries)

--- a/test/publisher/functional_test/cases.js
+++ b/test/publisher/functional_test/cases.js
@@ -891,6 +891,83 @@ module.exports = {
       ]
     },
     {
+      'description': 'Test MaxRetriesExceeded is not set when final retry succeeds ',
+      'configuration': {
+        'accessKey': 'myaccesskey',
+        'region': 'us-west-2',
+        'environmentVariables': {
+          'AWS_CSM_ENABLED': 'true'
+        },
+        'sharedConfigFile': {},
+        'maxRetries': 1
+      },
+      'apiCalls': [
+        {
+          'serviceId': 'CSM Test',
+          'operationName': 'TestOperation',
+          'params': {},
+          'attemptResponses': [
+            {
+              'httpStatus': 503,
+              'responseHeaders': {},
+              'errorCode': 'ServiceUnavailable',
+              'errorMessage': 'Service is unavailable'
+            },
+            {
+              'httpStatus': 200,
+              'responseHeaders': {},
+            }
+          ]
+        }
+      ],
+      'expectedMonitoringEvents': [
+        {
+          'Version': 1,
+          'Type': 'ApiCallAttempt',
+          'Service': 'CSM Test',
+          'Api': 'TestOperation',
+          'ClientId': '',
+          'Timestamp': 'ANY_INT',
+          'AttemptLatency': 'ANY_INT',
+          'Fqdn': 'csmtest.us-west-2.amazonaws.com',
+          'Region': 'us-west-2',
+          'UserAgent': 'ANY_STR',
+          'AccessKey': 'myaccesskey',
+          'HttpStatusCode': 503,
+          'AwsException': 'ServiceUnavailable',
+          'AwsExceptionMessage': 'Service is unavailable'
+        },
+        {
+          'Version': 1,
+          'Type': 'ApiCallAttempt',
+          'Service': 'CSM Test',
+          'Api': 'TestOperation',
+          'ClientId': '',
+          'Timestamp': 'ANY_INT',
+          'AttemptLatency': 'ANY_INT',
+          'Fqdn': 'csmtest.us-west-2.amazonaws.com',
+          'Region': 'us-west-2',
+          'UserAgent': 'ANY_STR',
+          'AccessKey': 'myaccesskey',
+          'HttpStatusCode': 200
+        },
+        {
+          'Version': 1,
+          'Type': 'ApiCall',
+          'Service': 'CSM Test',
+          'Api': 'TestOperation',
+          'ClientId': '',
+          'Timestamp': 'ANY_INT',
+          'Latency': 'ANY_INT',
+          'AttemptCount': 2,
+          'MaxRetriesExceeded': 0,
+          'UserAgent': 'ANY_STR',
+          'Region': 'us-west-2',
+          'FinalHttpStatusCode': 200
+        }
+      ]
+    },
+    {
       'description': 'Test max retries from AWS exception',
       'configuration': {
         'accessKey': 'myaccesskey',


### PR DESCRIPTION
#### Related Issue
https://github.com/aws/aws-sdk-js/issues/3189

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
