### PR TITLE
Fix: do not require credentials when using config file

### DIFF
--- a/.changes/next-release/bugfix-Credentials-d9f9a3b7.json
+++ b/.changes/next-release/bugfix-Credentials-d9f9a3b7.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Do not require credentials file when loading from config."
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -966,10 +966,16 @@ var util = {
         filename: process.env[util.sharedConfigFileEnv]
       });
     }
-    var profilesFromCreds = iniLoader.loadFrom({
-      filename: filename ||
-        (process.env[util.configOptInEnv] && process.env[util.sharedCredentialsFileEnv])
-    });
+    var profilesFromCreds= {};
+    try {
+      var profilesFromCreds = iniLoader.loadFrom({
+        filename: filename ||
+          (process.env[util.configOptInEnv] && process.env[util.sharedCredentialsFileEnv])
+      });
+    } catch (error) {
+      // if using config, assume it is fully descriptive without a credentials file:
+      if (!process.env[util.configOptInEnv]) throw error;
+    }
     for (var i = 0, profileNames = Object.keys(profilesFromConfig); i < profileNames.length; i++) {
       profiles[profileNames[i]] = objectAssign(profiles[profileNames[i]] || {}, profilesFromConfig[profileNames[i]]);
     }

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -358,6 +358,22 @@
           validateCredentials(creds);
           return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/);
         });
+        it('does not require ~/.aws/credentials if AWS_SDK_LOAD_CONFIG is set', function() {
+          var creds, mock;
+          process.env.AWS_SDK_LOAD_CONFIG = '1';
+          mock = '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session';
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake(function(path) {
+            if (path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]credentials/)) {
+              throw new Error('ENOENT: no such file or directory');
+            } else {
+              return '[default]\naws_access_key_id = akid\naws_secret_access_key = secret\naws_session_token = session';
+            }
+          });
+          creds = new AWS.SharedIniFileCredentials();
+          creds.get();
+          validateCredentials(creds);
+          return expect(AWS.util.readFileSync.calls[0]['arguments'][0]).to.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/);
+        });
         it('prefers credentials from ~/.aws/credentials if AWS_SDK_LOAD_CONFIG is set', function() {
           var creds;
           process.env.AWS_SDK_LOAD_CONFIG = '1';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Resolves #3436 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] ~`.d.ts` file is updated~
- [x] changelog is added, `npm run add-change`
- [ ] ~run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed~
- [ ] ~run `npm run integration` if integration test is changed~
- [ ] ~non-code related change (markdown/git settings etc)~
