### PR TITLE
add notification of V3 GA in API reference header

### DIFF
--- a/doc-src/templates/default/layout/html/layout.erb
+++ b/doc-src/templates/default/layout/html/layout.erb
@@ -22,6 +22,7 @@
       <iframe id="search_frame"></iframe>
 
       <div id="content">
+        <%= erb(:v3note) %>
         <!--REGION_DISCLAIMER_DO_NOT_REMOVE-->
         <%= yieldall %>
       </div>

--- a/doc-src/templates/default/layout/html/v3note.erb
+++ b/doc-src/templates/default/layout/html/v3note.erb
@@ -1,5 +1,5 @@
 <div class="note">
-  <p><strong>Note:</strong> You are viewing the documentation for an older major version of the JS SDK (v2).</p>
-  <p><a href="https://github.com/aws/aws-sdk-js-v3">JS SDK v3</a> is now General Available. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/">Developer Guide</a>
+  <p><strong>Note:</strong> You are viewing the documentation for an older major version of the AWS SDK for JavaScript (v2).</p>
+  <p><a href="https://github.com/aws/aws-sdk-js-v3">The modular AWS SDK for JavaScript (v3)</a> is now General Available. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/">Developer Guide</a>
   or <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference</a>.</p>
 </div>

--- a/doc-src/templates/default/layout/html/v3note.erb
+++ b/doc-src/templates/default/layout/html/v3note.erb
@@ -1,0 +1,5 @@
+<div class="note">
+  <p><strong>Note:</strong> You are viewing the documentation for an older major version of the JS SDK (v2).</p>
+  <p><a href="https://github.com/aws/aws-sdk-js-v3">JS SDK v3</a> is now General Available. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/">Developer Guide</a>
+  or <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference</a>.</p>
+</div>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Added a notification to the API reference stating v3 SDK is available.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)

![Screen Shot 2021-01-27 at 11 52 42 PM](https://user-images.githubusercontent.com/7614947/106176741-8e6f4e00-614c-11eb-9f21-2ddbdfc5067f.png)



