### PR TITLE
 fix #3401: call customBackoff() only upon retryable errors

### DIFF
--- a/.changes/next-release/bugfix-lib-9b4cd6a2.json
+++ b/.changes/next-release/bugfix-lib-9b4cd6a2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "lib",
+  "description": "call customBackoff() only upon retryable errors"
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -117,7 +117,7 @@ var PromisesDependency;
  *       retry count and error and returns the amount of time to delay in
  *       milliseconds. If the result is a non-zero negative value, no further
  *       retry attempts will be made. The `base` option will be ignored if this
- *       option is supplied.
+ *       option is supplied. The function is only called for retryable errors.
  *
  * @!attribute httpOptions
  *   @return [map] A set of options to pass to the low-level HTTP request.
@@ -270,7 +270,7 @@ AWS.Config = AWS.util.inherit({
    *     retry count and error and returns the amount of time to delay in
    *     milliseconds. If the result is a non-zero negative value, no further
    *     retry attempts will be made. The `base` option will be ignored if this
-   *     option is supplied.
+   *     option is supplied. The function is only called for retryable errors.
    * @option options httpOptions [map] A set of options to pass to the low-level
    *   HTTP request. Currently supported options are:
    *

--- a/lib/util.js
+++ b/lib/util.js
@@ -873,13 +873,17 @@ var util = {
     var errCallback = function(err) {
       var maxRetries = options.maxRetries || 0;
       if (err && err.code === 'TimeoutError') err.retryable = true;
-      var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions, err);
-      if (err && err.retryable && retryCount < maxRetries && delay >= 0) {
-        retryCount++;
-        setTimeout(sendRequest, delay + (err.retryAfter || 0));
-      } else {
-        cb(err);
+
+      // Call `calculateRetryDelay()` only when relevant, see #3401
+      if (err && err.retryable && retryCount < maxRetries) {
+        var delay = util.calculateRetryDelay(retryCount, options.retryDelayOptions, err);
+        if (delay >= 0) {
+          retryCount++;
+          setTimeout(sendRequest, delay + (err.retryAfter || 0));
+          return;
+        }
       }
+      cb(err);
     };
 
     var sendRequest = function() {


### PR DESCRIPTION
This patch tries to address #3401. 

Would appreciate some quick feedback about the general direction here!


- [x] `npm run test` passes
- [ ] `.d.ts` file is updated (would love to make `err: Error` being passed to `customBackoff()` a _guarantee_, but that's maybe a follow-up
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed (not yet: waiting for initial feedback)
- [ ] run `npm run integration` if integration test is changed  (not yet: waiting for initial feedback)
- [ ] non-code related change (markdown/git settings etc)
