### PR TITLE
chore(deps): bump buffer from 4.9.1 to 4.9.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack": "^1.15.0"
   },
   "dependencies": {
-    "buffer": "4.9.1",
+    "buffer": "4.9.2",
     "events": "1.1.1",
     "ieee754": "1.1.13",
     "jmespath": "0.15.0",


### PR DESCRIPTION
Warning shown while running `yarn install`

```console
$ yarn
yarn install v1.22.4
info No lockfile found.
[1/5] Validating package.json...
[2/5] Resolving packages...
warning buffer@4.9.1: This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer
```

##### Checklist

- [x] `npm run test` passes
- [ ] changelog is added, `npm run add-change`