### PR TITLE
Allow types for HttpRequest.body to be either a string or a buffer

### DIFF
--- a/.changes/next-release/bugfix-HttpRequest-0e36296c.json
+++ b/.changes/next-release/bugfix-HttpRequest-0e36296c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "HttpRequest",
+  "description": "Allows request body to be either a string or a buffer"
+}

--- a/lib/http_request.d.ts
+++ b/lib/http_request.d.ts
@@ -18,7 +18,7 @@ export class HttpRequest {
     /**
      * The request body payload.
      */
-    body: string;
+    body: string | Buffer;
     /**
      * The endpoint for the request.
      */

--- a/ts/request.ts
+++ b/ts/request.ts
@@ -19,6 +19,11 @@ request.on('error', function(err, response) {
 
 });
 request.on('build', function(request) {
+    // test body as string
+    request.httpRequest.body = 'Hello'
+    // test body as buffer
+    request.httpRequest.body = Buffer.from('Hello')
+
     console.log(request.httpRequest.method);
 });
 request.on('complete', function(response) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This PR adds typescript support for HttpRequest body as a string or buffer. This became apparent to me when working on sending a gzipped buffer body. The [typescript](https://github.com/aws/aws-sdk-js/blob/14e9bf0abab009e2f34f11623949375b7bd07d2a/lib/http_request.d.ts#L21) types, which allow for string only, need to be in sync with the [javascript](https://github.com/aws/aws-sdk-js/blob/14e9bf0abab009e2f34f11623949375b7bd07d2a/lib/http/node.js#L115-L142) source code, which allows for either a string or buffer.

This was brought up in a tangential comment to this issue: https://github.com/aws/aws-sdk-js/issues/2855#issuecomment-713710117

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `npm run tstest` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`

