### PR TITLE
Update uuid dependency to 8.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "querystring": "0.2.0",
     "sax": "1.2.1",
     "url": "0.10.3",
-    "uuid": "3.3.2",
+    "uuid": "8.3.2",
     "xml2js": "0.4.19"
   },
   "main": "lib/aws.js",


### PR DESCRIPTION
Resolves deprecation warning from uuid module:

```
warning aws-sdk > uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

The only usage of this module is [here](https://github.com/aws/aws-sdk-js/blob/e26ac616265a6f59913248c060f02146cd126d10/lib/util.js#L925).

As per the [uuid docs](https://github.com/uuidjs/uuid#upgrading-from-uuid3) there is no need for any code changes.
