### PR TITLE
fix: adding lookout metrics content header updates

### DIFF
--- a/.changes/next-release/bugfix-Lookout Metrics-00fddba1.json
+++ b/.changes/next-release/bugfix-Lookout Metrics-00fddba1.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Lookout Metrics",
+  "description": "Update Lookout Metrics to set Content-Type header to be application/x-amz-json-1.1"
+}

--- a/clients/lookoutmetrics.js
+++ b/clients/lookoutmetrics.js
@@ -5,6 +5,7 @@ var apiLoader = AWS.apiLoader;
 
 apiLoader.services['lookoutmetrics'] = {};
 AWS.LookoutMetrics = Service.defineService('lookoutmetrics', ['2017-07-25']);
+require('../lib/services/lookoutmetrics');
 Object.defineProperty(apiLoader.services['lookoutmetrics'], '2017-07-25', {
   get: function get() {
     var model = require('../apis/lookoutmetrics-2017-07-25.min.json');

--- a/lib/services/lookoutmetrics.js
+++ b/lib/services/lookoutmetrics.js
@@ -1,0 +1,22 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.LookoutMetrics.prototype, {
+  /**
+   * @api private
+   */
+  setupRequestListeners: function setupRequestListeners(request) {
+    request.addListener('build', this.modifyContentType);
+  },
+
+  /**
+   * Normally rest-json services require `Content-Type` header to be 'application/json',
+   * However lookout metrics services requires the header to be 'application/x-amz-json-1.1'.
+   *
+   * @api private
+   */
+  modifyContentType: function modifyContentType(request) {
+    if (request.httpRequest.headers['Content-Type'] === 'application/json') {
+      request.httpRequest.headers['Content-Type'] = 'application/x-amz-json-1.1';
+    }
+  }
+});

--- a/test/services/lookoutmetrics.spec.js
+++ b/test/services/lookoutmetrics.spec.js
@@ -1,0 +1,16 @@
+var helpers = require('../helpers');
+var AWS = helpers.AWS;
+
+describe('AWS.LookoutMetrics', function() {
+  var lookoutmetrics = null;
+  beforeEach(function() {
+    lookoutmetrics = new AWS.LookoutMetrics();
+  });
+
+  it('should set Content-Type header to application/x-amz-json-1.1', function () {
+    helpers.mockHttpResponse(200, {}, '');
+    req = lookoutmetrics.listAnomalyDetectors({ MaxResults: 10 });
+    req.build();
+    return expect(req.httpRequest.headers['Content-Type']).to.equal('application/x-amz-json-1.1');
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Updating lookout metrics. Mirrors lex changes: https://github.com/aws/aws-sdk-js/pull/3616/files

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
