### PR TITLE
handle 'continue' event only once

### DIFF
--- a/.changes/next-release/bugfix-s3-a986db56.json
+++ b/.changes/next-release/bugfix-s3-a986db56.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "handle 'continue' event only once"
+}

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -98,7 +98,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
 
     var expect = httpRequest.headers.Expect || httpRequest.headers.expect;
     if (expect === '100-continue') {
-      stream.on('continue', function() {
+      stream.once('continue', function() {
         self.writeBody(stream, httpRequest);
       });
     } else {


### PR DESCRIPTION
Linode Object Storage sends multiple '100 continue' lines as a response
to 'Expect: 100-continue'. This causes node.js to parse the response
correctly and fire the 'continue' event twice.

See also #3404

##### Checklist

- [X] `npm run test` passes - 2 tests fail but they are failing even without this change
- [X] changelog is added, `npm run add-change`

