### PR TITLE
Simplify consumption of client generation tools

### DIFF
--- a/dist-tools/client-creator.js
+++ b/dist-tools/client-creator.js
@@ -1,7 +1,15 @@
 var fs = require('fs');
 var path = require('path');
 
-// Generate service clients
+/**
+ * Generate service clients
+ *
+ * Pass optional path to target directory.
+ * The directory must include the apis/ folder and service customizations at
+ * `lib/services`. Clients will be generated in `clients/`.
+ *
+ * If parameter is not passed the repository root will be used.
+ */
 function ClientCreator(basePath) {
   basePath = basePath || path.join(__dirname, '..');
   this._metadataPath = path.join(basePath, 'apis', 'metadata.json');
@@ -9,6 +17,7 @@ function ClientCreator(basePath) {
   this._clientFolderPath = path.join(basePath, 'clients');
   this._serviceCustomizationsFolderPath = path.join(basePath, 'lib', 'services');
   this._packageJsonPath = path.join(basePath, 'package.json');
+  // Lazy loading values on usage to avoid side-effects in constructor
   this._apiFileNames = null;
   this._metadata = null;
 }

--- a/dist-tools/client-creator.js
+++ b/dist-tools/client-creator.js
@@ -2,14 +2,26 @@ var fs = require('fs');
 var path = require('path');
 
 // Generate service clients
-function ClientCreator() {
-  this._metadata = require('../apis/metadata');
-  this._apisFolderPath = path.join(__dirname, '..', 'apis');
-  this._clientFolderPath = path.join(__dirname, '..', 'clients');
-  this._serviceCustomizationsFolderPath = path.join(__dirname, '..', 'lib', 'services');
-  this._packageJsonPath = path.join(__dirname, '..', 'package.json');
+function ClientCreator(basePath) {
+  basePath = basePath || path.join(__dirname, '..');
+  this._metadataPath = path.join(basePath, 'apis', 'metadata.json');
+  this._apisFolderPath = path.join(basePath, 'apis');
+  this._clientFolderPath = path.join(basePath, 'clients');
+  this._serviceCustomizationsFolderPath = path.join(basePath, 'lib', 'services');
+  this._packageJsonPath = path.join(basePath, 'package.json');
   this._apiFileNames = null;
+  this._metadata = null;
 }
+
+ClientCreator.prototype.loadMetadata = function loadMetadata() {
+    if (this._metadata) {
+      return this._metadata;
+    }
+
+    var metadataFile = fs.readFileSync(this._metadataPath);
+    this.metadata = JSON.parse(metadataFile);
+    return this.metadata;
+};
 
 ClientCreator.prototype.getAllApiFilenames = function getAllApiFilenames() {
     if (this._apiFileNames) {
@@ -155,7 +167,7 @@ ClientCreator.prototype.generateDefinePropertySource = function generateDefinePr
 };
 
 ClientCreator.prototype.generateAllServicesSource = function generateAllServicesSource(services, fileName) {
-  var metadata = this._metadata;
+  var metadata = this.loadMetadata();
   var self = this;
   var code = '';
   code += 'require(\'../lib/node_loader\');\n';
@@ -176,7 +188,7 @@ ClientCreator.prototype.generateAllServicesSource = function generateAllServices
 };
 
 ClientCreator.prototype.getDefaultServices = function getDefaultServices() {
-  var metadata = this._metadata;
+  var metadata = this.loadMetadata();
   var services = [];
   for (var key in metadata) {
     if (!metadata.hasOwnProperty(key)) {
@@ -190,7 +202,7 @@ ClientCreator.prototype.getDefaultServices = function getDefaultServices() {
 };
 
 ClientCreator.prototype.writeClientServices = function writeClientServices() {
-  var metadata = this._metadata;
+  var metadata = this.loadMetadata();
   var services = [];
   var corsServices = [];
   for (var key in metadata) {

--- a/dist-tools/create-all-services.js
+++ b/dist-tools/create-all-services.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var path = require('path');
+
 /*
  * Pass optional path to target directory as command line argument.
  *

--- a/dist-tools/create-all-services.js
+++ b/dist-tools/create-all-services.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+/*
+ * Pass optional path to target directory as command line argument.
+ *
+ * The directory must include the apis/ folder and service customizations at
+ * `lib/services`. Clients will be generated in `clients/`.
+ *
+ * If parameter is not passed the repository root will be used.
+ */
+
 var ClientCreator = require('./client-creator');
 
 var cc = new ClientCreator(process.argv[2] || path.join(__dirname, '..'));

--- a/dist-tools/create-all-services.js
+++ b/dist-tools/create-all-services.js
@@ -1,6 +1,8 @@
+#!/usr/bin/env node
+
 var ClientCreator = require('./client-creator');
 
-var cc = new ClientCreator();
+var cc = new ClientCreator(process.argv[2] || path.join(__dirname, '..'));
 
 cc.writeClientServices();
 console.log('Finished updating services.');

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -16,7 +16,6 @@ function TSGenerator(options) {
     this._clientsDir = path.join(this._sdkRootDir, 'clients');
     this.metadata = null;
     this.typings = {};
-    this.fillApiModelFileNames(this._apiRootDir);
     this.streamTypes = {};
 }
 
@@ -32,8 +31,8 @@ TSGenerator.prototype.loadMetadata = function loadMetadata() {
 /**
  * Modifies metadata to include api model filenames.
  */
-TSGenerator.prototype.fillApiModelFileNames = function fillApiModelFileNames(apisPath) {
-    var modelPaths = fs.readdirSync(apisPath);
+TSGenerator.prototype.fillApiModelFileNames = function fillApiModelFileNames() {
+    var modelPaths = fs.readdirSync(this._apiRootDir);
     if (!this.metadata) {
         this.loadMetadata();
     }
@@ -639,6 +638,7 @@ TSGenerator.prototype.writeTypingsFile = function writeTypingsFile(name, directo
  * Create the typescript definition files for every service.
  */
 TSGenerator.prototype.generateAllClientTypings = function generateAllClientTypings() {
+    this.fillApiModelFileNames();
     var self = this;
     var metadata = this.metadata;
     // Iterate over every service

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -14,6 +14,7 @@ function TSGenerator(options) {
     this._apiRootDir = path.join(this._sdkRootDir, 'apis');
     this._metadataPath = path.join(this._apiRootDir, 'metadata.json');
     this._clientsDir = path.join(this._sdkRootDir, 'clients');
+    // Lazy loading values on usage to avoid side-effects in constructor
     this.metadata = null;
     this.typings = {};
     this.streamTypes = {};

--- a/scripts/translate-api
+++ b/scripts/translate-api
@@ -6,10 +6,21 @@ var removeEventStreamOperations = require('./lib/remove-event-stream-ops').remov
 var util = require('util');
 var path = require('path');
 
+/*
+ * Minimizes all .normal.json files by flattening shapes, removing
+ * documentation and removing unused shapes. The result will be written to
+ * `.min.json` file.
+ *
+ * The passed parameter is base path. The directory must include the apis/
+ * folder.
+ */
 function ApiTranslator(basePath) {
   this._apisPath = path.join(basePath, 'apis');
 }
 
+/*
+ * minimize passed .normal.json filepath into .min.json
+ */
 ApiTranslator.prototype.minimizeFile = function minimizeFile(filepath) {
   var opath = filepath.replace(/\.normal\.json$/, '.min.json');
   var data = JSON.parse(fs.readFileSync(path.join(this._apisPath, filepath)).toString());
@@ -23,6 +34,10 @@ ApiTranslator.prototype.minimizeFile = function minimizeFile(filepath) {
   fs.writeFileSync(path.join(this._apisPath, opath), json);
 };
 
+/*
+ * minimize files in api path. If optional modelName is passed only that model
+ * is minimized otherwise all .normal.json files found.
+ */
 ApiTranslator.prototype.translateAll = function translateAll(modelName) {
   var paths = fs.readdirSync(this._apisPath);
   var self = this;
@@ -35,6 +50,16 @@ ApiTranslator.prototype.translateAll = function translateAll(modelName) {
   });
 };
 
+/*
+ * if executed as script initialize the ApiTranslator and minimize API files
+ *
+ * Optional first parameter specifies which model to minimize. If omitted all
+ * files are selected.
+ *
+ * Optional second parameter specifies base path. The directory must include
+ * the apis/ folder with .normal.json files. Output is written into the same
+ * path. If parameter is not passed the repository root will be used.
+ */
 if (require.main === module) {
   var modelName = process.argv[2] || '';
   var basePath = process.argv[3] || path.join(__dirname, '..');

--- a/scripts/translate-api
+++ b/scripts/translate-api
@@ -4,22 +4,41 @@ var fs = require('fs');
 var Translator = require('./lib/translator');
 var removeEventStreamOperations = require('./lib/remove-event-stream-ops').removeEventStreamOperations;
 var util = require('util');
+var path = require('path');
 
-var basePath = __dirname + '/../apis/';
-var paths = fs.readdirSync(basePath);
-var modelName = process.argv[2] || '';
+function ApiTranslator(basePath) {
+  this._apisPath = path.join(basePath, 'apis');
+}
 
-paths.forEach(function (path) {
-  if (path.match(new RegExp(modelName + ".+\\.normal\\.json$"))) {
-    var opath = path.replace(/\.normal\.json$/, '.min.json');
-    var data = JSON.parse(fs.readFileSync(basePath + path).toString());
-    var didModify = removeEventStreamOperations(data);
-    if (didModify) {
-      // original model modified, replace existing normal.json so docs/ts definitions are accurate
-      fs.writeFileSync(basePath + path, JSON.stringify(data, null, '  '));
-    }
-    var translated = new Translator(data, {documentation: false});
-    var json = JSON.stringify(translated, null, '  ');
-    fs.writeFileSync(basePath + opath, json);
+ApiTranslator.prototype.minimizeFile = function minimizeFile(filepath) {
+  var opath = filepath.replace(/\.normal\.json$/, '.min.json');
+  var data = JSON.parse(fs.readFileSync(path.join(this._apisPath, filepath)).toString());
+  var didModify = removeEventStreamOperations(data);
+  if (didModify) {
+    // original model modified, replace existing normal.json so docs/ts definitions are accurate
+    fs.writeFileSync(path.join(this._apisPath, filepath), JSON.stringify(data, null, '  '));
   }
-});
+  var translated = new Translator(data, {documentation: false});
+  var json = JSON.stringify(translated, null, '  ');
+  fs.writeFileSync(path.join(this._apisPath, opath), json);
+};
+
+ApiTranslator.prototype.translateAll = function translateAll(modelName) {
+  var paths = fs.readdirSync(this._apisPath);
+  var self = this;
+  paths.forEach(function(filepath) {
+    if (filepath.endsWith('.normal.json')) {
+      if (!modelName || filepath.startsWith(modelName)) {
+        self.minimizeFile(filepath);
+      }
+    }
+  });
+};
+
+if (require.main === module) {
+  var modelName = process.argv[2] || '';
+  var basePath = process.argv[3] || path.join(__dirname, '..');
+  new ApiTranslator(basePath).translateAll(modelName);
+}
+
+module.exports = ApiTranslator;

--- a/scripts/typings-generator.js
+++ b/scripts/typings-generator.js
@@ -1,9 +1,12 @@
+#!/usr/bin/env node
+
 var path = require('path');
 var TSGenerator = require('./lib/ts-generator');
 
+var basePath = process.argv[2] || path.join(__dirname, '..');
 
 var tsGenerator = new TSGenerator({
-    SdkRootDirectory: path.join(__dirname, '..')
+    SdkRootDirectory: basePath
 });
 
 tsGenerator.generateAllClientTypings();
@@ -11,5 +14,3 @@ tsGenerator.generateGroupedClients();
 tsGenerator.updateDynamoDBDocumentClient();
 tsGenerator.generateConfigurationServicePlaceholders();
 console.log('TypeScript Definitions created.');
-
-

--- a/scripts/typings-generator.js
+++ b/scripts/typings-generator.js
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+/*
+ * Pass optional path to target directory as command line argument.
+ *
+ * The directory must include the apis/ folder and service customizations at
+ * `lib/services`. Clients will be generated in `clients/`.
+ *
+ * If parameter is not passed the repository root will be used.
+ */
+
 var path = require('path');
 var TSGenerator = require('./lib/ts-generator');
 


### PR DESCRIPTION
This is a backwards compatible change to make the client generator,
typings generator and minimize json easier to consume for building
clients not included in the SDK.

Changes are:

* Paths are not hard-coded anymore but instead a `basePath` can be
provided which specifies the path to the sdk.
* Make `translate-api`, `client-creator.js` and `ts-generator.js`
callable as script and accept an optional `basePath` parameter
* Make `translate-api` optionally consumable as class. `Translator` is
already consumable but having a generic reading and writing of the
minimized file is beneficial as well.
* It removes side-effects from constructors to avoid unexpected changes
on initialization.

example:

```
import * as TSGenerator from "aws-sdk/scripts/lib/ts-generator";
import * as Translator from "aws-sdk/scripts/translate-api";
import * as ClientGenerator from "aws-sdk/dist-tools/client-creator";

const basePath = "....";

const translator = new Translator(basePath);
translator.translateAll();

const tsGenerator = new TSGenerator({ SdkRootDirectory: basePath });
tsGenerator.generateAllClientTypings();
tsGenerator.generateGroupedClients();

const clientGenerator = new ClientGenerator(basePath);
clientGenerator.writeClientServices();
```

##### Checklist

- [x] `npm run test` passes
- [ ] changelog is added, `npm run add-change`