### PR TITLE
test: pass stsRegionalEndpoints as regional in STS

### DIFF
--- a/configuration.sample
+++ b/configuration.sample
@@ -1,6 +1,5 @@
 {
   "region": "us-east-1",
-  "stsRegionalEndpoints": "regional",
   "s3": {
     "params": { "Bucket": "test-s3-bucket" }
   },

--- a/features/sts/step_definitions/sts.js
+++ b/features/sts/step_definitions/sts.js
@@ -1,6 +1,8 @@
 module.exports = function() {
   this.Before('@sts', function (callback) {
-    this.service = new this.AWS.STS();
+    this.service = new this.AWS.STS({
+      stsRegionalEndpoints: "regional"
+    });
     callback();
   });
 


### PR DESCRIPTION
Explicitly passing stsRegionalEndpoints as `"regional"`

```console
$ npm run integration -- --tags @sts

> aws-sdk@2.697.0 integration /Users/trivikr/workspace/aws-sdk-js
> cucumber.js "--tags" "@sts"

@sts
Feature: AWS Security Token Service

  I want to use AWS Security Token Service

  @requiresakid @nosession
  Scenario: Get a session token                                           # features/sts/sts.feature:8
    Given I get an STS session token with a duration of 900 seconds       # features/sts/sts.feature:9
    Then the result should contain an access key ID and secret access key # features/sts/sts.feature:10


  Scenario: Error handling                                         # features/sts/sts.feature:12
    Given I get an STS session token with a duration of 60 seconds # features/sts/sts.feature:13
    Then the error code should be "ValidationError"                # features/sts/sts.feature:14


2 scenarios (2 passed)
4 steps (4 passed)
```

##### Checklist

- [x] run `npm run integration` if integration test is changed