### PR TITLE
Use a global endpoint for SavingsPlans

### DIFF
--- a/.changes/next-release/bugfix-Global-Services-557677e4.json
+++ b/.changes/next-release/bugfix-Global-Services-557677e4.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Global Services",
+  "description": "Add global endpoint for SavingsPlans"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -14,6 +14,7 @@
     },
     "*/budgets": "globalSSL",
     "*/cloudfront": "globalSSL",
+    "*/savingsplans": "globalSSL",
     "*/sts": "globalSSL",
     "*/importexport": {
       "endpoint": "{service}.amazonaws.com",

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -56,6 +56,22 @@ describe('region_config.js', function() {
     expect(service.endpoint.host).to.equal('route53.amazonaws.com.cn');
   });
 
+  it('uses "global" endpoint for SavingsPlans in us-east-1', function() {
+    var service = new AWS.SavingsPlans({
+      region: 'us-east-1'
+    });
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.endpoint.host).to.equal('savingsplans.amazonaws.com');
+  });
+
+  it('uses "global" endpoint for SavingsPlans in ap-southeast-1', function() {
+    var service = new AWS.SavingsPlans({
+      region: 'ap-southeast-1'
+    });
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.endpoint.host).to.equal('savingsplans.amazonaws.com');
+  });
+
   it('enables signature version 4 signing in cn-*', function() {
     var service = new AWS.IAM({
       region: 'cn-north-1'


### PR DESCRIPTION
Savings Plans uses a global endpoint: https://docs.aws.amazon.com/general/latest/gr/billing.html#billing-savingsplans

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
