### PR TITLE
Add Type Definitions for apiLoader

### DIFF
--- a/lib/api_loader.d.ts
+++ b/lib/api_loader.d.ts
@@ -1,0 +1,4 @@
+export const apiLoader: {
+  (svc: string, version: string): void;
+  services: object;
+};


### PR DESCRIPTION
#### Description

This PR adds TypeScript definitions for [`lib/api_loader.js`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/apiLoader/services.html).

##### Checklist

- [x] `npm run test` passes (same 4 failures as on current master branch)
- [x] `.d.ts` file is updated

I don't think a changelog entry is necessary for this change.