### PR TITLE
Set the CORS support flag to Athena client

### DIFF
--- a/.changes/next-release/feature-CORS-39c57e5c.json
+++ b/.changes/next-release/feature-CORS-39c57e5c.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "CORS",
+  "description": "Set the CORS support flag for Athena  to Athena client"
+}

--- a/apis/metadata.json
+++ b/apis/metadata.json
@@ -448,7 +448,8 @@
     "name": "MarketplaceEntitlementService"
   },
   "athena": {
-    "name": "Athena"
+    "name": "Athena",
+    "cors": true
   },
   "greengrass": {
     "name": "Greengrass"


### PR DESCRIPTION
Resolves #3741 

Adding Athena to browser SDK. Confirmed Athena to be CORS compatible: https://github.com/AllanZhengYP/cors-test/blob/master/output.md

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
- [x] non-code related change (markdown/git settings etc)
