### PR TITLE
Add dualstack by modifying existing config.endpoint

### DIFF
--- a/.changes/next-release/bugfix-DualStack-a5f57529.json
+++ b/.changes/next-release/bugfix-DualStack-a5f57529.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "DualStack",
+  "description": "Add dualstack by modifying existing endpoint in config"
+}

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -50,7 +50,10 @@ function configureEndpoint(service) {
       // set dualstack endpoint
       if (service.config.useDualstack && util.isDualstackAvailable(service)) {
         config = util.copy(config);
-        config.endpoint = '{service}.dualstack.{region}.amazonaws.com';
+        config.endpoint = config.endpoint.replace(
+          /{service}\.({region}\.)?/,
+          '{service}.dualstack.{region}.'
+        );
       }
 
       // set global endpoint

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -111,6 +111,24 @@ describe('AWS.S3', function() {
         useDualstack: true
       });
       expect(s3.endpoint.hostname).to.equal('s3.dualstack.us-east-1.amazonaws.com');
+
+      s3 = new AWS.S3({
+        region: 'cn-north-1',
+        useDualstack: true
+      });
+      expect(s3.endpoint.hostname).to.equal('s3.dualstack.cn-north-1.amazonaws.com.cn');
+
+      s3 = new AWS.S3({
+        region: 'us-iso-east-1',
+        useDualstack: true
+      });
+      expect(s3.endpoint.hostname).to.equal('s3.dualstack.us-iso-east-1.c2s.ic.gov');
+
+      s3 = new AWS.S3({
+        region: 'us-isob-east-1',
+        useDualstack: true
+      });
+      expect(s3.endpoint.hostname).to.equal('s3.dualstack.us-isob-east-1.sc2s.sgov.gov');
     });
   });
 

--- a/test/services/s3control.spec.js
+++ b/test/services/s3control.spec.js
@@ -28,6 +28,13 @@ describe('AWS.S3Control', function() {
     request.send();
     expect(request.httpRequest.headers.Host).to.eql('222.s3-control.dualstack.us-east-1.amazonaws.com');
     expect(request.httpRequest.endpoint.hostname).to.eql('222.s3-control.dualstack.us-east-1.amazonaws.com');
+
+    client = new AWS.S3Control({region: 'cn-north-1', useDualstack: true});
+    request = client.getPublicAccessBlock({AccountId: '222'});
+    helpers.mockResponse({data: {}});
+    request.send();
+    expect(request.httpRequest.headers.Host).to.eql('222.s3-control.dualstack.cn-north-1.amazonaws.com.cn');
+    expect(request.httpRequest.endpoint.hostname).to.eql('222.s3-control.dualstack.cn-north-1.amazonaws.com.cn');
   });
 
   it('append accountId to hostname when supplied and using customized endpoint', function() {


### PR DESCRIPTION
Problem: S3 endpoint is set to `s3.dualstack.cn-northwest-1.amazonaws.com` instead of `s3.dualstack.cn-northwest-1.amazonaws.com.cn` when useDualStack is set to true for region cn-northwest-1

<details>
<summary>Code</summary>

```js
const AWS = require("aws-sdk");

(async () => {
  const client = new AWS.S3({
    region: "cn-northwest-1",
    useDualstack: true
  });
  console.log(await client.listBuckets().promise());
})();
```

</details>

<details>
<summary>Output</summary>

```console
(node:50212) UnhandledPromiseRejectionWarning: UnknownEndpoint: Inaccessible host: `s3.dualstack.cn-northwest-1.amazonaws.com'. This service may not be available in the `cn-northwest-1' region.
    at Request.ENOTFOUND_ERROR (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/event_listeners.js:495:46)
    at Request.callListeners (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/request.js:683:14)
    at ClientRequest.error (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/event_listeners.js:333:22)
    at ClientRequest.<anonymous> (/Users/trivikr/workspace/dualStackTest/node_modules/aws-sdk/lib/http/node.js:96:19)
    at ClientRequest.emit (events.js:311:20)
    at ClientRequest.EventEmitter.emit (domain.js:482:12)
    at TLSSocket.socketErrorListener (_http_client.js:426:9)
    at TLSSocket.emit (events.js:311:20)
(node:50212) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:50212) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

</details>

Relevant PRs from git blame:
* The code to update dualstack endpoint was added on `Aug 10, 2016`
  * commit: https://github.com/aws/aws-sdk-js/commit/0303d2f2efee9a0604e61ce58f0aca462a254709
* `.cn` has been appended to endpoints in China region prior to that (commit from `Jun 23, 2014`)
  * commit: https://github.com/aws/aws-sdk-js/commit/59e994a74df153ef077d19b0bc015578c8eaff7e

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
