### PR TITLE
Update NodeJS versions in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "6"
   - "8"
   - "10"
+  - "12"
+  - "14"
 script:
   - npm run coverage


### PR DESCRIPTION
Everything older than NodeJS 10 is deprecated according to https://nodejs.org/en/about/releases/

In addition I added 12 and 14 as the current active LTS versions.

The travis build takes ages. I hope by dropping the ancient node versions it could make it faster.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
