### PR TITLE
docs: remove Node.js <10.x end of support notice

### DIFF
--- a/doc-src/templates/default/layout/html/layout.erb
+++ b/doc-src/templates/default/layout/html/layout.erb
@@ -21,7 +21,6 @@
 
       <div id="content">
         <%= erb(:v3note) %>
-        <%= erb(:nodeVersionNotice) %>
         <!--REGION_DISCLAIMER_DO_NOT_REMOVE-->
         <%= yieldall %>
       </div>

--- a/doc-src/templates/default/layout/html/nodeVersionNotice.erb
+++ b/doc-src/templates/default/layout/html/nodeVersionNotice.erb
@@ -1,3 +1,4 @@
+<!-- Retaining this file for future deprecation reference -->
 <div id="node-version-notice" class="alert alert-warning" style="display:none;">
 	<div class="alert-icon"></div>
 	<div>


### PR DESCRIPTION
Removes notice added in https://github.com/aws/aws-sdk-js/pull/3880

The API reference can be viewed at https://aws-sdk-js-3935.netlify.app/aws/s3
Note that div with `id="node-version-notice"` is not present between alert and region disclaimer comment.

<details>
<summary>Before</summary>

![Screen Shot 2021-10-29 at 11 35 33 AM](https://user-images.githubusercontent.com/16024985/139485481-b3c4573c-29f0-4782-8d33-be6f2cabbe4f.png)

</details>

<details>
<summary>After</summary>

![Screen Shot 2021-10-29 at 11 40 08 AM](https://user-images.githubusercontent.com/16024985/139485883-147966e8-3464-439b-af37-e285eea43656.png)

</details>

##### Checklist

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)
