### PR TITLE
Retry http request on ECONNRESET error

### DIFF
--- a/.changes/next-release/bugfix-retry-c648c8ae.json
+++ b/.changes/next-release/bugfix-retry-c648c8ae.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "retry",
+  "description": "Retry http request on ECONNRESET error"
+}

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -93,7 +93,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
         connectTimeoutId = null;
       }
       if (stream.didCallback) return; stream.didCallback = true;
-      if (['ECONNRESET', 'EPIPE', 'ETIMEDOUT'].includes(err.code)) {
+      if ('ECONNRESET' === err.code || 'EPIPE' === err.code || 'ETIMEDOUT' === err.code) {
         errCallback(AWS.util.error(err, {code: 'TimeoutError'}));
       } else {
         errCallback(err);

--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -87,13 +87,17 @@ AWS.NodeHttpClient = AWS.util.inherit({
       stream.abort();
     });
 
-    stream.on('error', function() {
+    stream.on('error', function(err) {
       if (connectTimeoutId) {
         clearTimeout(connectTimeoutId);
         connectTimeoutId = null;
       }
       if (stream.didCallback) return; stream.didCallback = true;
-      errCallback.apply(stream, arguments);
+      if (['ECONNRESET', 'EPIPE', 'ETIMEDOUT'].includes(err.code)) {
+        errCallback(AWS.util.error(err, {code: 'TimeoutError'}));
+      } else {
+        errCallback(err);
+      }
     });
 
     var expect = httpRequest.headers.Expect || httpRequest.headers.expect;

--- a/lib/util.js
+++ b/lib/util.js
@@ -877,7 +877,7 @@ var util = {
 
     var errCallback = function(err) {
       var maxRetries = options.maxRetries || 0;
-      if (err && err.code === 'TimeoutError') err.retryable = true;
+      if (err && (err.code === 'TimeoutError' || err.code === 'ECONNRESET')) err.retryable = true;
 
       // Call `calculateRetryDelay()` only when relevant, see #3401
       if (err && err.retryable && retryCount < maxRetries) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -877,7 +877,7 @@ var util = {
 
     var errCallback = function(err) {
       var maxRetries = options.maxRetries || 0;
-      if (err && (err.code === 'TimeoutError' || err.code === 'ECONNRESET')) err.retryable = true;
+      if (err && err.code === 'TimeoutError') err.retryable = true;
 
       // Call `calculateRetryDelay()` only when relevant, see #3401
       if (err && err.retryable && retryCount < maxRetries) {


### PR DESCRIPTION
> ECONNRESET (Connection reset by peer): A connection was forcibly
closed by a peer. This normally results from a loss of the connection on
the remote socket due to a timeout or reboot. Commonly encountered via
the http and net modules.

This error can for example happen when fetching Fargate credentials from
metadata endpoint.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`

