### PR TITLE
Remove support for accesspoint pseudo regions

### DIFF
--- a/.changes/next-release/feature-endpoint-a9213d51.json
+++ b/.changes/next-release/feature-endpoint-a9213d51.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "endpoint",
+  "description": "Remove unsupported accesspoint pseudo regions"
+}

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -127,7 +127,7 @@ function getRealRegion(region) {
       ? 'us-east-1'
       : region === 'fips-aws-us-gov-global'
       ? 'us-gov-west-1'
-      : region.replace(/fips-(dkr-|prod-|accesspoint-)?|-fips/, '')
+      : region.replace(/fips-(dkr-|prod-)?|-fips/, '')
     : region;
 }
 

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -6,7 +6,6 @@ function generateRegionPrefix(region) {
   if (isFipsRegion(region)) {
     if (isFipsCnRegion(region)) return 'fips-cn-*';
     if (isFipsUsGovRegion(region)) return 'fips-us-gov-*';
-    if (region.startsWith('fips-accesspoint-')) return 'fips-accesspoint-*';
     return 'fips-*';
   }
 

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -88,9 +88,6 @@
     "fips-*/transcribe": "fipsDotPrefix",
     "fips-us-gov-*/transcribe": "fipsDotPrefix",
     "fips-*/waf": "fipsWithoutRegion",
-    "fips-accesspoint-*/*": {
-      "endpoint": "{service}-accesspoint-fips.{region}.amazonaws.com"
-    },
     "fips-us-gov-*/acm-pca": "fipsWithServiceOnly",
     "fips-us-gov-*/batch": "fipsWithServiceOnly",
     "fips-us-gov-*/config": "fipsWithServiceOnly",

--- a/scripts/region-checker/allowlist.js
+++ b/scripts/region-checker/allowlist.js
@@ -28,7 +28,7 @@ var allowlist = {
         112
     ],
     '/region_config.js': [
-        127
+        126
     ],
     '/request.js': [
         318,

--- a/test/endpoint/fips/test_cases_supported.json
+++ b/test/endpoint/fips/test_cases_supported.json
@@ -2282,41 +2282,6 @@
     "hostname": "runtime-fips.sagemaker.us-west-2.amazonaws.com"
   },
   {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-ca-central-1",
-    "signingRegion": "ca-central-1",
-    "hostname": "s3-accesspoint-fips.ca-central-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-east-1",
-    "signingRegion": "us-east-1",
-    "hostname": "s3-accesspoint-fips.us-east-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-east-2",
-    "signingRegion": "us-east-2",
-    "hostname": "s3-accesspoint-fips.us-east-2.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-west-1",
-    "signingRegion": "us-west-1",
-    "hostname": "s3-accesspoint-fips.us-west-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-west-2",
-    "signingRegion": "us-west-2",
-    "hostname": "s3-accesspoint-fips.us-west-2.amazonaws.com"
-  },
-  {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "ca-central-1-fips",
@@ -3806,20 +3771,6 @@
     "region": "us-gov-west-1-fips",
     "signingRegion": "us-gov-west-1",
     "hostname": "runtime.sagemaker.us-gov-west-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-gov-east-1",
-    "signingRegion": "us-gov-east-1",
-    "hostname": "s3-accesspoint-fips.us-gov-east-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-gov-west-1",
-    "signingRegion": "us-gov-west-1",
-    "hostname": "s3-accesspoint-fips.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3",


### PR DESCRIPTION
The accesspoint pseudo regions are no longer supported.
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2973

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed