### PR TITLE
Set loglevel to debug

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -39,6 +39,6 @@ jobs:
         minimum-upvotes-to-exempt: 10
 
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        # loglevel: DEBUG
+        loglevel: DEBUG
         # Set dry-run to true to not perform label or close actions.
         # dry-run: true


### PR DESCRIPTION
Set log level to debug to get the logs since the action failed while the bot was trying to put a comment on the issue with empty message.

- [x] non-code related change (markdown/git settings etc)
