### PR TITLE
Fix types for fetching Credentials from AWS.config

### DIFF
--- a/.changes/next-release/bugfix-Types-f4456f24.json
+++ b/.changes/next-release/bugfix-Types-f4456f24.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Types",
+  "description": "Update types for fetching credentials from config"
+}

--- a/lib/config-base.d.ts
+++ b/lib/config-base.d.ts
@@ -9,7 +9,7 @@ export class ConfigBase extends ConfigurationOptions{
     /**
      * Loads credentials from the configuration object.
      */
-    getCredentials(callback: (err: AWSError) => void): void;
+    getCredentials(callback: (err: AWSError|null, credentials: Credentials|CredentialsOptions|null) => void): void;
     /**
      * Loads configuration data from a JSON file into this config object.
      * Loading configuration will reset all existing configuration on the object.

--- a/lib/credentials.d.ts
+++ b/lib/credentials.d.ts
@@ -70,7 +70,7 @@ export class Credentials {
     sessionToken: string;
 }
 
-interface CredentialsOptions {
+export interface CredentialsOptions {
     /**
      * AWS access key ID.
      */


### PR DESCRIPTION
Making the error optional since it's only set if there is an error and
exposing optional second parameter with the actual parameter on
`getCredentials` method. That means the `CredentialsOptions` needs to be
exported as well in order to make use of it.

https://github.com/aws/aws-sdk-js/blob/master/lib/config.js#L386
<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [X] `.d.ts` file is updated
- [X] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
