### PR TITLE
fix: switch replaceAll with replace in change-creator

### DIFF
--- a/.changes/next-release/bugfix-changelog-e6277489.json
+++ b/.changes/next-release/bugfix-changelog-e6277489.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "changelog",
+  "description": "switch replaceAll with replace in change-creator"
+}

--- a/scripts/changelog/change-creator.js
+++ b/scripts/changelog/change-creator.js
@@ -24,7 +24,7 @@ function generateRandomIdentifier() {
  * Ref: https://github.com/aws/aws-sdk-js/issues/3691
  */
 function sanitizeFileName(filename) {
-    return filename.replaceAll(/[^a-zA-Z0-9\\.]/g, '-');
+    return filename.replace(/[^a-zA-Z0-9\\.]/g, '-');
 }
 
 var CHANGES_DIR = path.join(process.cwd(), '.changes');


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3751

### Testing

The `npm run add-change` was added on Node.js `v8.11.3`

```
$ node -v
v8.17.0

$ npm run add-change
...
Valid types are "feature" or "bugfix"
type: bugfix

Category can be a service identifier or something like: Paginator
category: changelog

A brief description of your change.
description: switch replaceAll with replace in change-creator

File created at /Users/trivikr/workspace/aws-sdk-js/.changes/next-release/bugfix-changelog-e6277489.json
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
