### PR TITLE
Make PromiseResult.$promise optional in TypeScript types as it is not always present.

### DIFF
--- a/.changes/next-release/bugfix-Types-d92a7d91.json
+++ b/.changes/next-release/bugfix-Types-d92a7d91.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Types",
+  "description": "Make PromiseResult.$promise optional in TypeScript types as it is not always present."
+}

--- a/lib/request.d.ts
+++ b/lib/request.d.ts
@@ -326,7 +326,7 @@ export class Request<D, E> {
 
 }
 
-export type PromiseResult<D, E> = D & {$response: Response<D, E>};
+export type PromiseResult<D, E> = D & {$response?: Response<D, E>};
 
 export interface Progress {
     loaded: number;

--- a/ts/request.ts
+++ b/ts/request.ts
@@ -33,8 +33,10 @@ request.on('complete', function(response) {
 request.promise().then(
     data => {
         console.log(data.content);
-        console.log(data.$response.requestId);
-        console.log(data.$response.hasNextPage());
+        if (data.$response) {
+            console.log(data.$response.requestId);
+            console.log(data.$response.hasNextPage());
+        }
     },
     error => {
         console.error(error);


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes (NOTE: I had a couple of timeouts, but these exist before any changes)
- [X] `.d.ts` file is updated
- [X] changelog is added, `npm run add-change`
- [X] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
