### PR TITLE
chore: highlight general availability of v3

### DIFF
--- a/doc-src/templates/default/layout/html/v3note.erb
+++ b/doc-src/templates/default/layout/html/v3note.erb
@@ -1,5 +1,7 @@
-<div class="note">
-  <p><strong>Note:</strong> You are viewing the documentation for an older major version of the AWS SDK for JavaScript (v2).</p>
-  <p><a href="https://github.com/aws/aws-sdk-js-v3">The modular AWS SDK for JavaScript (v3)</a> is now General Available. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/">Developer Guide</a>
-  or <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference</a>.</p>
+<div class="alert">
+	<div class="alert-icon"></div>
+	<div>
+		<div class="alert-title">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
+		<div class="alert-text"> The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a> </div>
+	</div>
 </div>

--- a/doc-src/yard-js/templates/default/fulldoc/html/css/style.css
+++ b/doc-src/yard-js/templates/default/fulldoc/html/css/style.css
@@ -8,3 +8,20 @@
   margin-left: -15px; font-family: monospace; display: block; font-size: 1em;
 }
 .summary .note.title.event { font-size: 1.1em; font-family: monospace; }
+
+.alert {
+  border: 1px solid #0073bb;
+  border-radius: 2px;
+  background-color: #f1faff;
+  padding: 12px 20px;
+  display: flex;
+}
+.alert .alert-icon:before {
+  content: "ⓘ";
+  font-size: 2em;
+  padding-right: 15px;
+}
+.alert .alert-title {
+  font-weight: bold;
+  padding-bottom: 5px;
+}


### PR DESCRIPTION
Internal JS-2689

#### Screenshots

<details>
<summary>Before</summary>

![current](https://user-images.githubusercontent.com/16024985/131756825-9f8d59bc-5a72-4698-9fe4-e8c7f8ac8024.png)

</details>

<details>
<summary>After</summary>

![updated](https://user-images.githubusercontent.com/16024985/131756817-bdfcd99f-4351-4cfe-8417-b12dc38af165.png)

</details>

##### Checklist

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)
