### PR TITLE
Fixes Request onAsync() listener types by adding doneCallback()

### DIFF
--- a/.changes/next-release/bugfix-Request-ba6e1274.json
+++ b/.changes/next-release/bugfix-Request-ba6e1274.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Request",
+  "description": "Fixes Request onAsync() listener types by adding doneCallback()"
+}

--- a/lib/request.d.ts
+++ b/lib/request.d.ts
@@ -54,7 +54,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request is being validated.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    on(event: "validate", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    on(event: "validate", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when the request payload is being built.
      *
@@ -62,7 +62,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request's payload is being built.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    on(event: "build", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    on(event: "build", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when a request is being signed.
      *
@@ -70,7 +70,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request is being signed.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    on(event: "sign", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    on(event: "sign", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when a request is ready to be sent.
      *
@@ -190,7 +190,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request is being validated.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    onAsync(event: "validate", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    onAsync(event: "validate", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when the request payload is being built.
      *
@@ -198,7 +198,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request's payload is being built.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    onAsync(event: "build", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    onAsync(event: "build", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when a request is being signed.
      *
@@ -206,7 +206,7 @@ export class Request<D, E> {
      * @param {function} listener - Callback to run when the request is being signed.
      * @param {boolean} prepend - If set, prepends listener instead of appending.
      */
-    onAsync(event: "sign", listener: (request: Request<D, E>) => void, prepend?: boolean): Request<D, E>;
+    onAsync(event: "sign", listener: (request: Request<D, E>, doneCallback?: () => void) => void, prepend?: boolean): Request<D, E>;
     /**
      * Adds a listener that is triggered when a request is ready to be sent.
      *

--- a/ts/request.ts
+++ b/ts/request.ts
@@ -18,6 +18,10 @@ request.send(function(err, data) {
 request.on('error', function(err, response) {
 
 });
+request.onAsync('validate', function(request, done) {
+  console.log(request.httpRequest.body);
+  if (done) done()
+})
 request.on('build', function(request) {
     console.log(request.httpRequest.method);
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This PR adds typing for the second `doneCallback()` argument for request `onAsync()` event listener callbacks. The issue is described in more detail here: https://github.com/aws/aws-sdk-js/issues/2855

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `npm run tstest` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`

