### PR TITLE
revert removing integration tests

### DIFF
--- a/features/devicefarm/devicefarm.feature
+++ b/features/devicefarm/devicefarm.feature
@@ -10,9 +10,8 @@ Feature: AWS Device Farm
     And the value at "devices" should be a list
 
   Scenario: Error handling
-    # # Remove the assertion on 07/13/2021 because the service returns InternalFailure
-    # Given I run the "getDevice" operation with params:
-    # """
-    # { "arn": "arn:aws:devicefarm:us-west-2::device:00000000000000000000000000000000" }
-    # """
-    # Then the error code should be "NotFoundException"
+    Given I run the "getDevice" operation with params:
+    """
+    { "arn": "arn:aws:devicefarm:us-west-2::device:00000000000000000000000000000000" }
+    """
+    Then the error code should be "NotFoundException"

--- a/features/opsworks/opsworks.feature
+++ b/features/opsworks/opsworks.feature
@@ -12,8 +12,7 @@ Feature: AWS OpsWorks
     And I describe the OpsWorks user profiles
     Then the IAM user ARN should be in the result
     And the name should be equal to the IAM username
-# Temporary: Removing step to unblock release on 7/13.
-#    And the SSH username should be equal to the IAM username
+    And the SSH username should be equal to the IAM username
     And I delete the OpsWorks user profile
     And I delete the IAM user
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Server-side issue fixed:
```console
AWS_REGION=us-east-1 ./node_modules/cucumber/bin/cucumber.js -t @devicefarm,@opsworks
@devicefarm
Feature: AWS Device Farm

  I want to use AWS Device Farm


  Scenario: Listing devices                     # features/devicefarm/devicefarm.feature:7
    Given I run the "listDevices" operation     # features/devicefarm/devicefarm.feature:8
    Then the request should be successful       # features/devicefarm/devicefarm.feature:9
    And the value at "devices" should be a list # features/devicefarm/devicefarm.feature:10


  Scenario: Error handling                             # features/devicefarm/devicefarm.feature:12
    Given I run the "getDevice" operation with params: # features/devicefarm/devicefarm.feature:13
      """
      { "arn": "arn:aws:devicefarm:us-west-2::device:00000000000000000000000000000000" }
      """
    Then the error code should be "NotFoundException"  # features/devicefarm/devicefarm.feature:17

@opsworks
Feature: AWS OpsWorks

  I want to use AWS OpsWorks


  Scenario: Creating and deleting user profiles                 # features/opsworks/opsworks.feature:7
    Given I have an IAM username "aws-js-sdk"                   # features/opsworks/opsworks.feature:8
    And I create an IAM user with the username                  # features/opsworks/opsworks.feature:9
    And I create an OpsWorks user profile with the IAM user ARN # features/opsworks/opsworks.feature:10
    And the IAM user ARN is in the result                       # features/opsworks/opsworks.feature:11
    And I describe the OpsWorks user profiles                   # features/opsworks/opsworks.feature:12
    Then the IAM user ARN should be in the result               # features/opsworks/opsworks.feature:13
    And the name should be equal to the IAM username            # features/opsworks/opsworks.feature:14
    And the SSH username should be equal to the IAM username    # features/opsworks/opsworks.feature:15
    And I delete the OpsWorks user profile                      # features/opsworks/opsworks.feature:16
    And I delete the IAM user                                   # features/opsworks/opsworks.feature:17


  Scenario: Error handling                                      # features/opsworks/opsworks.feature:19
    Given I have an IAM username ""                             # features/opsworks/opsworks.feature:20
    And I create an OpsWorks user profile with the IAM user ARN # features/opsworks/opsworks.feature:21
    Then the error code should be "ValidationException"         # features/opsworks/opsworks.feature:22
    Then the error message should be:                           # features/opsworks/opsworks.feature:23
      """
      Please provide user ARN
      """


4 scenarios (4 passed)
19 steps (19 passed)
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] run `npm run integration` if integration test is changed
- [ x ] non-code related change (markdown/git settings etc)
