### PR TITLE
fix: test IAM.getUser instead of listUsers

### DIFF
--- a/features/iam/iam.feature
+++ b/features/iam/iam.feature
@@ -7,8 +7,8 @@ Feature: IAM
   Scenario: Users
     Given I have an IAM username "js-test"
     And I create an IAM user with the username
-    And I list the IAM users
-    Then the list should contain the user
+    And I get the IAM user
+    Then the IAM user should exist
     And I delete the IAM user
 
   Scenario: Roles

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -21,15 +21,12 @@ module.exports = function() {
     this.request('iam', 'createUser', {UserName: this.iamUser}, next, false);
   });
 
-  this.Given(/^I list the IAM users$/, function(callback) {
-    this.request('iam', 'listUsers', {}, callback);
+  this.Given(/^I get the IAM user$/, function(callback) {
+    this.request('iam', 'getUser', {UserName: this.iamUser}, callback);
   });
 
-  this.Then(/^the list should contain the user$/, function(callback) {
-    var name = this.iamUser;
-    this.assert.contains(this.data.Users, function(user) {
-      return user.UserName === name;
-    });
+  this.Then(/^the IAM user should exist$/, function(callback) {
+    this.assert.equal(this.data.User.UserName, this.iamUser);
     callback();
   });
 


### PR DESCRIPTION
The test fails if there are more than 100 users, as it parses users from
first page of results. This code change explicitly requests for the created user
to ensure it doesn't return pages of results.

##### Testing

```console
$ npm run integration -- --tags @iam

> aws-sdk@2.797.0 integration /Users/trivikr/workspace/aws-sdk-js
> cucumber.js "--tags" "@iam"

@iam
Feature: IAM

  I want to use IAM


  Scenario: Users                              # features/iam/iam.feature:7
    Given I have an IAM username "js-test"     # features/iam/iam.feature:8
    And I create an IAM user with the username # features/iam/iam.feature:9
    And I get the IAM user                     # features/iam/iam.feature:10
    Then the IAM user should exist             # features/iam/iam.feature:11
    And I delete the IAM user                  # features/iam/iam.feature:12


  Scenario: Roles                                            # features/iam/iam.feature:14
    Given I create an IAM role with name prefix "aws-sdk-js" # features/iam/iam.feature:15
    Then the IAM role should exist                           # features/iam/iam.feature:16
    And I delete the IAM role                                # features/iam/iam.feature:17


  Scenario: Error handling                              # features/iam/iam.feature:19
    Given I have an IAM username "js-test-dupe"         # features/iam/iam.feature:20
    And I create an IAM user with the username          # features/iam/iam.feature:21
    And I create an IAM user with the username          # features/iam/iam.feature:22
    Then the error code should be "EntityAlreadyExists" # features/iam/iam.feature:23
    And I delete the IAM user                           # features/iam/iam.feature:24


3 scenarios (3 passed)
13 steps (13 passed)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `npm run integration` if integration test is changed
