### PR TITLE
Disable Rescue SES InvalidParameterValue test

### DIFF
--- a/features/ses/ses.feature
+++ b/features/ses/ses.feature
@@ -13,8 +13,8 @@ Feature: SES
     When I ask to verify the email address "foo@example.com"
     Then the status code should be 200
 
-  Scenario: Rescue SES InvalidParameterValue
-    When I ask to verify the email address "abc123"
-    Then I should get the error:
-    | code                  | message                        |
-    | InvalidParameterValue | Invalid email address<abc123>. |
+  # Scenario: Rescue SES InvalidParameterValue
+  #   When I ask to verify the email address "abc123"
+  #   Then I should get the error:
+  #   | code                  | message                        |
+  #   | InvalidParameterValue | Invalid email address<abc123>. |


### PR DESCRIPTION
Internal JS-2945

Disabling integration test which started failing with no change in the SDK.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `npm run integration` if integration test is changed