### PR TITLE
Add repo-sync GitHub Action to sync with mirror

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -21,5 +21,5 @@ jobs:
       name: Create pull request
       with:
         source_branch: ${{ secrets.INTERMEDIATE_BRANCH }}
-        destination_branch: main
+        destination_branch: master
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,25 @@
+name: Repo Sync
+
+on:
+  schedule: 
+  - cron: "0 0 * * *"
+
+jobs:
+  repo-sync:
+    name: Repo Sync
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: repo-sync/github-sync@v2
+      name: Sync repo to branch
+      with:
+        source_repo: ${{ secrets.SOURCE_REPO }}
+        source_branch: master
+        destination_branch: ${{ secrets.INTERMEDIATE_BRANCH }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: repo-sync/pull-request@v2
+      name: Create pull request
+      with:
+        source_branch: ${{ secrets.INTERMEDIATE_BRANCH }}
+        destination_branch: main
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This Action is used to keep aws/aws-sdk-js in sync with it's private mirror.
It can also be used to keep forks in sync.

Docs: https://github.com/repo-sync/repo-sync

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
