### PR TITLE
Fix CloudFront signer RFC5987 support

### DIFF
--- a/lib/cloudfront/signer.js
+++ b/lib/cloudfront/signer.js
@@ -180,22 +180,27 @@ AWS.CloudFront.Signer = inherit({
             return handleError(err, cb);
         }
 
-        var parsedUrl = url.parse(options.url, true),
-            signatureHash = Object.prototype.hasOwnProperty.call(options, 'policy')
-                ? signWithCustomPolicy(options.policy, this.keyPairId, this.privateKey)
-                : signWithCannedPolicy(resource, options.expires, this.keyPairId, this.privateKey);
+        var signatureHash = Object.prototype.hasOwnProperty.call(options, 'policy')
+            ? signWithCustomPolicy(options.policy, this.keyPairId, this.privateKey)
+            : signWithCannedPolicy(resource, options.expires, this.keyPairId, this.privateKey);
 
-        parsedUrl.search = null;
-        for (var key in signatureHash) {
-            if (Object.prototype.hasOwnProperty.call(signatureHash, key)) {
-                parsedUrl.query[key] = signatureHash[key];
-            }
+        var signatureHashUrlQuery = Object.keys(signatureHash).map(function (key) {
+            return key + '=' + signatureHash[key];
+        }).join('&');
+        var urlHasQuery = resource.split('/').pop().includes('?');
+
+        var formattedUrl = resource;
+        if (urlHasQuery) {
+            formattedUrl += '&';
+        } else {
+            formattedUrl += '?';
         }
+        formattedUrl += signatureHashUrlQuery;
 
         try {
             var signedUrl = determineScheme(options.url) === 'rtmp'
-                    ? getRtmpUrl(url.format(parsedUrl))
-                    : url.format(parsedUrl);
+                    ? getRtmpUrl(formattedUrl)
+                    : formattedUrl;
         } catch (err) {
             return handleError(err, cb);
         }


### PR DESCRIPTION
`url.parse(someUrl, true)` in combination with nulling its `search` property has a side-effect when re-encoding using `url.format`.
https://github.com/aws/aws-sdk-js/blob/821e9a11f3917551e26d5cbc794bf319979ceb00/lib/cloudfront/signer.js#L183
https://github.com/aws/aws-sdk-js/blob/821e9a11f3917551e26d5cbc794bf319979ceb00/lib/cloudfront/signer.js#L188

It causes URL queries existing before the signing process to get re-encoded improperly during the `url.format` stage here:
https://github.com/aws/aws-sdk-js/blob/821e9a11f3917551e26d5cbc794bf319979ceb00/lib/cloudfront/signer.js#L197-L198


This breaks the usage of some special characters in URL queries, even when they have been properly URL encoded. One example is setting the filename in a specific charset using the `response-content-disposition` query field. For example, the `response-content-disposition`  query value ([RFC5987 examples](https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.2)) may contain:
```
attachment%3Bfilename%2A%3DUTF-8%27%27abc%2520def.mp4
```
Although the current functionality returns a signed URL that has the query value formatted as:
```
attachment%3Bfilename*%3DUTF-8''abc%2520def.mp4
```

This invalidates the generated signature and CloudFront replies with:
```
<Error>
<Code>AccessDenied</Code>
<Message>Access denied</Message>
</Error>
```

To replicate the issue in isolation:
```
> var u = url.parse('https://asdf.cloudfront.net/932e9e5d-cbdf-4c73-a3dc-e07758bd3adb?response-content-disposition=attachment%3Bfilename%2A%3DUTF-8%27%27abc%2520def.mp4', true)
> url.format(u)
'https://asdf.cloudfront.net/932e9e5d-cbdf-4c73-a3dc-e07758bd3adb?response-content-disposition=attachment%3Bfilename%2A%3DUTF-8%27%27abc%2520def.mp4'
> u.search=null
> url.format(u)
"https://asdf.cloudfront.net/932e9e5d-cbdf-4c73-a3dc-e07758bd3adb?response-content-disposition=attachment%3Bfilename*%3DUTF-8''abc%2520def.mp4"

```
The example input URL query works fine in `aws-sdk-php` and `boto3`.

Fixes #2952. 