### PR TITLE
Rename isDnsCompatible to dnsCompatibleBucketName

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -222,7 +222,7 @@ AWS.util.update(AWS.S3.prototype, {
     }
     var accessPoint = parsedArn.resource.split(delimiter)[1];
     var accessPointPrefix = accessPoint + '-' + parsedArn.accountId;
-    if (!req.service.isDnsCompatible(accessPointPrefix) || accessPointPrefix.match(/\./)) {
+    if (!req.service.dnsCompatibleBucketName(accessPointPrefix) || accessPointPrefix.match(/\./)) {
       throw AWS.util.error(new Error(), {
         code: 'InvalidAccessPointARN',
         message: 'Access point ARN is not DNS compatible. Got ' + accessPoint
@@ -621,7 +621,7 @@ AWS.util.update(AWS.S3.prototype, {
     if (this.config.s3ForcePathStyle) return true;
     if (this.config.s3BucketEndpoint) return false;
 
-    if (this.isDnsCompatible(bucketName)) {
+    if (this.dnsCompatibleBucketName(bucketName)) {
       return (this.config.sslEnabled && bucketName.match(/\./)) ? true : false;
     } else {
       return true; // not dns compatible names must always use path style
@@ -634,7 +634,7 @@ AWS.util.update(AWS.S3.prototype, {
    *
    * @api private
    */
-  isDnsCompatible: function isDnsCompatible(bucketName) {
+  dnsCompatibleBucketName: function dnsCompatibleBucketName(bucketName) {
     var b = bucketName;
     var domain = new RegExp(/^[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$/);
     var ipAddress = new RegExp(/(\d+\.){3}\d+/);
@@ -890,7 +890,7 @@ AWS.util.update(AWS.S3.prototype, {
     if (cachedRegion && cachedRegion !== request.httpRequest.region) {
       service.updateReqBucketRegion(request, cachedRegion);
       done();
-    } else if (!service.isDnsCompatible(bucket)) {
+    } else if (!service.dnsCompatibleBucketName(bucket)) {
       service.updateReqBucketRegion(request, 'us-east-1');
       if (bucketRegionCache[bucket] !== 'us-east-1') {
         bucketRegionCache[bucket] = 'us-east-1';

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -21,42 +21,42 @@ describe('AWS.S3', function() {
     return done();
   });
 
-  describe('isDnsCompatible', function() {
+  describe('dnsCompatibleBucketName', function() {
     it('must be at least 3 characters', function() {
-      expect(s3.isDnsCompatible('aa')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('aa')).to.equal(false);
     });
 
     it('must not be longer than 63 characters', function() {
       var b;
       b = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-      expect(s3.isDnsCompatible(b)).to.equal(false);
+      expect(s3.dnsCompatibleBucketName(b)).to.equal(false);
     });
 
     it('must start with a lower-cased letter or number', function() {
-      expect(s3.isDnsCompatible('Abc')).to.equal(false);
-      expect(s3.isDnsCompatible('-bc')).to.equal(false);
-      expect(s3.isDnsCompatible('abc')).to.equal(true);
+      expect(s3.dnsCompatibleBucketName('Abc')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('-bc')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('abc')).to.equal(true);
     });
 
     it('must end with a lower-cased letter or number', function() {
-      expect(s3.isDnsCompatible('abC')).to.equal(false);
-      expect(s3.isDnsCompatible('ab-')).to.equal(false);
-      expect(s3.isDnsCompatible('abc')).to.equal(true);
+      expect(s3.dnsCompatibleBucketName('abC')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('ab-')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('abc')).to.equal(true);
     });
 
     it('may not contain multiple contiguous dots', function() {
-      expect(s3.isDnsCompatible('abc.123')).to.equal(true);
-      expect(s3.isDnsCompatible('abc..123')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('abc.123')).to.equal(true);
+      expect(s3.dnsCompatibleBucketName('abc..123')).to.equal(false);
     });
 
     it('may only contain letters numbers and dots', function() {
-      expect(s3.isDnsCompatible('abc123')).to.equal(true);
-      expect(s3.isDnsCompatible('abc_123')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('abc123')).to.equal(true);
+      expect(s3.dnsCompatibleBucketName('abc_123')).to.equal(false);
     });
 
     it('must not look like an ip address', function() {
-      expect(s3.isDnsCompatible('1.2.3.4')).to.equal(false);
-      expect(s3.isDnsCompatible('a.b.c.d')).to.equal(true);
+      expect(s3.dnsCompatibleBucketName('1.2.3.4')).to.equal(false);
+      expect(s3.dnsCompatibleBucketName('a.b.c.d')).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Refs: https://github.com/aws/aws-sdk-js/pull/3362#pullrequestreview-452926152

This name was updated as part of access point PR in https://github.com/aws/aws-sdk-js/pull/2987
Changing the name back, as this function only validates the bucket name. The host label is more permissible.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes