### PR TITLE
Add fallback to use the Code attribute for error codes

### DIFF
--- a/.changes/next-release/bugfix-protocol-2b15d604.json
+++ b/.changes/next-release/bugfix-protocol-2b15d604.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "protocol",
+  "description": "Allow error code extraction from pascal cased Code attribute in the JSON body response"
+}

--- a/dist/aws-sdk-core-react-native.js
+++ b/dist/aws-sdk-core-react-native.js
@@ -1951,8 +1951,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (httpResponse.body.length > 0) {
 	    try {
 	      var e = JSON.parse(httpResponse.body.toString());
-	      if (e.__type || e.code) {
-	        error.code = (e.__type || e.code).split('#').pop();
+	      var code = e.__type || e.code || e.Code;
+	      if (code) {
+	        error.code = code.split('#').pop();
 	      }
 	      if (error.code === 'RequestEntityTooLarge') {
 	        error.message = 'Request body must be less than 1 MB';

--- a/lib/protocol/json.js
+++ b/lib/protocol/json.js
@@ -31,8 +31,9 @@ function extractError(resp) {
   if (httpResponse.body.length > 0) {
     try {
       var e = JSON.parse(httpResponse.body.toString());
-      if (e.__type || e.code) {
-        error.code = (e.__type || e.code).split('#').pop();
+      var code = e.__type || e.code || e.Code;
+      if (code) {
+        error.code = code.split('#').pop();
       }
       if (error.code === 'RequestEntityTooLarge') {
         error.message = 'Request body must be less than 1 MB';

--- a/test/protocol/json.spec.js
+++ b/test/protocol/json.spec.js
@@ -122,8 +122,20 @@
         expect(response.error.code).to.equal('ErrorCode');
         return expect(response.data).to.equal(null);
       });
-      it('returns the full code when a # is not present', function() {
+      it('returns the full code when a # is not present using the __type attribute', function() {
         extractError('{"__type":"ErrorCode" }');
+        expect(response.error).to.be.instanceOf(Error);
+        expect(response.error.code).to.equal('ErrorCode');
+        return expect(response.data).to.equal(null);
+      });
+      it('returns the full code when a # is not present using the code attribute', function() {
+        extractError('{"code":"ErrorCode" }');
+        expect(response.error).to.be.instanceOf(Error);
+        expect(response.error.code).to.equal('ErrorCode');
+        return expect(response.data).to.equal(null);
+      });
+      it('returns the full code when a # is not present using the Code attribute', function() {
+        extractError('{"Code":"ErrorCode" }');
         expect(response.error).to.be.instanceOf(Error);
         expect(response.error.code).to.equal('ErrorCode');
         return expect(response.data).to.equal(null);


### PR DESCRIPTION
Allow the error code extraction to happen also when the body has `Code` instead of `code` as the attribute. Preference is still maintained as before. This makes it consistent with how the message is being extracted where it checks for both `message` and `Message`. This also makes it consistent with how the Go SDK processes these attributes: https://github.com/aws/aws-sdk-go/blob/6ca8a5496cb4723ad4ef1e6709ed593ea81ce000/private/protocol/restjson/unmarshal_error.go#L131-L134

Issue encountered when trying to parse a response from the Amazon Interactive Video service API, which has an error body like below

```
{
  "Code" : "SomeException",
  "Message" : "ivs.SomeException: Some message",
  "RequestID" : "some guid"
}
```

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [ ] ~`.d.ts` file is updated~
- [X] changelog is added, `npm run add-change`
- [ ] ~run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed~
- [ ] ~run `npm run integration` if integration test is changed~
- [ ] ~non-code related change (markdown/git settings etc)~
