### PR TITLE
Make sure credential process inherit environment variables from parent

### DIFF
--- a/lib/credentials/process_credentials.js
+++ b/lib/credentials/process_credentials.js
@@ -116,7 +116,7 @@ AWS.ProcessCredentials = AWS.util.inherit(AWS.Credentials, {
   * @throws ProcessCredentialsProviderFailure
   */
   loadViaCredentialProcess: function loadViaCredentialProcess(profile, callback) {
-    proc.exec(profile['credential_process'], function(err, stdOut, stdErr) {
+    proc.exec(profile['credential_process'], { env: process.env }, function(err, stdOut, stdErr) {
       if (err) {
         callback(AWS.util.error(
           new Error('credential_process returned error'),

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -653,7 +653,7 @@
           futureExpiration = AWS.util.date.unixTimestamp() + 900;
           futureExpiration = AWS.util.date.iso8601(new Date(futureExpiration * 1000));
           mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": "' + futureExpiration + '"}';
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, _, cb) {
             cb(undefined, mockProcess, undefined);
           });
           creds = new AWS.ProcessCredentials();

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -576,7 +576,7 @@
           mockConfig = '[default]\ncredential_process=federated_cli_mock';
           helpers.spyOn(AWS.util, 'readFileSync').andReturn(mockConfig);
           mockProcess = '{"Version": 1,"AccessKeyId": "akid","SecretAccessKey": "secret","SessionToken": "session","Expiration": ""}';
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, _, cb) {
             cb(undefined, mockProcess, undefined);
           });
         });
@@ -608,7 +608,7 @@
         it('throws error if version is not 1', function(done) {
           var child_process = require('child_process');
           mockProcess = '{"Version": 2,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": ""}';
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, _, cb) {
             cb(undefined, mockProcess, undefined);
           });
           var creds = new AWS.ProcessCredentials();
@@ -623,7 +623,7 @@
           var expired;
           expired = AWS.util.date.iso8601(new Date(0));
           mockProcess = '{"Version": 1,"AccessKeyId": "xxx","SecretAccessKey": "yyy","SessionToken": "zzz","Expiration": "' + expired +'"}';
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, _, cb) {
             cb(undefined, mockProcess, undefined);
           });
           var creds = new AWS.ProcessCredentials();
@@ -637,7 +637,7 @@
           var child_process = require('child_process');
           var mockErr;
           mockErr = 'foo Error';
-          helpers.spyOn(child_process, 'exec').andCallFake(function (_, cb) {
+          helpers.spyOn(child_process, 'exec').andCallFake(function (_, _, cb) {
             cb(mockErr, undefined, undefined);
           });
           var creds = new AWS.ProcessCredentials();


### PR DESCRIPTION
Credential process needs to inherit the environment variables from parent process.

##### Checklist

- [x] `npm run test` passes
