### PR TITLE
Update README.md: Node.js TypeScript Usage Example

### DIFF
--- a/.changes/next-release/bugfix-readme-7b6ab577.json
+++ b/.changes/next-release/bugfix-readme-7b6ab577.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "readme",
+  "description": "Corrected Node.js TypeScript Usage example in README.md"
+}

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ In a TypeScript file:
 
 ```javascript
 // import entire SDK
-import AWS from 'aws-sdk';
+import * as AWS from 'aws-sdk';
 // import AWS object without services
-import AWS from 'aws-sdk/global';
+import * as AWS from 'aws-sdk/global';
 // import individual service
-import S3 from 'aws-sdk/clients/s3';
+import * as S3 from 'aws-sdk/clients/s3';
 ```
 
 In a JavaScript file:


### PR DESCRIPTION
Updated the _Usage_ example for Node.js / TypeScript. While it was syntactically correct, it caused an error as there is no default export in `aws-sdk`. This is a fix for issue [#2654](https://github.com/aws/aws-sdk-js/issues/2654).

In summary, the examples given for TypeScript return these errors:

```
* TS1192: Module '"/<snip>/node_modules/aws-sdk/index"' has no default export.
* TS1259: Module '"/<snip>/node_modules/aws-sdk/clients/s3"' can only be default-imported using the 'esModuleInterop' flag
```

The node.js TypeScript example _should_ use the `import * as name from 'module-name';` syntax:

```javascript
// import entire SDK
import * as AWS from 'aws-sdk';
// import AWS object without services
import * as AWS from 'aws-sdk/global';
// import individual service
import * as S3 from 'aws-sdk/clients/s3';
```

The specific error that occurs is demonstrated below. 

Putting the usage example which was taken directly from the previous [README.md](https://github.com/aws/aws-sdk-js/blob/b15ce7af13ff67fe3af3acfbab43f4f10231d539/README.md) into a file `src/aws-sdk-import-example.ts`:

```javascript
// aws-sdk-import-example.ts
// This won't work in TypeScript

// import entire SDK
import AWS from 'aws-sdk';
// import AWS object without services
import AWS2 from 'aws-sdk/global';
// import individual service
import S3 from 'aws-sdk/clients/s3';
```

Compile with `tsc` and 💥 :

```
$ tsc src/aws-sdk-import-example.ts
src/aws-sdk-import-example.ts:2:8 - error TS1192: Module '"/<snip>/node_modules/aws-sdk/index"' has no default export.

2 import AWS from 'aws-sdk';
         ~~~

src/aws-sdk-import-example.ts:4:8 - error TS1192: Module '"/<snip>/node_modules/aws-sdk/global"' has no default export.

4 import AWS2 from 'aws-sdk/global';
         ~~~~

src/aws-sdk-import-example.ts:6:8 - error TS1259: Module '"/<snip>/node_modules/aws-sdk/clients/s3"' can only be default-imported using the 'esModuleInterop' flag

6 import S3 from 'aws-sdk/clients/s3';
         ~~

  node_modules/aws-sdk/clients/s3.d.ts:5159:1
    5159 export = S3;
         ~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 3 errors.
```

##### Checklist

- [x] changelog is added, `npm run add-change`
- [x] non-code related change (markdown/git settings etc)
