### PR TITLE
`region`'s type is a string - update the documentation to match

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,7 +24,7 @@ var PromisesDependency;
  * @!attribute region
  *   @example Set the global region setting to us-west-2
  *     AWS.config.update({region: 'us-west-2'});
- *   @return [AWS.Credentials] The region to send service requests to.
+ *   @return [String] The region to send service requests to.
  *   @see http://docs.amazonwebservices.com/general/latest/gr/rande.html
  *     A list of available endpoints for each AWS service
  *


### PR DESCRIPTION
Based on [the type definitions](https://github.com/aws/aws-sdk-js/blob/master/lib/config.d.ts#L235), `region` is a string - this updates the docs to match.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
  - I wasn't able to get this to run locally - there were issues installing and running `yard`.  Happy to file a bug report if that would be helpful.

