### PR TITLE
fix: managed upload resolves config repeatedly

### DIFF
--- a/.changes/next-release/bugfix-ManagedUpload-2bd31158.json
+++ b/.changes/next-release/bugfix-ManagedUpload-2bd31158.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "ManagedUpload",
-  "description": "fix a bug that credentials refresh to frequently"
+  "description": "Use resolved credentials if customer supplies configured S3 Client"
 }

--- a/.changes/next-release/bugfix-ManagedUpload-2bd31158.json
+++ b/.changes/next-release/bugfix-ManagedUpload-2bd31158.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ManagedUpload",
+  "description": "fix a bug that credentials refresh to frequently"
+}

--- a/lib/s3/managed_upload.js
+++ b/lib/s3/managed_upload.js
@@ -283,12 +283,18 @@ AWS.S3.ManagedUpload = AWS.util.inherit({
     if (!self.service) {
       self.service = new AWS.S3({params: params});
     } else {
+      // Create a new S3 client from the supplied client's constructor.
       var service = self.service;
-      var config = AWS.util.copy(service._originalConfig || {});
+      var config = AWS.util.copy(service.config);
       config.signatureVersion = service.getSignatureVersion();
       self.service = new service.constructor.__super__(config);
       self.service.config.params =
         AWS.util.merge(self.service.config.params || {}, params);
+      Object.defineProperty(self.service, '_originalConfig', {
+        get: function() { return service._originalConfig; },
+        enumerable: false,
+        configurable: true
+      });
     }
   },
 

--- a/scripts/changelog/change-creator.js
+++ b/scripts/changelog/change-creator.js
@@ -24,7 +24,7 @@ function generateRandomIdentifier() {
  * Ref: https://github.com/aws/aws-sdk-js/issues/3691
  */
 function sanitizeFileName(filename) {
-    return filename.replaceAll(/[^a-zA-Z0-9\\.]/g, '-');
+    return filename.replace(/[^a-zA-Z0-9\\.]/g, '-');
 }
 
 var CHANGES_DIR = path.join(process.cwd(), '.changes');

--- a/scripts/changelog/change-creator.js
+++ b/scripts/changelog/change-creator.js
@@ -24,7 +24,7 @@ function generateRandomIdentifier() {
  * Ref: https://github.com/aws/aws-sdk-js/issues/3691
  */
 function sanitizeFileName(filename) {
-    return filename.replace(/[^a-zA-Z0-9\\.]/g, '-');
+    return filename.replaceAll(/[^a-zA-Z0-9\\.]/g, '-');
 }
 
 var CHANGES_DIR = path.join(process.cwd(), '.changes');

--- a/test/s3/managed_upload.spec.js
+++ b/test/s3/managed_upload.spec.js
@@ -68,6 +68,7 @@
         }
       });
     };
+
     it('defaults to using sigv4', function() {
       var upload = new AWS.S3.ManagedUpload({
         params: {
@@ -76,6 +77,7 @@
       });
       expect(upload.service.getSignatureVersion()).to.eql('v4');
     });
+
     it('uses sigv4 if customer supplies a configured S3 client', function() {
       var upload = new AWS.S3.ManagedUpload({
         params: {
@@ -85,6 +87,7 @@
       });
       expect(upload.service.getSignatureVersion()).to.eql('v4');
     });
+
     it('uses sigv2 if customer supplies a configured S3 client', function() {
       var upload = new AWS.S3.ManagedUpload({
         params: {
@@ -94,7 +97,19 @@
       });
       expect(upload.service.getSignatureVersion()).to.eql('s3');
     });
-    return describe('send', function() {
+
+    it('uses resolved credential if customer supplies a configured S3 client', function() {
+      var credential = 'Some Credential Providers';
+      var upload = new AWS.S3.ManagedUpload({
+        params: {
+          Body: 'body'
+        },
+        service: new AWS.S3({credentials: credential })
+      });
+      expect(upload.service.config.credentials).to.be[credential];
+    });
+
+    describe('send', function() {
       it('default callback throws', function() {
         helpers.mockResponses([
           {


### PR DESCRIPTION
Previously the managed upload creates new S3 clients with the
constructor parameters of the S3 client used to create the managed
upload. That results in that the newly created S3 client needs to
resolve every config, including the credentials over and over
again.

This issue was introduced by #3109 to make sure the internal S3
client inside of managed upload has the same constructor parameters
of the S3 client used to create the managed upload. So that the
logic relies on the constructor parameters like access point
and endpoint discovery works properly.

This change supply the resolved client config to create the
managed upload internal S3 client so configs don't need to be
resolved again, like credentials. Meanwhile, we explicitly set
the constructor parameter to be the same as that of S3 client
used to create the managed upload.

Resolves: https://github.com/aws/aws-sdk-js/issues/3481

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
