### PR TITLE
xml entity encoding for carriage return and line feed charaters

### DIFF
--- a/.changes/next-release/bugfix-Serializer-1f02d1b1.json
+++ b/.changes/next-release/bugfix-Serializer-1f02d1b1.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Serializer",
+  "description": "XML entity encoding for carriage return, line feed, next line, and line separator characters"
+}

--- a/lib/xml/escape-element.js
+++ b/lib/xml/escape-element.js
@@ -2,7 +2,13 @@
  * Escapes characters that can not be in an XML element.
  */
 function escapeElement(value) {
-    return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return value.replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/\r/g, '&#x0D;')
+                .replace(/\n/g, '&#x0A;')
+                .replace(/\u0085/g, '&#x85;')
+                .replace(/\u2028/, '&#x2028;');
 }
 
 /**

--- a/test/xml/escape-element.spec.js
+++ b/test/xml/escape-element.spec.js
@@ -1,8 +1,8 @@
 var escapeElement = require('../../lib/xml/escape-element').escapeElement;
 
 describe('escape-element', function() {
-    it('escapes: & < >', function() {
-        var value = 'abc 123 &<>"%';
-        expect(escapeElement(value)).to.equal('abc 123 &amp;&lt;&gt;"%');
+    it('escapes: & < > \\r \\n \u0085\u2028', function() {
+        var value = 'abc 123 &<>"%\r\n\u0085\u2028';
+        expect(escapeElement(value)).to.equal('abc 123 &amp;&lt;&gt;"%&#x0D;&#x0A;&#x85;&#x2028;');
     });
 });


### PR DESCRIPTION
XML entity encoding for carriage return, line feed, next line, and line separator characters
double and single quote character is not escaped compared to v3, to keep absolute backwards compatibility.

JS-2318

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
