### PR TITLE
Allow core-only loading (no service classes loading)

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -1,6 +1,5 @@
-require('./node_loader');
-
-var AWS = require('./core');
+// Load core-only
+var AWS = require('./aws_core_loader');
 
 // Load all service classes
 require('../clients/all');

--- a/lib/aws_core_loader.js
+++ b/lib/aws_core_loader.js
@@ -1,0 +1,8 @@
+require('./node_loader');
+
+var AWS = require('./core');
+
+/**
+ * @api private
+ */
+module.exports = AWS;

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -1,0 +1,19 @@
+(function() {
+  var AWS;
+
+  if (typeof window === 'undefined') {
+    AWS = require('../lib/aws_core_loader');
+  } else {
+    AWS = window.AWS;
+  }
+
+  describe('Loading only core and util, no services', function() {
+    describe('AWS.Endpoint', function() {
+      it('can construct', function() {
+        const endpoint = new AWS.Endpoint('http://localhost');
+        return expect(endpoint.host).to.equal('localhost');
+      });
+    });
+  });
+
+}).call(this);


### PR DESCRIPTION
This PR closes #3544 .
Users will be able to load "core" modules with no service classes.
This would be helpful for minimizing bundle by tree shaking.

```js
const coreOnlyAWS = require('aws-sdk/aws_core_loader');
const endpoint = new coreOnlyAWS.Endpoint('http://localhost');
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
