### PR TITLE
Replace public-read ACL integ test with private

### DIFF
--- a/features/s3/objects.feature
+++ b/features/s3/objects.feature
@@ -44,11 +44,12 @@ Feature: Working with Objects in S3
     Then the object "byebye" should contain "world"
     Then I delete the object "byebye"
 
-  @unauthenticated
-  Scenario: Unauthenticated requests
-    When I put "world" to the public key "hello"
-    And I make an unauthenticated request to read object "hello"
+  @private
+  Scenario: Private ACL
+    When I put "world" to the private key "hello"
+    Then I get the object "hello"
     Then the object "hello" should contain "world"
+    Then I delete the object "hello"
 
   @blank
   Scenario: Putting nothing to an object

--- a/features/s3/step_definitions/objects.js
+++ b/features/s3/step_definitions/objects.js
@@ -246,11 +246,8 @@ module.exports = function () {
     req.send(callback);
   });
 
-  this.When(/^I put "([^"]*)" to the (public|private) key "([^"]*)"$/, function(data, access, key, next) {
-    var acl;
-    if (access === 'public') acl = 'public-read';
-    else if (access === 'private') acl = access;
-    var params = {Bucket: this.sharedBucket, Key: key, Body: data, ACL: acl};
+  this.When(/^I put "([^"]*)" to the private key "([^"]*)"$/, function(data, key, next) {
+    var params = {Bucket: this.sharedBucket, Key: key, Body: data, ACL: 'private'};
     this.request('s3', 'putObject', params, next);
   });
 
@@ -273,15 +270,6 @@ module.exports = function () {
       SSECustomerKey: 'aaaabbbbccccddddaaaabbbbccccdddd'
     };
     this.request('s3', 'getObject', params, next);
-  });
-
-  this.Then(/^I make an unauthenticated request to read object "([^"]*)"$/, function(key, next) {
-    var params = {Bucket: this.sharedBucket, Key: key};
-    this.s3.makeUnauthenticatedRequest('getObject', params, function (err, data) {
-      if (err) return next(err);
-      this.data = data;
-      next();
-    }.bind(this));
   });
 
   this.Given(/^I generate the MD5 checksum of "([^"]*)"$/, function(data, next) {


### PR DESCRIPTION
The integration test which uses `public-read` in ACL value needs to be removed, as public access needs to removed from AWS Account used for integration testing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `npm run integration` if integration test is changed