### PR TITLE
Add awsdocs-legal-zone-copyright div in API reference

### DIFF
--- a/.changes/next-release/bugfix-docs-924e57de.json
+++ b/.changes/next-release/bugfix-docs-924e57de.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "docs",
+  "description": "Add awsdocs-legal-zone-copyright div"
+}

--- a/doc-src/templates/default/layout/html/footer.erb
+++ b/doc-src/templates/default/layout/html/footer.erb
@@ -1,7 +1,10 @@
 <div id="footer">
-  Generated on <%= Time.now.strftime("%c") %> by
-  <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  <%= YARD::VERSION %> (ruby-<%= RUBY_VERSION %>).
+  <div>
+    Generated on <%= Time.now.strftime("%c") %> by
+    <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
+    <%= YARD::VERSION %> (ruby-<%= RUBY_VERSION %>).
+  </div>
+  <div id="awsdocs-legal-zone-copyright"></div>
 </div>
 
 <!-- BEGIN-SECTION -->


### PR DESCRIPTION
Internal issue for reference JS-1986
Refs: https://github.com/aws/aws-sdk-js/pull/3374

<details>
<summary>Screenshot of footer when script will run in Prod</summary>

![Screen Shot 2020-08-05 at 1 09 09 PM](https://user-images.githubusercontent.com/16024985/89459056-ec325880-d71c-11ea-880c-5453b82b3abf.png)

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed