### PR TITLE
fix issue of incorrectly cached resolved S3 ARN  in S3/S3Control

### DIFF
--- a/.changes/next-release/bugfix-S3/S3Control-a4ff147c.json
+++ b/.changes/next-release/bugfix-S3/S3Control-a4ff147c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3/S3Control",
+  "description": "fix the issue that previously resolved S3 ARN incorrectly cached in S3/S3Control client"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -65,8 +65,8 @@ AWS.util.update(AWS.S3.prototype, {
     }
 
     var _super = AWS.Service.prototype.getSigningName;
-    return (this._parsedArn && this._parsedArn.service)
-      ? this._parsedArn.service
+    return (req && req._parsedArn && req._parsedArn.service)
+      ? req._parsedArn.service
       : _super.call(this);
   },
 
@@ -143,14 +143,14 @@ AWS.util.update(AWS.S3.prototype, {
     //deal with ARNs supplied to Bucket
     if (request.operation !== 'createBucket' && s3util.isArnInParam(request, 'Bucket')) {
       // avoid duplicate parsing in the future
-      request.service._parsedArn = AWS.util.ARN.parse(request.params.Bucket);
+      request._parsedArn = AWS.util.ARN.parse(request.params.Bucket);
 
       request.removeListener('validate', this.validateBucketName);
       request.removeListener('build', this.populateURI);
-      if (request.service._parsedArn.service === 's3') {
+      if (request._parsedArn.service === 's3') {
         request.addListener('validate', s3util.validateS3AccessPointArn);
         request.addListener('validate', this.validateArnResourceType);
-      } else if (request.service._parsedArn.service === 's3-outposts') {
+      } else if (request._parsedArn.service === 's3-outposts') {
         request.addListener('validate', s3util.validateOutpostsAccessPointArn);
         request.addListener('validate', s3util.validateOutpostsArn);
       }
@@ -200,7 +200,7 @@ AWS.util.update(AWS.S3.prototype, {
    * Validate resource-type supplied in S3 ARN
    */
   validateArnResourceType: function validateArnResourceType(req) {
-    var resource = req.service._parsedArn.resource;
+    var resource = req._parsedArn.resource;
 
     if (
       resource.indexOf('accesspoint:') !== 0 &&
@@ -344,7 +344,7 @@ AWS.util.update(AWS.S3.prototype, {
    * populate the URI according to the ARN.
    */
   populateUriFromAccessPointArn: function populateUriFromAccessPointArn(req) {
-    var accessPointArn = req.service._parsedArn;
+    var accessPointArn = req._parsedArn;
 
     var isOutpostArn = accessPointArn.service === 's3-outposts';
     var isObjectLambdaArn = accessPointArn.service === 's3-object-lambda';

--- a/lib/services/s3control.js
+++ b/lib/services/s3control.js
@@ -15,14 +15,14 @@ AWS.util.update(AWS.S3Control.prototype, {
     var isArnInName = s3util.isArnInParam(request, 'Name');
 
     if (isArnInBucket) {
-      request.service._parsedArn = AWS.util.ARN.parse(request.params['Bucket']);
-      request.service.signingName = request.service._parsedArn.service;
+      request._parsedArn = AWS.util.ARN.parse(request.params['Bucket']);
+      // request.service.signingName = request._parsedArn.service;
       request.addListener('validate', this.validateOutpostsBucketArn);
       request.addListener('validate', s3util.validateOutpostsArn);
       request.addListener('afterBuild', this.addOutpostIdHeader);
     } else if (isArnInName) {
-      request.service._parsedArn = AWS.util.ARN.parse(request.params['Name']);
-      request.service.signingName = request.service._parsedArn.service;
+      request._parsedArn = AWS.util.ARN.parse(request.params['Name']);
+      // request.service.signingName = request._parsedArn.service;
       request.addListener('validate', s3util.validateOutpostsAccessPointArn);
       request.addListener('validate', s3util.validateOutpostsArn);
       request.addListener('afterBuild', this.addOutpostIdHeader);
@@ -41,7 +41,6 @@ AWS.util.update(AWS.S3Control.prototype, {
     if (request.params.OutpostId &&
         (request.operation === 'createBucket' ||
           request.operation === 'listRegionalBuckets')) {
-      request.service.signingName = 's3-outposts';
       request.addListener('build', this.populateEndpointForOutpostId);
     }
   },
@@ -50,14 +49,14 @@ AWS.util.update(AWS.S3Control.prototype, {
    * Adds outpostId header
    */
   addOutpostIdHeader: function addOutpostIdHeader(req) {
-    req.httpRequest.headers['x-amz-outpost-id'] = req.service._parsedArn.outpostId;
+    req.httpRequest.headers['x-amz-outpost-id'] = req._parsedArn.outpostId;
   },
 
   /**
    * Validate Outposts ARN supplied in Bucket parameter is a valid bucket name
    */
   validateOutpostsBucketArn: function validateOutpostsBucketArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     //can be ':' or '/'
     var delimiter = parsedArn.resource['outpost'.length];
@@ -78,14 +77,14 @@ AWS.util.update(AWS.S3Control.prototype, {
     }
 
     //set parsed valid bucket
-    req.service._parsedArn.bucket = bucket;
+    req._parsedArn.bucket = bucket;
   },
 
   /**
    * @api private
    */
   populateParamFromArn: function populateParamFromArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
     if (s3util.isArnInParam(req, 'Bucket')) {
       req.params.Bucket = parsedArn.bucket;
     } else if (s3util.isArnInParam(req, 'Name')) {
@@ -97,7 +96,7 @@ AWS.util.update(AWS.S3Control.prototype, {
    * Populate URI according to the ARN
    */
   populateUriFromArn: function populateUriFromArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     var endpoint = req.httpRequest.endpoint;
     var useArnRegion = req.service.config.s3UseArnRegion;
@@ -141,7 +140,7 @@ AWS.util.update(AWS.S3Control.prototype, {
     var params = req.params;
     var inputModel = req.service.api.operations[req.operation].input;
     if (inputModel.members.AccountId) {
-      var parsedArn = req.service._parsedArn;
+      var parsedArn = req._parsedArn;
       if (parsedArn.accountId) {
         if (params.AccountId) {
           if (params.AccountId !== parsedArn.accountId) {
@@ -190,10 +189,16 @@ AWS.util.update(AWS.S3Control.prototype, {
   /**
    * @api private
    */
-  getSigningName: function getSigningName() {
+  getSigningName: function getSigningName(req) {
     var _super = AWS.Service.prototype.getSigningName;
-    return (this.signingName)
-      ? this.signingName
-      : _super.call(this);
+    if (req && req._parsedArn && req._parsedArn.service) {
+      return req._parsedArn.service;
+    } else if (req.params.OutpostId &&
+      (req.operation === 'createBucket' ||
+        req.operation === 'listRegionalBuckets')) {
+      return 's3-outposts';
+    } else {
+      return _super.call(this);
+    }
   },
 });

--- a/lib/services/s3control.js
+++ b/lib/services/s3control.js
@@ -16,13 +16,11 @@ AWS.util.update(AWS.S3Control.prototype, {
 
     if (isArnInBucket) {
       request._parsedArn = AWS.util.ARN.parse(request.params['Bucket']);
-      // request.service.signingName = request._parsedArn.service;
       request.addListener('validate', this.validateOutpostsBucketArn);
       request.addListener('validate', s3util.validateOutpostsArn);
       request.addListener('afterBuild', this.addOutpostIdHeader);
     } else if (isArnInName) {
       request._parsedArn = AWS.util.ARN.parse(request.params['Name']);
-      // request.service.signingName = request._parsedArn.service;
       request.addListener('validate', s3util.validateOutpostsAccessPointArn);
       request.addListener('validate', s3util.validateOutpostsArn);
       request.addListener('afterBuild', this.addOutpostIdHeader);
@@ -198,7 +196,7 @@ AWS.util.update(AWS.S3Control.prototype, {
         req.operation === 'listRegionalBuckets')) {
       return 's3-outposts';
     } else {
-      return _super.call(this);
+      return _super.call(this, req);
     }
   },
 });

--- a/lib/services/s3util.js
+++ b/lib/services/s3util.js
@@ -16,7 +16,7 @@ var s3util = {
    * Validate service component from ARN supplied in Bucket parameter
    */
   validateArnService: function validateArnService(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     if (parsedArn.service !== 's3'
       && parsedArn.service !== 's3-outposts'
@@ -32,7 +32,7 @@ var s3util = {
    * Validate account ID from ARN supplied in Bucket parameter is a valid account
    */
   validateArnAccount: function validateArnAccount(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     if (!/[0-9]{12}/.exec(parsedArn.accountId)) {
       throw AWS.util.error(new Error(), {
@@ -46,7 +46,7 @@ var s3util = {
    * Validate ARN supplied in Bucket parameter is a valid access point ARN
    */
   validateS3AccessPointArn: function validateS3AccessPointArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     //can be ':' or '/'
     var delimiter = parsedArn.resource['accesspoint'.length];
@@ -68,14 +68,14 @@ var s3util = {
     }
 
     //set parsed valid access point
-    req.service._parsedArn.accessPoint = accessPoint;
+    req._parsedArn.accessPoint = accessPoint;
   },
 
   /**
    * Validate Outposts ARN supplied in Bucket parameter is a valid outposts ARN
    */
   validateOutpostsArn: function validateOutpostsArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     if (
       parsedArn.resource.indexOf('outpost:') !== 0 &&
@@ -97,14 +97,14 @@ var s3util = {
         message: 'Outpost resource in ARN is not DNS compatible. Got ' + outpostId
       });
     }
-    req.service._parsedArn.outpostId = outpostId;
+    req._parsedArn.outpostId = outpostId;
   },
 
   /**
    * Validate Outposts ARN supplied in Bucket parameter is a valid outposts ARN
    */
   validateOutpostsAccessPointArn: function validateOutpostsAccessPointArn(req) {
-    var parsedArn = req.service._parsedArn;
+    var parsedArn = req._parsedArn;
 
     //can be ':' or '/'
     var delimiter = parsedArn.resource['outpost'.length];
@@ -126,7 +126,7 @@ var s3util = {
     }
 
     //set parsed valid access point
-    req.service._parsedArn.accessPoint = accessPoint;
+    req._parsedArn.accessPoint = accessPoint;
   },
 
   /**
@@ -134,7 +134,7 @@ var s3util = {
    */
   validateArnRegion: function validateArnRegion(req) {
     var useArnRegion = s3util.loadUseArnRegionConfig(req);
-    var regionFromArn = req.service._parsedArn.region;
+    var regionFromArn = req._parsedArn.region;
     var clientRegion = req.service.config.region;
 
     if (!regionFromArn) {
@@ -176,7 +176,7 @@ var s3util = {
       });
     }
 
-    if (req.service._parsedArn.service === 's3-outposts' && req.service.config.useDualstack) {
+    if (req._parsedArn.service === 's3-outposts' && req.service.config.useDualstack) {
       throw AWS.util.error(new Error(), {
         code: 'InvalidConfiguration',
         message: 'useDualstack config is not supported with outposts access point ARN'

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -392,9 +392,9 @@ describe('AWS.S3', function() {
       s3 = new AWS.S3({
         region: 'us-east-1'
       });
-      s3._parsedArn = { service: 'SERVICE_NAME' };
-      expect(s3.getSigningName()).to.equal(
-        s3._parsedArn.service
+      var req = { _parsedArn: { service: 'SERVICE_NAME' } };
+      expect(s3.getSigningName(req)).to.equal(
+        req._parsedArn.service
       );
       done();
     });


### PR DESCRIPTION
Previously the parsed S3 access point ARN is cached on the S3 client so the ARN won't be parsed repeatedly in different event listeners. However, the cache will not be invalidated. So, if same client is used to send request with a different access point ARN, the request is likely to be sent to previous ARNs. This change fix the issue.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
