### PR TITLE
support document type trait

### DIFF
--- a/.changes/next-release/feature-Model-9fa0db5a.json
+++ b/.changes/next-release/feature-Model-9fa0db5a.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Model",
+  "description": "support document types trait that allows serializing and parsing unmodeled json value"
+}

--- a/lib/core.d.ts
+++ b/lib/core.d.ts
@@ -25,3 +25,4 @@ export {Response} from './response';
 export {Service} from './service';
 export {AWSError} from './error';
 export {IniLoader} from './shared-ini/ini-loader';
+export {DocumentType} from './model';

--- a/lib/json/builder.js
+++ b/lib/json/builder.js
@@ -18,6 +18,9 @@ function translate(value, shape) {
 }
 
 function translateStructure(structure, shape) {
+  if (shape.isDocument) {
+    return structure;
+  }
   var struct = {};
   util.each(structure, function(name, value) {
     var memberShape = shape.members[name];

--- a/lib/json/parser.js
+++ b/lib/json/parser.js
@@ -19,6 +19,7 @@ function translate(value, shape) {
 
 function translateStructure(structure, shape) {
   if (structure == null) return undefined;
+  if (shape.isDocument) return structure;
 
   var struct = {};
   var shapeMembers = shape.members;

--- a/lib/model/index.d.ts
+++ b/lib/model/index.d.ts
@@ -1,7 +1,4 @@
-export type DocumentType =
-  | null
-  | boolean
-  | number
-  | string
-  | DocumentType[]
-  | { [prop: string]: DocumentType };
+export type DocumentType = Scalar | Structure | List;
+type Scalar = string | number | boolean | null;
+type Structure = { [member: string]: DocumentType };
+interface List extends Array<DocumentType> {}

--- a/lib/model/index.d.ts
+++ b/lib/model/index.d.ts
@@ -1,0 +1,7 @@
+export type DocumentType =
+  | null
+  | boolean
+  | number
+  | string
+  | DocumentType[]
+  | { [prop: string]: DocumentType };

--- a/lib/model/shape.js
+++ b/lib/model/shape.js
@@ -166,6 +166,7 @@ function StructureShape(shape, options) {
     property(this, 'memberNames', []);
     property(this, 'required', []);
     property(this, 'isRequired', function() { return false; });
+    property(this, 'isDocument', Boolean(shape.document));
   }
 
   if (shape.members) {

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -308,6 +308,9 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
         return code += tabs(tabCount) + 'export type ' + shapeKey + ' = EventStream<{' + events.join(',') + '}>;\n'; 
     }
     if (type === 'structure') {
+        if (shape.isDocument) {
+            return code += tabs(tabCount) + 'export type ' + shapeKey + ' = DocumentType;\n'
+        }
         code += tabs(tabCount) + 'export interface ' + shapeKey + ' {\n';
         var members = shape.members;
         // cycle through members
@@ -508,6 +511,16 @@ TSGenerator.prototype.containsEventStreams = function containsEventStreams(model
     return false;
 };
 
+TSGenerator.prototype.containsDocumentType = function containsDocumentType(model) {
+    var shapeNames = Object.keys(model.shapes);
+    for (var name of shapeNames) {
+        if (model.shapes[name].isDocument) {
+            return true;
+        }
+    }
+    return false;
+};
+
 /**
  * Generates the typings for a service based on the serviceIdentifier.
  */
@@ -551,6 +564,9 @@ TSGenerator.prototype.processServiceModel = function processServiceModel(service
     }
     if (this.containsEventStreams(model)) {
         code += 'import {EventStream} from \'../lib/event-stream/event-stream\';\n';
+    }
+    if (this.containsDocumentType(model)) {
+        code += 'import {DocumentType} from \'../lib/model\';\n';
     }
     // import custom namespaces
     if (customNamespaces) {

--- a/test/json/builder.spec.js
+++ b/test/json/builder.spec.js
@@ -63,10 +63,24 @@
             Items: null
           })).to.equal('{}');
         });
-        return it('ignores undefined', function() {
+        it('ignores undefined', function() {
           return expect(build(rules, {
             Items: void 0
           })).to.equal('{}');
+        });
+        it('builds document types', function() {
+          var docTypeRules = {
+            type: 'structure',
+            members: {
+              Items: {
+                type: 'structure',
+                document: true
+              }
+            }
+          };
+          expect(build(docTypeRules, {
+            Items: {foo: 'fooValue', bar: null }
+          })).to.equal('{"Items":{"foo":"fooValue","bar":null}}');
         });
       });
       describe('lists', function() {

--- a/test/json/builder.spec.js
+++ b/test/json/builder.spec.js
@@ -79,8 +79,8 @@
             }
           };
           expect(build(docTypeRules, {
-            Items: {foo: 'fooValue', bar: null }
-          })).to.equal('{"Items":{"foo":"fooValue","bar":null}}');
+            Items: {strKey: 'str', numKey: 1, boolKey: true, nullKey: null}
+          })).to.equal('{"Items":{"strKey":"str","numKey":1,"boolKey":true,"nullKey":null}}');
         });
       });
       describe('lists', function() {

--- a/test/json/parser.spec.js
+++ b/test/json/parser.spec.js
@@ -62,8 +62,22 @@
             }
           });
         });
-        return it('ignores null', function() {
+        it('ignores null', function() {
           return expect(parse(rules, '{"Items": null}')).to.eql({});
+        });
+        it('translates document types', function() {
+          var docTypeRules = {
+            type: 'structure',
+            members: {
+              Items: {
+                type: 'structure',
+                document: true
+              }
+            }
+          };
+          expect(parse(docTypeRules, '{"Items":{"foo":"fooValue","bar":null}}')).to.eql({
+            Items: {foo: 'fooValue', bar: null }
+          });
         });
       });
       describe('lists', function() {

--- a/test/json/parser.spec.js
+++ b/test/json/parser.spec.js
@@ -75,8 +75,13 @@
               }
             }
           };
-          expect(parse(docTypeRules, '{"Items":{"foo":"fooValue","bar":null}}')).to.eql({
-            Items: {foo: 'fooValue', bar: null }
+          expect(
+            parse(
+              docTypeRules,
+              '{"Items":{"strKey":"str","numKey":1,"boolKey":true,"nullKey":null}}'
+            )
+          ).to.eql({
+            Items: {strKey: 'str', numKey: 1, boolKey: true, nullKey: null }
           });
         });
       });

--- a/ts/core.ts
+++ b/ts/core.ts
@@ -38,3 +38,5 @@ if (core.CognitoIdentityCredentials) {
 } else if (core.IniLoader) {
   
 }
+
+const document: core.DocumentType = {}

--- a/ts/dynamodb.ts
+++ b/ts/dynamodb.ts
@@ -48,7 +48,7 @@ const record: DynamoDB.AttributeMap = DynamoDB.Converter.marshall(
     options
 );
 
-const jsType: any = DynamoDB.Converter.output('string');
+const jsType: any = DynamoDB.Converter.output({ S: 'string' });
 const jsObject: {[key: string]: any} = DynamoDB.Converter.unmarshall({
     string: {S: 'foo'},
     list: {L: [{S: 'fizz'}, {S: 'buzz'}, {S: 'pop'}]},


### PR DESCRIPTION
Add document type trait support. The trait is applicable to structure shape in JSON protocols. For shapes with this trait, JSON value will be serialized/deserialized to/from JS object and JSON value.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`