### PR TITLE
fix: cloudwatch logs integ test doesn't page log groups properly

### DIFF
--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -11,7 +11,7 @@ module.exports = function() {
   });
 
   this.Given(/^I list the CloudWatch logGroups$/, function (callback) {
-    this.request(null, 'describeLogGroups', {}, callback);
+    this.request(null, 'describeLogGroups', {logGroupNamePrefix: this.logGroupName}, callback);
   });
 
   this.Then(/^the list should contain the CloudWatch logGroup$/, function (callback) {


### PR DESCRIPTION
Cloudwatch integration test fails if we have too many logs due to not paging the response correctly. 

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
