### PR TITLE
Remove region config exceptions for streams.dynamodb

### DIFF
--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -81,9 +81,6 @@
     "fips-*/runtime.sagemaker": {
       "endpoint": "runtime-fips.sagemaker.{region}.amazonaws.com"
     },
-    "fips-*/streams.dynamodb": {
-      "endpoint": "dynamodb-fips.{region}.amazonaws.com"
-    },
     "fips-*/route53": "fipsWithoutRegion",
     "fips-*/transcribe": "fipsDotPrefix",
     "fips-us-gov-*/transcribe": "fipsDotPrefix",
@@ -113,9 +110,6 @@
     "fips-us-gov-*/sts": "fipsWithServiceOnly",
     "fips-us-gov-west-1/states": "fipsWithServiceOnly",
     "fips-us-gov-*/support": "fipsWithServiceOnly",
-    "fips-us-gov-*/streams.dynamodb": {
-      "endpoint": "dynamodb.{region}.amazonaws.com"
-    },
     "fips-us-iso-east-1/elasticfilesystem": {
       "endpoint": "elasticfilesystem-fips.{region}.c2s.ic.gov"
     }

--- a/test/endpoint/fips/test_cases_supported.json
+++ b/test/endpoint/fips/test_cases_supported.json
@@ -2762,35 +2762,35 @@
     "clientName": "DynamoDBStreams",
     "region": "ca-central-1-fips",
     "signingRegion": "ca-central-1",
-    "hostname": "dynamodb-fips.ca-central-1.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-east-1-fips",
     "signingRegion": "us-east-1",
-    "hostname": "dynamodb-fips.us-east-1.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-east-2-fips",
     "signingRegion": "us-east-2",
-    "hostname": "dynamodb-fips.us-east-2.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-east-2.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-west-1-fips",
     "signingRegion": "us-west-1",
-    "hostname": "dynamodb-fips.us-west-1.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-west-2-fips",
     "signingRegion": "us-west-2",
-    "hostname": "dynamodb-fips.us-west-2.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-west-2.amazonaws.com"
   },
   {
     "endpointPrefix": "sts",
@@ -3973,14 +3973,14 @@
     "clientName": "DynamoDBStreams",
     "region": "us-gov-east-1-fips",
     "signingRegion": "us-gov-east-1",
-    "hostname": "dynamodb.us-gov-east-1.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-gov-west-1-fips",
     "signingRegion": "us-gov-west-1",
-    "hostname": "dynamodb.us-gov-west-1.amazonaws.com"
+    "hostname": "streams.dynamodb-fips.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sts",


### PR DESCRIPTION
The previous endpoints for streans.dynamodb were outdated, and were corrected when endpoints were updated in v3 in https://github.com/aws/aws-sdk-js-v3/pull/2973

The exceptions are no longer required.

##### Checklist

- [x] `npm run test` passes