### PR TITLE
Specify global endpoint and signature region for other partitions

### DIFF
--- a/.changes/next-release/bugfix-Global Services-7a32dfd9.json
+++ b/.changes/next-release/bugfix-Global Services-7a32dfd9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Global Services",
+  "description": "Add default signing region for IAM and Route53 in China and GovCloud"
+}

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -58,8 +58,8 @@ function configureEndpoint(service) {
 
       // set global endpoint
       service.isGlobalEndpoint = !!config.globalEndpoint;
-      if (config.signatureRegion) {
-        service.signatureRegion = config.signatureRegion;
+      if (config.signingRegion) {
+        service.signingRegion = config.signingRegion;
       }
 
       // signature version

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -58,6 +58,9 @@ function configureEndpoint(service) {
 
       // set global endpoint
       service.isGlobalEndpoint = !!config.globalEndpoint;
+      if (config.signatureRegion) {
+        service.signatureRegion = config.signatureRegion;
+      }
 
       // signature version
       if (!config.signatureVersion) config.signatureVersion = 'v4';

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -25,7 +25,7 @@
     "cn-*/route53": {
       "endpoint": "{service}.amazonaws.com.cn",
       "globalEndpoint": true,
-      "signatureRegion": "cn-northwest-1"
+      "signingRegion": "cn-northwest-1"
     },
     "us-gov-*/route53": "globalGovCloud",
 
@@ -35,7 +35,7 @@
     "cn-*/iam": {
       "endpoint": "{service}.cn-north-1.amazonaws.com.cn",
       "globalEndpoint": true,
-      "signatureRegion": "cn-north-1"
+      "signingRegion": "cn-north-1"
     },
     "us-gov-*/iam": "globalGovCloud",
 
@@ -68,12 +68,12 @@
     "globalSSL": {
       "endpoint": "https://{service}.amazonaws.com",
       "globalEndpoint": true,
-      "signatureRegion": "us-east-1"
+      "signingRegion": "us-east-1"
     },
     "globalGovCloud": {
       "endpoint": "{service}.us-gov.amazonaws.com",
       "globalEndpoint": true,
-      "signatureRegion": "us-gov-west-1"
+      "signingRegion": "us-gov-west-1"
     },
     "s3signature": {
       "endpoint": "{service}.{region}.amazonaws.com",

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -14,20 +14,31 @@
     },
     "*/budgets": "globalSSL",
     "*/cloudfront": "globalSSL",
-    "*/iam": "globalSSL",
     "*/sts": "globalSSL",
     "*/importexport": {
       "endpoint": "{service}.amazonaws.com",
       "signatureVersion": "v2",
       "globalEndpoint": true
     },
-    "*/route53": {
-      "endpoint": "https://{service}.amazonaws.com",
-      "signatureVersion": "v3https",
-      "globalEndpoint": true
+
+    "*/route53": "globalSSL",
+    "cn-*/route53": {
+      "endpoint": "{service}.amazonaws.com.cn",
+      "globalEndpoint": true,
+      "signatureRegion": "cn-northwest-1"
     },
+    "us-gov-*/route53": "globalGovCloud",
+
     "*/waf": "globalSSL",
+
+    "*/iam": "globalSSL",
+    "cn-*/iam": {
+      "endpoint": "{service}.cn-north-1.amazonaws.com.cn",
+      "globalEndpoint": true,
+      "signatureRegion": "cn-north-1"
+    },
     "us-gov-*/iam": "globalGovCloud",
+
     "us-gov-*/sts": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },
@@ -56,10 +67,13 @@
   "patterns": {
     "globalSSL": {
       "endpoint": "https://{service}.amazonaws.com",
-      "globalEndpoint": true
+      "globalEndpoint": true,
+      "signatureRegion": "us-east-1"
     },
     "globalGovCloud": {
-      "endpoint": "{service}.us-gov.amazonaws.com"
+      "endpoint": "{service}.us-gov.amazonaws.com",
+      "globalEndpoint": true,
+      "signatureRegion": "us-gov-west-1"
     },
     "s3signature": {
       "endpoint": "{service}.{region}.amazonaws.com",

--- a/lib/request.js
+++ b/lib/request.js
@@ -314,7 +314,14 @@ AWS.Request = inherit({
     var customUserAgent = service.config.customUserAgent;
 
     // global endpoints sign as us-east-1
-    if (service.isGlobalEndpoint) region = 'us-east-1';
+    if (service.isGlobalEndpoint) {
+      region = 'us-east-1';
+      if (service.signatureRegion) {
+        region = service.signatureRegion;
+      } else {
+        region = 'us-east-1';
+      }
+    }
 
     this.domain = domain && domain.active;
     this.service = service;

--- a/lib/request.js
+++ b/lib/request.js
@@ -314,8 +314,8 @@ AWS.Request = inherit({
     var customUserAgent = service.config.customUserAgent;
 
     if (service.isGlobalEndpoint) {
-      if (service.signatureRegion) {
-        region = service.signatureRegion;
+      if (service.signingRegion) {
+        region = service.signingRegion;
       } else {
         region = 'us-east-1';
       }

--- a/lib/request.js
+++ b/lib/request.js
@@ -313,9 +313,7 @@ AWS.Request = inherit({
     var region = service.config.region;
     var customUserAgent = service.config.customUserAgent;
 
-    // global endpoints sign as us-east-1
     if (service.isGlobalEndpoint) {
-      region = 'us-east-1';
       if (service.signatureRegion) {
         region = service.signatureRegion;
       } else {

--- a/scripts/region-checker/whitelist.js
+++ b/scripts/region-checker/whitelist.js
@@ -25,8 +25,7 @@ var whitelist = {
         112
     ],
     '/request.js': [
-        315,
-        316
+        319
     ],
     '/services/s3.js': [
         70,

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -38,12 +38,22 @@ describe('region_config.js', function() {
     expect(service.endpoint.host).to.equal('s3.amazonaws.com');
   });
 
-  it('does not use any global endpoints in cn-*', function() {
+  it('uses "global" endpoint for IAM in cn-northwest-1', function() {
     var service = new AWS.IAM({
+      region: 'cn-northwest-1'
+    });
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.signatureRegion).to.equal('cn-north-1');
+    expect(service.endpoint.host).to.equal('iam.cn-north-1.amazonaws.com.cn');
+  });
+
+  it('uses "global" endpoint for Route53 in cn-north-1', function() {
+    var service = new AWS.Route53({
       region: 'cn-north-1'
     });
-    expect(service.isGlobalEndpoint).to.equal(false);
-    expect(service.endpoint.host).to.equal('iam.cn-north-1.amazonaws.com.cn');
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.signatureRegion).to.equal('cn-northwest-1');
+    expect(service.endpoint.host).to.equal('route53.amazonaws.com.cn');
   });
 
   it('enables signature version 4 signing in cn-*', function() {
@@ -85,9 +95,10 @@ describe('region_config.js', function() {
 
   it('uses us-gov endpoint for IAM in GovCloud', function() {
     var service = new AWS.IAM({
-      region: 'us-gov-west-1'
+      region: 'us-gov-east-1'
     });
-    expect(service.isGlobalEndpoint).to.equal(false);
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.signatureRegion).to.equal('us-gov-west-1');
     expect(service.endpoint.host).to.equal('iam.us-gov.amazonaws.com');
   });
 

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -43,7 +43,7 @@ describe('region_config.js', function() {
       region: 'cn-northwest-1'
     });
     expect(service.isGlobalEndpoint).to.equal(true);
-    expect(service.signatureRegion).to.equal('cn-north-1');
+    expect(service.signingRegion).to.equal('cn-north-1');
     expect(service.endpoint.host).to.equal('iam.cn-north-1.amazonaws.com.cn');
   });
 
@@ -52,7 +52,7 @@ describe('region_config.js', function() {
       region: 'cn-north-1'
     });
     expect(service.isGlobalEndpoint).to.equal(true);
-    expect(service.signatureRegion).to.equal('cn-northwest-1');
+    expect(service.signingRegion).to.equal('cn-northwest-1');
     expect(service.endpoint.host).to.equal('route53.amazonaws.com.cn');
   });
 
@@ -98,7 +98,7 @@ describe('region_config.js', function() {
       region: 'us-gov-east-1'
     });
     expect(service.isGlobalEndpoint).to.equal(true);
-    expect(service.signatureRegion).to.equal('us-gov-west-1');
+    expect(service.signingRegion).to.equal('us-gov-west-1');
     expect(service.endpoint.host).to.equal('iam.us-gov.amazonaws.com');
   });
 


### PR DESCRIPTION
So far the global endpoint had `us-east-1` for normal partition
hard-coded and it did not work in other partitions like China or us-gov.

https://github.com/aws/aws-sdk-js/issues/3192

Route53 endpoint pattern ([source](https://docs.aws.amazon.com/general/latest/gr/r53.html#r53_region))

| Partition | Endpoint | Region |
| --- | --- | --- |
| aws | route53.amazonaws.com | us-east-1 |
| aws-cn | route53.amazonaws.com.cn | cn-northwest-1 |

IAM endpoint pattern ([source](https://docs.aws.amazon.com/general/latest/gr/iam-service.html))

| Partition | Endpoint | Region |
| --- | --- | --- |
| aws | iam.amazonaws.com | us-east-1 |
| aws-cn | iam.cn-north-1.amazonaws.com.cn | cn-north-1 |
| aws-us-gov | iam.us-gov.amazonaws.com | us-gov-west-1 |

##### testing

script:

```
var iam_aws = new AWS.IAM({ region: 'me-south-1', credentials: creds_aws });
iam_aws.listRoles(function(err, data) { console.log({ p: 'aws', data: data, err: err }); });
var route53_aws = new AWS.Route53({ region: 'me-south-1', credentials: creds_aws });
route53_aws.listHostedZones(function(err, data) { console.log({ p: 'aws', data: data, err: err }); });

var iam_aws_cn = new AWS.IAM({ region: 'cn-northwest-1', credentials: creds_aws_cn });
iam_aws_cn.listRoles(function(err, data) { console.log({ p: 'aws-cn', data: data, err: err }); });
var route53_aws_cn = new AWS.Route53({ region: 'cn-north-1', credentials: creds_aws_cn });
route53_aws_cn.listHostedZones(function(err, data) { console.log({ p: 'aws-cn', data: data, err: err }); });

var iam_aws_us_gov = new AWS.IAM({ region: 'us-gov-east-1', credentials: creds_aws_us_gov });
iam_aws_us_gov.listRoles(function(err, data) { console.log({ p: 'aws-us-gov', data: data, err: err }); });
var route53_aws_us_gov = new AWS.Route53({ region: 'us-gov-east-1', credentials: creds_aws_us_gov });
route53_aws_us_gov.listHostedZones(function(err, data) { console.log({ p: 'aws-us-gov', data: data, err: err }); });
```

before:

```
{
  p: 'aws-cn',
  err: Error: getaddrinfo ENOTFOUND iam.cn-northwest-1.amazonaws.com.cn
      at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:66:26) {
    errno: -3008,
    code: 'NetworkingError',
    syscall: 'getaddrinfo',
    hostname: 'iam.cn-northwest-1.amazonaws.com.cn',
    region: 'cn-northwest-1',
    retryable: true,
    time: 2020-05-24T16:46:11.006Z
  }
}
{
  p: 'aws-us-gov',
  err: InvalidClientTokenId: The security token included in the request is invalid
      ...
      at Request.callListeners (/Volumes/unix/aws-sdk-js/lib/sequential_executor.js:116:18) {
    code: 'InvalidClientTokenId',
    time: 2020-05-24T16:46:11.204Z,
    requestId: '0b8388dc-2ce9-40b1-85f4-40d25d5097eb',
    statusCode: 403,
    retryable: false,
    retryDelay: 57.79329267683981
  }
}
{
  p: 'aws-cn',
  err: Error: getaddrinfo ENOTFOUND route53.cn-north-1.amazonaws.com.cn
      at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:66:26) {
    errno: -3008,
    code: 'NetworkingError',
    syscall: 'getaddrinfo',
    hostname: 'route53.cn-north-1.amazonaws.com.cn',
    region: 'cn-north-1',
    retryable: true,
    time: 2020-05-24T16:46:11.244Z
  }
}
{ p: 'aws', err: null }
{
  p: 'aws-us-gov',
  err: SignatureDoesNotMatch: Credential should be scoped to a valid region, not 'us-gov-east-1'. 
      ...
      at Request.callListeners (/Volumes/unix/aws-sdk-js/lib/sequential_executor.js:116:18) {
    code: 'SignatureDoesNotMatch',
    time: 2020-05-24T16:46:11.483Z,
    requestId: '85819340-2931-414c-931d-59c2996763a6',
    statusCode: 403,
    retryable: false,
    retryDelay: 94.41183963355235
  }
}
{ p: 'aws', err: null }
```

after:

```
{ p: 'aws', err: null }
{ p: 'aws-us-gov', err: null }
{ p: 'aws', err: null }
{ p: 'aws-us-gov', err: null }
{ p: 'aws-cn', err: null }
{ p: 'aws-cn', err: null }
```

##### Checklist

- [x] `npm run test` passes
- [ ] changelog is added, `npm run add-change`
