### PR TITLE
fix: sanitize type and category in next-release filename

### DIFF
--- a/.changes/next-release/bugfix-changelog-release-ae823f1f.json
+++ b/.changes/next-release/bugfix-changelog-release-ae823f1f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "changelog/release",
+  "description": "Sanitize type and category in next-release filename"
+}

--- a/scripts/changelog/change-creator.js
+++ b/scripts/changelog/change-creator.js
@@ -19,6 +19,14 @@ function generateRandomIdentifier() {
     return crypto.randomBytes(4).toString('hex');
 }
 
+/**
+ * Escapes illegal characters from filename
+ * Ref: https://github.com/aws/aws-sdk-js/issues/3691
+ */
+function sanitizeFileName(filename) {
+    return filename.replaceAll(/[^a-zA-Z0-9\\.]/, '-');
+}
+
 var CHANGES_DIR = path.join(process.cwd(), '.changes');
 
 /**
@@ -169,7 +177,8 @@ ChangeCreator.prototype = {
             return config['inFile'];
         }
         // Determine default location
-        var newFileName = this._type + '-' + this._category + '-' + generateRandomIdentifier() + '.json';
+        var newFileName = sanitizeFileName(this._type) + '-' + sanitizeFileName(this._category)
+            + '-' + generateRandomIdentifier() + '.json';
         return path.join(process.cwd(), '.changes', 'next-release', newFileName);
     },
 

--- a/scripts/changelog/change-creator.js
+++ b/scripts/changelog/change-creator.js
@@ -24,7 +24,7 @@ function generateRandomIdentifier() {
  * Ref: https://github.com/aws/aws-sdk-js/issues/3691
  */
 function sanitizeFileName(filename) {
-    return filename.replaceAll(/[^a-zA-Z0-9\\.]/, '-');
+    return filename.replaceAll(/[^a-zA-Z0-9\\.]/g, '-');
 }
 
 var CHANGES_DIR = path.join(process.cwd(), '.changes');


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3691

Tested as follows:
```console
$ npm run add-change

...

Valid types are "feature" or "bugfix"
type: bugfix

Category can be a service identifier or something like: Paginator
category: changelog/release

A brief description of your change.
description: Sanitize type and category in next-release filename

File created at /Users/trivikr/workspace/aws-sdk-js/.changes/next-release/bugfix-changelog-release-ae823f1f.json
```

Verified that the filename is `next-release/bugfix-changelog-release-ae823f1f.json` and not `next-release/bugfix-changelog/release-ae823f1f.json`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] non-code related change (markdown/git settings etc)
