### PR TITLE
Support S3 Object Lambda in AWS.Signers.V4

### DIFF
--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -179,7 +179,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
 
   hexEncodedBodyHash: function hexEncodedBodyHash() {
     var request = this.request;
-    if (this.isPresigned() && this.serviceName === 's3' && !request.body) {
+    if (this.isPresigned() && (['s3', 's3-object-lambda'].indexOf(this.serviceName) > -1) && !request.body) {
       return 'UNSIGNED-PAYLOAD';
     } else if (request.headers['X-Amz-Content-Sha256']) {
       return request.headers['X-Amz-Content-Sha256'];


### PR DESCRIPTION
When generating signed url for `GET` request to `s3-object-lambda` service via the `AWS.Signers.V4` and all the information should be stored in the query string, it expects the `bodyHash` to be `UNSIGNED-PAYLOAD` as with regular `s3` signing process.
Currently the `s3-object-lambda` service isn't supported in `AWS.Signers.V4` and the result is `InvalidSignature`.

This proposal adds support for the `s3-object-lambda` service and fixes this issue.

Usage example (as mentioned in the [Adding signing information to the Query string](https://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html#sigv4-add-signature-querystring) documentation):
```
const httpRequest = new AWS.HttpRequest(
  `${AWS::S3ObjectLambda::AccessPoint.Name}-${AWS::AccountId}.s3-object-lambda.${AWS::Region}.amazonaws.com/PATH_TO_FILE`,
  process.env.Region
)

httpRequest.method = 'GET'
httpRequest.headers = {
  host: `${AWS::S3ObjectLambda::AccessPoint.Name}-${AWS::AccountId}.s3-object-lambda.${AWS::Region}.amazonaws.com`,
  'presigned-expires': 900
}

const signer = new AWS.Signers.V4(
  httpRequest,
  's3-object-lambda',
  true
)

signer.addAuthorization(AWS.config.credentials, AWS.util.date.getDate())
const signature = httpRequest.headers.Authorization.split(
  ' '
)[3].split('=')[1]

const url = `https://${httpRequest.headers.host}${httpRequest.path}&X-Amz-Signature=${signature}`
window.open(url, '_blank')
```

The `s3.getSignedUrl` doesn't work for `s3-object-lambda` (I couldn't find the cause for that) so I implemented it directly through the `AWS.Signers.V4`:
```
const url = s3.getSignedUrl('getObject', {
  Bucket: `arn:aws:s3-object-lambda:${AWS::Region}:${AWS::AccountId}:accesspoint/${AWS::S3ObjectLambda::AccessPoint.Name}`,
  Key: `PATH_TO_FILE`
})
window.open(url, '_blank')
```

The error is:
```
<Error xmlns="">
    <Code>MissingAuthenticationToken</Code>
    <Message>Missing authentication token.</Message>
    <RequestId>4764bc1b-ae88-43c0-bf90-285d3a083382</RequestId>
    <HostId>{host-id}</HostId>
</Error>
```