### PR TITLE
fix: Missing credentials file with config file

### DIFF
--- a/.changes/next-release/bugfix-Credentials-c59044aa.json
+++ b/.changes/next-release/bugfix-Credentials-c59044aa.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "Do not require credentials file when loading region from config."
+}

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -98,7 +98,13 @@ AWS.util.update(AWS.Config.prototype.keys, {
       ];
       var iniLoader = AWS.util.iniLoader;
       while (!region && toCheck.length) {
-        var configFile = iniLoader.loadFrom(toCheck.shift());
+        var configFile = {};
+        var fileInfo = toCheck.shift();
+        try {
+          configFile = iniLoader.loadFrom(fileInfo);
+        } catch (err) {
+          if (fileInfo.isConfig) throw err;
+        }
         var profile = configFile[env.AWS_PROFILE || AWS.util.defaultProfile];
         region = profile && profile.region;
       }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -150,6 +150,20 @@ describe('AWS.Config', function() {
           var config = new AWS.Config();
           expect(config.region).to.equal('us-east-1');
         });
+
+        it('non-existent credentials file returns empty', function() {
+          process.env.AWS_SDK_LOAD_CONFIG = '1';
+          var mock = '[default]\nregion = us-west-2';
+          helpers.spyOn(AWS.util, 'readFileSync').andCallFake(function(path) {
+            if (path.match(/[\/\\]home[\/\\]user[\/\\].aws[\/\\]config/)) {
+              return mock;
+            } else {
+              throw new Error('File does not exist!');
+            }
+          });
+          var config = new AWS.Config();
+          expect(config.region).to.equal('us-west-2');
+        });
       });
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
When the environment variable `AWS_SDK_LOAD_CONFIG` is set to a truthy value, the expected behavior is to suppress errors caused by a missing credentials file, as introduced in #3492. The SDK's behavior does not currently match when it tries to read a region from a profile.

The bug fix instead treats a missing credentials file as empty rather than raising an exception. A test was added to check that the fix correctly implements the expected behavior.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes (all but 2 that were already failing)
- [x] changelog is added, `npm run add-change`
