### PR TITLE
Fix typings for AWSError

### DIFF
--- a/.changes/next-release/bugfix-Types-3007af51.json
+++ b/.changes/next-release/bugfix-Types-3007af51.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Types",
+  "description": "Fix type of AWSError"
+}

--- a/lib/error.d.ts
+++ b/lib/error.d.ts
@@ -1,7 +1,7 @@
 /**
  * A structure containing information about a service or networking error.
  */
-export class AWSError extends Error {
+export type AWSError = Error & {
     /**
      * A unique short code representing the error that was emitted.
      */
@@ -13,11 +13,11 @@ export class AWSError extends Error {
     /**
      * Whether the error message is retryable.
      */
-    retryable: boolean;
+    retryable?: boolean;
     /**
      * In the case of a request that reached the service, this value contains the response status code.
      */
-    statusCode: number;
+    statusCode?: number;
     /**
      * The date time object when the error occurred.
      */
@@ -25,25 +25,29 @@ export class AWSError extends Error {
     /**
      * Set when a networking error occurs to easily identify the endpoint of the request.
      */
-    hostname: string;
+    hostname?: string;
     /**
      * Set when a networking error occurs to easily identify the region of the request.
      */
-    region: string;
+    region?: string;
     /**
      * Amount of time (in seconds) that the request waited before being resent.
      */
-    retryDelay: number;
+    retryDelay?: number;
     /**
      * The unique request ID associated with the response.
      */
-    requestId: string;
+    requestId?: string;
     /**
      * Second request ID associated with the response from S3.
      */
-    extendedRequestId: string;
+    extendedRequestId?: string;
     /**
      * CloudFront request ID associated with the response.
      */
-    cfId: string;
+    cfId?: string;
+    /**
+     * The original error which caused this Error
+     */
+    originalError?: Error
 }


### PR DESCRIPTION
AWSError is not a class. It's based on Error but with additional properties on top:

https://github.com/aws/aws-sdk-js/blob/master/lib/util.js#L570-L603

By wrongly declaring a class statements like `if (error instanceof AWSError)` would compile but during runtime `AWSError` is `undefined` since it's just a type. Fixing the types prevents this issue. In addition many properties are optional. Declaring them as required can cause type errors and makes mocking more difficult.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm run test` passes
- [X] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
