### PR TITLE
fix: only delete endpoint which has expired in EndpointCache

### DIFF
--- a/.changes/next-release/bugfix-EndpointCache-1e794ec2.json
+++ b/.changes/next-release/bugfix-EndpointCache-1e794ec2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "EndpointCache",
+  "description": "Only delete endpoint which has expired in EndpointCache"
+}

--- a/vendor/endpoint-cache/index.js
+++ b/vendor/endpoint-cache/index.js
@@ -29,12 +29,15 @@ var EndpointCache = /** @class */ (function () {
         var now = Date.now();
         var records = this.cache.get(keyString);
         if (records) {
-            for (var i = 0; i < records.length; i++) {
+            for (var i = records.length-1; i >= 0; i--) {
                 var record = records[i];
                 if (record.Expire < now) {
-                    this.cache.remove(keyString);
-                    return undefined;
+                    records.splice(i, 1);
                 }
+            }
+            if (records.length === 0) {
+                this.cache.remove(keyString);
+                return undefined;
             }
         }
         return records;


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3750

### Testing

Code:
```js
import AWS from "../aws-sdk-js/index.js";

const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

const endpointCache = new AWS.EndpointCache(1000);
endpointCache.put("key", [
  // First endpoint expires in 3 seconds
  { Address: "expires-in-3-seconds", CachePeriodInMinutes: 0.05 },
  // First endpoint expires in 6 seconds
  { Address: "expires-in-6-seconds", CachePeriodInMinutes: 0.1 },
]);

// prints both endpoints
console.log(endpointCache.get("key"));

// Wait for 4 seconds.
await sleep(4000);
// prints endpoint "expires-in-6-seconds"
console.log(endpointCache.get("key"));

await sleep(3000);
// prints undefined
console.log(endpointCache.get("key"));

```

Output:
```console
[
  { Address: 'expires-in-3-seconds', Expire: 1620242995498 },
  { Address: 'expires-in-6-seconds', Expire: 1620242998498 }
]
[ { Address: 'expires-in-6-seconds', Expire: 1620242998498 } ]
undefined
```

##### Checklist

- [x] changelog is added, `npm run add-change`