### PR TITLE
chore: fix typo in docstring

### DIFF
--- a/lib/credentials.d.ts
+++ b/lib/credentials.d.ts
@@ -8,7 +8,7 @@ export class Credentials {
     constructor(options: CredentialsOptions);
     /**
      * Creates a Credentials object with a given set of credential information as positional arguments.
-     *          *
+     *
      * @param {string} accessKeyId - The AWS access key ID.
      * @param {string} secretAccessKey - The AWS secret access key.
      * @param {string} sessionToken - The optional AWS session token.


### PR DESCRIPTION
This PR removes a stray `*` from the middle docstring of a typescript file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated


