### PR TITLE
adds default value comment for "enabled" field of CreateApiKeyRequest

### DIFF
--- a/.changes/next-release/feature-ApiGateway-3501231a.json
+++ b/.changes/next-release/feature-ApiGateway-3501231a.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "ApiGateway",
+  "description": "adds mention of default value for \"enabled\" field of CreateApiKeyRequest for better documentation"
+}

--- a/clients/apigateway.d.ts
+++ b/clients/apigateway.d.ts
@@ -1218,7 +1218,7 @@ declare namespace APIGateway {
      */
     description?: String;
     /**
-     * Specifies whether the ApiKey can be used by callers.
+     * Default: false. Specifies whether the ApiKey can be used by callers.
      */
     enabled?: Boolean;
     /**


### PR DESCRIPTION
I have assumed the default value was `true` and had to spend some time investigating why my API key was not being accepted.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] changelog is added, `npm run add-change`
