### PR TITLE
Updated validateStructure to accept null and undefined values for par…

### DIFF
--- a/.changes/next-release/feature-ParamValidator-971ace5c.json
+++ b/.changes/next-release/feature-ParamValidator-971ace5c.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "ParamValidator",
+  "description": "Updated validateStructure to accept null and undefined values for params not described in the input shape"
+}

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -73,7 +73,7 @@ AWS.ParamValidator = AWS.util.inherit({
       if (memberShape !== undefined) {
         var memberContext = [context, paramName].join('.');
         this.validateMember(memberShape, paramValue, memberContext);
-      } else {
+      } else if (paramValue !== undefined && paramValue !== null) {
         this.fail('UnexpectedParameter',
           'Unexpected key \'' + paramName + '\' found in ' + context);
       }

--- a/test/param_validator.spec.js
+++ b/test/param_validator.spec.js
@@ -94,6 +94,12 @@
           string3: 'xyz'
         });
       });
+      it('accepts null and undefined values for params not described in the input', function() {
+        return expectValid({
+          string3: null,
+          string4: undefined
+        });
+      });
       return it('rejects nested params that are not described in the input', function() {
         expectValid({
           hash: {


### PR DESCRIPTION
…ams not described in the input shape

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `npm run test` passes

Addresses #3248 

Red test:

```
AWS.ParamValidator
    empty input
      ✓ accepts an empty hash when the input are an empty hash
      ✓ does not accept params in the given hash
    param keys
      ✓ accepts string keys
      ✓ rejects keys that do not match case
    unexpected params
      ✓ throws an ArgumentError for un-described params
      1) accepts null and undefined values for params not described in the input
      ✓ rejects nested params that are not described in the input
    uri params
      ✓ throws an error if a uri parameter is empty
      ✓ does not throw an error if a uri parameter is populated
    required params
      ✓ throws an error if a top-level required param is omitted
      ✓ throws an error if a top-level required param is null
      ✓ optional params can be omitted, even if they have required params
      ✓ requires nested required params when the parent is present
      ✓ accepts nested required params
      ✓ accepts empty strings in required params
      ✓ accepts 0 in required params
      ✓ accepts false in required params
    structure
      ✓ accepts hashes
      ✓ accepts hashes with params
      ✓ throws an error for non hashes
      ✓ throws an error for unknown hash members
      ✓ allows nesting structures
      ✓ rejects unknown members
      ✓ does not check inherited properties on parameters
    list
      ✓ accepts an array for list params
      ✓ throws an error if list params are not arrays
      ✓ supports nested structures
    map
      ✓ accepts maps
      ✓ accepts null
      ✓ rejects non-maps
      ✓ accepts user-supplied maps keys
      ✓ supports nested params
    boolean
      ✓ accepts true
      ✓ accepts false
      ✓ accepts null
      ✓ rejects other values
    timestamp
      ✓ accepts Date objects
      ✓ accepts strings formatted like datetimes
      ✓ accepts UNIX timestamps as number values
      ✓ accepts null
      ✓ rejects other param values
    string
      ✓ accepts strings
      ✓ accepts empty string
      ✓ accepts null
      ✓ rejects other objects
      ✓ accepts anything JSON-encodable if the member is a JSONValue
    float
      ✓ accepts floats
      ✓ accepts integers
      ✓ accepts floats formatted as strings
      ✓ accepts null
      ✓ rejects other objects
    integer
      ✓ accepts integers
      ✓ accepts integers formatted as strings
      ✓ accepts null
      ✓ rejects other objects
    base64
      ✓ accepts strings
      ✓ accepts Buffers
      ✓ accepts typed arrays
      ✓ accepts null
      ✓ rejects other objects
    binary
      ✓ accepts strings
      ✓ accepts Buffers
      ✓ accepts Streams
      ✓ accepts null
      ✓ rejects other objects
    payloads
      ✓ validates from payload key if input include an xml element
    error messages
      ✓ throws helpful messages for unknown params
      ✓ throws helpful messages for nested unknown params
      ✓ throws helpful messages for missing required params
      ✓ throws helpul messages for invalid structures
      ✓ throws helpul messages for invalid lists
      ✓ throws helpful messages for invalid list members
      ✓ throws helpful messages for invalid maps
      ✓ throws helpful messages for invalid map members
      ✓ throws helpful messages for invalid strings
      ✓ throws helpful messages for invalid integers
      ✓ throws helpful messages for invalid timestamps
      ✓ throws helpful messages for invalid booleans
      ✓ throws helpful messages for invalid floats
      ✓ throws helpful messages for invalid base64 params
      ✓ throws helpful messages for invalid binary params
    multiple errors
      ✓ groups multiple errors together
    strict range validation
      ✓ ignores max violations when max is disabled
      ✓ ignores min violations when min is disabled
      ✓ accepts numbers at maximum
      ✓ rejects numbers above maximum
      ✓ accepts numbers at minimum
      ✓ accepts numbers above minimum
      ✓ rejects numbers below minimum
      ✓ accepts strings at minimum
      ✓ accepts strings above minimum
      ✓ rejects strings below minimum
      ✓ accepts strings at maximum
      ✓ rejects strings above maximum
      ✓ accepts lists at minimum
      ✓ accepts lists above minimum
      ✓ accepts lists at maximum
      ✓ rejects lists below minimum
      ✓ rejects lists above maximum
      ✓ accepts maps at minimum
      ✓ accepts maps at maximum
      ✓ rejects maps below minimum
      ✓ rejects maps above maximum member count
      ✓ rejects maps where key is out of range
    strict enum validation
      ✓ ignores enum violations when strict is disabled
      ✓ accepts strings matching first enum value
      ✓ accepts strings matching last enum value
      ✓ rejects strings not in enum list
      ✓ rejects strings not exactly in enum list
      ✓ accepts map keys found in enum trait
      ✓ rejects map keys not found in enum trait
    strict pattern validation
      ✓ ignores pattern violations when strict is disabled
      ✓ accepts strings matching pattern
      ✓ rejects strings that do not match pattern

  113 passing (375ms)
  1 failing

  1) AWS.ParamValidator unexpected params accepts null and undefined values for params not described in the input:
     MultipleValidationErrors: There were 2 validation errors:
* UnexpectedParameter: Unexpected key 'string3' found in params
* UnexpectedParameter: Unexpected key 'string4' found in params
      at ParamValidator.validate (lib/param_validator.js:40:28)
      at validate (test/param_validator.spec.js:20:45)
      at expectValid (test/param_validator.spec.js:23:21)
      at Context.<anonymous> (test/param_validator.spec.js:98:16)
      at process.topLevelDomainCallback (domain.js:126:23)
```

Green test:

```
AWS.ParamValidator
    empty input
      ✓ accepts an empty hash when the input are an empty hash
      ✓ does not accept params in the given hash
    param keys
      ✓ accepts string keys
      ✓ rejects keys that do not match case
    unexpected params
      ✓ throws an ArgumentError for un-described params
      ✓ accepts null and undefined values for params not described in the input
      ✓ rejects nested params that are not described in the input
    uri params
      ✓ throws an error if a uri parameter is empty
      ✓ does not throw an error if a uri parameter is populated
    required params
      ✓ throws an error if a top-level required param is omitted
      ✓ throws an error if a top-level required param is null
      ✓ optional params can be omitted, even if they have required params
      ✓ requires nested required params when the parent is present
      ✓ accepts nested required params
      ✓ accepts empty strings in required params
      ✓ accepts 0 in required params
      ✓ accepts false in required params
    structure
      ✓ accepts hashes
      ✓ accepts hashes with params
      ✓ throws an error for non hashes
      ✓ throws an error for unknown hash members
      ✓ allows nesting structures
      ✓ rejects unknown members
      ✓ does not check inherited properties on parameters
    list
      ✓ accepts an array for list params
      ✓ throws an error if list params are not arrays
      ✓ supports nested structures
    map
      ✓ accepts maps
      ✓ accepts null
      ✓ rejects non-maps
      ✓ accepts user-supplied maps keys
      ✓ supports nested params
    boolean
      ✓ accepts true
      ✓ accepts false
      ✓ accepts null
      ✓ rejects other values
    timestamp
      ✓ accepts Date objects
      ✓ accepts strings formatted like datetimes
      ✓ accepts UNIX timestamps as number values
      ✓ accepts null
      ✓ rejects other param values
    string
      ✓ accepts strings
      ✓ accepts empty string
      ✓ accepts null
      ✓ rejects other objects
      ✓ accepts anything JSON-encodable if the member is a JSONValue
    float
      ✓ accepts floats
      ✓ accepts integers
      ✓ accepts floats formatted as strings
      ✓ accepts null
      ✓ rejects other objects
    integer
      ✓ accepts integers
      ✓ accepts integers formatted as strings
      ✓ accepts null
      ✓ rejects other objects
    base64
      ✓ accepts strings
      ✓ accepts Buffers
      ✓ accepts typed arrays
      ✓ accepts null
      ✓ rejects other objects
    binary
      ✓ accepts strings
      ✓ accepts Buffers
      ✓ accepts Streams
      ✓ accepts null
      ✓ rejects other objects
    payloads
      ✓ validates from payload key if input include an xml element
    error messages
      ✓ throws helpful messages for unknown params
      ✓ throws helpful messages for nested unknown params
      ✓ throws helpful messages for missing required params
      ✓ throws helpul messages for invalid structures
      ✓ throws helpul messages for invalid lists
      ✓ throws helpful messages for invalid list members
      ✓ throws helpful messages for invalid maps
      ✓ throws helpful messages for invalid map members
      ✓ throws helpful messages for invalid strings
      ✓ throws helpful messages for invalid integers
      ✓ throws helpful messages for invalid timestamps
      ✓ throws helpful messages for invalid booleans
      ✓ throws helpful messages for invalid floats
      ✓ throws helpful messages for invalid base64 params
      ✓ throws helpful messages for invalid binary params
    multiple errors
      ✓ groups multiple errors together
    strict range validation
      ✓ ignores max violations when max is disabled
      ✓ ignores min violations when min is disabled
      ✓ accepts numbers at maximum
      ✓ rejects numbers above maximum
      ✓ accepts numbers at minimum
      ✓ accepts numbers above minimum
      ✓ rejects numbers below minimum
      ✓ accepts strings at minimum
      ✓ accepts strings above minimum
      ✓ rejects strings below minimum
      ✓ accepts strings at maximum
      ✓ rejects strings above maximum
      ✓ accepts lists at minimum
      ✓ accepts lists above minimum
      ✓ accepts lists at maximum
      ✓ rejects lists below minimum
      ✓ rejects lists above maximum
      ✓ accepts maps at minimum
      ✓ accepts maps at maximum
      ✓ rejects maps below minimum
      ✓ rejects maps above maximum member count
      ✓ rejects maps where key is out of range
    strict enum validation
      ✓ ignores enum violations when strict is disabled
      ✓ accepts strings matching first enum value
      ✓ accepts strings matching last enum value
      ✓ rejects strings not in enum list
      ✓ rejects strings not exactly in enum list
      ✓ accepts map keys found in enum trait
      ✓ rejects map keys not found in enum trait
    strict pattern validation
      ✓ ignores pattern violations when strict is disabled
      ✓ accepts strings matching pattern
      ✓ rejects strings that do not match pattern

  114 passing (402ms)
```