### PR TITLE
issue 3908: add VersionId to SendData type

### DIFF
--- a/lib/s3/managed_upload.d.ts
+++ b/lib/s3/managed_upload.d.ts
@@ -57,6 +57,10 @@ export namespace ManagedUpload {
          * Key to which the object was uploaded.
          */
         Key: string;
+        /**
+         * Version which was assigned to the uploaded object by S3 in case the bucket is versioning-enabled.
+         */
+        VersionId? : string;
     }
     export interface ManagedUploadOptions {
         /**


### PR DESCRIPTION
As described in this Issue: https://github.com/aws/aws-sdk-js/issues/3908 the property VersionId is missing in the SendData return type from ManagedUpload. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
