### PR TITLE
fix issue that s3 without config throws at access point arn

### DIFF
--- a/.changes/next-release/bugfix-S3-7316cf71.json
+++ b/.changes/next-release/bugfix-S3-7316cf71.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "Fixed a bug where S3 client throws when client config is undefined and Bucket is an AccessPoint ARN"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -449,7 +449,7 @@ AWS.util.update(AWS.S3.prototype, {
    * @api private
    */
   populateUriFromAccessPoint: function populateUriFromAccessPoint(req) {
-    if (req.service._originalConfig.endpoint) {
+    if (req.service._originalConfig && req.service._originalConfig.endpoint) {
       throw AWS.util.error(new Error(), {
         code: 'InvalidConfiguration',
         message: 'Custom endpoint is not compatible with access point ARN'

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -3493,6 +3493,23 @@ describe('AWS.S3', function() {
       });
     });
 
+    it('should correctly generate access point endpoint with no client config', function(done) {
+      helpers.mockHttpResponse(200, {}, '');
+      client = new AWS.S3();
+      var request = client.getObject({
+        Bucket: 'arn:aws:s3:us-west-2:123456789012:accesspoint/myendpoint',
+        Key: 'key'
+      });
+      request.send(function(err, data) {
+        expect(err).to.not.exist;
+        expect(request.httpRequest.endpoint.hostname).to.equal(
+          'myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com'
+        );
+        expect(request.httpRequest.path).to.equal('/key');
+        done();
+      });
+    });
+
     it('should correctly generate access point endpoint containing \':\'', function(done) {
       helpers.mockHttpResponse(200, {}, '');
       var request = s3.getObject({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Previously, S3 client will throw when create with no config object, when supplied with an assess point ARN;
```javascript
const AWS = require('aws-sdk');
AWS.config.update({ region });
const s3 = new AWS.S3();

s3.headObject({
    Bucket: ACCESS_POINT_ARN,
    Key: OBJECT_KEY
}).promise().then((data) => {
    console.log(`HEAD result ${JSON.stringify(data)}`);
}).catch((err) => {
    console.error(`HEAD ERROR: ${err}`);
});
```
User will see the error below:

```console
HEAD ERROR: TypeError: Cannot read property 'endpoint' of undefined
```

This change fix the issue.

Internal tracking id: JS-1882

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
