### PR TITLE
chore: prefix Node.js before <10.x in notice content

### DIFF
--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -3,7 +3,7 @@
 	<div>
 		<div class="alert-header">End of support for Node.js &lt;10.x in the AWS SDK for JavaScript (v2).</div>
 		<div class="alert-content">
-			Starting November 1 2021, the AWS SDK For JavaScript (v2) will no longer support &lt;10.x.
+			Starting November 1 2021, the AWS SDK For JavaScript (v2) will no longer support Node.js &lt;10.x.
 			For more information, see the <a href="https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-node-js-runtimes-10-x-in-the-aws-sdk-for-javascript-v2/">announcement</a>
 			on AWS Developer Tools Blog.
 		</div>


### PR DESCRIPTION
Follow-up to https://github.com/aws/aws-sdk-js/pull/3880

The prefix Node.js was missed in the content for the alert warning shown in Node.js <10.x end of support notice. This PR adds it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)
