### PR TITLE
Add Node.js <10.x end of support postinstall script

### DIFF
--- a/.changes/next-release/feature-Node.js-25435344.json
+++ b/.changes/next-release/feature-Node.js-25435344.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Node.js",
+  "description": "Add postinstall script warning end-of-support for Node.js <10.x"
+}

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "translate-api-test": "mocha scripts/lib/translate-api.spec.js",
     "typings-generator-test": "mocha scripts/lib/prune-shapes.spec.js",
     "helper-test": "mocha scripts/lib/test-helper.spec.js",
-    "csm-functional-test": "mocha test/publisher/functional_test"
+    "csm-functional-test": "mocha test/publisher/functional_test",
+    "postinstall": "node scripts/check-node-version.js"
   }
 }

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -2,7 +2,7 @@ var version = process.version;
 
 if (version && parseInt(version.substring(1, version.indexOf('.'))) < 10) {
   console.warn('The AWS SDK for JavaScript (v2) will no longer support Node.js ' + version
-  + '\nas of November 1, 2021. To continue receiving updates to AWS services,'
-  + '\nbug fixes, and security updates please upgrade to Node.js 10.x or later.'
+  + '\nas of November 1, 2021. To continue receiving updates to AWS services'
+  + '\nand bug fixes please upgrade to Node.js 10.x or later.'
   + '\n\nMore information can be found at: https://a.co/cf10B3y');
 }

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,8 @@
+var version = process.version;
+
+if (version && parseInt(version.substring(1, version.indexOf('.'))) < 10) {
+  console.warn('The AWS SDK for JavaScript (v2) will no longer support Node.js ' + version
+  + '\nas of November 1, 2021. To continue receiving updates to AWS services, bug fixes,'
+  + '\nand security updates please upgrade to Node.js 10.x or later.'
+  + '\n\nMore information can be found at: https://a.co/cf10B3y');
+}

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -2,7 +2,7 @@ var version = process.version;
 
 if (version && parseInt(version.substring(1, version.indexOf('.'))) < 10) {
   console.warn('The AWS SDK for JavaScript (v2) will no longer support Node.js ' + version
-  + '\nas of November 1, 2021. To continue receiving updates to AWS services, bug fixes,'
-  + '\nand security updates please upgrade to Node.js 10.x or later.'
+  + '\nas of November 1, 2021. To continue receiving updates to AWS services,'
+  + '\nbug fixes, and security updates please upgrade to Node.js 10.x or later.'
   + '\n\nMore information can be found at: https://a.co/cf10B3y');
 }


### PR DESCRIPTION
Add Node.js <10.x end of support postinstall script

```console
$ fnm use 8
Using Node v8.17.0
$ node scripts/check-node-version.js
The AWS SDK for JavaScript (v2) will no longer support Node.js v8.17.0
as of November 1, 2021. To continue receiving updates to AWS services
and bug fixes please upgrade to Node.js 10.x or later.

More information can be found at: https://a.co/cf10B3y

$ fnm use 10
Using Node v10.23.1

$ node scripts/check-node-version.js
```

The postinstall script for a published package was tested in https://github.com/trivikr/test-postinstall-node-version-check

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] non-code related change (markdown/git settings etc)
