### PR TITLE
Add Connection Default Timeout To EC2 Credentials

### DIFF
--- a/lib/credentials/ec2_metadata_credentials.js
+++ b/lib/credentials/ec2_metadata_credentials.js
@@ -36,6 +36,8 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
     if (!options.httpOptions) options.httpOptions = {};
     options.httpOptions = AWS.util.merge(
       {timeout: this.defaultTimeout}, options.httpOptions);
+    options.httpOptions = AWS.util.merge(
+      {connectTimeout: this.defaultConnectTimeout}, options.httpOptions);
 
     this.metadataService = new AWS.MetadataService(options);
     this.metadata = {};
@@ -45,6 +47,11 @@ AWS.EC2MetadataCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   defaultTimeout: 1000,
+
+  /**
+   * @api private
+   */
+  defaultConnectTimeout: 1000,
 
   /**
    * @api private

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -29,20 +29,13 @@ AWS.MetadataService = inherit({
    */
 
   /**
-   * Default HTTP options. By default, the metadata service sets the timeout
-   * to 1 second. This can be overridden by passing a different httpOptions on initialization.
+   * Default HTTP options. By default, the metadata service is set to not
+   * timeout on long requests. This means that on non-EC2 machines, this
+   * request will never return. If you are calling this operation from an
+   * environment that may not always run on EC2, set a `timeout` value so
+   * the SDK will abort the request after a given number of milliseconds.
    */
-  httpOptions: {
-    connectionTimeout: 1000,
-    timeout: 1000
-  },
-
-  /*
-  * Default of max retries. By default, the metadata service retries the
-  * request 2 times. This can be overridden by setting the httpOptions on your service.
-  *
-  */
-  maxRetries: 2,
+  httpOptions: { timeout: 0 },
 
   /**
    * when enabled, metadata service will not fetch token
@@ -201,7 +194,7 @@ AWS.MetadataService = inherit({
     if (self.disableFetchToken) {
       self.fetchCredentials({}, callbacks);
     } else {
-      self.fetchMetadataToken(function (tokenError, token) {
+      self.fetchMetadataToken(function(tokenError, token) {
         if (tokenError) {
           if (tokenError.code === 'TimeoutError') {
             self.disableFetchToken = true;

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -201,7 +201,7 @@ AWS.MetadataService = inherit({
     if (self.disableFetchToken) {
       self.fetchCredentials({}, callbacks);
     } else {
-      self.fetchMetadataToken(function (tokenError, token) {
+      self.fetchMetadataToken(function(tokenError, token) {
         if (tokenError) {
           if (tokenError.code === 'TimeoutError') {
             self.disableFetchToken = true;

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -29,13 +29,20 @@ AWS.MetadataService = inherit({
    */
 
   /**
-   * Default HTTP options. By default, the metadata service is set to not
-   * timeout on long requests. This means that on non-EC2 machines, this
-   * request will never return. If you are calling this operation from an
-   * environment that may not always run on EC2, set a `timeout` value so
-   * the SDK will abort the request after a given number of milliseconds.
+   * Default HTTP options. By default, the metadata service sets the timeout
+   * to 1 second. This can be overridden by passing a different httpOptions on initialization.
    */
-  httpOptions: { timeout: 0 },
+  httpOptions: {
+    connectionTimeout: 1000,
+    timeout: 1000
+  },
+
+  /*
+  * Default of max retries. By default, the metadata service retries the
+  * request 2 times. This can be overridden by setting the httpOptions on your service.
+  *
+  */
+  maxRetries: 2,
 
   /**
    * when enabled, metadata service will not fetch token
@@ -194,7 +201,7 @@ AWS.MetadataService = inherit({
     if (self.disableFetchToken) {
       self.fetchCredentials({}, callbacks);
     } else {
-      self.fetchMetadataToken(function(tokenError, token) {
+      self.fetchMetadataToken(function (tokenError, token) {
         if (tokenError) {
           if (tokenError.code === 'TimeoutError') {
             self.disableFetchToken = true;

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -201,7 +201,7 @@ AWS.MetadataService = inherit({
     if (self.disableFetchToken) {
       self.fetchCredentials({}, callbacks);
     } else {
-      self.fetchMetadataToken(function(tokenError, token) {
+      self.fetchMetadataToken(function (tokenError, token) {
         if (tokenError) {
           if (tokenError.code === 'TimeoutError') {
             self.disableFetchToken = true;


### PR DESCRIPTION
EC2 Metadata Credentials doesn't define a default connection timeout. So, if we try to run the command without the credentials set in a non-AWS environment, the requests hangs for about 2 minutes and half.

The issue has been reported: https://github.com/aws/aws-sdk-js/issues/2983

##### Checklist

- [X] `npm run test` passes
