### PR TITLE
Check for ValidationException in EFS integ tests

### DIFF
--- a/.changes/next-release/bugfix-EFS-6f61768f.json
+++ b/.changes/next-release/bugfix-EFS-6f61768f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "EFS",
+  "description": "Check for ValidationException in integration tests"
+}

--- a/features/efs/efs.feature
+++ b/features/efs/efs.feature
@@ -14,4 +14,4 @@ Feature: Amazon Elastic File System
     """
     { "FileSystemId": "fake-id" }
     """
-    Then the error code should be "BadRequest"
+    Then the error code should be "ValidationException"


### PR DESCRIPTION
EFS started throwing `ValidationException` instead of `BadRequest` for `deleteFileSystem` operation on Saturday 06/20

Updating the tests after verifying that `ValidationException` is thrown also on AWS CLI:
```console
$ date
Mon Jun 22 09:42:00 PDT 2020

$ aws --version
aws-cli/1.16.226 Python/3.7.3 Darwin/18.7.0 botocore/1.12.216

$ aws efs delete-file-system --file-system-id fake-id

An error occurred (ValidationException) when calling the DeleteFileSystem operation: 1 validation error detected: Value 'fake-id' at 'fileSystemId' failed to satisfy constraint: Member must satisfy regular expression pattern: ^fs-[0-9a-f]{8,40}
```

Ensured that integration tests are successful for EFS:
```console
$ AWS_REGION=us-west-2 node node_modules/cucumber/bin/cucumber.js --tag @efs
@efs
Feature: Amazon Elastic File System

  I want to use Amazon Elastic File System


  Scenario: Listing file systems                    # features/efs/efs.feature:7
    Given I run the "describeFileSystems" operation # features/efs/efs.feature:8
    Then the request should be successful           # features/efs/efs.feature:9
    And the value at "FileSystems" should be a list # features/efs/efs.feature:10


  Scenario: Error handling                                    # features/efs/efs.feature:12
    Given I run the "deleteFileSystem" operation with params: # features/efs/efs.feature:13
      """
      { "FileSystemId": "fake-id" }
      """
    Then the error code should be "ValidationException"       # features/efs/efs.feature:17


2 scenarios (2 passed)
5 steps (5 passed)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed