### PR TITLE
Add closing script tag for GDPR compliance script

### DIFF
--- a/doc-src/templates/default/layout/html/footer.erb
+++ b/doc-src/templates/default/layout/html/footer.erb
@@ -10,7 +10,7 @@
 <!-- BEGIN-SECTION -->
 <!-- SiteCatalyst code version: H.25.2. Copyright 1996-2012 Adobe, Inc. All Rights Reserved.
 More info available at http://www.omniture.com -->
-<script type="text/javascript" src="https://a0.awsstatic.com/s_code/js/2.0/awshome_s_code.js" />
+<script type="text/javascript" src="https://a0.awsstatic.com/s_code/js/2.0/awshome_s_code.js"></script>
 <script language="JavaScript" type="text/javascript">
   <!--
   s.prop66='AWS SDK for JavaScript';


### PR DESCRIPTION
Fix attempt for discrepancies across browsers in showing GDPR message
Refs: https://github.com/aws/aws-sdk-js/pull/3374 

##### Checklist

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
