### PR TITLE
Update s_code script handling

### DIFF
--- a/.changes/next-release/feature-docs-3ee0e046.json
+++ b/.changes/next-release/feature-docs-3ee0e046.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "docs",
+  "description": "Update s_code Script Handling"
+}

--- a/doc-src/templates/default/layout/html/footer.erb
+++ b/doc-src/templates/default/layout/html/footer.erb
@@ -6,28 +6,3 @@
   </div>
   <div id="awsdocs-legal-zone-copyright"></div>
 </div>
-
-<!-- BEGIN-SECTION -->
-<!-- SiteCatalyst code version: H.25.2. Copyright 1996-2012 Adobe, Inc. All Rights Reserved.
-More info available at http://www.omniture.com -->
-<script type="text/javascript" src="https://a0.awsstatic.com/s_code/js/2.0/awshome_s_code.js"></script>
-<script language="JavaScript" type="text/javascript">
-  <!--
-  s.prop66='AWS SDK for JavaScript';
-  s.eVar66='D=c66';
-  s.prop65='API Reference';
-  s.eVar65='D=c65';
-  var s_code=s.t();if(s_code)document.write(s_code)
-  //-->
-</script>
-<script language="JavaScript" type="text/javascript">
-  <!--if(navigator.appVersion.indexOf('MSIE')>=0)document.write(unescape('%3C')+'\!-'+'-')
-  //-->
-</script>
-<script type="text/javascript" src="/assets/js/awsdocs-boot.js" defer></script>
-<noscript>
-  <img src="http://amazonwebservices.d2.sc.omtrdc.net/b/ss/awsamazondev/1/H.25.2--NS/0" height="1" width="1" border="0" alt="">
-</noscript>
-<!--/DO NOT REMOVE/-->
-<!-- End SiteCatalyst code version: H.25.2. -->
-<!-- END-SECTION -->

--- a/doc-src/templates/default/layout/html/layout.erb
+++ b/doc-src/templates/default/layout/html/layout.erb
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="guide-name" content="API Reference">
+    <meta name="service-name" content="AWS SDK for JavaScript">
+    <script type="text/javascript" src="/assets/js/awsdocs-boot.js"></script>
     <%= erb(:headers) %>
   </head>
   <body>


### PR DESCRIPTION
Internal issue JS-2070

### Testing
* Verified locally that legal zone links appear in footer
  <details>
  <summary>Screenshot</summary>

  ![verify_legal_zone_links](https://user-images.githubusercontent.com/16024985/94887573-8ec03c80-042b-11eb-90fc-4c8e0c6911e6.png)

  </details>
* Verified locally that script `https://a0.awsstatic.com/s_code/js/3.0/awshome_s_code.js` gets added after the page load
  <details>
  <summary>Screenshot</summary>

  ![verify_s_code_inclusion](https://user-images.githubusercontent.com/16024985/94887655-c3cc8f00-042b-11eb-92c1-af8b88c33e83.png)

  </details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed