### PR TITLE
Fix for array equality bug in the Node.js XML parser

### DIFF
--- a/.changes/next-release/bugfix-XML-c6eb8219.json
+++ b/.changes/next-release/bugfix-XML-c6eb8219.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "XML",
+  "description": "Fixed an array equality bug in the Node.js XML parser"
+}

--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -139,7 +139,7 @@ function parseUnknown(xml) {
 
   // empty object
   var keys = Object.keys(xml), i;
-  if (keys.length === 0 || keys === ['$']) {
+  if (keys.length === 0 || (keys.length === 1 && keys[0] === '$')) {
     return {};
   }
 

--- a/test/xml/parser.spec.js
+++ b/test/xml/parser.spec.js
@@ -36,6 +36,13 @@
           return expect(data).to.eql({});
         });
       });
+      it('returns an empty object from an empty document with attributes', function() {
+        var xml;
+        xml = '<xml xmlns="http://foo.bar.com"/>';
+        return parse(xml, rules, function(data) {
+          return expect(data).to.eql({});
+        });
+      });
       it('returns empty elements as empty string', function() {
         var xml;
         xml = '<xml><element/></xml>';


### PR DESCRIPTION
Array equality bug in the Node.js XML parser

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
