### PR TITLE
fix content type header for lex model v2

### DIFF
--- a/.changes/next-release/bugfix-Lex Models V2-eca422d9.json
+++ b/.changes/next-release/bugfix-Lex Models V2-eca422d9.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "Lex Models V2",
-  "description": "Lex Models V2 service requires Content-Type header to be application/x-amz-json-1.1 other than other normal rest-json services"
+  "description": "Lex Models V2 service requires Content-Type header to be application/x-amz-json-1.1"
 }

--- a/.changes/next-release/bugfix-Lex Models V2-eca422d9.json
+++ b/.changes/next-release/bugfix-Lex Models V2-eca422d9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Lex Models V2",
+  "description": "Lex Models V2 service requires Content-Type header to be application/x-amz-json-1.1 other than other normal rest-json services"
+}

--- a/clients/lexmodelsv2.js
+++ b/clients/lexmodelsv2.js
@@ -5,6 +5,7 @@ var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lexmodelsv2'] = {};
 AWS.LexModelsV2 = Service.defineService('lexmodelsv2', ['2020-08-07']);
+require('../lib/services/lexmodelsv2');
 Object.defineProperty(apiLoader.services['lexmodelsv2'], '2020-08-07', {
   get: function get() {
     var model = require('../apis/models.lex.v2-2020-08-07.min.json');

--- a/lib/services/lexmodelsv2.js
+++ b/lib/services/lexmodelsv2.js
@@ -1,0 +1,23 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.LexModelsV2.prototype, {
+  /**
+   * @api private
+   */
+  setupRequestListeners: function setupRequestListeners(request) {
+    request.addListener('build', this.modifyContentType);
+  },
+
+  /**
+   * Normally rest-json services require `Content-Type` header to be 'application/json',
+   * However Lex Model V2 services requires the header to be 'application/x-amz-json-1.1'.
+   *
+   * @api private
+   */
+  modifyContentType: function modifyContentType(request) {
+    if (request.httpRequest.headers['Content-Type'] === 'application/json') {
+      request.httpRequest.headers['Content-Type'] = 'application/x-amz-json-1.1';
+    }
+  }
+});
+

--- a/test/services/lexmodelsv2.spec.js
+++ b/test/services/lexmodelsv2.spec.js
@@ -1,0 +1,16 @@
+var helpers = require('../helpers');
+var AWS = helpers.AWS;
+
+describe('AWS.LexModelsV2', function() {
+  var lexmodelsv2 = null;
+  beforeEach(function() {
+    lexmodelsv2 = new AWS.LexModelsV2();
+  });
+
+  it('should set Content-Type header to application/x-amz-json-1.1', function () {
+    helpers.mockHttpResponse(200, {}, '');
+    req = lexmodelsv2.listBots();
+    req.build();
+    return expect(req.httpRequest.headers['Content-Type']).to.equal('application/x-amz-json-1.1');
+  });
+});


### PR DESCRIPTION
Lex Models V2 service requires Content-Type header to be `application/x-amz-json-1.1` other than other normal rest-json services, it's `application/json`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`