### PR TITLE
Move metadata service internal code under its namespace

### DIFF
--- a/lib/metadata_service/endpoint.js
+++ b/lib/metadata_service/endpoint.js
@@ -1,9 +1,8 @@
+var AWS = require('../core');
+
 AWS.MetadataService.Endpoint = {
   IPv4: 'http://169.254.169.254',
   IPv6: 'http://[fd00:ec2::254]',
 };
 
-/**
- * @constant
- */
 module.exports = AWS.MetadataService.Endpoint;

--- a/lib/metadata_service/endpoint.js
+++ b/lib/metadata_service/endpoint.js
@@ -1,6 +1,9 @@
-var Endpoint = {
+AWS.MetadataService.Endpoint = {
   IPv4: 'http://169.254.169.254',
   IPv6: 'http://[fd00:ec2::254]',
 };
 
-module.exports = Endpoint;
+/**
+ * @constant
+ */
+module.exports = AWS.MetadataService.Endpoint;

--- a/lib/metadata_service/endpoint_config_options.js
+++ b/lib/metadata_service/endpoint_config_options.js
@@ -1,3 +1,5 @@
+var AWS = require('../core');
+
 var ENV_ENDPOINT_NAME = 'AWS_EC2_METADATA_SERVICE_ENDPOINT';
 var CONFIG_ENDPOINT_NAME = 'ec2_metadata_service_endpoint';
 

--- a/lib/metadata_service/endpoint_config_options.js
+++ b/lib/metadata_service/endpoint_config_options.js
@@ -1,14 +1,10 @@
 var ENV_ENDPOINT_NAME = 'AWS_EC2_METADATA_SERVICE_ENDPOINT';
 var CONFIG_ENDPOINT_NAME = 'ec2_metadata_service_endpoint';
 
-var ENDPOINT_CONFIG_OPTIONS = {
+AWS.MetadataService.ENDPOINT_CONFIG_OPTIONS = {
   environmentVariableSelector: function(env) { return env[ENV_ENDPOINT_NAME]; },
   configFileSelector: function(profile) { return profile[CONFIG_ENDPOINT_NAME]; },
   default: undefined,
 };
 
-module.exports = {
-  ENV_ENDPOINT_NAME: ENV_ENDPOINT_NAME,
-  CONFIG_ENDPOINT_NAME: CONFIG_ENDPOINT_NAME,
-  ENDPOINT_CONFIG_OPTIONS: ENDPOINT_CONFIG_OPTIONS
-};
+module.exports = AWS.MetadataService.ENDPOINT_CONFIG_OPTIONS;

--- a/lib/metadata_service/endpoint_mode.js
+++ b/lib/metadata_service/endpoint_mode.js
@@ -1,3 +1,5 @@
+var AWS = require('../core');
+
 AWS.MetadataService.EndpointMode = {
   IPv4: 'IPv4',
   IPv6: 'IPv6',

--- a/lib/metadata_service/endpoint_mode.js
+++ b/lib/metadata_service/endpoint_mode.js
@@ -1,6 +1,6 @@
-var EndpointMode = {
+AWS.MetadataService.EndpointMode = {
   IPv4: 'IPv4',
   IPv6: 'IPv6',
 };
 
-module.exports = EndpointMode;
+module.exports = AWS.MetadataService.EndpointMode;

--- a/lib/metadata_service/endpoint_mode_config_options.js
+++ b/lib/metadata_service/endpoint_mode_config_options.js
@@ -3,14 +3,10 @@ var EndpointMode = require('./endpoint_mode');
 var ENV_ENDPOINT_MODE_NAME = 'AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE';
 var CONFIG_ENDPOINT_MODE_NAME = 'ec2_metadata_service_endpoint_mode';
 
-var ENDPOINT_MODE_CONFIG_OPTIONS = {
+AWS.MetadataService.ENDPOINT_MODE_CONFIG_OPTIONS = {
   environmentVariableSelector: function(env) { return env[ENV_ENDPOINT_MODE_NAME]; },
   configFileSelector: function(profile) { return profile[CONFIG_ENDPOINT_MODE_NAME]; },
   default: EndpointMode.IPv4,
 };
 
-module.exports = {
-  ENV_ENDPOINT_MODE_NAME: ENV_ENDPOINT_MODE_NAME,
-  CONFIG_ENDPOINT_MODE_NAME: CONFIG_ENDPOINT_MODE_NAME,
-  ENDPOINT_MODE_CONFIG_OPTIONS: ENDPOINT_MODE_CONFIG_OPTIONS
-};
+module.exports = AWS.MetadataService.ENDPOINT_MODE_CONFIG_OPTIONS;

--- a/lib/metadata_service/endpoint_mode_config_options.js
+++ b/lib/metadata_service/endpoint_mode_config_options.js
@@ -1,4 +1,4 @@
-var EndpointMode = require('./endpoint_mode');
+var AWS = require('../core');
 
 var ENV_ENDPOINT_MODE_NAME = 'AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE';
 var CONFIG_ENDPOINT_MODE_NAME = 'ec2_metadata_service_endpoint_mode';
@@ -6,7 +6,7 @@ var CONFIG_ENDPOINT_MODE_NAME = 'ec2_metadata_service_endpoint_mode';
 AWS.MetadataService.ENDPOINT_MODE_CONFIG_OPTIONS = {
   environmentVariableSelector: function(env) { return env[ENV_ENDPOINT_MODE_NAME]; },
   configFileSelector: function(profile) { return profile[CONFIG_ENDPOINT_MODE_NAME]; },
-  default: EndpointMode.IPv4,
+  default: AWS.MetadataService.EndpointMode.IPv4,
 };
 
 module.exports = AWS.MetadataService.ENDPOINT_MODE_CONFIG_OPTIONS;

--- a/lib/metadata_service/get_metadata_service_endpoint.js
+++ b/lib/metadata_service/get_metadata_service_endpoint.js
@@ -3,8 +3,8 @@ var AWS = require('../core');
 var Endpoint = require('./endpoint');
 var EndpointMode = require('./endpoint_mode');
 
-var ENDPOINT_CONFIG_OPTIONS = require('./endpoint_config_options').ENDPOINT_CONFIG_OPTIONS;
-var ENDPOINT_MODE_CONFIG_OPTIONS = require('./endpoint_mode_config_options').ENDPOINT_MODE_CONFIG_OPTIONS;
+var ENDPOINT_CONFIG_OPTIONS = require('./endpoint_config_options');
+var ENDPOINT_MODE_CONFIG_OPTIONS = require('./endpoint_mode_config_options');
 
 var getMetadataServiceEndpoint = function() {
   var endpoint = AWS.util.loadConfig(ENDPOINT_CONFIG_OPTIONS);


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3952
Follow-up to https://github.com/aws/aws-sdk-js/pull/3853

### Testing

Docs can be viewed at https://aws-sdk-js-3952.netlify.app/
* The metadata service modules are not shown under [Top Level Namespace](https://aws-sdk-js-3952.netlify.app/top-level-namespace.html).
* The modules are now shown under [MetadataService](https://aws-sdk-js-3952.netlify.app/aws/metadataservice).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] changelog is added, `npm run add-change`