### PR TITLE
feat: add dismissible Node.js <10.x deprecation notice

### DIFF
--- a/doc-src/templates/default/fulldoc/css/custom.css
+++ b/doc-src/templates/default/fulldoc/css/custom.css
@@ -1,0 +1,3 @@
+* {
+  font-family: 'Courier New', Courier, monospace;
+}

--- a/doc-src/templates/default/fulldoc/css/custom.css
+++ b/doc-src/templates/default/fulldoc/css/custom.css
@@ -35,3 +35,8 @@
   font-weight: bold;
   padding-bottom: 5px;
 }
+
+.alert .alert-dismiss:after {
+  content: "✕";
+  padding-left: 10px;
+}

--- a/doc-src/templates/default/fulldoc/css/custom.css
+++ b/doc-src/templates/default/fulldoc/css/custom.css
@@ -36,6 +36,10 @@
   padding-bottom: 5px;
 }
 
+.alert .alert-dismiss {
+  cursor: pointer;
+}
+
 .alert .alert-dismiss:after {
   content: "✕";
   padding-left: 10px;

--- a/doc-src/templates/default/fulldoc/css/custom.css
+++ b/doc-src/templates/default/fulldoc/css/custom.css
@@ -38,6 +38,7 @@
 
 .alert .alert-dismiss {
   cursor: pointer;
+  margin-left: auto;
 }
 
 .alert .alert-dismiss:after {

--- a/doc-src/templates/default/fulldoc/css/custom.css
+++ b/doc-src/templates/default/fulldoc/css/custom.css
@@ -1,3 +1,37 @@
-* {
-  font-family: 'Courier New', Courier, monospace;
+.alert {
+  border: 1px solid;
+  border-radius: 2px;
+  display: flex;
+  margin: 10px 0px;
+  padding: 12px 20px;
+}
+
+.alert.alert-info {
+  border-color: #0073bb;
+  background-color: #f1faff;
+}
+
+.alert.alert-warning {
+  border-color: #d13212;
+  background-color: #fdf3f1;
+}
+
+.alert .alert-icon:before {
+  font-size: 2em;
+  padding-right: 15px;
+}
+
+.alert-info .alert-icon:before {
+  content: "ⓘ";
+  color: #0073bb;
+}
+
+.alert-warning .alert-icon:before {
+  content: "⚠";
+  color: #d13212;
+}
+
+.alert .alert-header {
+  font-weight: bold;
+  padding-bottom: 5px;
 }

--- a/doc-src/templates/default/fulldoc/js/custom.js
+++ b/doc-src/templates/default/fulldoc/js/custom.js
@@ -1,0 +1,1 @@
+console.log('Hello World');

--- a/doc-src/templates/default/fulldoc/js/custom.js
+++ b/doc-src/templates/default/fulldoc/js/custom.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
   var trueValue = 'true';
-  var nodeVersionNoticeKey = 'dismissNodeDeprecationNotice';
+  var nodeVersionNoticeKey = 'nodeVersionNoticeDismissed';
   var dismissNodeDepNotice = localStorage.getItem(nodeVersionNoticeKey);
 
   if (dismissNodeDepNotice !== trueValue) {

--- a/doc-src/templates/default/fulldoc/js/custom.js
+++ b/doc-src/templates/default/fulldoc/js/custom.js
@@ -1,1 +1,6 @@
-console.log('Hello World');
+$(document).ready(function() {
+  $('#node-version-notice').slideDown();
+  $('#node-version-notice .alert-dismiss').click(function() {
+    $(this).parent().slideUp();
+  });
+});

--- a/doc-src/templates/default/fulldoc/js/custom.js
+++ b/doc-src/templates/default/fulldoc/js/custom.js
@@ -1,6 +1,13 @@
 $(document).ready(function() {
-  $('#node-version-notice').slideDown();
-  $('#node-version-notice .alert-dismiss').click(function() {
-    $(this).parent().slideUp();
-  });
+  var trueValue = 'true';
+  var nodeVersionNoticeKey = 'dismissNodeDeprecationNotice';
+  var dismissNodeDepNotice = localStorage.getItem(nodeVersionNoticeKey);
+
+  if (dismissNodeDepNotice !== trueValue) {
+    $('#node-version-notice').slideDown();
+    $('#node-version-notice .alert-dismiss').click(function() {
+      localStorage.setItem(nodeVersionNoticeKey, trueValue);
+      $(this).parent().slideUp();
+    });
+  }
 });

--- a/doc-src/templates/default/layout/html/layout.erb
+++ b/doc-src/templates/default/layout/html/layout.erb
@@ -21,6 +21,7 @@
 
       <div id="content">
         <%= erb(:v3note) %>
+        <%= erb(:nodeVersionNotice) %>
         <!--REGION_DISCLAIMER_DO_NOT_REMOVE-->
         <%= yieldall %>
       </div>

--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -8,4 +8,5 @@
 			on AWS Developer Tools Blog.
 		</div>
 	</div>
+	<div class="alert-dismiss"></div>
 </div>

--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -1,0 +1,7 @@
+<div class="alert">
+	<div class="alert-icon"></div>
+	<div>
+		<div class="alert-title">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
+		<div class="alert-text"> The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a> </div>
+	</div>
+</div>

--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -1,7 +1,11 @@
-<div class="alert">
+<div class="alert alert-warning">
 	<div class="alert-icon"></div>
 	<div>
-		<div class="alert-title">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
-		<div class="alert-text"> The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a> </div>
+		<div class="alert-header">End of support for Node.js &lt;10.x in the AWS SDK for JavaScript (v2).</div>
+		<div class="alert-content">
+			Starting November 1 2021, the AWS SDK For JavaScript (v2) will no longer support &lt;10.x.
+			For more information, see the <a href="https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-runtimes-10-x-in-the-aws-sdk-for-javascript-v2/">announcement</a>
+			on AWS Developer Tools Blog.
+		</div>
 	</div>
 </div>

--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -1,4 +1,4 @@
-<div class="alert alert-warning">
+<div id="node-version-notice" class="alert alert-warning" style="display:none;">
 	<div class="alert-icon"></div>
 	<div>
 		<div class="alert-header">End of support for Node.js &lt;10.x in the AWS SDK for JavaScript (v2).</div>

--- a/doc-src/templates/default/layout/html/setup.rb
+++ b/doc-src/templates/default/layout/html/setup.rb
@@ -1,0 +1,7 @@
+def stylesheets
+  super + %w(css/custom.css)
+end
+
+def javascripts
+  super + %w(js/custom.js)
+end

--- a/doc-src/templates/default/layout/html/v3note.erb
+++ b/doc-src/templates/default/layout/html/v3note.erb
@@ -4,7 +4,7 @@
 		<div class="alert-header">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
 		<div class="alert-content">
 			The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use.
-			For more information see the
+			For more information, see the
 				<a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and 
 				<a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a>
 		</div>

--- a/doc-src/templates/default/layout/html/v3note.erb
+++ b/doc-src/templates/default/layout/html/v3note.erb
@@ -1,7 +1,12 @@
-<div class="alert">
+<div class="alert alert-info">
 	<div class="alert-icon"></div>
 	<div>
-		<div class="alert-title">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
-		<div class="alert-text"> The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use. For more information see the <a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and <a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a> </div>
+		<div class="alert-header">You are viewing the documentation for an older major version of the AWS SDK for JavaScript.</div>
+		<div class="alert-content">
+			The modular AWS SDK for JavaScript (v3), the latest major version of AWS SDK for JavaScript, is now stable and recommended for general use.
+			For more information see the
+				<a href="https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/migrating-to-v3.html">Migration Guide</a> and 
+				<a href="https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html">API Reference.</a>
+		</div>
 	</div>
 </div>

--- a/doc-src/yard-js/templates/default/fulldoc/html/css/style.css
+++ b/doc-src/yard-js/templates/default/fulldoc/html/css/style.css
@@ -8,20 +8,3 @@
   margin-left: -15px; font-family: monospace; display: block; font-size: 1em;
 }
 .summary .note.title.event { font-size: 1.1em; font-family: monospace; }
-
-.alert {
-  border: 1px solid #0073bb;
-  border-radius: 2px;
-  background-color: #f1faff;
-  padding: 12px 20px;
-  display: flex;
-}
-.alert .alert-icon:before {
-  content: "ⓘ";
-  font-size: 2em;
-  padding-right: 15px;
-}
-.alert .alert-title {
-  font-weight: bold;
-  padding-bottom: 5px;
-}


### PR DESCRIPTION
The API reference can be viewed at: https://aws-sdk-js-3880.netlify.app/aws/s3
Verified that notice is not shown after it's dismissed, till the cookies are cleared.

<details>
<summary>Screen recording</summary>

https://user-images.githubusercontent.com/16024985/131924723-91b055e5-c411-41ef-af5b-e738059111b1.mov

</details>

Screenshots:
* <details>
  <summary>By default key `nodeVersionNoticeDismissed` is not set</summary>

  ![no-localStorage-key](https://user-images.githubusercontent.com/16024985/131926629-3c3cbc9c-b108-44cc-a30b-632b2c2d8e57.png)

  </details>
* <details>
  <summary>The key `nodeVersionNoticeDismissed` is set when version notice is dismissed</summary>

  ![localStorage-key](https://user-images.githubusercontent.com/16024985/131926650-38c9c9fd-1c8c-4b56-8d59-742109961450.png)

  </details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)
