### PR TITLE
fix documentation of DynamoDB.DocumentClient.transactWrite

### DIFF
--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -61,7 +61,7 @@ export class DocumentClient {
     transactGet(params: DocumentClient.TransactGetItemsInput, callback?: (err: AWSError, data: DocumentClient.TransactGetItemsOutput) => void): Request<DocumentClient.TransactGetItemsOutput, AWSError>;
 
     /**
-     * Synchronous write operation that groups up to 10 action requests
+     * Synchronous write operation that groups up to 25 action requests.
      */
     transactWrite(params: DocumentClient.TransactWriteItemsInput, callback?: (err: AWSError, data: DocumentClient.TransactWriteItemsOutput) => void): Request<DocumentClient.TransactWriteItemsOutput, AWSError>;
 }

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -395,7 +395,7 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
   },
 
   /**
-   * Synchronous write operation that groups up to 10 action requests
+   * Synchronous write operation that groups up to 25 action requests.
    *
    * Supply the same parameters as {AWS.DynamoDB.transactWriteItems} with
    * `AttributeValue`s substituted by native JavaScript types.


### PR DESCRIPTION
transactWrite uses transactWriteItems under the hood, which has a limit of
25 items per transaction.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] non-code related change (markdown/git settings etc)
