### PR TITLE
chore(deps-dev): bump codecov to ^3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "6.0.92",
     "browserify": "13.1.0",
     "chai": "^3.0",
-    "codecov": "^3.6.5",
+    "codecov": "^3.8.2",
     "coffeeify": "*",
     "coffeescript": "^1.12.7",
     "cucumber": "0.5.x",


### PR DESCRIPTION
Latest vulnerability in CodeCov https://snyk.io/vuln/SNYK-JS-CODECOV-585979
The recommendation is to upgrade codecov to version 3.7.1 or higher.

The repository aws/aws-sdk-js is not impacted as we use latest version of 3.x
The version is bumped so that internal security vulnerability detection systems don't get triggered.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes