### PR TITLE
fix issues with required endpoint discovery feature

### DIFF
--- a/.changes/next-release/bugfix-EndpointDiscovery-f55d6800.json
+++ b/.changes/next-release/bugfix-EndpointDiscovery-f55d6800.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "EndpointDiscovery",
+  "description": "* If at least one operation requires endpoint discovery then the SDK enables endpoint discovery by default including operational endpoint discovery operations; * Users can set config `endpointDiscoveryEnabled`, env `AWS_ENDPOINT_DISCOVERY_ENABLED`, config file entry `endpoint_discovery_enabled` to `false` to explictly disable endpoint discovery, even operations the require endpoint discovery will fail; * SDK throws if endpoint discovery is explicitly disabled but operation requires endpoint discovery; * Now SDK throws more clear error message when required endpoint operation fails"
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -164,9 +164,13 @@ var PromisesDependency;
  *     Defaults to `true`.
  *
  * @!attribute endpointDiscoveryEnabled
- *   @return [Boolean] whether to enable endpoint discovery for operations that
- *     allow optionally using an endpoint returned by the service.
- *     Defaults to 'false'
+ *   @return [Boolean|undefined] whether to call operations with endpoints
+ *     given by service dynamically. Setting this config to `true` will enable
+ *     endpoint discovery for all applicable operations. Setting it to `false`
+ *     will explicitly disable endpoint discovery even though operations that
+ *     require endpoint discovery will presumably fail. Leaving it to
+ *     `undefined` means SDK only do endpoint discovery when it's required.
+ *     Defaults to `undefined`
  *
  * @!attribute endpointCacheSize
  *   @return [Number] the size of the global cache storing endpoints from endpoint
@@ -319,10 +323,13 @@ AWS.Config = AWS.util.inherit({
    *   S3 Transfer Acceleration endpoint with the S3 service. Default: `false`.
    * @option options clientSideMonitoring [Boolean] whether to collect and
    *   publish this client's performance metrics of all its API requests.
-   * @option options endpointDiscoveryEnabled [Boolean] whether to enable endpoint
-   *   discovery for operations that allow optionally using an endpoint returned by
-   *   the service.
-   *   Defaults to 'false'
+   * @option options endpointDiscoveryEnabled [Boolean|undefined] whether to
+   *   call operations with endpoints given by service dynamically. Setting this
+   * config to `true` will enable endpoint discovery for all applicable operations.
+   *   Setting it to `false` will explicitly disable endpoint discovery even though
+   *   operations that require endpoint discovery will presumably fail. Leaving it
+   *   to `undefined` means SDK will only do endpoint discovery when it's required.
+   *   Defaults to `undefined`
    * @option options endpointCacheSize [Number] the size of the global cache storing
    *   endpoints from endpoint discovery operations. Once endpoint cache is created,
    *   updating this setting cannot change existing cache size.
@@ -553,7 +560,7 @@ AWS.Config = AWS.util.inherit({
     retryDelayOptions: {},
     useAccelerateEndpoint: false,
     clientSideMonitoring: false,
-    endpointDiscoveryEnabled: false,
+    endpointDiscoveryEnabled: undefined,
     endpointCacheSize: 1000,
     hostPrefixEnabled: true,
     stsRegionalEndpoints: 'legacy'

--- a/lib/discover_endpoint.js
+++ b/lib/discover_endpoint.js
@@ -167,19 +167,14 @@ function requiredDiscoverEndpoint(request, done) {
     }]);
     endpointRequest.send(function(err, data) {
       if (err) {
-        var errorParams = {
-          code: 'EndpointDiscoveryException',
-          message: 'Request cannot be fulfilled without specifying an endpoint',
-          retryable: false
-        };
-        request.response.error = util.error(err, errorParams);
+        request.response.error = util.error(err, { retryable: false });
         AWS.endpointCache.remove(cacheKey);
 
         //fail all the pending requests in batch
         if (requestQueue[cacheKeyStr]) {
           var pendingRequests = requestQueue[cacheKeyStr];
           util.arrayEach(pendingRequests, function(requestContext) {
-            requestContext.request.response.error = util.error(err, errorParams);
+            requestContext.request.response.error = util.error(err, { retryable: false });
             requestContext.callback();
           });
           delete requestQueue[cacheKeyStr];
@@ -264,23 +259,28 @@ function isFalsy(value) {
 }
 
 /**
- * If endpoint discovery should perform for this request when endpoint discovery is optional.
+ * If endpoint discovery should perform for this request when no operation requires endpoint
+ * discovery for the given service.
  * SDK performs config resolution in order like below:
- * 1. If turned on client configuration(default to off) then turn on endpoint discovery.
- * 2. If turned on in env AWS_ENABLE_ENDPOINT_DISCOVERY then turn on endpoint discovery.
- * 3. If turned on in shared ini config file with key 'endpoint_discovery_enabled', then
- *   turn on endpoint discovery.
+ * 1. If set in client configuration.
+ * 2. If set in env AWS_ENABLE_ENDPOINT_DISCOVERY.
+ * 3. If set in shared ini config file with key 'endpoint_discovery_enabled'.
  * @param [object] request request object.
+ * @returns [boolean|undefined] if endpoint discovery config is not set in any source, this
+ *  function returns undefined
  * @api private
  */
-function isEndpointDiscoveryEnabled(request) {
+function resolveEndpointDiscoveryConfig(request) {
   var service = request.service || {};
-  if (service.config.endpointDiscoveryEnabled === true) return true;
+  if (service.config.endpointDiscoveryEnabled !== undefined) {
+    return service.config.endpointDiscoveryEnabled;
+  }
 
   //shared ini file is only available in Node
   //not to check env in browser
-  if (util.isBrowser()) return false;
+  if (util.isBrowser()) return undefined;
 
+  // If any of recognized endpoint discovery config env is set
   for (var i = 0; i < endpointDiscoveryEnabledEnvs.length; i++) {
     var env = endpointDiscoveryEnabledEnvs[i];
     if (Object.prototype.hasOwnProperty.call(process.env, env)) {
@@ -290,7 +290,7 @@ function isEndpointDiscoveryEnabled(request) {
           message: 'environmental variable ' + env + ' cannot be set to nothing'
         });
       }
-      if (!isFalsy(process.env[env])) return true;
+      return !isFalsy(process.env[env]);
     }
   }
 
@@ -311,9 +311,9 @@ function isEndpointDiscoveryEnabled(request) {
         message: 'config file entry \'endpoint_discovery_enabled\' cannot be set to nothing'
       });
     }
-    if (!isFalsy(sharedFileConfig.endpoint_discovery_enabled)) return true;
+    return !isFalsy(sharedFileConfig.endpoint_discovery_enabled);
   }
-  return false;
+  return undefined;
 }
 
 /**
@@ -328,27 +328,32 @@ function discoverEndpoint(request, done) {
   var operations = service.api.operations || {};
   var operationModel = operations[request.operation];
   var isEndpointDiscoveryRequired = operationModel ? operationModel.endpointDiscoveryRequired : 'NULL';
-  var isEnabled = isEndpointDiscoveryEnabled(request);
+  var isEnabled = resolveEndpointDiscoveryConfig(request);
+  var hasRequiredEndpointDiscovery = service.api.hasRequiredEndpointDiscovery;
 
-  if (!isEnabled) {
-    // Unless endpoint discovery is required, SDK will fallback to normal regional endpoints.
-    if (isEndpointDiscoveryRequired === 'REQUIRED') {
-      throw util.error(new Error(), {
-        code: 'ConfigurationException',
-        message: 'Endpoint Discovery is not enabled but this operation requires it.'
-      });
-    }
-    return done();
-  }
-
-  request.httpRequest.appendToUserAgent('endpoint-discovery');
   switch (isEndpointDiscoveryRequired) {
     case 'OPTIONAL':
-      optionalDiscoverEndpoint(request);
-      request.addNamedListener('INVALIDATE_CACHED_ENDPOINTS', 'extractError', invalidateCachedEndpoints);
+      if (isEnabled || hasRequiredEndpointDiscovery) {
+        // For a given service; if at least one operation requires endpoint discovery then the SDK must enable endpoint discovery
+        // by default for all operations of that service, including operations where endpoint discovery is optional.
+        optionalDiscoverEndpoint(request);
+        request.addNamedListener('INVALIDATE_CACHED_ENDPOINTS', 'extractError', invalidateCachedEndpoints);
+        request.httpRequest.appendToUserAgent('endpoint-discovery');
+      }
       done();
       break;
     case 'REQUIRED':
+      if (isEnabled === false) {
+        // For a given operation; if endpoint discovery is required and it has been disabled on the SDK client,
+        // then the SDK must return a clear and actionable exception.
+        request.response.error = util.error(new Error(), {
+          code: 'ConfigurationException',
+          message: 'Endpoint Discovery is disabled but this operation requires it. Please check your configurations'
+        });
+        done();
+        break;
+      }
+      request.httpRequest.appendToUserAgent('endpoint-discovery');
       request.addNamedListener('INVALIDATE_CACHED_ENDPOINTS', 'extractError', invalidateCachedEndpoints);
       requiredDiscoverEndpoint(request, done);
       break;

--- a/lib/discover_endpoint.js
+++ b/lib/discover_endpoint.js
@@ -330,7 +330,11 @@ function discoverEndpoint(request, done) {
   var isEndpointDiscoveryRequired = operationModel ? operationModel.endpointDiscoveryRequired : 'NULL';
   var isEnabled = resolveEndpointDiscoveryConfig(request);
   var hasRequiredEndpointDiscovery = service.api.hasRequiredEndpointDiscovery;
-
+  if (isEnabled || hasRequiredEndpointDiscovery) {
+    // Once a customer enables endpoint discovery, the SDK should start appending
+    // the string endpoint-discovery to the user-agent on all requests.
+    request.httpRequest.appendToUserAgent('endpoint-discovery');
+  }
   switch (isEndpointDiscoveryRequired) {
     case 'OPTIONAL':
       if (isEnabled || hasRequiredEndpointDiscovery) {
@@ -338,7 +342,6 @@ function discoverEndpoint(request, done) {
         // by default for all operations of that service, including operations where endpoint discovery is optional.
         optionalDiscoverEndpoint(request);
         request.addNamedListener('INVALIDATE_CACHED_ENDPOINTS', 'extractError', invalidateCachedEndpoints);
-        request.httpRequest.appendToUserAgent('endpoint-discovery');
       }
       done();
       break;
@@ -348,12 +351,12 @@ function discoverEndpoint(request, done) {
         // then the SDK must return a clear and actionable exception.
         request.response.error = util.error(new Error(), {
           code: 'ConfigurationException',
-          message: 'Endpoint Discovery is disabled but this operation requires it. Please check your configurations'
+          message: 'Endpoint Discovery is disabled but ' + service.api.className + '.' + request.operation +
+                    '() requires it. Please check your configurations.'
         });
         done();
         break;
       }
-      request.httpRequest.appendToUserAgent('endpoint-discovery');
       request.addNamedListener('INVALIDATE_CACHED_ENDPOINTS', 'extractError', invalidateCachedEndpoints);
       requiredDiscoverEndpoint(request, done);
       break;

--- a/lib/model/api.js
+++ b/lib/model/api.js
@@ -51,6 +51,13 @@ function Api(api, options) {
     if (operation.endpointoperation === true) {
       property(self, 'endpointOperation', util.string.lowerFirst(name));
     }
+    if (operation.endpointdiscovery && !self.hasRequiredEndpointDiscovery) {
+      property(
+        self,
+        'hasRequiredEndpointDiscovery',
+        operation.endpointdiscovery.required === true
+      );
+    }
   }
 
   property(this, 'operations', new Collection(api.operations, options, function(name, operation) {

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -4,9 +4,9 @@ var whitelist = {
         25,
         85,
         86,
-        197,
-        251,
-        252
+        201,
+        255,
+        256
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,

--- a/test/discover_endpoint.spec.js
+++ b/test/discover_endpoint.spec.js
@@ -12,6 +12,7 @@ var api = {
     apiVersion: '2018-09-19',
     endpointPrefix: 'mockservice',
     serviceId: 'MockService',
+    serviceAbbreviation: 'MockService',
     protocol: 'json'
   },
   operations: {
@@ -757,7 +758,9 @@ describe('endpoint discovery', function() {
         expect(err).not.to.eql(null);
         expect(data).to.eql(null);
         expect(err.code).to.eql('ConfigurationException');
-        expect(err.message).to.eql('Endpoint Discovery is disabled but this operation requires it. Please check your configurations');
+        expect(err.message).to.eql(
+          'Endpoint Discovery is disabled but MockService.requiredEDOperation() requires it. Please check your configurations.'
+        );
       });
     });
 
@@ -774,7 +777,9 @@ describe('endpoint discovery', function() {
         expect(err).not.to.eql(null);
         // expect(data).to.eql(null);
         expect(err.code).to.eql('ConfigurationException');
-        expect(err.message).to.eql('Endpoint Discovery is disabled but this operation requires it. Please check your configurations');
+        expect(err.message).to.eql(
+          'Endpoint Discovery is disabled but MockService.requiredEDOperation() requires it. Please check your configurations.'
+        );
       });
     });
 
@@ -871,7 +876,9 @@ describe('endpoint discovery', function() {
           expect(err).not.to.eql(null);
           // expect(data).to.eql(null);
           expect(err.code).to.eql('ConfigurationException');
-          expect(err.message).to.eql('Endpoint Discovery is disabled but this operation requires it. Please check your configurations');
+          expect(err.message).to.eql(
+            'Endpoint Discovery is disabled but MockService.requiredEDOperation() requires it. Please check your configurations.'
+          );
         });
       });
 

--- a/test/model/api.spec.js
+++ b/test/model/api.spec.js
@@ -86,7 +86,7 @@
     });
 
     describe('endpoint operation', function() {
-      it('adds endpiont discovery opeation name when exists', function() {
+      it('adds endpiont discovery opeation name and required flag when exists', function() {
         var api = make({
           operations: {
             DescribeEndpoints: {
@@ -117,6 +117,7 @@
           }
         });
         expect(api.endpointOperation).to.equal('describeEndpoints');
+        expect(api.hasRequiredEndpointDiscovery).to.equal(true);
         expect(api.operations.someOperation.endpointDiscoveryRequired).to.equal('NULL');
         expect(api.operations.optionalEndpointOperation.endpointDiscoveryRequired).to.equal('OPTIONAL');
         expect(api.operations.requiredEndpointOperation.endpointDiscoveryRequired).to.equal('REQUIRED');


### PR DESCRIPTION
Previously, SDK will throw errors if `endpointDiscoveryEnabled` 
is not `true` when calling operations that **require** endpoint 
discovery. Setting the config to `false`(default value) doesn't mean
anything to SDK behavior.
This PR changes the behavior in following ways:

* For a given service; if at least one operation requires endpoint
  discovery then the SDK enables endpoint discovery by default
  for all operations of that service, including operations where
  endpoint discovery is optional.

* Users can set config `endpointDiscoveryEnabled`, env `AWS_ENDPOINT_DISCOVERY_ENABLED`,
  config file entry `endpoint_discovery_enabled` to `false` to
  explictly disable endpoint discovery, even operations the require
  endpoint discovery will fail;

* SDK throws if endpoint discovery is explicitly disabled but
  operation requires endpoint discovery;

This PR also include another minor fix:

* Now SDK throws more clear error message when required endpoint
  operation fails

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
