### PR TITLE
Add options.wrapNumbers doc in DynamoDB.DocumentClient

### DIFF
--- a/.changes/next-release/bugfix-DocumentClient-dcfcdc69.json
+++ b/.changes/next-release/bugfix-DocumentClient-dcfcdc69.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "DocumentClient",
+  "description": "Add options.wrapNumbers doc in DynamoDB.DocumentClient"
+}

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -52,6 +52,9 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *  the document client to convert empty values (0-length strings, binary
    *  buffers, and sets) to be converted to NULL types when persisting to
    *  DynamoDB.
+   * @option options wrapNumbers [Boolean] Whether to return numbers as a
+   *  NumberValue object instead of converting them to native JavaScript numbers.
+   *  This allows for the safe round-trip transport of numbers of arbitrary size.
    * @see AWS.DynamoDB.constructor
    *
    */

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -52,7 +52,7 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    *  the document client to convert empty values (0-length strings, binary
    *  buffers, and sets) to be converted to NULL types when persisting to
    *  DynamoDB.
-   * @option options wrapNumbers [Boolean] Whether to return numbers as a
+   * @option options wrapNumbers [Boolean] Set to true to return numbers as a
    *  NumberValue object instead of converting them to native JavaScript numbers.
    *  This allows for the safe round-trip transport of numbers of arbitrary size.
    * @see AWS.DynamoDB.constructor


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
options.wrapNumbers is not documented in DynamoDB.DocumentClient

Code flow:
* DynamoDB DocumentClient passes options to translator https://github.com/aws/aws-sdk-js/blob/5ae5a7d7d24d1000dbc089cc15f8ed2c7b06c542/lib/dynamodb/document_client.js#L513-L515
* Translator reads convertEmptyValues and wrapNumbers from options and passes it to Converter https://github.com/aws/aws-sdk-js/blob/5ae5a7d7d24d1000dbc089cc15f8ed2c7b06c542/lib/dynamodb/translator.js#L7-L8 https://github.com/aws/aws-sdk-js/blob/5ae5a7d7d24d1000dbc089cc15f8ed2c7b06c542/lib/dynamodb/translator.js#L26-L29
* Converter passes wrapNumbers attribute while converting Numbers https://github.com/aws/aws-sdk-js/blob/5ae5a7d7d24d1000dbc089cc15f8ed2c7b06c542/lib/dynamodb/converter.js#L151-L153 https://github.com/aws/aws-sdk-js/blob/5ae5a7d7d24d1000dbc089cc15f8ed2c7b06c542/lib/dynamodb/converter.js#L223-L225

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] non-code related change (markdown/git settings etc)
