### PR TITLE
Revert "fix: BigInt Support for DynamoDB Convert (#3019)"

### DIFF
--- a/lib/dynamodb/converter.js
+++ b/lib/dynamodb/converter.js
@@ -49,8 +49,6 @@ AWS.DynamoDB.Converter = {
       return { BOOL: data };
     } else if (type === 'null') {
       return { NULL: true };
-    } else if (type === 'BigInt') {
-      return { N: data.toString() };
     } else if (type !== 'undefined' && type !== 'Function') {
       // this value has a custom constructor
       return formatMap(data, options);
@@ -223,15 +221,7 @@ function formatList(data, options) {
  * @param wrapNumbers [Boolean]
  */
 function convertNumber(value, wrapNumbers) {
-  if (wrapNumbers) {
-    return new NumberValue(value);
-  }
-  var numberValue = Number(value);
-  try {
-    return Number.isSafeInteger(numberValue) ? numberValue : BigInt(value);
-  } catch (err) {
-    return numberValue;
-  }
+  return wrapNumbers ? new NumberValue(value) : Number(value);
 }
 
 /**

--- a/test/dynamodb/converter.spec.js
+++ b/test/dynamodb/converter.spec.js
@@ -57,17 +57,6 @@ describe('AWS.DynamoDB.Converter', function() {
       it('should convert numbers to NumberAttributeValues', function() {
         expect(input(42)).to.deep.equal({N: '42'});
       });
-      it('should convert bigint to NumberAttributeValues', function() {
-        try {
-          var largeInt = BigInt(1576706763859);
-          if (largeInt) {
-            expect(input(largeInt)).to.deep.equal({N: '1576706763859'});
-          }
-        } catch (err) {
-          expect(err.message).to.equal('BigInt is not defined');
-          expect(input(1576706763859)).to.deep.equal({N: '1576706763859'});
-        }
-      });
     });
 
     describe('null', function() {
@@ -384,21 +373,6 @@ describe('AWS.DynamoDB.Converter', function() {
           var unsafeInteger = '9007199254740991000';
           var converted = output({N: unsafeInteger}, {wrapNumbers: true});
           expect(converted.toString()).to.equal(unsafeInteger);
-        }
-      );
-
-      it('should convert NumberAttributeValues to NumberValues of BigInt',
-        function() {
-          var unsafeInteger = '9007199254740991000';
-          try {
-            var largeInt = BigInt(unsafeInteger);
-            var converted = output({N: unsafeInteger});
-            expect(converted).to.equal(largeInt);
-            expect(typeof converted).to.equal('bigint');
-          } catch (err) {
-            expect(err.message).to.equal('BigInt is not defined');
-            expect(output({N: unsafeInteger}).toString()).to.equal(unsafeInteger);
-          }
         }
       );
     });


### PR DESCRIPTION
Reverted: #3019 
Revert the bigint support because BigInt is not allowed to interop
with Numbers. It will break users when they used to expect Number
but suddenly changed to BigInt. (#3246)

This reverts commit 99e558d5fe8a29c7b8497ad44860b3be2fdf0e7e.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
