### PR TITLE
doc example update: S3.GetObject(..Range:) returns Body in the response sample

### DIFF
--- a/apis/s3-2006-03-01.examples.json
+++ b/apis/s3-2006-03-01.examples.json
@@ -740,7 +740,8 @@
           "LastModified": "Thu, 09 Oct 2014 22:57:28 GMT",
           "Metadata": {
           },
-          "VersionId": "null"
+          "VersionId": "null",
+	  "Body": "<Buffer containing the first 10 bytes of the file>"
         },
         "comments": {
           "input": {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Currently, the documentation example for S3.GetObject(...Range) misses 'Body' field in the response sample.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed