### PR TITLE
Allow use of AWS CLI's file cache in SharedIniFileCredentials

### DIFF
--- a/lib/credentials/shared_ini_file_credentials.d.ts
+++ b/lib/credentials/shared_ini_file_credentials.d.ts
@@ -14,4 +14,5 @@ interface SharedIniFileCredentialsOptions {
     tokenCodeFn?: (mfaSerial: string, callback: (err?: Error, token?: string) => void) => void
     httpOptions?: HTTPOptions
     callback?: (err?: Error) => void
+    useCache?: boolean
 }

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -1,5 +1,7 @@
 var AWS = require('../core');
 var STS = require('../../clients/sts');
+var path = require('path');
+var STSCredentialsCache = require('./sts_credentials_cache');
 var iniLoader = AWS.util.iniLoader;
 
 var ASSUME_ROLE_DEFAULT_REGION = 'us-east-1';
@@ -74,6 +76,16 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
    *   * **timeout** [Integer] &mdash; The number of milliseconds a request can
    *     take before automatically being terminated.
    *     Defaults to two minutes (120000).
+   *   * **xhrAsync** [Boolean] &mdash; Whether the SDK will send asynchronous
+   *     HTTP requests. Used in the browser environment only. Set to false to
+   *     send requests synchronously. Defaults to true (async on).
+   *   * **xhrWithCredentials** [Boolean] &mdash; Sets the "withCredentials"
+   *     property of an XMLHttpRequest object. Used in the browser environment
+   *     only. Defaults to false.
+   * @option options useCache [Boolean] (false) True to use filesystem cache
+   *   for assumed role credentials
+   * @option options cacheExpiryWindowSeconds [Number] (60 * 15) Remaining lifetime
+   *   in seconds to reuse cached credentials
    */
   constructor: function SharedIniFileCredentials(options) {
     AWS.Credentials.call(this);
@@ -86,6 +98,8 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     this.preferStaticCredentials = Boolean(options.preferStaticCredentials);
     this.tokenCodeFn = options.tokenCodeFn || null;
     this.httpOptions = options.httpOptions || null;
+    this.useCache = Boolean(options.useCache);
+    this.cacheExpiryWindowSeconds = options.cacheExpiryWindowSeconds || 60 * 15;
     this.get(options.callback || AWS.util.fn.noop);
   },
 
@@ -122,17 +136,11 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
-        this.loadRoleProfile(profiles, profile, function(err, data) {
-          if (err) {
-            callback(err);
-          } else {
+        this.loadRoleProfile(profiles, profile, function(err) {
+          if (!err) {
             self.expired = false;
-            self.accessKeyId = data.Credentials.AccessKeyId;
-            self.secretAccessKey = data.Credentials.SecretAccessKey;
-            self.sessionToken = data.Credentials.SessionToken;
-            self.expireTime = data.Credentials.Expiration;
-            callback(null);
           }
+          callback(err);
         });
         return;
       }
@@ -239,11 +247,6 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
     );
 
     this.roleArn = roleArn;
-    var sts = new STS({
-      credentials: sourceCredentials,
-      region: profileRegion,
-      httpOptions: this.httpOptions
-    });
 
     var roleParams = {
       RoleArn: roleArn,
@@ -254,29 +257,17 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       roleParams.ExternalId = externalId;
     }
 
-    if (mfaSerial && self.tokenCodeFn) {
+    if (mfaSerial) {
       roleParams.SerialNumber = mfaSerial;
-      self.tokenCodeFn(mfaSerial, function(err, token) {
-        if (err) {
-          var message;
-          if (err instanceof Error) {
-            message = err.message;
-          } else {
-            message = err;
-          }
-          callback(
-            AWS.util.error(
-              new Error('Error fetching MFA token: ' + message),
-              { code: 'SharedIniFileCredentialsProviderFailure' }
-            ));
-          return;
-        }
-
-        roleParams.TokenCode = token;
-        sts.assumeRole(roleParams, callback);
-      });
-      return;
     }
-    sts.assumeRole(roleParams, callback);
-  }
+    var options = {
+      useCache: this.useCache,
+      tokenCodeFn: this.tokenCodeFn,
+      expiryWindowSeconds: this.cacheExpiryWindowSeconds,
+      httpOptions: this.httpOptions,
+      region: profileRegion
+    };
+    var cache = new STSCredentialsCache(roleParams, sourceCredentials, options);
+    cache.assignCredentials(self, callback);
+ }
 });

--- a/lib/credentials/sts_credentials_cache.js
+++ b/lib/credentials/sts_credentials_cache.js
@@ -1,0 +1,175 @@
+var AWS = require('../core');
+var STS = require('../../clients/sts');
+
+STSCredentialsCache = AWS.util.inherit({
+
+  /**
+   * Optionally cache STS assumed role credentials.
+   *
+   * @api private
+   */
+  constructor: function STSCredentialsCache(params, sourceCredentials, options) {
+    options = options || {};
+    this.params = params;
+    this.expiryWindowSeconds = options.expiryWindowSeconds || 60 * 15;
+    this.tokenCodeFn = options.tokenCodeFn || null;
+    this.useCache = Boolean(options.useCache);
+    this.service = new STS({
+      credentials: sourceCredentials,
+      httpOptions: options.httpOptions,
+      region: options.region
+    });
+  },
+
+  /**
+   * @api private
+   */
+  assignCredentials: function assignCredentials(destinationCredentials, callback) {
+    if (!callback) callback = function(err) { if (err) throw err; };
+
+    if (this.useCache) {
+      var cacheKey = this.generateCacheKey();
+      this.credentialsFromCache(cacheKey, destinationCredentials, callback);
+    } else {
+      this.createCredentials(null, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  credentialsFromCache: function credentialsFromCache(cacheKey, destinationCredentials, callback) {
+    var cachedCreds = this.cacheRead(cacheKey);
+    if (this.credsValid(cachedCreds)) {
+      this.service.credentialsFrom(cachedCreds, destinationCredentials);
+      callback();
+    } else {
+      this.createCredentials(cacheKey, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  createCredentials: function createCredentials(cacheKey, destinationCredentials, callback) {
+    var self = this;
+
+    if (self.params.SerialNumber && self.tokenCodeFn) {
+      self.tokenCodeFn(self.params.SerialNumber, function(err, token) {
+        if (err) {
+          var message;
+          if (err instanceof Error) {
+            message = err.message;
+          } else {
+            message = err;
+          }
+          callback(
+            AWS.util.error(
+              new Error('Error fetching MFA token: ' + message),
+              { code: 'SharedIniFileCredentialsProviderFailure' }
+            ));
+          return;
+        }
+
+        self.params.TokenCode = token;
+        self.assumeRole(cacheKey, destinationCredentials, callback);
+      });
+    } else {
+      self.assumeRole(cacheKey, destinationCredentials, callback);
+    }
+  },
+
+  /**
+   * @api private
+   */
+  assumeRole: function assumeRole(cacheKey, destinationCredentials, callback) {
+    var self = this;
+    this.service.assumeRole(self.params, function (err, data) {
+      if (!err) {
+        self.service.credentialsFrom(data, destinationCredentials);
+        if (self.useCache && cacheKey) {
+          self.cacheWrite(cacheKey, data);
+        }
+      }
+      callback(err);
+    });
+  },
+
+  /**
+   * @api private
+   */
+  generateCacheKey: function generateCacheKey() {
+    var keys = Object.keys(this.params).filter(function(key) {
+      return key !== 'RoleSessionName';
+    });
+    var input = JSON.stringify(this.params, keys.sort());
+    return require('crypto').createHash('sha1').update(input).digest('hex');
+  },
+
+  /**
+   * @api private
+   */
+  cacheFilepath: function cacheFilepath(cacheKey) {
+    var path = require('path');
+    var home = require('os').homedir();
+    var defaultDir = path.join(home, '.aws', 'cli', 'cache');
+    var dir = process.env.AWS_CREDENTIAL_CACHE_DIRECTORY || defaultDir;
+    return path.join(dir, cacheKey) + '.json';
+  },
+
+  /**
+   * @api private
+   */
+  cacheRead: function cacheRead(cacheKey) {
+    try {
+      var contents = AWS.util.readFileSync(this.cacheFilepath(cacheKey));
+      if (contents) {
+        var a = JSON.parse(contents);
+        return a;
+      }
+    } catch (e) {
+      return {error: e};
+    }
+  },
+
+  /**
+   * @api private
+   */
+  cacheWrite: function cacheWrite(cacheKey, data) {
+    var fs = require('fs');
+    var path = require('path');
+    var cacheFilepath = this.cacheFilepath(cacheKey);
+    var dir = path.dirname(path.resolve(cacheFilepath));
+
+    // mkdir -p
+    dir.split(path.sep).reduce(function(parentDir, childDir) {
+      var curDir = path.resolve('/', parentDir, childDir);
+      try {
+        fs.mkdirSync(curDir);
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          throw err;
+        }
+      }
+      return curDir;
+    });
+
+    fs.writeFileSync(cacheFilepath, JSON.stringify(data), 'utf-8');
+  },
+
+  /**
+   * @api private
+   */
+  credsValid: function credsValid(creds) {
+    if (creds && creds['Credentials'] && creds['Credentials']['Expiration']) {
+      var now = AWS.util.date.getDate();
+      var expiration = new Date(creds['Credentials']['Expiration']);
+      var remaining = (expiration.getTime() - now.getTime()) / 1000;
+      return remaining > this.expiryWindowSeconds;
+    }
+    return false;
+  },
+
+});
+
+module.exports = STSCredentialsCache;


### PR DESCRIPTION
Please ignore for now. I'm just updating a stale patch to check it against your codebuild test environment.
____

This is based mostly off of https://github.com/boto/botocore/blob/879f8440a4e9ace5d3cf145ce8b3d5e5ffb892ef/botocore/credentials.py#L536
and is compatible/can use caches from boto.

(updated version of https://github.com/aws/aws-sdk-js/pull/2270)

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
