### PR TITLE
Added signatureHost option

### DIFF
--- a/.changes/next-release/feature-Signers-b7b8a9a9.json
+++ b/.changes/next-release/feature-Signers-b7b8a9a9.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Signers",
+  "description": "Added signatureHost config to override the host header when signing a request."
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -267,6 +267,11 @@ export abstract class ConfigurationOptions {
      */
     signatureCache?: boolean
     /**
+     * The Host header that will be used at the signing method (overriding the API endpoint). 
+		 * Only applies to the signature version 'v4'.
+     */
+    signatureHost?: string|null
+    /**
      * The signature version to sign requests with (overriding the API configuration).
      * Possible values: 'v2'|'v3'|'v4'
      */

--- a/lib/config.js
+++ b/lib/config.js
@@ -550,6 +550,7 @@ AWS.Config = AWS.util.inherit({
     systemClockOffset: 0,
     signatureVersion: null,
     signatureCache: true,
+    signatureHost: null,
     retryDelayOptions: {},
     useAccelerateEndpoint: false,
     clientSideMonitoring: false,

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -223,7 +223,8 @@ AWS.EventListeners = {
             {
               signatureCache: service.config.signatureCache,
               operation: operation,
-              signatureVersion: service.api.signatureVersion
+              signatureVersion: service.api.signatureVersion,
+              signatureHost: service.config.signatureHost
             });
           signer.setServiceClientId(service._clientId);
 

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -18,7 +18,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     this.signatureCache = typeof options.signatureCache === 'boolean' ? options.signatureCache : true;
     this.operation = options.operation;
     this.signatureVersion = options.signatureVersion;
-    this.signatureHost = options.signatureHost;
+    this.signatureHost = typeof options.signatureHost === 'string' ? options.signatureHost : null;
   },
 
   algorithm: 'AWS4-HMAC-SHA256',

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -18,6 +18,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
     this.signatureCache = typeof options.signatureCache === 'boolean' ? options.signatureCache : true;
     this.operation = options.operation;
     this.signatureVersion = options.signatureVersion;
+    this.signatureHost = options.signatureHost;
   },
 
   algorithm: 'AWS4-HMAC-SHA256',
@@ -144,6 +145,9 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
           throw AWS.util.error(new Error('Header ' + key + ' contains invalid value'), {
             code: 'InvalidHeader'
           });
+        }
+        if (key === 'host' && this.signatureHost) {
+          value = this.signatureHost;
         }
         parts.push(key + ':' +
           this.canonicalHeaderValues(value.toString()));

--- a/test/signers/v4.spec.js
+++ b/test/signers/v4.spec.js
@@ -58,9 +58,11 @@
         };
         signer = buildSigner(req, {
           signatureCache: true,
-          operation: operation
+          operation: operation,
+          signatureHost: 'example.com'
         });
         expect(signer.signatureCache).to.equal(true);
+        expect(signer.signatureHost).to.equal('example.com');
         return expect(signer.operation).to.equal(operation);
       });
       it('can set signatureCache to false', function() {
@@ -74,7 +76,7 @@
         });
         return expect(signer.signatureCache).to.equal(false);
       });
-      return it('defaults signatureCache to true', function() {
+      it('defaults signatureCache to true', function() {
         var operation, req;
         req = buildRequest();
         operation = {
@@ -82,6 +84,26 @@
         };
         signer = buildSigner(req);
         return expect(signer.signatureCache).to.equal(true);
+      });
+      it('can set signatureHost to example.com', function() {
+        var operation, req;
+        req = buildRequest();
+        operation = {
+          fake: 'bag'
+        };
+        signer = buildSigner(req, {
+          signatureHost: 'example.com'
+        });
+        return expect(signer.signatureHost).to.equal('example.com');
+      });
+      return it('defaults signatureHost to null', function() {
+        var operation, req;
+        req = buildRequest();
+        operation = {
+          fake: 'bag'
+        };
+        signer = buildSigner(req);
+        return expect(signer.signatureHost).to.equal(null);
       });
     });
     describe('addAuthorization', function() {

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -74,6 +74,7 @@ AWS.config.update({
     s3ForcePathStyle: true,
     signatureCache: false,
     signatureVersion: 'v4',
+    signatureHost: null,
     sslEnabled: true,
     systemClockOffset: 0,
     useAccelerateEndpoint: true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Added signatureHost option to service configuration. It enables overriding the host header that is different from the endpoint when calculating the signature request.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] `.d.ts` file is updated
- [X] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [X] non-code related change (markdown/git settings etc)
