### PR TITLE
Re-export ConfigBase to make client-generation backwards compatible

### DIFF
--- a/.changes/next-release/bugfix-Types-3d2fd91b.json
+++ b/.changes/next-release/bugfix-Types-3d2fd91b.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Types",
+  "description": "Re-export ConfigBase on previous config typings"
+}

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -44,3 +44,6 @@ export interface APIVersions {
      */
     apiVersions?: ConfigurationServiceApiVersions;
 }
+
+// for backwards compatible client generation
+export { ConfigBase } from "./config-base";


### PR DESCRIPTION
https://github.com/aws/aws-sdk-js/commit/9bd7fdbda9929d4f259996d468de80e210a4ce78 changed the interface for generated clients. That works great as long as the client is generated with the same aws-sdk-js version as it's consumed which is generally the case since the whole aws-sdk is shipped as one package. But in case of a private aws-sdk client it will break. When the sdk version used for generation is >2.740.0 the consumer needs to have a newer version as well. And the other way round.

This change will at least keep the old interface. A client generated with <2.740.0 will be sill consumable with a newer aws-sdk but not the other way round.

Otherwise it will fail with

```
client/lib/myclient.d.ts(6,9): error TS2459: Module '"../../../aws-sdk/lib/config"' declares 'ConfigBase' locally, but it is not exported.
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [X] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
