### PR TITLE
Extend package entry points for Node.js esm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
     "./lib/core.js": "./dist/aws-sdk-core-react-native.js",
     "xml2js": "./dist/xml2js.js"
   },
+  "exports": {
+    ".": "./lib/aws.js",
+    "./*": "./*.js",
+    "./clients/*": "./clients/*.js"
+  },
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
This change would help to import the aws-sdk natively in Node.js like this:

```javascript
// import entire SDK
import AWS from 'aws-sdk';
// import AWS object without services
import AWS from 'aws-sdk/global';
// import individual service
import S3 from 'aws-sdk/clients/s3';
```

Like described in the README.md for TypeScript: https://github.com/aws/aws-sdk-js#in-nodejs-1

Node.js doc: https://nodejs.org/api/packages.html#packages_package_entry_points

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
