### PR TITLE
Fix createPresignedPost dual-callback error

### DIFF
--- a/.changes/next-release/bugfix-S3-9d19dd09.json
+++ b/.changes/next-release/bugfix-S3-9d19dd09.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "fixed a bug where createPresignedPost could result in a process crash."
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -1079,9 +1079,13 @@ AWS.util.update(AWS.S3.prototype, {
       config.getCredentials(function (err) {
         if (err) {
           callback(err);
+        } else {
+          try {
+            callback(null, finalizePost());
+          } catch (err) {
+            callback(err);
+          }
         }
-
-        callback(null, finalizePost());
       });
     } else {
       return finalizePost();


### PR DESCRIPTION
This fixes a bug where using the callback version of createPresignedPost without proper AWS credentials configured would result in an un-catchable error and crash the node process.

Note: as discussed in #3486, I was not able to figure out a way to write a test to capture this error due to the nature of the error.  In the original code, the callback is called correctly at first, and only after that does the crash occur (when the callback is called a second time).

Resolves #3486

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
