### PR TITLE
Include port number on ENOTFOUND_ERROR error message

### DIFF
--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -524,7 +524,7 @@ AWS.EventListeners = {
           ['EAI_NONAME', 'EAI_NODATA'].indexOf(AWS.util.getSystemErrorName(err.errno) >= 0);
       }
       if (err.code === 'NetworkingError' && isDNSError(err)) {
-        var message = 'Inaccessible host: `' + err.hostname +
+        var message = 'Inaccessible host: `' + err.hostname + '\' at port `' + err.port +
           '\'. This service may not be available in the `' + err.region +
           '\' region.';
         this.response.error = AWS.util.error(new Error(message), {


### PR DESCRIPTION
This pull request includes the port number for the errors returned by `ENOTFOUND_ERROR`. 

This is important because sometimes there are multiple services running in the `hostname` but without the port number it is impossible to identify which one is not being found. 

##### Checklist

None of the items apply, since it is a simple message that is returned by `AWS.util.error()` 

