### PR TITLE
Fix nextPage typing in requests

### DIFF
--- a/.changes/next-release/bugfix-Paginator-887637f3.json
+++ b/.changes/next-release/bugfix-Paginator-887637f3.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Paginator",
+  "description": "Fix nextPage typing in requests"
+}

--- a/lib/response.d.ts
+++ b/lib/response.d.ts
@@ -8,7 +8,8 @@ export class Response<D, E> {
 		/**
 		 * Creates a new request for the next page of response data, calling the callback with the page data if a callback is provided.
 		 */
-		nextPage(callback?: (err: E, data: D) => void): Request<D, E>|void;
+		nextPage(): Request<D, E> | null;
+		nextPage(callback: (err: E, data: D) => void): void;
 		/**
 		 * The de-serialized response data from the service.
 		 * Can be null if an error occurred.


### PR DESCRIPTION
The fixes the return type of the `nextPage()` method. Before, it would
return `Request<D, E>|void` which is hard to work with, because you
couldn't runtime test for `void` (everything can be void). This change
splits up the definition into two overloads: one without a callback
provided that returns `Request<D, E> | null` and a second for the
callback version that always returns `void`. This also matches the
documentation in the implementation now.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
