### PR TITLE
Delete unused variables from credentials tests

### DIFF
--- a/.changes/next-release/bugfix-Test-43ccae7b.json
+++ b/.changes/next-release/bugfix-Test-43ccae7b.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Test",
+  "description": "Delete unused variable declarations from test"
+}

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -798,7 +798,6 @@
         credsCtorSpy = helpers.spyOn(AWS, 'SharedIniFileCredentials').andCallThrough();
         expect(creds.roleArn).to.equal('arn');
         return creds.refresh(function(err) {
-          var sourceCreds;
           expect(credsCtorSpy.calls.length).to.equal(1);
           parentCredsArg = credsCtorSpy.calls[0]['arguments'][0];
           expect(parentCredsArg.profile).to.equal('foo');
@@ -825,7 +824,6 @@
         credsCtorSpy = helpers.spyOn(AWS, 'SharedIniFileCredentials').andCallThrough();
         expect(creds.roleArn).to.equal('arn');
         return creds.refresh(function(err) {
-          var sourceCreds;
           expect(credsCtorSpy.calls.length).to.equal(1);
           parentCredsArg = credsCtorSpy.calls[0]['arguments'][0];
           expect(parentCredsArg.profile).to.equal('foo');


### PR DESCRIPTION
##### Checklist

- [X] `npm run test` passes
- [X] changelog is added, `npm run add-change`

Is there any intent or interest in improving the readability of the test code? I'm referring to things like the [long lines from single-quoted strings with line feed escapes](https://github.com/aws/aws-sdk-js/blob/3e8a7bfafbcffd1ff026a9ee45f94553ebf851f4/test/credentials.spec.js#L796), and artifacts of CoffeeScript conversion.