### PR TITLE
ManagedUpload.send's callback may return null instead of an Error

### DIFF
--- a/lib/s3/managed_upload.d.ts
+++ b/lib/s3/managed_upload.d.ts
@@ -16,7 +16,7 @@ export class ManagedUpload {
     /**
      * Initiates the managed upload for the payload.
      */
-    send(callback?: (err: AWSError, data: ManagedUpload.SendData) => void): void;
+    send(callback?: (err: AWSError|null, data: ManagedUpload.SendData) => void): void;
     /**
      * Adds a listener that is triggered when theuploader has uploaded more data.
      *


### PR DESCRIPTION
This callback's TypeScript definition says it would always return an AWSError, however, by looking at the actual code and JSDocs one notices that the `err` may also be `null`.

https://github.com/aws/aws-sdk-js/blob/a42ad578686801607b88358b7a85da48a8952bdc/lib/s3/managed_upload.js#L159

I don't intent to maintain this PR – I just though a code change would be more descriptive than filing an issue. Please edit this or commit it yourself if you must not have contributors without CLA signature in your code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [x] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
