### PR TITLE
Adds name to all CredentialProviderChain default providers in node_loadr

### DIFF
--- a/.changes/next-release/feature-CredentialProviderChain-be037bf6.json
+++ b/.changes/next-release/feature-CredentialProviderChain-be037bf6.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CredentialProviderChain",
+  "description": "Names all default functions in the node_loader"
+}

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -60,13 +60,41 @@ require('./credentials/process_credentials');
 // AWS.CredentialProviderChain.defaultProviders in
 // credentials/credential_provider_chain.js
 AWS.CredentialProviderChain.defaultProviders = [
-  function () { return new AWS.EnvironmentCredentials('AWS'); },
-  function () { return new AWS.EnvironmentCredentials('AMAZON'); },
-  function () { return new AWS.SharedIniFileCredentials(); },
-  function () { return new AWS.ECSCredentials(); },
-  function () { return new AWS.ProcessCredentials(); },
-  function () { return new AWS.TokenFileWebIdentityCredentials(); },
-  function () { return new AWS.EC2MetadataCredentials(); }
+  Object.defineProperty(
+    function () { return new AWS.EnvironmentCredentials('AWS'); },
+    'name',
+    { value: 'AWS.EnvironmentCredentials(\'AWS\')' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.EnvironmentCredentials('AMAZON'); },
+    'name',
+    { value: 'AWS.EnvironmentCredentials(\'AMAZON\')' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.SharedIniFileCredentials(); },
+    'name',
+    { value: 'AWS.SharedIniFileCredentials()' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.ECSCredentials(); },
+    'name',
+    { value: 'AWS.ECSCredentials()' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.ProcessCredentials(); },
+    'name',
+    { value: 'AWS.ProcessCredentials()' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.TokenFileWebIdentityCredentials(); },
+    'name',
+    { value: 'AWS.TokenFileWebIdentityCredentials()' }
+  ),
+  Object.defineProperty(
+    function () { return new AWS.EC2MetadataCredentials(); },
+    'name',
+    { value: 'AWS.EC2MetadataCredentials()' }
+  )
 ];
 
 // Update configuration keys

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -60,41 +60,13 @@ require('./credentials/process_credentials');
 // AWS.CredentialProviderChain.defaultProviders in
 // credentials/credential_provider_chain.js
 AWS.CredentialProviderChain.defaultProviders = [
-  Object.defineProperty(
-    function () { return new AWS.EnvironmentCredentials('AWS'); },
-    'name',
-    { value: 'AWS.EnvironmentCredentials(\'AWS\')' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.EnvironmentCredentials('AMAZON'); },
-    'name',
-    { value: 'AWS.EnvironmentCredentials(\'AMAZON\')' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.SharedIniFileCredentials(); },
-    'name',
-    { value: 'AWS.SharedIniFileCredentials()' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.ECSCredentials(); },
-    'name',
-    { value: 'AWS.ECSCredentials()' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.ProcessCredentials(); },
-    'name',
-    { value: 'AWS.ProcessCredentials()' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.TokenFileWebIdentityCredentials(); },
-    'name',
-    { value: 'AWS.TokenFileWebIdentityCredentials()' }
-  ),
-  Object.defineProperty(
-    function () { return new AWS.EC2MetadataCredentials(); },
-    'name',
-    { value: 'AWS.EC2MetadataCredentials()' }
-  )
+  function EnvironmentCredentialsAWS () { return new AWS.EnvironmentCredentials('AWS'); },
+  function EnvironmentCredentialsAMAZON () { return new AWS.EnvironmentCredentials('AMAZON'); },
+  function SharedIniFileCredentials () { return new AWS.SharedIniFileCredentials(); },
+  function ECSCredentials () { return new AWS.ECSCredentials(); },
+  function ProcessCredentials () { return new AWS.ProcessCredentials(); },
+  function TokenFileWebIdentityCredentials () { return new AWS.TokenFileWebIdentityCredentials(); },
+  function EC2MetadataCredentials () { return new AWS.EC2MetadataCredentials(); }
 ];
 
 // Update configuration keys

--- a/test/node_loader.spec.js
+++ b/test/node_loader.spec.js
@@ -4,16 +4,17 @@ const AWS = require('../lib/node_loader');
 describe('node_loader', () => {
   describe('AWS.CredentialProviderChain', () => {
     it('initiates providers with named functions', () => {
+      console.log(AWS.CredentialProviderChain.defaultProviders)
       expect(
         AWS.CredentialProviderChain.defaultProviders.map((fn) => fn.name)
       ).to.eql([
-          'AWS.EnvironmentCredentials(\'AWS\')',
-          'AWS.EnvironmentCredentials(\'AMAZON\')',
-          'AWS.SharedIniFileCredentials()',
-          'AWS.ECSCredentials()',
-          'AWS.ProcessCredentials()',
-          'AWS.TokenFileWebIdentityCredentials()',
-          'AWS.EC2MetadataCredentials()'
+          'EnvironmentCredentialsAWS',
+          'EnvironmentCredentialsAMAZON',
+          'SharedIniFileCredentials',
+          'ECSCredentials',
+          'ProcessCredentials',
+          'TokenFileWebIdentityCredentials',
+          'EC2MetadataCredentials'
       ]);
     });
   });

--- a/test/node_loader.spec.js
+++ b/test/node_loader.spec.js
@@ -1,12 +1,13 @@
 require('./helpers');
 const AWS = require('../lib/node_loader');
 
-describe('node_loader', () => {
-  describe('AWS.CredentialProviderChain', () => {
-    it('initiates providers with named functions', () => {
-      console.log(AWS.CredentialProviderChain.defaultProviders)
+describe('node_loader', function () {
+  describe('AWS.CredentialProviderChain', function () {
+    it('initiates providers with named functions', function () {
       expect(
-        AWS.CredentialProviderChain.defaultProviders.map((fn) => fn.name)
+        AWS.CredentialProviderChain.defaultProviders.map(function (fn) {
+          return fn.name;
+        })
       ).to.eql([
           'EnvironmentCredentialsAWS',
           'EnvironmentCredentialsAMAZON',

--- a/test/node_loader.spec.js
+++ b/test/node_loader.spec.js
@@ -1,0 +1,20 @@
+require('./helpers');
+const AWS = require('../lib/node_loader');
+
+describe('node_loader', () => {
+  describe('AWS.CredentialProviderChain', () => {
+    it('initiates providers with named functions', () => {
+      expect(
+        AWS.CredentialProviderChain.defaultProviders.map((fn) => fn.name)
+      ).to.eql([
+          'AWS.EnvironmentCredentials(\'AWS\')',
+          'AWS.EnvironmentCredentials(\'AMAZON\')',
+          'AWS.SharedIniFileCredentials()',
+          'AWS.ECSCredentials()',
+          'AWS.ProcessCredentials()',
+          'AWS.TokenFileWebIdentityCredentials()',
+          'AWS.EC2MetadataCredentials()'
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

While debugging some auth issues I've noticed the functions set in the CredentialProviderChain were anonymous, making it harder to debug and understand the chain. Loggin the providers (`AWS.config.credentialProvider.providers`) one would see:

```
[
  [Function],
  [Function],
  [Function],
  [Function],
  [Function],
  [Function],
  [Function]
]
```

Sure, it's easy to simply map these with a `toString`, therefore getting:

```
[
  "function () { return new AWS.EnvironmentCredentials('AWS'); }",
  "function () { return new AWS.EnvironmentCredentials('AMAZON'); }",
  'function () { return new AWS.SharedIniFileCredentials(); }',
  'function () { return new AWS.ECSCredentials(); }',
  'function () { return new AWS.ProcessCredentials(); }',
  'function () { return new AWS.TokenFileWebIdentityCredentials(); }',
  'function () { return new AWS.EC2MetadataCredentials(); }'
]
```

These are quite easy to read, but that's just because the function's content is quite trivial. Having a proper name would not depend on that while also not requiring people to inspect with toString, improving the API's transparency and understanding to developers.

With this change the simple log will look like:

```
[
  [Function: EnvironmentCredentialsAWS],
  [Function: EnvironmentCredentialsAMAZON],
  [Function: SharedIniFileCredentials],
  [Function: ECSCredentials],
  [Function: ProcessCredentials],
  [Function: TokenFileWebIdentityCredentials],
  [Function: EC2MetadataCredentials]
]
```

Better name could be set by using `Object.defineProperty(fn, "name", value: "Better names")`, but this fails in the pipeline for nodes < 4.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
