### PR TITLE
Move FIPS rules to a separate section in region_config

### DIFF
--- a/.changes/next-release/feature-endpoint-e156c0ec.json
+++ b/.changes/next-release/feature-endpoint-e156c0ec.json
@@ -1,5 +1,5 @@
 {
   "type": "feature",
   "category": "endpoint",
-  "description": "Move FIPS rules in a separate section in region_config"
+  "description": "Move FIPS rules to a separate section in region_config"
 }

--- a/.changes/next-release/feature-endpoint-e156c0ec.json
+++ b/.changes/next-release/feature-endpoint-e156c0ec.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "endpoint",
+  "description": "Move FIPS rules in a separate section in region_config"
+}

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -4,9 +4,7 @@ var regionConfig = require('./region_config_data.json');
 function generateRegionPrefix(region) {
   if (!region) return null;
   if (isFipsRegion(region)) {
-    if (isFipsCnRegion(region)) return 'fips-cn-*';
-    if (isFipsUsGovRegion(region)) return 'fips-us-gov-*';
-    return 'fips-*';
+    region = getRealRegion(region);
   }
 
   var parts = region.split('-');
@@ -42,12 +40,14 @@ function applyConfig(service, config) {
 
 function configureEndpoint(service) {
   var keys = derivedKeys(service);
+  var region = service.config.region;
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
     if (!key) continue;
 
-    if (Object.prototype.hasOwnProperty.call(regionConfig.rules, key)) {
-      var config = regionConfig.rules[key];
+    var rules = isFipsRegion(region) ? regionConfig.fipsRules : regionConfig.rules;
+    if (Object.prototype.hasOwnProperty.call(rules, key)) {
+      var config = rules[key];
       if (typeof config === 'string') {
         config = regionConfig.patterns[config];
       }
@@ -103,22 +103,6 @@ function getEndpointSuffix(region) {
 
 function isFipsRegion(region) {
   return region && (region.startsWith('fips-') || region.endsWith('-fips'));
-}
-
-function isFipsUsGovRegion(region) {
-  return (
-    region &&
-    region.startsWith('fips-us-gov-') ||
-    (region.startsWith('us-gov-') && region.endsWith('-fips'))
-  );
-}
-
-function isFipsCnRegion(region) {
-  return (
-    region &&
-    region.startsWith('fips-cn-') ||
-    (region.startsWith('cn-') && region.endsWith('-fips'))
-  );
 }
 
 function getRealRegion(region) {

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -3,11 +3,6 @@
     "*/*": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },
-    "fips-*/*": "fipsStandard",
-    "fips-us-gov-*/*": "fipsStandard",
-    "fips-cn-*/*": {
-      "endpoint": "{service}-fips.{region}.amazonaws.com.cn"
-    },
     "cn-*/*": {
       "endpoint": "{service}.{region}.amazonaws.com.cn"
     },
@@ -66,49 +61,57 @@
     "*/sdb": {
       "endpoint": "{service}.{region}.amazonaws.com",
       "signatureVersion": "v2"
-    },
+    }
+  },
 
-    "fips-*/api.ecr": "fips.api.ecr",
-    "fips-us-gov-*/api.ecr": "fips.api.ecr",
-    "fips-*/api.sagemaker": "fips.api.sagemaker",
-    "fips-us-gov-*/api.sagemaker": "fips.api.sagemaker",
-    "fips-*/batch": "fipsDotPrefix",
-    "fips-*/eks": "fipsDotPrefix",
-    "fips-*/models.lex": "fips.models.lex",
-    "fips-us-gov-*/models.lex": "fips.models.lex",
-    "fips-*/runtime.lex": "fips.runtime.lex",
-    "fips-us-gov-*/runtime.lex": "fips.runtime.lex",
-    "fips-*/runtime.sagemaker": {
+  "fipsRules": {
+    "*/*": "fipsStandard",
+    "us-gov-*/*": "fipsStandard",
+    "cn-*/*": {
+      "endpoint": "{service}-fips.{region}.amazonaws.com.cn"
+    },
+    "*/api.ecr": "fips.api.ecr",
+    "*/api.sagemaker": "fips.api.sagemaker",
+    "*/batch": "fipsDotPrefix",
+    "*/eks": "fipsDotPrefix",
+    "*/models.lex": "fips.models.lex",
+    "*/runtime.lex": "fips.runtime.lex",
+    "*/runtime.sagemaker": {
       "endpoint": "runtime-fips.sagemaker.{region}.amazonaws.com"
     },
-    "fips-*/route53": "fipsWithoutRegion",
-    "fips-*/transcribe": "fipsDotPrefix",
-    "fips-us-gov-*/transcribe": "fipsDotPrefix",
-    "fips-*/waf": "fipsWithoutRegion",
-    "fips-us-gov-*/acm-pca": "fipsWithServiceOnly",
-    "fips-us-gov-*/batch": "fipsWithServiceOnly",
-    "fips-us-gov-*/config": "fipsWithServiceOnly",
-    "fips-us-gov-*/eks": "fipsWithServiceOnly",
-    "fips-us-gov-*/elasticmapreduce": "fipsWithServiceOnly",
-    "fips-us-gov-*/identitystore": "fipsWithServiceOnly",
-    "fips-us-gov-*/dynamodb": "fipsWithServiceOnly",
-    "fips-us-gov-*/elasticloadbalancing": "fipsWithServiceOnly",
-    "fips-us-gov-*/guardduty": "fipsWithServiceOnly",
-    "fips-us-gov-*/monitoring": "fipsWithServiceOnly",
-    "fips-aws-us-gov-global/organizations": "fipsWithServiceOnly",
-    "fips-us-gov-*/resource-groups": "fipsWithServiceOnly",
-    "fips-aws-us-gov-global/route53": {
-      "endpoint": "route53.us-gov.amazonaws.com"
-    },
-    "fips-us-gov-*/runtime.sagemaker": "fipsWithServiceOnly",
-    "fips-us-gov-*/servicecatalog-appregistry": "fipsWithServiceOnly",
-    "fips-us-gov-*/servicequotas": "fipsWithServiceOnly",
-    "fips-us-gov-*/ssm": "fipsWithServiceOnly",
-    "fips-us-gov-*/sts": "fipsWithServiceOnly",
+    "*/route53": "fipsWithoutRegion",
+    "*/transcribe": "fipsDotPrefix",
+    "*/waf": "fipsWithoutRegion",
+
+    "us-gov-*/transcribe": "fipsDotPrefix",
+    "us-gov-*/api.ecr": "fips.api.ecr",
+    "us-gov-*/api.sagemaker": "fips.api.sagemaker",
+    "us-gov-*/models.lex": "fips.models.lex",
+    "us-gov-*/runtime.lex": "fips.runtime.lex",
+    "us-gov-*/acm-pca": "fipsWithServiceOnly",
+    "us-gov-*/batch": "fipsWithServiceOnly",
+    "us-gov-*/config": "fipsWithServiceOnly",
+    "us-gov-*/eks": "fipsWithServiceOnly",
+    "us-gov-*/elasticmapreduce": "fipsWithServiceOnly",
+    "us-gov-*/identitystore": "fipsWithServiceOnly",
+    "us-gov-*/dynamodb": "fipsWithServiceOnly",
+    "us-gov-*/elasticloadbalancing": "fipsWithServiceOnly",
+    "us-gov-*/guardduty": "fipsWithServiceOnly",
+    "us-gov-*/monitoring": "fipsWithServiceOnly",
+    "us-gov-*/resource-groups": "fipsWithServiceOnly",
+    "us-gov-*/runtime.sagemaker": "fipsWithServiceOnly",
+    "us-gov-*/servicecatalog-appregistry": "fipsWithServiceOnly",
+    "us-gov-*/servicequotas": "fipsWithServiceOnly",
+    "us-gov-*/ssm": "fipsWithServiceOnly",
+    "us-gov-*/sts": "fipsWithServiceOnly",
+    "us-gov-*/support": "fipsWithServiceOnly",
     "fips-us-gov-west-1/states": "fipsWithServiceOnly",
-    "fips-us-gov-*/support": "fipsWithServiceOnly",
     "fips-us-iso-east-1/elasticfilesystem": {
       "endpoint": "elasticfilesystem-fips.{region}.c2s.ic.gov"
+    },
+    "fips-aws-us-gov-global/organizations": "fipsWithServiceOnly",
+    "fips-aws-us-gov-global/route53": {
+      "endpoint": "route53.us-gov.amazonaws.com"
     }
   },
 

--- a/scripts/region-checker/allowlist.js
+++ b/scripts/region-checker/allowlist.js
@@ -28,7 +28,7 @@ var allowlist = {
         112
     ],
     '/region_config.js': [
-        126
+        110
     ],
     '/request.js': [
         318,


### PR DESCRIPTION
Refactor of FIPs support added in:
* https://github.com/aws/aws-sdk-js/pull/3923
* https://github.com/aws/aws-sdk-js/pull/3929

This PR moves fips rules to it's own section.
This helps in removing redundant `fips-` prefix, and allows adding future configs (dualstack and dualstack+fips) 

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed
