### PR TITLE
Fix typings for credentials provider chain

### DIFF
--- a/.changes/next-release/bugfix-Types-7306bc23.json
+++ b/.changes/next-release/bugfix-Types-7306bc23.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Types",
+  "description": "Update types for credential provider chain"
+}

--- a/lib/credentials/credential_provider_chain.d.ts
+++ b/lib/credentials/credential_provider_chain.d.ts
@@ -8,7 +8,7 @@ export class CredentialProviderChain {
     /**
      * Resolves the provider chain by searching for the first set of credentials in providers.
      */
-    resolve(callback:(err: AWSError, credentials: Credentials) => void): CredentialProviderChain;
+    resolve(callback:(err: AWSError|null, credentials?: Credentials) => void): CredentialProviderChain;
     /**
      * Return a Promise on resolve() function
      */
@@ -16,7 +16,7 @@ export class CredentialProviderChain {
     /**
      * Returns a list of credentials objects or functions that return credentials objects. If the provider is a function, the function will be executed lazily when the provider needs to be checked for valid credentials. By default, this object will be set to the defaultProviders.
      */
-    providers: Credentials[]|provider[];
+    providers: Array<Credentials|provider>;
 
     static defaultProviders: provider[]
 }


### PR DESCRIPTION
`Credentials[]|providers[]` means either an array with `Credentials` or
an array with `providers`. But in reality it's a array with both.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] `.d.ts` file is updated
- [X] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
