### PR TITLE
Remove support for unused accesspoint pseudo regions

### DIFF
--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -6,7 +6,6 @@ function generateRegionPrefix(region) {
   if (isFipsRegion(region)) {
     if (isFipsCnRegion(region)) return 'fips-cn-*';
     if (isFipsUsGovRegion(region)) return 'fips-us-gov-*';
-    if (region.startsWith('fips-accesspoint-')) return 'fips-accesspoint-*';
     return 'fips-*';
   }
 
@@ -128,7 +127,7 @@ function getRealRegion(region) {
       ? 'us-east-1'
       : region === 'fips-aws-us-gov-global'
       ? 'us-gov-west-1'
-      : region.replace(/fips-(dkr-|prod-|accesspoint-)?|-fips/, '')
+      : region.replace(/fips-(dkr-|prod-)?|-fips/, '')
     : region;
 }
 

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -88,9 +88,6 @@
     "fips-*/transcribe": "fipsDotPrefix",
     "fips-us-gov-*/transcribe": "fipsDotPrefix",
     "fips-*/waf": "fipsWithoutRegion",
-    "fips-accesspoint-*/*": {
-      "endpoint": "{service}-accesspoint-fips.{region}.amazonaws.com"
-    },
     "fips-us-gov-*/acm-pca": "fipsWithServiceOnly",
     "fips-us-gov-*/batch": "fipsWithServiceOnly",
     "fips-us-gov-*/config": "fipsWithServiceOnly",

--- a/test/endpoint/fips/test_cases_supported.json
+++ b/test/endpoint/fips/test_cases_supported.json
@@ -2282,41 +2282,6 @@
     "hostname": "runtime-fips.sagemaker.us-west-2.amazonaws.com"
   },
   {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-ca-central-1",
-    "signingRegion": "ca-central-1",
-    "hostname": "s3-accesspoint-fips.ca-central-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-east-1",
-    "signingRegion": "us-east-1",
-    "hostname": "s3-accesspoint-fips.us-east-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-east-2",
-    "signingRegion": "us-east-2",
-    "hostname": "s3-accesspoint-fips.us-east-2.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-west-1",
-    "signingRegion": "us-west-1",
-    "hostname": "s3-accesspoint-fips.us-west-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-west-2",
-    "signingRegion": "us-west-2",
-    "hostname": "s3-accesspoint-fips.us-west-2.amazonaws.com"
-  },
-  {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "ca-central-1-fips",
@@ -3806,20 +3771,6 @@
     "region": "us-gov-west-1-fips",
     "signingRegion": "us-gov-west-1",
     "hostname": "runtime.sagemaker.us-gov-west-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-gov-east-1",
-    "signingRegion": "us-gov-east-1",
-    "hostname": "s3-accesspoint-fips.us-gov-east-1.amazonaws.com"
-  },
-  {
-    "endpointPrefix": "s3",
-    "clientName": "S3",
-    "region": "fips-accesspoint-us-gov-west-1",
-    "signingRegion": "us-gov-west-1",
-    "hostname": "s3-accesspoint-fips.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3",


### PR DESCRIPTION
The unused accesspoint pseudo regions were removed from endpoints.json
Refs: https://github.com/aws/aws-sdk-js-v3/pull/2973

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] run `npm run integration` if integration test is changed
