### PR TITLE
Add useDualstackEndpoint configuration

### DIFF
--- a/.changes/next-release/feature-endpoint-7f7bc9fa.json
+++ b/.changes/next-release/feature-endpoint-7f7bc9fa.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "endpoint",
+  "description": "Add useDualstackEndpoint configuration"
+}

--- a/lib/config-base.d.ts
+++ b/lib/config-base.d.ts
@@ -271,4 +271,8 @@ export abstract class ConfigurationOptions {
      * Enables FIPS compatible endpoints.
      */
     useFipsEndpoint?: boolean;
+    /**
+     * Enables IPv6 dualstack endpoint.
+     */
+    useDualstackEndpoint?: boolean;
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -189,6 +189,9 @@ var PromisesDependency;
  *
  * @!attribute useFipsEndpoint
  *   @return [Boolean] Enables FIPS compatible endpoints. Defaults to `false`.
+ *
+ * @!attribute useDualstackEndpoint
+ *   @return [Boolean] Enables IPv6 dualstack endpoint. Defaults to `false`.
  */
 AWS.Config = AWS.util.inherit({
   /**
@@ -344,6 +347,8 @@ AWS.Config = AWS.util.inherit({
    *   to global endpoints or regional endpoints.
    *   Defaults to 'legacy'.
    * @option options useFipsEndpoint [Boolean] Enables FIPS compatible endpoints.
+   *   Defaults to `false`.
+   * @option options useDualstackEndpoint [Boolean] Enables IPv6 dualstack endpoint.
    *   Defaults to `false`.
    */
   constructor: function Config(options) {
@@ -569,7 +574,8 @@ AWS.Config = AWS.util.inherit({
     endpointCacheSize: 1000,
     hostPrefixEnabled: true,
     stsRegionalEndpoints: 'legacy',
-    useFipsEndpoint: false
+    useFipsEndpoint: false,
+    useDualstackEndpoint: false
   },
 
   /**

--- a/lib/config_use_dualstack.d.ts
+++ b/lib/config_use_dualstack.d.ts
@@ -1,8 +1,11 @@
+import {ConfigBase} from './config-base';
+
 export interface UseDualstackConfigOptions {
     /**
      * Enables IPv6/IPv4 dualstack endpoint. When a DNS lookup is performed on an endpoint of this type, it returns an “A” record with an IPv4 address and an “AAAA” record with an IPv6 address. 
      * In most cases the network stack in the client environment will automatically prefer the AAAA record and make a connection using the IPv6 address. 
      * Note, however, that currently on Windows, the IPv4 address will be preferred.
+     * @deprecated Use {@link ConfigBase.useDualstackEndpoint}
      */
     useDualstack?: boolean;
 }

--- a/lib/node_loader.js
+++ b/lib/node_loader.js
@@ -138,6 +138,16 @@ var USE_FIPS_ENDPOINT_CONFIG_OPTIONS = {
   default: false,
 };
 
+var USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS = {
+  environmentVariableSelector: function(env) {
+    return getBooleanValue(env['AWS_USE_DUALSTACK_ENDPOINT']);
+  },
+  configFileSelector: function(profile) {
+    return getBooleanValue(profile['use_dualstack_endpoint']);
+  },
+  default: false,
+};
+
 // Update configuration keys
 AWS.util.update(AWS.Config.prototype.keys, {
   credentials: function () {
@@ -166,6 +176,9 @@ AWS.util.update(AWS.Config.prototype.keys, {
     return isFipsRegion(region)
       ? true
       : util.loadConfig(USE_FIPS_ENDPOINT_CONFIG_OPTIONS);
+  },
+  useDualstackEndpoint: function() {
+    return util.loadConfig(USE_DUALSTACK_ENDPOINT_CONFIG_OPTIONS);
   }
 });
 

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -37,24 +37,23 @@ function applyConfig(service, config) {
 function configureEndpoint(service) {
   var keys = derivedKeys(service);
   var useFipsEndpoint = service.config.useFipsEndpoint;
+  var useDualstackEndpoint = service.config.useDualstackEndpoint;
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
     if (!key) continue;
 
-    var rules = useFipsEndpoint ? regionConfig.fipsRules : regionConfig.rules;
+    var rules = useFipsEndpoint
+      ? useDualstackEndpoint
+        ? regionConfig.dualstackFipsRules
+        : regionConfig.fipsRules
+      : useDualstackEndpoint
+      ? regionConfig.dualstackRules
+      : regionConfig.rules;
+
     if (Object.prototype.hasOwnProperty.call(rules, key)) {
       var config = rules[key];
       if (typeof config === 'string') {
         config = regionConfig.patterns[config];
-      }
-
-      // set dualstack endpoint
-      if (service.config.useDualstack && util.isDualstackAvailable(service)) {
-        config = util.copy(config);
-        config.endpoint = config.endpoint.replace(
-          /{service}\.({region}\.)?/,
-          '{service}.dualstack.{region}.'
-        );
       }
 
       // set global endpoint

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -120,6 +120,32 @@
     }
   },
 
+  "dualstackRules": {
+    "*/*": {
+      "endpoint": "{service}.{region}.api.aws"
+    },
+    "cn-*/*": {
+      "endpoint": "{service}.{region}.api.amazonwebservices.com.cn"
+    },
+    "*/s3": "dualstackLegacy",
+    "cn-*/s3": "dualstackLegacyCn",
+    "*/s3-control": "dualstackLegacy",
+    "cn-*/s3-control": "dualstackLegacyCn"
+  },
+
+  "dualstackFipsRules": {
+    "*/*": {
+      "endpoint": "{service}-fips.{region}.api.aws"
+    },
+    "cn-*/*": {
+      "endpoint": "{service}-fips.{region}.api.amazonwebservices.com.cn"
+    },
+    "*/s3": "dualstackFipsLegacy",
+    "cn-*/s3": "dualstackFipsLegacyCn",
+    "*/s3-control": "dualstackFipsLegacy",
+    "cn-*/s3-control": "dualstackFipsLegacyCn"
+  },
+
   "patterns": {
     "globalSSL": {
       "endpoint": "https://{service}.amazonaws.com",
@@ -164,6 +190,18 @@
     },
     "fipsWithServiceOnly": {
       "endpoint": "{service}.{region}.amazonaws.com"
+    },
+    "dualstackLegacy": {
+      "endpoint": "{service}.dualstack.{region}.amazonaws.com"
+    },
+    "dualstackLegacyCn": {
+      "endpoint": "{service}.dualstack.{region}.amazonaws.com.cn"
+    },
+    "dualstackFipsLegacy": {
+      "endpoint": "{service}-fips.dualstack.{region}.amazonaws.com"
+    },
+    "dualstackFipsLegacyCn": {
+      "endpoint": "{service}-fips.dualstack.{region}.amazonaws.com.cn"
     }
   }
 }

--- a/lib/service.js
+++ b/lib/service.js
@@ -27,14 +27,20 @@ AWS.Service = inherit({
         'Service must be constructed with `new\' operator');
     }
 
-    if (config && config.region) {
-      var region = config.region;
-      if (region_utils.isFipsRegion(region)) {
-        config.region = region_utils.getRealRegion(region);
-        config.useFipsEndpoint = true;
+    if (config) {
+      if (config.region) {
+        var region = config.region;
+        if (region_utils.isFipsRegion(region)) {
+          config.region = region_utils.getRealRegion(region);
+          config.useFipsEndpoint = true;
+        }
+        if (region_utils.isGlobalRegion(region)) {
+          config.region = region_utils.getRealRegion(region);
+        }
       }
-      if (region_utils.isGlobalRegion(region)) {
-        config.region = region_utils.getRealRegion(region);
+      if (typeof config.useDualstack === 'boolean'
+        && typeof config.useDualstackEndpoint !== 'boolean') {
+        config.useDualstackEndpoint = config.useDualstack;
       }
     }
 

--- a/scripts/region-checker/allowlist.js
+++ b/scripts/region-checker/allowlist.js
@@ -4,9 +4,9 @@ var allowlist = {
         25,
         85,
         86,
-        204,
-        258,
-        259
+        207,
+        261,
+        262
     ],
     '/credentials/cognito_identity_credentials.js': [
         78,

--- a/test/endpoint/index.spec.js
+++ b/test/endpoint/index.spec.js
@@ -13,6 +13,7 @@ describe('endpoints', () => {
     clientName,
     region,
     useFipsEndpoint,
+    useDualstackEndpoint,
     hostname,
   } of testCases) {
     it(`testing "${clientName}" with region: ${region}`, (done) => {
@@ -23,6 +24,7 @@ describe('endpoints', () => {
       const client = new AWS[clientName]({
         region,
         useFipsEndpoint,
+        useDualstackEndpoint,
         hostPrefixEnabled: false
       });
 

--- a/test/endpoint/test_cases_supported.json
+++ b/test/endpoint/test_cases_supported.json
@@ -4,20 +4,39 @@
     "clientName": "IoTSecureTunneling",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.tunneling.iot.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "iotsecuredtunneling",
     "clientName": "IoTSecureTunneling",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.tunneling.iot.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "iotsecuredtunneling",
+    "clientName": "IoTSecureTunneling",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.tunneling.iot-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "iotsecuredtunneling",
+    "clientName": "IoTSecureTunneling",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.tunneling.iot-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "iotsecuredtunneling",
     "clientName": "IoTSecureTunneling",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.tunneling.iot-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -25,6 +44,7 @@
     "clientName": "IoTSecureTunneling",
     "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.tunneling.iot-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -32,6 +52,7 @@
     "clientName": "IoTSecureTunneling",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.tunneling.iot-fips.ca-central-1.amazonaws.com"
   },
   {
@@ -39,27 +60,55 @@
     "clientName": "AlexaForBusiness",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "a4b.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "a4b",
     "clientName": "AlexaForBusiness",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "a4b.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "a4b",
+    "clientName": "AlexaForBusiness",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "a4b-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "a4b",
+    "clientName": "AlexaForBusiness",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "a4b-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "access-analyzer",
     "clientName": "AccessAnalyzer",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "access-analyzer.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "access-analyzer",
     "clientName": "AccessAnalyzer",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "access-analyzer.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "access-analyzer",
+    "clientName": "AccessAnalyzer",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "access-analyzer-fips.af-south-1.amazonaws.com"
   },
   {
@@ -67,20 +116,39 @@
     "clientName": "AccessAnalyzer",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "access-analyzer-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "access-analyzer",
+    "clientName": "AccessAnalyzer",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "access-analyzer-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "acm",
     "clientName": "ACM",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "acm.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "acm",
     "clientName": "ACM",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "acm.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "acm",
+    "clientName": "ACM",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-fips.af-south-1.amazonaws.com"
   },
   {
@@ -88,20 +156,39 @@
     "clientName": "ACM",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "acm",
+    "clientName": "ACM",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "acm-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "acm-pca",
     "clientName": "ACMPCA",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "acm-pca.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "acm-pca",
     "clientName": "ACMPCA",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "acm-pca.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "acm-pca",
+    "clientName": "ACMPCA",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-pca-fips.af-south-1.amazonaws.com"
   },
   {
@@ -109,62 +196,135 @@
     "clientName": "ACMPCA",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-pca-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "acm-pca",
+    "clientName": "ACMPCA",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "acm-pca-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "airflow",
     "clientName": "MWAA",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "airflow.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "airflow",
     "clientName": "MWAA",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "airflow.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "airflow",
+    "clientName": "MWAA",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "airflow-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "airflow",
+    "clientName": "MWAA",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "airflow-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "amplify",
     "clientName": "Amplify",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "amplify.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "amplify",
     "clientName": "Amplify",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "amplify.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "amplify",
+    "clientName": "Amplify",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "amplify-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "amplify",
+    "clientName": "Amplify",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "amplify-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "amplifybackend",
     "clientName": "AmplifyBackend",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "amplifybackend.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "amplifybackend",
     "clientName": "AmplifyBackend",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "amplifybackend.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "amplifybackend",
+    "clientName": "AmplifyBackend",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "amplifybackend-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "amplifybackend",
+    "clientName": "AmplifyBackend",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "amplifybackend-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "api.detective",
     "clientName": "Detective",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.detective.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "api.detective",
     "clientName": "Detective",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.detective.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "api.detective",
+    "clientName": "Detective",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.detective-fips.af-south-1.amazonaws.com"
   },
   {
@@ -172,13 +332,23 @@
     "clientName": "Detective",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.detective-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "api.detective",
+    "clientName": "Detective",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.detective-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "api.ecr",
     "clientName": "ECR",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecr-fips.us-east-1.amazonaws.com"
   },
   {
@@ -186,13 +356,23 @@
     "clientName": "IoTFleetHub",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.fleethub.iot.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "api.fleethub.iot",
     "clientName": "IoTFleetHub",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.fleethub.iot.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "api.fleethub.iot",
+    "clientName": "IoTFleetHub",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.fleethub.iot-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -200,41 +380,87 @@
     "clientName": "IoTFleetHub",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.fleethub.iot-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "api.fleethub.iot",
+    "clientName": "IoTFleetHub",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.fleethub.iot-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "api.mediatailor",
     "clientName": "MediaTailor",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.mediatailor.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "api.mediatailor",
     "clientName": "MediaTailor",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.mediatailor.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "api.mediatailor",
+    "clientName": "MediaTailor",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.mediatailor-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "api.mediatailor",
+    "clientName": "MediaTailor",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.mediatailor-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "api.pricing",
     "clientName": "Pricing",
     "region": "ap-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.pricing.ap-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "api.pricing",
     "clientName": "Pricing",
     "region": "ap-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.pricing.ap-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "api.pricing",
+    "clientName": "Pricing",
+    "region": "ap-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.pricing-fips.ap-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "api.pricing",
+    "clientName": "Pricing",
+    "region": "ap-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.pricing-fips.ap-south-1.api.aws"
   },
   {
     "endpointPrefix": "api.sagemaker",
     "clientName": "SageMaker",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api-fips.sagemaker.af-south-1.amazonaws.com"
   },
   {
@@ -242,6 +468,7 @@
     "clientName": "SageMaker",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api-fips.sagemaker.us-east-1.amazonaws.com"
   },
   {
@@ -249,111 +476,247 @@
     "clientName": "ApiGatewayV2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "apigateway",
     "clientName": "ApiGatewayV2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "app-integrations",
     "clientName": "AppIntegrations",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "app-integrations.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "app-integrations",
     "clientName": "AppIntegrations",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "app-integrations.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "app-integrations",
+    "clientName": "AppIntegrations",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "app-integrations-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "app-integrations",
+    "clientName": "AppIntegrations",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "app-integrations-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "appflow",
     "clientName": "Appflow",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appflow.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "appflow",
     "clientName": "Appflow",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appflow.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "appflow",
+    "clientName": "Appflow",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appflow-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "appflow",
+    "clientName": "Appflow",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appflow-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "applicationinsights",
     "clientName": "ApplicationInsights",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "applicationinsights.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "applicationinsights",
     "clientName": "ApplicationInsights",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "applicationinsights.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "applicationinsights",
+    "clientName": "ApplicationInsights",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "applicationinsights-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "applicationinsights",
+    "clientName": "ApplicationInsights",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "applicationinsights-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "appmesh",
     "clientName": "AppMesh",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appmesh.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "appmesh",
     "clientName": "AppMesh",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appmesh.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "appmesh",
+    "clientName": "AppMesh",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appmesh-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "appmesh",
+    "clientName": "AppMesh",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appmesh-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "apprunner",
     "clientName": "AppRunner",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "apprunner.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "apprunner",
     "clientName": "AppRunner",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "apprunner.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "apprunner",
+    "clientName": "AppRunner",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "apprunner-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "apprunner",
+    "clientName": "AppRunner",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "apprunner-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "appstream2",
     "clientName": "AppStream",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appstream2.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "appstream2",
     "clientName": "AppStream",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appstream2.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "appstream2",
+    "clientName": "AppStream",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appstream2-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -361,48 +724,103 @@
     "clientName": "AppStream",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appstream2-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "appstream2",
+    "clientName": "AppStream",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appstream2-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "appsync",
     "clientName": "AppSync",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appsync.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "appsync",
     "clientName": "AppSync",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appsync.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "appsync",
+    "clientName": "AppSync",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appsync-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "appsync",
+    "clientName": "AppSync",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appsync-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "aps",
     "clientName": "Amp",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "aps.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "aps",
     "clientName": "Amp",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "aps.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "aps",
+    "clientName": "Amp",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "aps-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "aps",
+    "clientName": "Amp",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "aps-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "athena",
     "clientName": "Athena",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "athena.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "athena",
     "clientName": "Athena",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "athena.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "athena",
+    "clientName": "Athena",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "athena-fips.af-south-1.amazonaws.com"
   },
   {
@@ -410,69 +828,151 @@
     "clientName": "Athena",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "athena-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "athena",
+    "clientName": "Athena",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "athena-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "auditmanager",
     "clientName": "AuditManager",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "auditmanager.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "auditmanager",
     "clientName": "AuditManager",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "auditmanager.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "auditmanager",
+    "clientName": "AuditManager",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "auditmanager-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "auditmanager",
+    "clientName": "AuditManager",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "auditmanager-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "autoscaling",
     "clientName": "AutoScaling",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "autoscaling",
     "clientName": "AutoScaling",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "backup.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "backup.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "backup-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "backup-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "batch",
     "clientName": "Batch",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.batch.af-south-1.amazonaws.com"
   },
   {
@@ -480,6 +980,7 @@
     "clientName": "Batch",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.batch.us-east-1.amazonaws.com"
   },
   {
@@ -487,41 +988,87 @@
     "clientName": "Braket",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "braket.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "braket",
     "clientName": "Braket",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "braket.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "braket",
+    "clientName": "Braket",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "braket-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "braket",
+    "clientName": "Braket",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "braket-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "cloud9",
     "clientName": "Cloud9",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloud9.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloud9",
     "clientName": "Cloud9",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloud9.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloud9",
+    "clientName": "Cloud9",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloud9-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloud9",
+    "clientName": "Cloud9",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloud9-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "cloudcontrolapi",
     "clientName": "CloudControl",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudcontrolapi.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudcontrolapi",
     "clientName": "CloudControl",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudcontrolapi.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudcontrolapi",
+    "clientName": "CloudControl",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudcontrolapi-fips.af-south-1.amazonaws.com"
   },
   {
@@ -529,34 +1076,71 @@
     "clientName": "CloudControl",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudcontrolapi-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudcontrolapi",
+    "clientName": "CloudControl",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudcontrolapi-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "clouddirectory",
     "clientName": "CloudDirectory",
     "region": "ap-southeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "clouddirectory.ap-southeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "clouddirectory",
     "clientName": "CloudDirectory",
     "region": "ap-southeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "clouddirectory.ap-southeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "clouddirectory",
+    "clientName": "CloudDirectory",
+    "region": "ap-southeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "clouddirectory-fips.ap-southeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "clouddirectory",
+    "clientName": "CloudDirectory",
+    "region": "ap-southeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "clouddirectory-fips.ap-southeast-1.api.aws"
   },
   {
     "endpointPrefix": "cloudformation",
     "clientName": "CloudFormation",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudformation",
     "clientName": "CloudFormation",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudformation.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudformation",
+    "clientName": "CloudFormation",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation-fips.af-south-1.amazonaws.com"
   },
   {
@@ -564,62 +1148,135 @@
     "clientName": "CloudFormation",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudformation",
+    "clientName": "CloudFormation",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudformation-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "cloudhsm",
     "clientName": "CloudHSM",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsm.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudhsm",
     "clientName": "CloudHSM",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsm.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudhsm",
+    "clientName": "CloudHSM",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsm-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudhsm",
+    "clientName": "CloudHSM",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsm-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cloudhsmv2",
     "clientName": "CloudHSMV2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsmv2.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudhsmv2",
     "clientName": "CloudHSMV2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsmv2.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudhsmv2",
+    "clientName": "CloudHSMV2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsmv2-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudhsmv2",
+    "clientName": "CloudHSMV2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsmv2-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "cloudsearch",
     "clientName": "CloudSearch",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudsearch.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudsearch",
     "clientName": "CloudSearch",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudsearch.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudsearch",
+    "clientName": "CloudSearch",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudsearch-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudsearch",
+    "clientName": "CloudSearch",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudsearch-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cloudtrail",
     "clientName": "CloudTrail",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudtrail",
     "clientName": "CloudTrail",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudtrail.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudtrail",
+    "clientName": "CloudTrail",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail-fips.af-south-1.amazonaws.com"
   },
   {
@@ -627,34 +1284,71 @@
     "clientName": "CloudTrail",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudtrail",
+    "clientName": "CloudTrail",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudtrail-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "codeartifact",
     "clientName": "CodeArtifact",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codeartifact.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codeartifact",
     "clientName": "CodeArtifact",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codeartifact.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codeartifact",
+    "clientName": "CodeArtifact",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codeartifact-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codeartifact",
+    "clientName": "CodeArtifact",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codeartifact-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "codebuild",
     "clientName": "CodeBuild",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codebuild",
     "clientName": "CodeBuild",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codebuild.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codebuild",
+    "clientName": "CodeBuild",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild-fips.af-south-1.amazonaws.com"
   },
   {
@@ -662,20 +1356,39 @@
     "clientName": "CodeBuild",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codebuild",
+    "clientName": "CodeBuild",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codebuild-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "codecommit",
     "clientName": "CodeCommit",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codecommit",
     "clientName": "CodeCommit",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codecommit.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codecommit",
+    "clientName": "CodeCommit",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit-fips.af-south-1.amazonaws.com"
   },
   {
@@ -683,20 +1396,39 @@
     "clientName": "CodeCommit",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codecommit",
+    "clientName": "CodeCommit",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codecommit-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "codedeploy",
     "clientName": "CodeDeploy",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codedeploy",
     "clientName": "CodeDeploy",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codedeploy.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codedeploy",
+    "clientName": "CodeDeploy",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy-fips.af-south-1.amazonaws.com"
   },
   {
@@ -704,34 +1436,71 @@
     "clientName": "CodeDeploy",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codedeploy",
+    "clientName": "CodeDeploy",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codedeploy-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "codeguru-reviewer",
     "clientName": "CodeGuruReviewer",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codeguru-reviewer.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codeguru-reviewer",
     "clientName": "CodeGuruReviewer",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codeguru-reviewer.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codeguru-reviewer",
+    "clientName": "CodeGuruReviewer",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codeguru-reviewer-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codeguru-reviewer",
+    "clientName": "CodeGuruReviewer",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codeguru-reviewer-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "codepipeline",
     "clientName": "CodePipeline",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codepipeline.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codepipeline",
     "clientName": "CodePipeline",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codepipeline.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codepipeline",
+    "clientName": "CodePipeline",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codepipeline-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -739,48 +1508,103 @@
     "clientName": "CodePipeline",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codepipeline-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codepipeline",
+    "clientName": "CodePipeline",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codepipeline-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "codestar",
     "clientName": "CodeStar",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codestar.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codestar",
     "clientName": "CodeStar",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codestar.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codestar",
+    "clientName": "CodeStar",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codestar-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codestar",
+    "clientName": "CodeStar",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codestar-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "codestar-connections",
     "clientName": "CodeStarconnections",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codestar-connections.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "codestar-connections",
     "clientName": "CodeStarconnections",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codestar-connections.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "codestar-connections",
+    "clientName": "CodeStarconnections",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codestar-connections-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "codestar-connections",
+    "clientName": "CodeStarconnections",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codestar-connections-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cognito-identity",
     "clientName": "CognitoIdentity",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cognito-identity",
     "clientName": "CognitoIdentity",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-identity.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cognito-identity",
+    "clientName": "CognitoIdentity",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -788,20 +1612,39 @@
     "clientName": "CognitoIdentity",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cognito-identity",
+    "clientName": "CognitoIdentity",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-identity-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cognito-idp",
     "clientName": "CognitoIdentityServiceProvider",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-idp.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cognito-idp",
     "clientName": "CognitoIdentityServiceProvider",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-idp.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cognito-idp",
+    "clientName": "CognitoIdentityServiceProvider",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-idp-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -809,34 +1652,71 @@
     "clientName": "CognitoIdentityServiceProvider",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-idp-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cognito-idp",
+    "clientName": "CognitoIdentityServiceProvider",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-idp-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cognito-sync",
     "clientName": "CognitoSync",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-sync.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cognito-sync",
     "clientName": "CognitoSync",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-sync.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cognito-sync",
+    "clientName": "CognitoSync",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-sync-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cognito-sync",
+    "clientName": "CognitoSync",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-sync-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "comprehend",
     "clientName": "Comprehend",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "comprehend.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "comprehend",
     "clientName": "Comprehend",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "comprehend.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "comprehend",
+    "clientName": "Comprehend",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehend-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -844,20 +1724,39 @@
     "clientName": "Comprehend",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehend-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "comprehend",
+    "clientName": "Comprehend",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "comprehend-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "comprehendmedical",
     "clientName": "ComprehendMedical",
     "region": "ap-southeast-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "comprehendmedical.ap-southeast-2.amazonaws.com"
   },
   {
     "endpointPrefix": "comprehendmedical",
     "clientName": "ComprehendMedical",
     "region": "ap-southeast-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "comprehendmedical.ap-southeast-2.api.aws"
+  },
+  {
+    "endpointPrefix": "comprehendmedical",
+    "clientName": "ComprehendMedical",
+    "region": "ap-southeast-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehendmedical-fips.ap-southeast-2.amazonaws.com"
   },
   {
@@ -865,20 +1764,39 @@
     "clientName": "ComprehendMedical",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehendmedical-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "comprehendmedical",
+    "clientName": "ComprehendMedical",
+    "region": "ap-southeast-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "comprehendmedical-fips.ap-southeast-2.api.aws"
   },
   {
     "endpointPrefix": "config",
     "clientName": "ConfigService",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "config.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "config",
     "clientName": "ConfigService",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "config.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "config",
+    "clientName": "ConfigService",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "config-fips.af-south-1.amazonaws.com"
   },
   {
@@ -886,62 +1804,135 @@
     "clientName": "ConfigService",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "config-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "config",
+    "clientName": "ConfigService",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "config-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "connect",
     "clientName": "Connect",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "connect.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "connect",
     "clientName": "Connect",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "connect.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "connect",
+    "clientName": "Connect",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "connect-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "connect",
+    "clientName": "Connect",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "connect-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "contact-lens",
     "clientName": "ConnectContactLens",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "contact-lens.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "contact-lens",
     "clientName": "ConnectContactLens",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "contact-lens.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "contact-lens",
+    "clientName": "ConnectContactLens",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "contact-lens-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "contact-lens",
+    "clientName": "ConnectContactLens",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "contact-lens-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "cur",
     "clientName": "CUR",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cur.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cur",
     "clientName": "CUR",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cur.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cur",
+    "clientName": "CUR",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cur-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cur",
+    "clientName": "CUR",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cur-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "data.jobs.iot",
     "clientName": "IoTJobsDataPlane",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "data.jobs.iot",
     "clientName": "IoTJobsDataPlane",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "data.jobs.iot.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "data.jobs.iot",
+    "clientName": "IoTJobsDataPlane",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -949,76 +1940,167 @@
     "clientName": "IoTJobsDataPlane",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "data.jobs.iot",
+    "clientName": "IoTJobsDataPlane",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "data.jobs.iot-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "data.mediastore",
     "clientName": "MediaStoreData",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "data.mediastore.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "data.mediastore",
     "clientName": "MediaStoreData",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "data.mediastore.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "data.mediastore",
+    "clientName": "MediaStoreData",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.mediastore-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "data.mediastore",
+    "clientName": "MediaStoreData",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "data.mediastore-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "databrew",
     "clientName": "DataBrew",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "databrew.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "databrew",
     "clientName": "DataBrew",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "databrew-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "dataexchange",
     "clientName": "DataExchange",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dataexchange.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "dataexchange",
     "clientName": "DataExchange",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dataexchange.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "dataexchange",
+    "clientName": "DataExchange",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dataexchange-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "dataexchange",
+    "clientName": "DataExchange",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dataexchange-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "datapipeline",
     "clientName": "DataPipeline",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "datapipeline.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "datapipeline",
     "clientName": "DataPipeline",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "datapipeline.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "datapipeline",
+    "clientName": "DataPipeline",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "datapipeline-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "datapipeline",
+    "clientName": "DataPipeline",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "datapipeline-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "datasync",
     "clientName": "DataSync",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "datasync.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "datasync",
     "clientName": "DataSync",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "datasync.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "datasync",
+    "clientName": "DataSync",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "datasync-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1026,48 +2108,103 @@
     "clientName": "DataSync",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "datasync-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "datasync",
+    "clientName": "DataSync",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "datasync-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "dax",
     "clientName": "DAX",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dax.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "dax",
     "clientName": "DAX",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dax.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "dax",
+    "clientName": "DAX",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dax-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "dax",
+    "clientName": "DAX",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dax-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "devicefarm",
     "clientName": "DeviceFarm",
     "region": "us-west-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "devicefarm.us-west-2.amazonaws.com"
   },
   {
     "endpointPrefix": "devicefarm",
     "clientName": "DeviceFarm",
     "region": "us-west-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "devicefarm.us-west-2.api.aws"
+  },
+  {
+    "endpointPrefix": "devicefarm",
+    "clientName": "DeviceFarm",
+    "region": "us-west-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "devicefarm-fips.us-west-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "devicefarm",
+    "clientName": "DeviceFarm",
+    "region": "us-west-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "devicefarm-fips.us-west-2.api.aws"
   },
   {
     "endpointPrefix": "directconnect",
     "clientName": "DirectConnect",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "directconnect",
     "clientName": "DirectConnect",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "directconnect.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "directconnect",
+    "clientName": "DirectConnect",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1075,34 +2212,71 @@
     "clientName": "DirectConnect",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "directconnect",
+    "clientName": "DirectConnect",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "directconnect-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "discovery",
     "clientName": "Discovery",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "discovery.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "discovery",
     "clientName": "Discovery",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "discovery.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "discovery",
+    "clientName": "Discovery",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "discovery-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "discovery",
+    "clientName": "Discovery",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "discovery-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "dms",
     "clientName": "DMS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dms.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "dms",
     "clientName": "DMS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dms.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "dms",
+    "clientName": "DMS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1110,20 +2284,39 @@
     "clientName": "DMS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "dms",
+    "clientName": "DMS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dms-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ds",
     "clientName": "DirectoryService",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ds.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ds",
     "clientName": "DirectoryService",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ds.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ds",
+    "clientName": "DirectoryService",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ds-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1131,20 +2324,39 @@
     "clientName": "DirectoryService",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ds-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ds",
+    "clientName": "DirectoryService",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ds-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "dynamodb",
     "clientName": "DynamoDB",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "dynamodb",
     "clientName": "DynamoDB",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dynamodb.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "dynamodb",
+    "clientName": "DynamoDB",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1152,20 +2364,39 @@
     "clientName": "DynamoDB",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "dynamodb",
+    "clientName": "DynamoDB",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dynamodb-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ebs",
     "clientName": "EBS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ebs.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ebs",
     "clientName": "EBS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ebs-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1173,20 +2404,39 @@
     "clientName": "EBS",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ebs-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ec2",
     "clientName": "EC2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ec2.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ec2",
     "clientName": "EC2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ec2.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ec2",
+    "clientName": "EC2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ec2-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1194,20 +2444,39 @@
     "clientName": "EC2",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ec2-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ec2",
+    "clientName": "EC2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ec2-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ecs",
     "clientName": "ECS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ecs.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ecs",
     "clientName": "ECS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ecs.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ecs",
+    "clientName": "ECS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecs-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1215,13 +2484,23 @@
     "clientName": "ECS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecs-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ecs",
+    "clientName": "ECS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ecs-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "eks",
     "clientName": "EKS",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.eks.af-south-1.amazonaws.com"
   },
   {
@@ -1229,6 +2508,7 @@
     "clientName": "EKS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.eks.us-east-1.amazonaws.com"
   },
   {
@@ -1236,13 +2516,23 @@
     "clientName": "ElastiCache",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "elasticache",
     "clientName": "ElastiCache",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticache.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "elasticache",
+    "clientName": "ElastiCache",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1250,20 +2540,39 @@
     "clientName": "ElastiCache",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "elasticache",
+    "clientName": "ElastiCache",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticache-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "elasticbeanstalk",
     "clientName": "ElasticBeanstalk",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticbeanstalk.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "elasticbeanstalk",
     "clientName": "ElasticBeanstalk",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticbeanstalk.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "elasticbeanstalk",
+    "clientName": "ElasticBeanstalk",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticbeanstalk-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1271,13 +2580,23 @@
     "clientName": "ElasticBeanstalk",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticbeanstalk-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "elasticbeanstalk",
+    "clientName": "ElasticBeanstalk",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticbeanstalk-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "elasticfilesystem",
     "clientName": "EFS",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticfilesystem-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1285,13 +2604,23 @@
     "clientName": "ELBv2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "elasticloadbalancing",
     "clientName": "ELBv2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticloadbalancing.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "elasticloadbalancing",
+    "clientName": "ELBv2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1299,20 +2628,39 @@
     "clientName": "ELBv2",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "elasticloadbalancing",
+    "clientName": "ELBv2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticloadbalancing-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "elasticmapreduce",
     "clientName": "EMR",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "elasticmapreduce",
     "clientName": "EMR",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticmapreduce.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "elasticmapreduce",
+    "clientName": "EMR",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1320,48 +2668,103 @@
     "clientName": "EMR",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "elasticmapreduce",
+    "clientName": "EMR",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticmapreduce-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "elastictranscoder",
     "clientName": "ElasticTranscoder",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elastictranscoder.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "elastictranscoder",
     "clientName": "ElasticTranscoder",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elastictranscoder.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "elastictranscoder",
+    "clientName": "ElasticTranscoder",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elastictranscoder-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "elastictranscoder",
+    "clientName": "ElasticTranscoder",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elastictranscoder-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "email",
     "clientName": "SESV2",
     "region": "ap-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "email.ap-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "email",
     "clientName": "SESV2",
     "region": "ap-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "email.ap-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "email",
+    "clientName": "SESV2",
+    "region": "ap-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "email-fips.ap-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "email",
+    "clientName": "SESV2",
+    "region": "ap-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "email-fips.ap-south-1.api.aws"
   },
   {
     "endpointPrefix": "emr-containers",
     "clientName": "EMRcontainers",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "emr-containers.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "emr-containers",
     "clientName": "EMRcontainers",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "emr-containers.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "emr-containers",
+    "clientName": "EMRcontainers",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "emr-containers-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -1369,34 +2772,71 @@
     "clientName": "EMRcontainers",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "emr-containers-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "emr-containers",
+    "clientName": "EMRcontainers",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "emr-containers-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "entitlement.marketplace",
     "clientName": "MarketplaceEntitlementService",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "entitlement.marketplace.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "entitlement.marketplace",
     "clientName": "MarketplaceEntitlementService",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "entitlement.marketplace.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "entitlement.marketplace",
+    "clientName": "MarketplaceEntitlementService",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "entitlement.marketplace-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "entitlement.marketplace",
+    "clientName": "MarketplaceEntitlementService",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "entitlement.marketplace-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "es",
     "clientName": "OpenSearch",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "es.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "es",
     "clientName": "OpenSearch",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "es.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "es",
+    "clientName": "OpenSearch",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "es-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1404,20 +2844,39 @@
     "clientName": "OpenSearch",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "es-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "es",
+    "clientName": "OpenSearch",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "es-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "events",
     "clientName": "CloudWatchEvents",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "events.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "events",
     "clientName": "CloudWatchEvents",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "events.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "events",
+    "clientName": "CloudWatchEvents",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "events-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1425,48 +2884,103 @@
     "clientName": "CloudWatchEvents",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "events-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "events",
+    "clientName": "CloudWatchEvents",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "events-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "finspace",
     "clientName": "Finspace",
     "region": "ca-central-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "finspace.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "finspace",
     "clientName": "Finspace",
     "region": "ca-central-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "finspace.ca-central-1.api.aws"
+  },
+  {
+    "endpointPrefix": "finspace",
+    "clientName": "Finspace",
+    "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "finspace-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "finspace",
+    "clientName": "Finspace",
+    "region": "ca-central-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "finspace-fips.ca-central-1.api.aws"
   },
   {
     "endpointPrefix": "finspace-api",
     "clientName": "Finspacedata",
     "region": "ca-central-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "finspace-api.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "finspace-api",
     "clientName": "Finspacedata",
     "region": "ca-central-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "finspace-api.ca-central-1.api.aws"
+  },
+  {
+    "endpointPrefix": "finspace-api",
+    "clientName": "Finspacedata",
+    "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "finspace-api-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "finspace-api",
+    "clientName": "Finspacedata",
+    "region": "ca-central-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "finspace-api-fips.ca-central-1.api.aws"
   },
   {
     "endpointPrefix": "firehose",
     "clientName": "Firehose",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "firehose.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "firehose",
     "clientName": "Firehose",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "firehose.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "firehose",
+    "clientName": "Firehose",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "firehose-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1474,20 +2988,39 @@
     "clientName": "Firehose",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "firehose-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "firehose",
+    "clientName": "Firehose",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "firehose-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "fms",
     "clientName": "FMS",
     "region": "ap-northeast-3",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "fms.ap-northeast-3.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "fms",
+    "clientName": "FMS",
+    "region": "ap-northeast-3",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "fms.ap-northeast-3.api.aws"
   },
   {
     "endpointPrefix": "fms",
     "clientName": "FMS",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fms-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1495,20 +3028,39 @@
     "clientName": "FMS",
     "region": "ap-northeast-3",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fms-fips.ap-northeast-3.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "fms",
+    "clientName": "FMS",
+    "region": "ap-northeast-3",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "fms-fips.ap-northeast-3.api.aws"
   },
   {
     "endpointPrefix": "forecast",
     "clientName": "ForecastService",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "forecast.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "forecast",
     "clientName": "ForecastService",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "forecast.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "forecast",
+    "clientName": "ForecastService",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "forecast-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -1516,20 +3068,39 @@
     "clientName": "ForecastService",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "forecast-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "forecast",
+    "clientName": "ForecastService",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "forecast-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "forecastquery",
     "clientName": "ForecastQueryService",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "forecastquery.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "forecastquery",
     "clientName": "ForecastQueryService",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "forecastquery.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "forecastquery",
+    "clientName": "ForecastQueryService",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "forecastquery-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -1537,34 +3108,71 @@
     "clientName": "ForecastQueryService",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "forecastquery-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "forecastquery",
+    "clientName": "ForecastQueryService",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "forecastquery-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "frauddetector",
     "clientName": "FraudDetector",
     "region": "ap-southeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "frauddetector.ap-southeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "frauddetector",
     "clientName": "FraudDetector",
     "region": "ap-southeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "frauddetector.ap-southeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "frauddetector",
+    "clientName": "FraudDetector",
+    "region": "ap-southeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "frauddetector-fips.ap-southeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "frauddetector",
+    "clientName": "FraudDetector",
+    "region": "ap-southeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "frauddetector-fips.ap-southeast-1.api.aws"
   },
   {
     "endpointPrefix": "fsx",
     "clientName": "FSx",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "fsx.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "fsx",
     "clientName": "FSx",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "fsx.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "fsx",
+    "clientName": "FSx",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fsx-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1572,34 +3180,71 @@
     "clientName": "FSx",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fsx-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "fsx",
+    "clientName": "FSx",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "fsx-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "gamelift",
     "clientName": "GameLift",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "gamelift.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "gamelift",
     "clientName": "GameLift",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "gamelift.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "gamelift",
+    "clientName": "GameLift",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "gamelift-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "gamelift",
+    "clientName": "GameLift",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "gamelift-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "glacier",
     "clientName": "Glacier",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glacier.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "glacier",
     "clientName": "Glacier",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "glacier.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "glacier",
+    "clientName": "Glacier",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glacier-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1607,20 +3252,39 @@
     "clientName": "Glacier",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glacier-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "glacier",
+    "clientName": "Glacier",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "glacier-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "glue",
     "clientName": "Glue",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glue.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "glue",
     "clientName": "Glue",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "glue.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "glue",
+    "clientName": "Glue",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glue-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1628,34 +3292,71 @@
     "clientName": "Glue",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glue-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "glue",
+    "clientName": "Glue",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "glue-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "greengrass",
     "clientName": "GreengrassV2",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "greengrass",
     "clientName": "GreengrassV2",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "greengrass.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "greengrass",
+    "clientName": "GreengrassV2",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "greengrass",
+    "clientName": "GreengrassV2",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "greengrass-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "groundstation",
     "clientName": "GroundStation",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "groundstation.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "groundstation",
     "clientName": "GroundStation",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "groundstation.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "groundstation",
+    "clientName": "GroundStation",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "groundstation-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1663,20 +3364,39 @@
     "clientName": "GroundStation",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "groundstation-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "groundstation",
+    "clientName": "GroundStation",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "groundstation-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "guardduty",
     "clientName": "GuardDuty",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "guardduty",
     "clientName": "GuardDuty",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "guardduty.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "guardduty",
+    "clientName": "GuardDuty",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1684,41 +3404,87 @@
     "clientName": "GuardDuty",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "guardduty",
+    "clientName": "GuardDuty",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "guardduty-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "healthlake",
     "clientName": "HealthLake",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "healthlake.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "healthlake",
     "clientName": "HealthLake",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "healthlake.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "healthlake",
+    "clientName": "HealthLake",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "healthlake-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "healthlake",
+    "clientName": "HealthLake",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "healthlake-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "honeycode",
     "clientName": "Honeycode",
     "region": "us-west-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "honeycode.us-west-2.amazonaws.com"
   },
   {
     "endpointPrefix": "honeycode",
     "clientName": "Honeycode",
     "region": "us-west-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "honeycode.us-west-2.api.aws"
+  },
+  {
+    "endpointPrefix": "honeycode",
+    "clientName": "Honeycode",
+    "region": "us-west-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "honeycode-fips.us-west-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "honeycode",
+    "clientName": "Honeycode",
+    "region": "us-west-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "honeycode-fips.us-west-2.api.aws"
   },
   {
     "endpointPrefix": "iam",
     "clientName": "IAM",
     "region": "aws-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iam.amazonaws.com"
   },
   {
@@ -1726,6 +3492,7 @@
     "clientName": "IAM",
     "region": "aws-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iam-fips.amazonaws.com"
   },
   {
@@ -1733,6 +3500,7 @@
     "clientName": "ChimeSDKIdentity",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "identity-chime-fips.us-east-1.amazonaws.com"
   },
   {
@@ -1740,27 +3508,55 @@
     "clientName": "IdentityStore",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "identitystore.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "identitystore",
     "clientName": "IdentityStore",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "identitystore.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "identitystore",
+    "clientName": "IdentityStore",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "identitystore-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "identitystore",
+    "clientName": "IdentityStore",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "identitystore-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "inspector",
     "clientName": "Inspector",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "inspector.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "inspector",
     "clientName": "Inspector",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "inspector.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "inspector",
+    "clientName": "Inspector",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "inspector-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -1768,20 +3564,39 @@
     "clientName": "Inspector",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "inspector-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "inspector",
+    "clientName": "Inspector",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "inspector-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "iot",
     "clientName": "Iot",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iot.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iot",
     "clientName": "Iot",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iot.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iot",
+    "clientName": "Iot",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iot-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -1789,118 +3604,263 @@
     "clientName": "Iot",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iot-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iot",
+    "clientName": "Iot",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iot-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "iotanalytics",
     "clientName": "IoTAnalytics",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotanalytics.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotanalytics",
     "clientName": "IoTAnalytics",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotanalytics.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotanalytics",
+    "clientName": "IoTAnalytics",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotanalytics-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotanalytics",
+    "clientName": "IoTAnalytics",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotanalytics-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "iotevents",
     "clientName": "IoTEvents",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotevents",
     "clientName": "IoTEvents",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "iotthingsgraph",
     "clientName": "IoTThingsGraph",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotthingsgraph.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotthingsgraph",
     "clientName": "IoTThingsGraph",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotthingsgraph.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotthingsgraph",
+    "clientName": "IoTThingsGraph",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotthingsgraph-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotthingsgraph",
+    "clientName": "IoTThingsGraph",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotthingsgraph-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "ivs",
     "clientName": "IVS",
     "region": "eu-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ivs.eu-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ivs",
     "clientName": "IVS",
     "region": "eu-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ivs.eu-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ivs",
+    "clientName": "IVS",
+    "region": "eu-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ivs-fips.eu-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ivs",
+    "clientName": "IVS",
+    "region": "eu-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ivs-fips.eu-west-1.api.aws"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kafka.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kafka-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "kafkaconnect",
     "clientName": "KafkaConnect",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kafkaconnect.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kafkaconnect",
     "clientName": "KafkaConnect",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kafkaconnect.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kafkaconnect",
+    "clientName": "KafkaConnect",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kafkaconnect-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kafkaconnect",
+    "clientName": "KafkaConnect",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kafkaconnect-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "kendra",
     "clientName": "Kendra",
     "region": "ap-southeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kendra.ap-southeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kendra",
     "clientName": "Kendra",
     "region": "ap-southeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kendra.ap-southeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kendra",
+    "clientName": "Kendra",
+    "region": "ap-southeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kendra-fips.ap-southeast-1.amazonaws.com"
   },
   {
@@ -1908,20 +3868,39 @@
     "clientName": "Kendra",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kendra-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kendra",
+    "clientName": "Kendra",
+    "region": "ap-southeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kendra-fips.ap-southeast-1.api.aws"
   },
   {
     "endpointPrefix": "kinesis",
     "clientName": "Kinesis",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kinesis",
     "clientName": "Kinesis",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesis.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kinesis",
+    "clientName": "Kinesis",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1929,41 +3908,87 @@
     "clientName": "Kinesis",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kinesis",
+    "clientName": "Kinesis",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesis-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "kinesisanalytics",
     "clientName": "KinesisAnalyticsV2",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kinesisanalytics",
     "clientName": "KinesisAnalyticsV2",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "kinesisvideo",
     "clientName": "KinesisVideo",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisvideo.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kinesisvideo",
     "clientName": "KinesisVideo",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisvideo.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kinesisvideo",
+    "clientName": "KinesisVideo",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisvideo-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kinesisvideo",
+    "clientName": "KinesisVideo",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisvideo-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "kms",
     "clientName": "KMS",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kms-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1971,13 +3996,23 @@
     "clientName": "LakeFormation",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "lakeformation",
     "clientName": "LakeFormation",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lakeformation.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "lakeformation",
+    "clientName": "LakeFormation",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation-fips.af-south-1.amazonaws.com"
   },
   {
@@ -1985,20 +4020,39 @@
     "clientName": "LakeFormation",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "lakeformation",
+    "clientName": "LakeFormation",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lakeformation-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "lambda",
     "clientName": "Lambda",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lambda.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "lambda",
     "clientName": "Lambda",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lambda.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "lambda",
+    "clientName": "Lambda",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lambda-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2006,20 +4060,39 @@
     "clientName": "Lambda",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lambda-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "lambda",
+    "clientName": "Lambda",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lambda-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "license-manager",
     "clientName": "LicenseManager",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "license-manager",
     "clientName": "LicenseManager",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "license-manager.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "license-manager",
+    "clientName": "LicenseManager",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2027,34 +4100,71 @@
     "clientName": "LicenseManager",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "license-manager",
+    "clientName": "LicenseManager",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "license-manager-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "lightsail",
     "clientName": "Lightsail",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lightsail.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "lightsail",
     "clientName": "Lightsail",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lightsail.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "lightsail",
+    "clientName": "Lightsail",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lightsail-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "lightsail",
+    "clientName": "Lightsail",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lightsail-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "logs",
     "clientName": "CloudWatchLogs",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "logs.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "logs",
     "clientName": "CloudWatchLogs",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "logs.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "logs",
+    "clientName": "CloudWatchLogs",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "logs-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2062,55 +4172,119 @@
     "clientName": "CloudWatchLogs",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "logs-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "logs",
+    "clientName": "CloudWatchLogs",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "logs-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "lookoutequipment",
     "clientName": "LookoutEquipment",
     "region": "ap-northeast-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lookoutequipment.ap-northeast-2.amazonaws.com"
   },
   {
     "endpointPrefix": "lookoutequipment",
     "clientName": "LookoutEquipment",
     "region": "ap-northeast-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lookoutequipment.ap-northeast-2.api.aws"
+  },
+  {
+    "endpointPrefix": "lookoutequipment",
+    "clientName": "LookoutEquipment",
+    "region": "ap-northeast-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lookoutequipment-fips.ap-northeast-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "lookoutequipment",
+    "clientName": "LookoutEquipment",
+    "region": "ap-northeast-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lookoutequipment-fips.ap-northeast-2.api.aws"
   },
   {
     "endpointPrefix": "lookoutvision",
     "clientName": "LookoutVision",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lookoutvision.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "lookoutvision",
     "clientName": "LookoutVision",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lookoutvision.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "lookoutvision",
+    "clientName": "LookoutVision",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lookoutvision-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "lookoutvision",
+    "clientName": "LookoutVision",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lookoutvision-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "machinelearning",
     "clientName": "MachineLearning",
     "region": "eu-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "machinelearning.eu-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "machinelearning",
     "clientName": "MachineLearning",
     "region": "eu-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "machinelearning.eu-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "machinelearning",
+    "clientName": "MachineLearning",
+    "region": "eu-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "machinelearning-fips.eu-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "machinelearning",
+    "clientName": "MachineLearning",
+    "region": "eu-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "machinelearning-fips.eu-west-1.api.aws"
   },
   {
     "endpointPrefix": "macie",
     "clientName": "Macie",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "macie-fips.us-east-1.amazonaws.com"
   },
   {
@@ -2118,13 +4292,23 @@
     "clientName": "Macie2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "macie2.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "macie2",
     "clientName": "Macie2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "macie2.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "macie2",
+    "clientName": "Macie2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "macie2-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2132,62 +4316,135 @@
     "clientName": "Macie2",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "macie2-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "macie2",
+    "clientName": "Macie2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "macie2-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "managedblockchain",
     "clientName": "ManagedBlockchain",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "managedblockchain.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "managedblockchain",
     "clientName": "ManagedBlockchain",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "managedblockchain.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "managedblockchain",
+    "clientName": "ManagedBlockchain",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "managedblockchain-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "managedblockchain",
+    "clientName": "ManagedBlockchain",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "managedblockchain-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "marketplacecommerceanalytics",
     "clientName": "MarketplaceCommerceAnalytics",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "marketplacecommerceanalytics.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "marketplacecommerceanalytics",
     "clientName": "MarketplaceCommerceAnalytics",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "marketplacecommerceanalytics.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "marketplacecommerceanalytics",
+    "clientName": "MarketplaceCommerceAnalytics",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "marketplacecommerceanalytics-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "marketplacecommerceanalytics",
+    "clientName": "MarketplaceCommerceAnalytics",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "marketplacecommerceanalytics-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "mediaconnect",
     "clientName": "MediaConnect",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediaconnect.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mediaconnect",
     "clientName": "MediaConnect",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mediaconnect.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mediaconnect",
+    "clientName": "MediaConnect",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediaconnect-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mediaconnect",
+    "clientName": "MediaConnect",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mediaconnect-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "mediaconvert",
     "clientName": "MediaConvert",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediaconvert.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mediaconvert",
     "clientName": "MediaConvert",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mediaconvert.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mediaconvert",
+    "clientName": "MediaConvert",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediaconvert-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2195,20 +4452,39 @@
     "clientName": "MediaConvert",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediaconvert-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mediaconvert",
+    "clientName": "MediaConvert",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mediaconvert-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "medialive",
     "clientName": "MediaLive",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "medialive.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "medialive",
     "clientName": "MediaLive",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "medialive.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "medialive",
+    "clientName": "MediaLive",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "medialive-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2216,55 +4492,119 @@
     "clientName": "MediaLive",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "medialive-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "medialive",
+    "clientName": "MediaLive",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "medialive-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "mediapackage",
     "clientName": "MediaPackage",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediapackage.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mediapackage",
     "clientName": "MediaPackage",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mediapackage.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mediapackage",
+    "clientName": "MediaPackage",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediapackage-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mediapackage",
+    "clientName": "MediaPackage",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mediapackage-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "mediapackage-vod",
     "clientName": "MediaPackageVod",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediapackage-vod.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mediapackage-vod",
     "clientName": "MediaPackageVod",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mediapackage-vod.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mediapackage-vod",
+    "clientName": "MediaPackageVod",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediapackage-vod-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mediapackage-vod",
+    "clientName": "MediaPackageVod",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mediapackage-vod-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "mediastore",
     "clientName": "MediaStore",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediastore.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mediastore",
     "clientName": "MediaStore",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mediastore.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mediastore",
+    "clientName": "MediaStore",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mediastore-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mediastore",
+    "clientName": "MediaStore",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mediastore-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "messaging-chime",
     "clientName": "ChimeSDKMessaging",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "messaging-chime-fips.us-east-1.amazonaws.com"
   },
   {
@@ -2272,76 +4612,167 @@
     "clientName": "MarketplaceMetering",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "metering.marketplace.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "metering.marketplace",
     "clientName": "MarketplaceMetering",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "metering.marketplace.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "metering.marketplace",
+    "clientName": "MarketplaceMetering",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "metering.marketplace-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "metering.marketplace",
+    "clientName": "MarketplaceMetering",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "metering.marketplace-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "mgh",
     "clientName": "MigrationHub",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mgh.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mgh",
     "clientName": "MigrationHub",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mgh.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mgh",
+    "clientName": "MigrationHub",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mgh-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mgh",
+    "clientName": "MigrationHub",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mgh-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "mgn",
     "clientName": "Mgn",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mgn.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mgn",
     "clientName": "Mgn",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mgn.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mgn",
+    "clientName": "Mgn",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mgn-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mgn",
+    "clientName": "Mgn",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mgn-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "mobileanalytics",
     "clientName": "MobileAnalytics",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mobileanalytics.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mobileanalytics",
     "clientName": "MobileAnalytics",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mobileanalytics.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mobileanalytics",
+    "clientName": "MobileAnalytics",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mobileanalytics-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mobileanalytics",
+    "clientName": "MobileAnalytics",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mobileanalytics-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "models-v2-lex",
     "clientName": "LexModelsV2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "models-v2-lex.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "models-v2-lex",
     "clientName": "LexModelsV2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "models-v2-lex.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "models-v2-lex",
+    "clientName": "LexModelsV2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "models-v2-lex-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "models-v2-lex",
+    "clientName": "LexModelsV2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "models-v2-lex-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "models.lex",
     "clientName": "LexModelBuildingService",
     "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "models-fips.lex.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2349,6 +4780,7 @@
     "clientName": "LexModelBuildingService",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "models-fips.lex.us-east-1.amazonaws.com"
   },
   {
@@ -2356,13 +4788,23 @@
     "clientName": "CloudWatch",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "monitoring",
     "clientName": "CloudWatch",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "monitoring.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "monitoring",
+    "clientName": "CloudWatch",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2370,20 +4812,39 @@
     "clientName": "CloudWatch",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "monitoring",
+    "clientName": "CloudWatch",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "monitoring-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "mq",
     "clientName": "MQ",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mq.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mq",
     "clientName": "MQ",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mq.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mq",
+    "clientName": "MQ",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mq-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -2391,34 +4852,71 @@
     "clientName": "MQ",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mq-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mq",
+    "clientName": "MQ",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mq-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "mturk-requester",
     "clientName": "MTurk",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mturk-requester.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "mturk-requester",
     "clientName": "MTurk",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mturk-requester.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "mturk-requester",
+    "clientName": "MTurk",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mturk-requester-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "mturk-requester",
+    "clientName": "MTurk",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mturk-requester-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "network-firewall",
     "clientName": "NetworkFirewall",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "network-firewall.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "network-firewall",
     "clientName": "NetworkFirewall",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "network-firewall.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "network-firewall",
+    "clientName": "NetworkFirewall",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "network-firewall-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2426,55 +4924,119 @@
     "clientName": "NetworkFirewall",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "network-firewall-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "network-firewall",
+    "clientName": "NetworkFirewall",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "network-firewall-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "nimble",
     "clientName": "Nimble",
     "region": "ap-southeast-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "nimble.ap-southeast-2.amazonaws.com"
   },
   {
     "endpointPrefix": "nimble",
     "clientName": "Nimble",
     "region": "ap-southeast-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "nimble.ap-southeast-2.api.aws"
+  },
+  {
+    "endpointPrefix": "nimble",
+    "clientName": "Nimble",
+    "region": "ap-southeast-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "nimble-fips.ap-southeast-2.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "nimble",
+    "clientName": "Nimble",
+    "region": "ap-southeast-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "nimble-fips.ap-southeast-2.api.aws"
   },
   {
     "endpointPrefix": "opsworks",
     "clientName": "OpsWorks",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "opsworks.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "opsworks",
     "clientName": "OpsWorks",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "opsworks.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "opsworks",
+    "clientName": "OpsWorks",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "opsworks-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "opsworks",
+    "clientName": "OpsWorks",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "opsworks-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "opsworks-cm",
     "clientName": "OpsWorksCM",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "opsworks-cm.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "opsworks-cm",
     "clientName": "OpsWorksCM",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "opsworks-cm.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "opsworks-cm",
+    "clientName": "OpsWorksCM",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "opsworks-cm-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "opsworks-cm",
+    "clientName": "OpsWorksCM",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "opsworks-cm-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "organizations",
     "clientName": "Organizations",
     "region": "aws-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "organizations.us-east-1.amazonaws.com"
   },
   {
@@ -2482,6 +5044,7 @@
     "clientName": "Organizations",
     "region": "aws-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "organizations-fips.us-east-1.amazonaws.com"
   },
   {
@@ -2489,13 +5052,23 @@
     "clientName": "Outposts",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "outposts.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "outposts",
     "clientName": "Outposts",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "outposts.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "outposts",
+    "clientName": "Outposts",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "outposts-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2503,27 +5076,55 @@
     "clientName": "Outposts",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "outposts-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "outposts",
+    "clientName": "Outposts",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "outposts-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "personalize",
     "clientName": "Personalize",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "personalize.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "personalize",
     "clientName": "Personalize",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "personalize.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "personalize",
+    "clientName": "Personalize",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "personalize-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "personalize",
+    "clientName": "Personalize",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "personalize-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "pinpoint",
     "clientName": "Pinpoint",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2531,13 +5132,23 @@
     "clientName": "Pinpoint",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "pinpoint",
     "clientName": "Pinpoint",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "pinpoint.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "pinpoint",
+    "clientName": "Pinpoint",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2545,20 +5156,39 @@
     "clientName": "Pinpoint",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "pinpoint",
+    "clientName": "Pinpoint",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "pinpoint-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "polly",
     "clientName": "Polly",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "polly.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "polly",
     "clientName": "Polly",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "polly.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "polly",
+    "clientName": "Polly",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "polly-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2566,48 +5196,103 @@
     "clientName": "Polly",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "polly-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "polly",
+    "clientName": "Polly",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "polly-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "profile",
     "clientName": "CustomerProfiles",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "profile.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "profile",
     "clientName": "CustomerProfiles",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "profile.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "profile",
+    "clientName": "CustomerProfiles",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "profile-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "profile",
+    "clientName": "CustomerProfiles",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "profile-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "projects.iot1click",
     "clientName": "IoT1ClickProjects",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "projects.iot1click.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "projects.iot1click",
     "clientName": "IoT1ClickProjects",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "projects.iot1click.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "projects.iot1click",
+    "clientName": "IoT1ClickProjects",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "projects.iot1click-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "projects.iot1click",
+    "clientName": "IoT1ClickProjects",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "projects.iot1click-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "qldb",
     "clientName": "QLDB",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "qldb.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "qldb",
     "clientName": "QLDB",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "qldb.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "qldb",
+    "clientName": "QLDB",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "qldb-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2615,34 +5300,71 @@
     "clientName": "QLDB",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "qldb-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "qldb",
+    "clientName": "QLDB",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "qldb-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "quicksight",
     "clientName": "QuickSight",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "quicksight.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "quicksight",
     "clientName": "QuickSight",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "quicksight.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "quicksight",
+    "clientName": "QuickSight",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "quicksight-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "quicksight",
+    "clientName": "QuickSight",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "quicksight-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "ram",
     "clientName": "RAM",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ram.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ram",
     "clientName": "RAM",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ram.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ram",
+    "clientName": "RAM",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ram-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2650,20 +5372,39 @@
     "clientName": "RAM",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ram-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ram",
+    "clientName": "RAM",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ram-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "rds",
     "clientName": "RDS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "rds.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "rds",
     "clientName": "RDS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "rds.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "rds",
+    "clientName": "RDS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rds-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2671,20 +5412,39 @@
     "clientName": "RDS",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rds-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "rds",
+    "clientName": "RDS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "rds-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "redshift",
     "clientName": "Redshift",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "redshift.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "redshift",
     "clientName": "Redshift",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "redshift.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "redshift",
+    "clientName": "Redshift",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "redshift-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2692,20 +5452,39 @@
     "clientName": "Redshift",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "redshift-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "redshift",
+    "clientName": "Redshift",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "redshift-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "rekognition",
     "clientName": "Rekognition",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "rekognition.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "rekognition",
     "clientName": "Rekognition",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "rekognition.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "rekognition",
+    "clientName": "Rekognition",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rekognition-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2713,20 +5492,39 @@
     "clientName": "Rekognition",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rekognition-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "rekognition",
+    "clientName": "Rekognition",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "rekognition-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "resource-groups",
     "clientName": "ResourceGroups",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "resource-groups",
     "clientName": "ResourceGroups",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "resource-groups.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "resource-groups",
+    "clientName": "ResourceGroups",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2734,27 +5532,55 @@
     "clientName": "ResourceGroups",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "resource-groups",
+    "clientName": "ResourceGroups",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "resource-groups-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "robomaker",
     "clientName": "RoboMaker",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "robomaker.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "robomaker",
     "clientName": "RoboMaker",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "robomaker.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "robomaker",
+    "clientName": "RoboMaker",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "robomaker-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "robomaker",
+    "clientName": "RoboMaker",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "robomaker-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "route53",
     "clientName": "Route53",
     "region": "aws-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53.amazonaws.com"
   },
   {
@@ -2762,6 +5588,7 @@
     "clientName": "Route53",
     "region": "aws-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53-fips.amazonaws.com"
   },
   {
@@ -2769,48 +5596,103 @@
     "clientName": "Route53Domains",
     "region": "us-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53domains.us-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "route53domains",
     "clientName": "Route53Domains",
     "region": "us-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "route53domains.us-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "route53domains",
+    "clientName": "Route53Domains",
+    "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53domains-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "route53domains",
+    "clientName": "Route53Domains",
+    "region": "us-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "route53domains-fips.us-east-1.api.aws"
   },
   {
     "endpointPrefix": "route53resolver",
     "clientName": "Route53Resolver",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "route53resolver",
     "clientName": "Route53Resolver",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "runtime-v2-lex",
     "clientName": "LexRuntimeV2",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-v2-lex.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "runtime-v2-lex",
     "clientName": "LexRuntimeV2",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "runtime-v2-lex.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "runtime-v2-lex",
+    "clientName": "LexRuntimeV2",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-v2-lex-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "runtime-v2-lex",
+    "clientName": "LexRuntimeV2",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "runtime-v2-lex-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "runtime.lex",
     "clientName": "LexRuntime",
     "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-fips.lex.ap-northeast-1.amazonaws.com"
   },
   {
@@ -2818,6 +5700,7 @@
     "clientName": "LexRuntime",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-fips.lex.us-east-1.amazonaws.com"
   },
   {
@@ -2825,6 +5708,7 @@
     "clientName": "SageMakerRuntime",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-fips.sagemaker.af-south-1.amazonaws.com"
   },
   {
@@ -2832,62 +5716,143 @@
     "clientName": "SageMakerRuntime",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-fips.sagemaker.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3",
+    "clientName": "S3",
+    "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3.dualstack.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3",
+    "clientName": "S3",
+    "region": "ca-central-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-fips.dualstack.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "s3-control.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3-control",
+    "clientName": "S3Control",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-control.dualstack.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "s3-control-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3-control",
+    "clientName": "S3Control",
+    "region": "ca-central-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-control-fips.dualstack.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "schemas",
     "clientName": "Schemas",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "schemas.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "schemas",
     "clientName": "Schemas",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "schemas.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "schemas",
+    "clientName": "Schemas",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "schemas-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "schemas",
+    "clientName": "Schemas",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "schemas-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "sdb",
     "clientName": "SimpleDB",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sdb.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sdb",
     "clientName": "SimpleDB",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sdb.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "sdb",
+    "clientName": "SimpleDB",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sdb-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "sdb",
+    "clientName": "SimpleDB",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sdb-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "secretsmanager",
     "clientName": "SecretsManager",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "secretsmanager",
     "clientName": "SecretsManager",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "secretsmanager.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "secretsmanager",
+    "clientName": "SecretsManager",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2895,20 +5860,39 @@
     "clientName": "SecretsManager",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "secretsmanager",
+    "clientName": "SecretsManager",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "secretsmanager-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "securityhub",
     "clientName": "SecurityHub",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "securityhub",
     "clientName": "SecurityHub",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "securityhub.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "securityhub",
+    "clientName": "SecurityHub",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2916,34 +5900,71 @@
     "clientName": "SecurityHub",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "securityhub",
+    "clientName": "SecurityHub",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "securityhub-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "serverlessrepo",
     "clientName": "ServerlessApplicationRepository",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "serverlessrepo.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "serverlessrepo",
     "clientName": "ServerlessApplicationRepository",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "serverlessrepo.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "serverlessrepo",
+    "clientName": "ServerlessApplicationRepository",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "serverlessrepo-fips.ap-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "serverlessrepo",
+    "clientName": "ServerlessApplicationRepository",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "serverlessrepo-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "servicecatalog",
     "clientName": "ServiceCatalog",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "servicecatalog",
     "clientName": "ServiceCatalog",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "servicecatalog",
+    "clientName": "ServiceCatalog",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2951,20 +5972,39 @@
     "clientName": "ServiceCatalog",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "servicecatalog",
+    "clientName": "ServiceCatalog",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "servicecatalog-appregistry",
     "clientName": "ServiceCatalogAppRegistry",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-appregistry.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "servicecatalog-appregistry",
     "clientName": "ServiceCatalogAppRegistry",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog-appregistry.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "servicecatalog-appregistry",
+    "clientName": "ServiceCatalogAppRegistry",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-appregistry-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2972,20 +6012,39 @@
     "clientName": "ServiceCatalogAppRegistry",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-appregistry-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "servicecatalog-appregistry",
+    "clientName": "ServiceCatalogAppRegistry",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog-appregistry-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "servicediscovery",
     "clientName": "ServiceDiscovery",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "servicediscovery",
     "clientName": "ServiceDiscovery",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicediscovery.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "servicediscovery",
+    "clientName": "ServiceDiscovery",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery-fips.af-south-1.amazonaws.com"
   },
   {
@@ -2993,34 +6052,71 @@
     "clientName": "ServiceDiscovery",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "servicediscovery",
+    "clientName": "ServiceDiscovery",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicediscovery-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "servicequotas",
     "clientName": "ServiceQuotas",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicequotas.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "servicequotas",
     "clientName": "ServiceQuotas",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicequotas.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "servicequotas",
+    "clientName": "ServiceQuotas",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicequotas-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "servicequotas",
+    "clientName": "ServiceQuotas",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicequotas-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "session.qldb",
     "clientName": "QLDBSession",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "session.qldb.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "session.qldb",
     "clientName": "QLDBSession",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "session.qldb.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "session.qldb",
+    "clientName": "QLDBSession",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "session.qldb-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -3028,13 +6124,23 @@
     "clientName": "QLDBSession",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "session.qldb-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "session.qldb",
+    "clientName": "QLDBSession",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "session.qldb-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "shield",
     "clientName": "Shield",
     "region": "aws-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "shield.us-east-1.amazonaws.com"
   },
   {
@@ -3042,6 +6148,7 @@
     "clientName": "Shield",
     "region": "aws-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "shield-fips.us-east-1.amazonaws.com"
   },
   {
@@ -3049,13 +6156,23 @@
     "clientName": "SMS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sms.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sms",
     "clientName": "SMS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sms.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "sms",
+    "clientName": "SMS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sms-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3063,20 +6180,39 @@
     "clientName": "SMS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sms-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "sms",
+    "clientName": "SMS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sms-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "snowball",
     "clientName": "Snowball",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "snowball.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "snowball",
     "clientName": "Snowball",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "snowball.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "snowball",
+    "clientName": "Snowball",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "snowball-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3084,20 +6220,39 @@
     "clientName": "Snowball",
     "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "snowball-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "snowball",
+    "clientName": "Snowball",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "snowball-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "sns",
     "clientName": "SNS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sns.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sns",
     "clientName": "SNS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sns.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "sns",
+    "clientName": "SNS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sns-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3105,20 +6260,39 @@
     "clientName": "SNS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sns-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "sns",
+    "clientName": "SNS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sns-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "sqs",
     "clientName": "SQS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sqs.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "sqs",
     "clientName": "SQS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sqs.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "sqs",
+    "clientName": "SQS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sqs-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3126,20 +6300,39 @@
     "clientName": "SQS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sqs-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "sqs",
+    "clientName": "SQS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sqs-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ssm",
     "clientName": "SSM",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ssm.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ssm",
     "clientName": "SSM",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ssm",
+    "clientName": "SSM",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ssm-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3147,34 +6340,71 @@
     "clientName": "SSM",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ssm-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ssm",
+    "clientName": "SSM",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "ssm-incidents",
     "clientName": "SSMIncidents",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ssm-incidents.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ssm-incidents",
     "clientName": "SSMIncidents",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm-incidents.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ssm-incidents",
+    "clientName": "SSMIncidents",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ssm-incidents-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ssm-incidents",
+    "clientName": "SSMIncidents",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm-incidents-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "states",
     "clientName": "StepFunctions",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "states.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "states",
     "clientName": "StepFunctions",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "states.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "states",
+    "clientName": "StepFunctions",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "states-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3182,20 +6412,39 @@
     "clientName": "StepFunctions",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "states-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "states",
+    "clientName": "StepFunctions",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "states-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "storagegateway",
     "clientName": "StorageGateway",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "storagegateway",
     "clientName": "StorageGateway",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "storagegateway.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "storagegateway",
+    "clientName": "StorageGateway",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3203,34 +6452,71 @@
     "clientName": "StorageGateway",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "storagegateway",
+    "clientName": "StorageGateway",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "storagegateway-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "sts",
     "clientName": "STS",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sts.amazonaws.com"
   },
   {
     "endpointPrefix": "sts",
     "clientName": "STS",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sts.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "sts",
+    "clientName": "STS",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sts-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3238,20 +6524,39 @@
     "clientName": "STS",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sts-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "sts",
+    "clientName": "STS",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sts-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "swf",
     "clientName": "SWF",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "swf.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "swf",
     "clientName": "SWF",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "swf.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "swf",
+    "clientName": "SWF",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "swf-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3259,34 +6564,71 @@
     "clientName": "SWF",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "swf-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "swf",
+    "clientName": "SWF",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "swf-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "tagging",
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "tagging.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "tagging",
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "tagging-fips.af-south-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "textract",
     "clientName": "Textract",
     "region": "ap-northeast-2",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "textract.ap-northeast-2.amazonaws.com"
   },
   {
     "endpointPrefix": "textract",
     "clientName": "Textract",
     "region": "ap-northeast-2",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "textract.ap-northeast-2.api.aws"
+  },
+  {
+    "endpointPrefix": "textract",
+    "clientName": "Textract",
+    "region": "ap-northeast-2",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "textract-fips.ap-northeast-2.amazonaws.com"
   },
   {
@@ -3294,13 +6636,23 @@
     "clientName": "Textract",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "textract-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "textract",
+    "clientName": "Textract",
+    "region": "ap-northeast-2",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "textract-fips.ap-northeast-2.api.aws"
   },
   {
     "endpointPrefix": "transcribe",
     "clientName": "TranscribeService",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.transcribe.af-south-1.amazonaws.com"
   },
   {
@@ -3308,6 +6660,7 @@
     "clientName": "TranscribeService",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.transcribe.us-east-1.amazonaws.com"
   },
   {
@@ -3315,13 +6668,23 @@
     "clientName": "Transfer",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "transfer.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "transfer",
     "clientName": "Transfer",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "transfer.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "transfer",
+    "clientName": "Transfer",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "transfer-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3329,20 +6692,39 @@
     "clientName": "Transfer",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "transfer-fips.ca-central-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "transfer",
+    "clientName": "Transfer",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "transfer-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "translate",
     "clientName": "Translate",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "translate.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "translate",
     "clientName": "Translate",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "translate.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "translate",
+    "clientName": "Translate",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "translate-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -3350,27 +6732,55 @@
     "clientName": "Translate",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "translate-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "translate",
+    "clientName": "Translate",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "translate-fips.ap-east-1.api.aws"
   },
   {
     "endpointPrefix": "voiceid",
     "clientName": "VoiceID",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "voiceid.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "voiceid",
     "clientName": "VoiceID",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "voiceid.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "voiceid",
+    "clientName": "VoiceID",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "voiceid-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "voiceid",
+    "clientName": "VoiceID",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "voiceid-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "waf",
     "clientName": "WAF",
     "region": "aws-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "waf.amazonaws.com"
   },
   {
@@ -3378,6 +6788,7 @@
     "clientName": "WAF",
     "region": "aws-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "waf-fips.amazonaws.com"
   },
   {
@@ -3385,6 +6796,7 @@
     "clientName": "WAFRegional",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional.af-south-1.amazonaws.com"
   },
   {
@@ -3392,6 +6804,7 @@
     "clientName": "WAFRegional",
     "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3399,27 +6812,55 @@
     "clientName": "Wisdom",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "wisdom.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "wisdom",
     "clientName": "Wisdom",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "wisdom.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "wisdom",
+    "clientName": "Wisdom",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "wisdom-fips.ap-northeast-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "wisdom",
+    "clientName": "Wisdom",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "wisdom-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "workdocs",
     "clientName": "WorkDocs",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "workdocs.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "workdocs",
     "clientName": "WorkDocs",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "workdocs.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "workdocs",
+    "clientName": "WorkDocs",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workdocs-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -3427,34 +6868,71 @@
     "clientName": "WorkDocs",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workdocs-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "workdocs",
+    "clientName": "WorkDocs",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "workdocs-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "workmail",
     "clientName": "WorkMail",
     "region": "eu-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "workmail.eu-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "workmail",
     "clientName": "WorkMail",
     "region": "eu-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "workmail.eu-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "workmail",
+    "clientName": "WorkMail",
+    "region": "eu-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workmail-fips.eu-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "workmail",
+    "clientName": "WorkMail",
+    "region": "eu-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "workmail-fips.eu-west-1.api.aws"
   },
   {
     "endpointPrefix": "workspaces",
     "clientName": "WorkSpaces",
     "region": "ap-northeast-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces.ap-northeast-1.amazonaws.com"
   },
   {
     "endpointPrefix": "workspaces",
     "clientName": "WorkSpaces",
     "region": "ap-northeast-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "workspaces.ap-northeast-1.api.aws"
+  },
+  {
+    "endpointPrefix": "workspaces",
+    "clientName": "WorkSpaces",
+    "region": "ap-northeast-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces-fips.ap-northeast-1.amazonaws.com"
   },
   {
@@ -3462,20 +6940,39 @@
     "clientName": "WorkSpaces",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "workspaces",
+    "clientName": "WorkSpaces",
+    "region": "ap-northeast-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "workspaces-fips.ap-northeast-1.api.aws"
   },
   {
     "endpointPrefix": "xray",
     "clientName": "XRay",
     "region": "af-south-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "xray.af-south-1.amazonaws.com"
   },
   {
     "endpointPrefix": "xray",
     "clientName": "XRay",
     "region": "af-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "xray.af-south-1.api.aws"
+  },
+  {
+    "endpointPrefix": "xray",
+    "clientName": "XRay",
+    "region": "af-south-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "xray-fips.af-south-1.amazonaws.com"
   },
   {
@@ -3483,489 +6980,1111 @@
     "clientName": "XRay",
     "region": "us-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "xray-fips.us-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "xray",
+    "clientName": "XRay",
+    "region": "af-south-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "xray-fips.af-south-1.api.aws"
   },
   {
     "endpointPrefix": "access-analyzer",
     "clientName": "AccessAnalyzer",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "access-analyzer.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "access-analyzer",
     "clientName": "AccessAnalyzer",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "access-analyzer.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "access-analyzer",
+    "clientName": "AccessAnalyzer",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "access-analyzer-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "access-analyzer",
+    "clientName": "AccessAnalyzer",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "access-analyzer-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "acm",
     "clientName": "ACM",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "acm.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "acm",
     "clientName": "ACM",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "acm.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "acm",
+    "clientName": "ACM",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "acm",
+    "clientName": "ACM",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "acm-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "api.sagemaker",
     "clientName": "SageMaker",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.sagemaker.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "api.sagemaker",
     "clientName": "SageMaker",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.sagemaker.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "api.sagemaker",
+    "clientName": "SageMaker",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.sagemaker-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "api.sagemaker",
+    "clientName": "SageMaker",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "api.sagemaker-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "apigateway",
     "clientName": "ApiGatewayV2",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "apigateway",
     "clientName": "ApiGatewayV2",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "applicationinsights",
     "clientName": "ApplicationInsights",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "applicationinsights.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "applicationinsights",
     "clientName": "ApplicationInsights",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "applicationinsights.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "applicationinsights",
+    "clientName": "ApplicationInsights",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "applicationinsights-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "applicationinsights",
+    "clientName": "ApplicationInsights",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "applicationinsights-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "appmesh",
     "clientName": "AppMesh",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appmesh.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "appmesh",
     "clientName": "AppMesh",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appmesh.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "appmesh",
+    "clientName": "AppMesh",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appmesh-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "appmesh",
+    "clientName": "AppMesh",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appmesh-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "appsync",
     "clientName": "AppSync",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "appsync.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "appsync",
     "clientName": "AppSync",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "appsync.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "appsync",
+    "clientName": "AppSync",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appsync-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "appsync",
+    "clientName": "AppSync",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "appsync-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "athena",
     "clientName": "Athena",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "athena.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "athena",
     "clientName": "Athena",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "athena.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "athena",
+    "clientName": "Athena",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "athena-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "athena",
+    "clientName": "Athena",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "athena-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "autoscaling",
     "clientName": "AutoScaling",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "autoscaling",
     "clientName": "AutoScaling",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "backup.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "backup.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "backup-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "backup-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "batch",
     "clientName": "Batch",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "batch.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "batch",
     "clientName": "Batch",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "batch.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "batch",
+    "clientName": "Batch",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "batch-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "batch",
+    "clientName": "Batch",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "batch-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "cloudformation",
     "clientName": "CloudFormation",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "cloudformation",
     "clientName": "CloudFormation",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudformation.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "cloudformation",
+    "clientName": "CloudFormation",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "cloudformation",
+    "clientName": "CloudFormation",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudformation-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "cloudtrail",
     "clientName": "CloudTrail",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "cloudtrail",
     "clientName": "CloudTrail",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudtrail.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "cloudtrail",
+    "clientName": "CloudTrail",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "cloudtrail",
+    "clientName": "CloudTrail",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudtrail-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "codebuild",
     "clientName": "CodeBuild",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "codebuild",
     "clientName": "CodeBuild",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codebuild.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "codebuild",
+    "clientName": "CodeBuild",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "codebuild",
+    "clientName": "CodeBuild",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codebuild-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "codecommit",
     "clientName": "CodeCommit",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "codecommit",
     "clientName": "CodeCommit",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codecommit.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "codecommit",
+    "clientName": "CodeCommit",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "codecommit",
+    "clientName": "CodeCommit",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codecommit-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "codedeploy",
     "clientName": "CodeDeploy",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "codedeploy",
     "clientName": "CodeDeploy",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "codedeploy.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "codedeploy",
+    "clientName": "CodeDeploy",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "codedeploy",
+    "clientName": "CodeDeploy",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "codedeploy-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "cognito-identity",
     "clientName": "CognitoIdentity",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "cognito-identity",
     "clientName": "CognitoIdentity",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-identity.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "cognito-identity",
+    "clientName": "CognitoIdentity",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "cognito-identity",
+    "clientName": "CognitoIdentity",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cognito-identity-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "config",
     "clientName": "ConfigService",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "config.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "config",
     "clientName": "ConfigService",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "config.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "config",
+    "clientName": "ConfigService",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "config-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "config",
+    "clientName": "ConfigService",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "config-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "cur",
     "clientName": "CUR",
     "region": "cn-northwest-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cur.cn-northwest-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "cur",
     "clientName": "CUR",
     "region": "cn-northwest-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cur.cn-northwest-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "cur",
+    "clientName": "CUR",
+    "region": "cn-northwest-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cur-fips.cn-northwest-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "cur",
+    "clientName": "CUR",
+    "region": "cn-northwest-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cur-fips.cn-northwest-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "data.jobs.iot",
     "clientName": "IoTJobsDataPlane",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "data.jobs.iot",
     "clientName": "IoTJobsDataPlane",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "data.jobs.iot.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "data.jobs.iot",
+    "clientName": "IoTJobsDataPlane",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "data.jobs.iot",
+    "clientName": "IoTJobsDataPlane",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "data.jobs.iot-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "databrew",
     "clientName": "DataBrew",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "databrew.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "databrew",
     "clientName": "DataBrew",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "databrew-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "dax",
     "clientName": "DAX",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dax.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "dax",
     "clientName": "DAX",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dax.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "dax",
+    "clientName": "DAX",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dax-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "dax",
+    "clientName": "DAX",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dax-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "directconnect",
     "clientName": "DirectConnect",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "directconnect",
     "clientName": "DirectConnect",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "directconnect.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "directconnect",
+    "clientName": "DirectConnect",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "directconnect",
+    "clientName": "DirectConnect",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "directconnect-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "dms",
     "clientName": "DMS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dms.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "dms",
     "clientName": "DMS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dms.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "dms",
+    "clientName": "DMS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "dms",
+    "clientName": "DMS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dms-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ds",
     "clientName": "DirectoryService",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ds.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ds",
     "clientName": "DirectoryService",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ds.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ds",
+    "clientName": "DirectoryService",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ds-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ds",
+    "clientName": "DirectoryService",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ds-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "dynamodb",
     "clientName": "DynamoDB",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "dynamodb",
     "clientName": "DynamoDB",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "dynamodb.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "dynamodb",
+    "clientName": "DynamoDB",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "dynamodb",
+    "clientName": "DynamoDB",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "dynamodb-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ebs",
     "clientName": "EBS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ebs.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ebs",
     "clientName": "EBS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ebs-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ec2",
     "clientName": "EC2",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ec2.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ec2",
     "clientName": "EC2",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ec2.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ec2",
+    "clientName": "EC2",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ec2-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ec2",
+    "clientName": "EC2",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ec2-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ecs",
     "clientName": "ECS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ecs.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ecs",
     "clientName": "ECS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ecs.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ecs",
+    "clientName": "ECS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecs-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ecs",
+    "clientName": "ECS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ecs-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "eks",
     "clientName": "EKS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "eks.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "eks",
     "clientName": "EKS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "eks.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "eks",
+    "clientName": "EKS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "eks-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "eks",
+    "clientName": "EKS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "eks-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "elasticache",
     "clientName": "ElastiCache",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "elasticache",
     "clientName": "ElastiCache",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticache.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticache",
+    "clientName": "ElastiCache",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticache",
+    "clientName": "ElastiCache",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticache-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "elasticbeanstalk",
     "clientName": "ElasticBeanstalk",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticbeanstalk.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "elasticbeanstalk",
     "clientName": "ElasticBeanstalk",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticbeanstalk.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticbeanstalk",
+    "clientName": "ElasticBeanstalk",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticbeanstalk-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticbeanstalk",
+    "clientName": "ElasticBeanstalk",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticbeanstalk-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "elasticfilesystem",
     "clientName": "EFS",
     "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticfilesystem-fips.cn-north-1.amazonaws.com.cn"
   },
   {
@@ -3973,601 +8092,1375 @@
     "clientName": "ELBv2",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "elasticloadbalancing",
     "clientName": "ELBv2",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticloadbalancing.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticloadbalancing",
+    "clientName": "ELBv2",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticloadbalancing",
+    "clientName": "ELBv2",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticloadbalancing-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "elasticmapreduce",
     "clientName": "EMR",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "elasticmapreduce",
     "clientName": "EMR",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticmapreduce.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticmapreduce",
+    "clientName": "EMR",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "elasticmapreduce",
+    "clientName": "EMR",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "elasticmapreduce-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "emr-containers",
     "clientName": "EMRcontainers",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "emr-containers.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "emr-containers",
     "clientName": "EMRcontainers",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "emr-containers.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "emr-containers",
+    "clientName": "EMRcontainers",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "emr-containers-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "emr-containers",
+    "clientName": "EMRcontainers",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "emr-containers-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "es",
     "clientName": "OpenSearch",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "es.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "es",
     "clientName": "OpenSearch",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "es.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "es",
+    "clientName": "OpenSearch",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "es-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "es",
+    "clientName": "OpenSearch",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "es-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "events",
     "clientName": "CloudWatchEvents",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "events.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "events",
     "clientName": "CloudWatchEvents",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "events.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "events",
+    "clientName": "CloudWatchEvents",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "events-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "events",
+    "clientName": "CloudWatchEvents",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "events-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "firehose",
     "clientName": "Firehose",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "firehose.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "firehose",
     "clientName": "Firehose",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "firehose.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "firehose",
+    "clientName": "Firehose",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "firehose-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "firehose",
+    "clientName": "Firehose",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "firehose-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "fms",
     "clientName": "FMS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "fms.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "fms",
     "clientName": "FMS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "fms.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "fms",
+    "clientName": "FMS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fms-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "fms",
+    "clientName": "FMS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "fms-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "fsx",
     "clientName": "FSx",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "fsx.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "fsx",
     "clientName": "FSx",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "fsx.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "fsx",
+    "clientName": "FSx",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fsx-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "fsx",
+    "clientName": "FSx",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "fsx-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "gamelift",
     "clientName": "GameLift",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "gamelift.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "gamelift",
     "clientName": "GameLift",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "gamelift.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "gamelift",
+    "clientName": "GameLift",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "gamelift-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "gamelift",
+    "clientName": "GameLift",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "gamelift-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "glacier",
     "clientName": "Glacier",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glacier.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "glacier",
     "clientName": "Glacier",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "glacier.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "glacier",
+    "clientName": "Glacier",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glacier-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "glacier",
+    "clientName": "Glacier",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "glacier-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "glue",
     "clientName": "Glue",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glue.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "glue",
     "clientName": "Glue",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "glue.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "glue",
+    "clientName": "Glue",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glue-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "glue",
+    "clientName": "Glue",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "glue-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "greengrass",
     "clientName": "GreengrassV2",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "greengrass",
     "clientName": "GreengrassV2",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "greengrass.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "greengrass",
+    "clientName": "GreengrassV2",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "greengrass",
+    "clientName": "GreengrassV2",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "greengrass-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "guardduty",
     "clientName": "GuardDuty",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "guardduty",
     "clientName": "GuardDuty",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "guardduty.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "guardduty",
+    "clientName": "GuardDuty",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "guardduty",
+    "clientName": "GuardDuty",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "guardduty-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "health",
     "clientName": "Health",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "health.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "health",
     "clientName": "Health",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "health.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "health",
+    "clientName": "Health",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "health-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "health",
+    "clientName": "Health",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "health-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "iot",
     "clientName": "Iot",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iot.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "iot",
     "clientName": "Iot",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iot.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "iot",
+    "clientName": "Iot",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iot-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "iot",
+    "clientName": "Iot",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iot-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "iotanalytics",
     "clientName": "IoTAnalytics",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotanalytics.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "iotanalytics",
     "clientName": "IoTAnalytics",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotanalytics.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "iotanalytics",
+    "clientName": "IoTAnalytics",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotanalytics-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "iotanalytics",
+    "clientName": "IoTAnalytics",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotanalytics-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "iotevents",
     "clientName": "IoTEvents",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "iotevents",
     "clientName": "IoTEvents",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kafka.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kafka-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "kinesis",
     "clientName": "Kinesis",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "kinesis",
     "clientName": "Kinesis",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesis.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "kinesis",
+    "clientName": "Kinesis",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "kinesis",
+    "clientName": "Kinesis",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesis-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "kinesisanalytics",
     "clientName": "KinesisAnalyticsV2",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "kinesisanalytics",
     "clientName": "KinesisAnalyticsV2",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "kms",
     "clientName": "KMS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kms.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "kms",
     "clientName": "KMS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kms.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "kms",
+    "clientName": "KMS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kms-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "kms",
+    "clientName": "KMS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kms-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "lakeformation",
     "clientName": "LakeFormation",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "lakeformation",
     "clientName": "LakeFormation",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lakeformation.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "lakeformation",
+    "clientName": "LakeFormation",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "lakeformation",
+    "clientName": "LakeFormation",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lakeformation-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "lambda",
     "clientName": "Lambda",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lambda.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "lambda",
     "clientName": "Lambda",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "lambda.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "lambda",
+    "clientName": "Lambda",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lambda-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "lambda",
+    "clientName": "Lambda",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "lambda-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "license-manager",
     "clientName": "LicenseManager",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "license-manager",
     "clientName": "LicenseManager",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "license-manager.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "license-manager",
+    "clientName": "LicenseManager",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "license-manager",
+    "clientName": "LicenseManager",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "license-manager-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "logs",
     "clientName": "CloudWatchLogs",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "logs.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "logs",
     "clientName": "CloudWatchLogs",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "logs.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "logs",
+    "clientName": "CloudWatchLogs",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "logs-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "logs",
+    "clientName": "CloudWatchLogs",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "logs-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "monitoring",
     "clientName": "CloudWatch",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "monitoring",
     "clientName": "CloudWatch",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "monitoring.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "monitoring",
+    "clientName": "CloudWatch",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "monitoring",
+    "clientName": "CloudWatch",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "monitoring-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "mq",
     "clientName": "MQ",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mq.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "mq",
     "clientName": "MQ",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "mq.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "mq",
+    "clientName": "MQ",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mq-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "mq",
+    "clientName": "MQ",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "mq-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "personalize",
     "clientName": "Personalize",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "personalize.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "personalize",
     "clientName": "Personalize",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "personalize.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "personalize",
+    "clientName": "Personalize",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "personalize-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "personalize",
+    "clientName": "Personalize",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "personalize-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "polly",
     "clientName": "Polly",
     "region": "cn-northwest-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "polly.cn-northwest-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "polly",
     "clientName": "Polly",
     "region": "cn-northwest-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "polly.cn-northwest-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "polly",
+    "clientName": "Polly",
+    "region": "cn-northwest-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "polly-fips.cn-northwest-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "polly",
+    "clientName": "Polly",
+    "region": "cn-northwest-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "polly-fips.cn-northwest-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ram",
     "clientName": "RAM",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ram.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ram",
     "clientName": "RAM",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ram.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ram",
+    "clientName": "RAM",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ram-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ram",
+    "clientName": "RAM",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ram-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "rds",
     "clientName": "RDS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "rds.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "rds",
     "clientName": "RDS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "rds.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "rds",
+    "clientName": "RDS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rds-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "rds",
+    "clientName": "RDS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "rds-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "redshift",
     "clientName": "Redshift",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "redshift.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "redshift",
     "clientName": "Redshift",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "redshift.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "redshift",
+    "clientName": "Redshift",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "redshift-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "redshift",
+    "clientName": "Redshift",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "redshift-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "resource-groups",
     "clientName": "ResourceGroups",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "resource-groups",
     "clientName": "ResourceGroups",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "resource-groups.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "resource-groups",
+    "clientName": "ResourceGroups",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "resource-groups",
+    "clientName": "ResourceGroups",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "resource-groups-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "route53resolver",
     "clientName": "Route53Resolver",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "route53resolver",
     "clientName": "Route53Resolver",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "runtime.sagemaker",
     "clientName": "SageMakerRuntime",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "runtime.sagemaker.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "runtime.sagemaker",
     "clientName": "SageMakerRuntime",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "runtime.sagemaker.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "runtime.sagemaker",
+    "clientName": "SageMakerRuntime",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime.sagemaker-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "runtime.sagemaker",
+    "clientName": "SageMakerRuntime",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "runtime.sagemaker-fips.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "s3",
+    "clientName": "S3",
+    "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3.dualstack.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "s3-control.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "s3-control",
+    "clientName": "S3Control",
+    "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-control.dualstack.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "secretsmanager",
     "clientName": "SecretsManager",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "secretsmanager",
     "clientName": "SecretsManager",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "secretsmanager.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "secretsmanager",
+    "clientName": "SecretsManager",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "secretsmanager",
+    "clientName": "SecretsManager",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "secretsmanager-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "securityhub",
     "clientName": "SecurityHub",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "securityhub",
     "clientName": "SecurityHub",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "securityhub.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "securityhub",
+    "clientName": "SecurityHub",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "securityhub",
+    "clientName": "SecurityHub",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "securityhub-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "serverlessrepo",
     "clientName": "ServerlessApplicationRepository",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "serverlessrepo.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "serverlessrepo",
     "clientName": "ServerlessApplicationRepository",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "serverlessrepo.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "serverlessrepo",
+    "clientName": "ServerlessApplicationRepository",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "serverlessrepo-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "serverlessrepo",
+    "clientName": "ServerlessApplicationRepository",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "serverlessrepo-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "servicecatalog",
     "clientName": "ServiceCatalog",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "servicecatalog",
     "clientName": "ServiceCatalog",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "servicecatalog",
+    "clientName": "ServiceCatalog",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "servicecatalog",
+    "clientName": "ServiceCatalog",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicecatalog-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "servicediscovery",
     "clientName": "ServiceDiscovery",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "servicediscovery",
     "clientName": "ServiceDiscovery",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "servicediscovery.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "servicediscovery",
+    "clientName": "ServiceDiscovery",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "servicediscovery",
+    "clientName": "ServiceDiscovery",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "servicediscovery-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "sms",
     "clientName": "SMS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sms.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "sms",
     "clientName": "SMS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sms.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "sms",
+    "clientName": "SMS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sms-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "sms",
+    "clientName": "SMS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sms-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "snowball",
     "clientName": "Snowball",
     "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "snowball-fips.cn-north-1.amazonaws.com.cn"
   },
   {
@@ -4575,146 +9468,327 @@
     "clientName": "SNS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sns.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "sns",
     "clientName": "SNS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sns.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "sns",
+    "clientName": "SNS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sns-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "sns",
+    "clientName": "SNS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sns-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "sqs",
     "clientName": "SQS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sqs.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "sqs",
     "clientName": "SQS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sqs.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "sqs",
+    "clientName": "SQS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sqs-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "sqs",
+    "clientName": "SQS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sqs-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "ssm",
     "clientName": "SSM",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ssm.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "ssm",
     "clientName": "SSM",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "ssm",
+    "clientName": "SSM",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ssm-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "ssm",
+    "clientName": "SSM",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ssm-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "states",
     "clientName": "StepFunctions",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "states.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "states",
     "clientName": "StepFunctions",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "states.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "states",
+    "clientName": "StepFunctions",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "states-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "states",
+    "clientName": "StepFunctions",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "states-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "storagegateway",
     "clientName": "StorageGateway",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "storagegateway",
     "clientName": "StorageGateway",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "storagegateway.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "storagegateway",
+    "clientName": "StorageGateway",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "storagegateway",
+    "clientName": "StorageGateway",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "storagegateway-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "sts",
     "clientName": "STS",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sts.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "sts",
     "clientName": "STS",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "sts.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "sts",
+    "clientName": "STS",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sts-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "sts",
+    "clientName": "STS",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "sts-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "swf",
     "clientName": "SWF",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "swf.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "swf",
     "clientName": "SWF",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "swf.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "swf",
+    "clientName": "SWF",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "swf-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "swf",
+    "clientName": "SWF",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "swf-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "tagging",
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "tagging.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "tagging",
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "tagging-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "transfer",
     "clientName": "Transfer",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "transfer.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "transfer",
     "clientName": "Transfer",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "transfer.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "transfer",
+    "clientName": "Transfer",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "transfer-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "transfer",
+    "clientName": "Transfer",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "transfer-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "waf-regional",
     "clientName": "WAFRegional",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional.cn-north-1.amazonaws.com.cn"
   },
   {
@@ -4722,6 +9796,7 @@
     "clientName": "WAFRegional",
     "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional-fips.cn-north-1.amazonaws.com.cn"
   },
   {
@@ -4729,34 +9804,71 @@
     "clientName": "WorkSpaces",
     "region": "cn-northwest-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces.cn-northwest-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "workspaces",
     "clientName": "WorkSpaces",
     "region": "cn-northwest-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "workspaces.cn-northwest-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "workspaces",
+    "clientName": "WorkSpaces",
+    "region": "cn-northwest-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces-fips.cn-northwest-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "workspaces",
+    "clientName": "WorkSpaces",
+    "region": "cn-northwest-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "workspaces-fips.cn-northwest-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "xray",
     "clientName": "XRay",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "xray.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "xray",
     "clientName": "XRay",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "xray.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "xray",
+    "clientName": "XRay",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "xray-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "xray",
+    "clientName": "XRay",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "xray-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "acm-pca",
     "clientName": "ACMPCA",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "acm-pca.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4764,6 +9876,7 @@
     "clientName": "Detective",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api.detective-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4771,6 +9884,7 @@
     "clientName": "ECR",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecr-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4778,6 +9892,7 @@
     "clientName": "SageMaker",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "api-fips.sagemaker.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4785,34 +9900,71 @@
     "clientName": "ApiGatewayV2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "apigateway",
     "clientName": "ApiGatewayV2",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "apigateway",
+    "clientName": "ApiGatewayV2",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "apigateway-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "application-autoscaling",
     "clientName": "ApplicationAutoScaling",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "application-autoscaling",
+    "clientName": "ApplicationAutoScaling",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "application-autoscaling-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "appstream2",
     "clientName": "AppStream",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "appstream2-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4820,6 +9972,7 @@
     "clientName": "Athena",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "athena-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4827,48 +9980,103 @@
     "clientName": "AutoScaling",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "autoscaling",
     "clientName": "AutoScaling",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "autoscaling",
+    "clientName": "AutoScaling",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "autoscaling-plans",
     "clientName": "AutoScalingPlans",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling-plans-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "autoscaling-plans",
+    "clientName": "AutoScalingPlans",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "autoscaling-plans-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "backup.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "backup",
     "clientName": "Backup",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "backup.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "backup-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "backup",
+    "clientName": "Backup",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "backup-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "batch",
     "clientName": "Batch",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "batch.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4876,6 +10084,7 @@
     "clientName": "CloudControl",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudcontrolapi-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4883,48 +10092,103 @@
     "clientName": "CloudDirectory",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "clouddirectory.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "clouddirectory",
     "clientName": "CloudDirectory",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "clouddirectory.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "clouddirectory",
+    "clientName": "CloudDirectory",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "clouddirectory-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "clouddirectory",
+    "clientName": "CloudDirectory",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "clouddirectory-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "cloudhsm",
     "clientName": "CloudHSM",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsm.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudhsm",
     "clientName": "CloudHSM",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsm.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudhsm",
+    "clientName": "CloudHSM",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsm-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudhsm",
+    "clientName": "CloudHSM",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsm-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "cloudhsmv2",
     "clientName": "CloudHSMV2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsmv2.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "cloudhsmv2",
     "clientName": "CloudHSMV2",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsmv2.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "cloudhsmv2",
+    "clientName": "CloudHSMV2",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cloudhsmv2-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "cloudhsmv2",
+    "clientName": "CloudHSMV2",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "cloudhsmv2-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "codebuild",
     "clientName": "CodeBuild",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codebuild-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4932,6 +10196,7 @@
     "clientName": "CodeCommit",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codecommit-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4939,6 +10204,7 @@
     "clientName": "CodeDeploy",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4946,6 +10212,7 @@
     "clientName": "CodePipeline",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "codepipeline-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4953,6 +10220,7 @@
     "clientName": "CognitoIdentity",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-identity-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4960,6 +10228,7 @@
     "clientName": "CognitoIdentityServiceProvider",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "cognito-idp-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4967,6 +10236,7 @@
     "clientName": "Comprehend",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehend-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4974,6 +10244,7 @@
     "clientName": "ComprehendMedical",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "comprehendmedical-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -4981,6 +10252,7 @@
     "clientName": "ConfigService",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "config.us-gov-east-1.amazonaws.com"
   },
   {
@@ -4988,20 +10260,39 @@
     "clientName": "Connect",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "connect.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "connect",
     "clientName": "Connect",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "connect.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "connect",
+    "clientName": "Connect",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "connect-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "connect",
+    "clientName": "Connect",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "connect-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "data.jobs.iot",
     "clientName": "IoTJobsDataPlane",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.jobs.iot-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5009,20 +10300,39 @@
     "clientName": "DataBrew",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "databrew.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "databrew",
     "clientName": "DataBrew",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "databrew-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "databrew",
+    "clientName": "DataBrew",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "databrew-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "datasync",
     "clientName": "DataSync",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "datasync-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5030,6 +10340,7 @@
     "clientName": "DirectoryService",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ds-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5037,6 +10348,7 @@
     "clientName": "DynamoDB",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5044,20 +10356,39 @@
     "clientName": "EBS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ebs.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "ebs",
     "clientName": "EBS",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ebs-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ebs",
+    "clientName": "EBS",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "ebs-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "ecs",
     "clientName": "ECS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ecs-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5065,6 +10396,7 @@
     "clientName": "EKS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "eks.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5072,6 +10404,7 @@
     "clientName": "EFS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticfilesystem-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5079,6 +10412,7 @@
     "clientName": "ELBv2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5086,6 +10420,7 @@
     "clientName": "EMR",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5093,6 +10428,7 @@
     "clientName": "SESV2",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "email-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5100,6 +10436,7 @@
     "clientName": "OpenSearch",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "es-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5107,6 +10444,7 @@
     "clientName": "Firehose",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "firehose-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5114,6 +10452,7 @@
     "clientName": "FMS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fms-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5121,6 +10460,7 @@
     "clientName": "FSx",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fsx-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5128,6 +10468,7 @@
     "clientName": "Glue",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "glue-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5135,6 +10476,7 @@
     "clientName": "GreengrassV2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5142,6 +10484,7 @@
     "clientName": "GreengrassV2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "greengrass-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5149,6 +10492,7 @@
     "clientName": "GuardDuty",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "guardduty.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5156,6 +10500,7 @@
     "clientName": "IdentityStore",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "identitystore.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5163,6 +10508,7 @@
     "clientName": "Inspector",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "inspector-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5170,6 +10516,7 @@
     "clientName": "Iot",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iot-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5177,48 +10524,103 @@
     "clientName": "IoTEvents",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotevents",
     "clientName": "IoTEvents",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotevents-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotevents",
+    "clientName": "IoTEvents",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotevents-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise.us-gov-west-1.amazonaws.com"
   },
   {
     "endpointPrefix": "iotsitewise",
     "clientName": "IoTSiteWise",
     "region": "us-gov-west-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise.us-gov-west-1.api.aws"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iotsitewise-fips.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "iotsitewise",
+    "clientName": "IoTSiteWise",
+    "region": "us-gov-west-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "iotsitewise-fips.us-gov-west-1.api.aws"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kafka.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kafka",
     "clientName": "Kafka",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kafka-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kafka",
+    "clientName": "Kafka",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kafka-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "kendra",
     "clientName": "Kendra",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kendra-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5226,20 +10628,39 @@
     "clientName": "KinesisAnalyticsV2",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "kinesisanalytics",
     "clientName": "KinesisAnalyticsV2",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kinesisanalytics-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "kinesisanalytics",
+    "clientName": "KinesisAnalyticsV2",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "kinesisanalytics-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "kms",
     "clientName": "KMS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kms-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5247,6 +10668,7 @@
     "clientName": "LakeFormation",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lakeformation-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5254,6 +10676,7 @@
     "clientName": "Lambda",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "lambda-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5261,6 +10684,7 @@
     "clientName": "LicenseManager",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5268,20 +10692,39 @@
     "clientName": "MarketplaceMetering",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "metering.marketplace.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "metering.marketplace",
     "clientName": "MarketplaceMetering",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "metering.marketplace.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "metering.marketplace",
+    "clientName": "MarketplaceMetering",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "metering.marketplace-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "metering.marketplace",
+    "clientName": "MarketplaceMetering",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "metering.marketplace-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "models.lex",
     "clientName": "LexModelBuildingService",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "models-fips.lex.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5289,6 +10732,7 @@
     "clientName": "CloudWatch",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5296,6 +10740,7 @@
     "clientName": "MQ",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "mq-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5303,6 +10748,7 @@
     "clientName": "NetworkFirewall",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "network-firewall-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5310,6 +10756,7 @@
     "clientName": "Organizations",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "organizations.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5317,6 +10764,7 @@
     "clientName": "Pinpoint",
     "region": "us-gov-west-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5324,6 +10772,7 @@
     "clientName": "Pinpoint",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "pinpoint-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5331,6 +10780,7 @@
     "clientName": "Polly",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "polly-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5338,20 +10788,39 @@
     "clientName": "QuickSight",
     "region": "api",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "quicksight.api.amazonaws.com"
   },
   {
     "endpointPrefix": "quicksight",
     "clientName": "QuickSight",
     "region": "api",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "quicksight.api.api.aws"
+  },
+  {
+    "endpointPrefix": "quicksight",
+    "clientName": "QuickSight",
+    "region": "api",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "quicksight-fips.api.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "quicksight",
+    "clientName": "QuickSight",
+    "region": "api",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "quicksight-fips.api.api.aws"
   },
   {
     "endpointPrefix": "rekognition",
     "clientName": "Rekognition",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rekognition-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5359,6 +10828,7 @@
     "clientName": "ResourceGroups",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "resource-groups.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5366,20 +10836,39 @@
     "clientName": "Route53Resolver",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "route53resolver",
     "clientName": "Route53Resolver",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "route53resolver",
+    "clientName": "Route53Resolver",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "route53resolver-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "runtime.lex",
     "clientName": "LexRuntime",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime-fips.lex.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5387,27 +10876,55 @@
     "clientName": "SageMakerRuntime",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "runtime.sagemaker.us-gov-west-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3",
+    "clientName": "S3",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3.dualstack.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "s3-control.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "s3-control",
     "clientName": "S3Control",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-control.dualstack.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3-control",
+    "clientName": "S3Control",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "s3-control-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "s3-control",
+    "clientName": "S3Control",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "s3-control-fips.dualstack.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "secretsmanager",
     "clientName": "SecretsManager",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5415,6 +10932,7 @@
     "clientName": "SecurityHub",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "securityhub-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5422,6 +10940,7 @@
     "clientName": "ServiceCatalog",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5429,6 +10948,7 @@
     "clientName": "ServiceCatalogAppRegistry",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicecatalog-appregistry.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5436,6 +10956,7 @@
     "clientName": "ServiceDiscovery",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicediscovery-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5443,6 +10964,7 @@
     "clientName": "ServiceQuotas",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "servicequotas.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5450,6 +10972,7 @@
     "clientName": "SMS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sms-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5457,6 +10980,7 @@
     "clientName": "Snowball",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "snowball-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5464,6 +10988,7 @@
     "clientName": "SSM",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "ssm.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5471,6 +10996,7 @@
     "clientName": "StepFunctions",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "states-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5478,6 +11004,7 @@
     "clientName": "StorageGateway",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "storagegateway-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5485,20 +11012,39 @@
     "clientName": "DynamoDBStreams",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "streams.dynamodb",
     "clientName": "DynamoDBStreams",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "streams.dynamodb",
+    "clientName": "DynamoDBStreams",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "streams.dynamodb-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "sts",
     "clientName": "STS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "sts.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5506,20 +11052,39 @@
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "tagging.us-gov-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "tagging",
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "us-gov-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging.us-gov-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "tagging-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "tagging",
+    "clientName": "ResourceGroupsTaggingAPI",
+    "region": "us-gov-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "tagging-fips.us-gov-east-1.api.aws"
   },
   {
     "endpointPrefix": "textract",
     "clientName": "Textract",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "textract-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5527,6 +11092,7 @@
     "clientName": "TranscribeService",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "fips.transcribe.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5534,6 +11100,7 @@
     "clientName": "Transfer",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "transfer-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5541,6 +11108,7 @@
     "clientName": "Translate",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "translate-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5548,6 +11116,7 @@
     "clientName": "WAFRegional",
     "region": "us-gov-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5555,6 +11124,7 @@
     "clientName": "WAFRegional",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "waf-regional-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5562,6 +11132,7 @@
     "clientName": "WorkSpaces",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces-fips.us-gov-west-1.amazonaws.com"
   },
   {
@@ -5569,6 +11140,7 @@
     "clientName": "XRay",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "xray-fips.us-gov-east-1.amazonaws.com"
   },
   {
@@ -5576,6 +11148,7 @@
     "clientName": "SageMaker",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "api.sagemaker.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5583,6 +11156,7 @@
     "clientName": "ApiGatewayV2",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "apigateway.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5590,6 +11164,7 @@
     "clientName": "ApplicationAutoScaling",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5597,6 +11172,7 @@
     "clientName": "AutoScaling",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5604,6 +11180,7 @@
     "clientName": "CloudFormation",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5611,6 +11188,7 @@
     "clientName": "CloudTrail",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5618,6 +11196,7 @@
     "clientName": "CodeDeploy",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5625,6 +11204,7 @@
     "clientName": "Comprehend",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "comprehend.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5632,6 +11212,7 @@
     "clientName": "ConfigService",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "config.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5639,6 +11220,7 @@
     "clientName": "DataPipeline",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "datapipeline.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5646,6 +11228,7 @@
     "clientName": "DirectConnect",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5653,6 +11236,7 @@
     "clientName": "DMS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5660,6 +11244,7 @@
     "clientName": "DirectoryService",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ds.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5667,6 +11252,7 @@
     "clientName": "DynamoDB",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5674,6 +11260,7 @@
     "clientName": "EBS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ebs.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5681,6 +11268,7 @@
     "clientName": "EC2",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ec2.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5688,6 +11276,7 @@
     "clientName": "ECS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ecs.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5695,6 +11284,7 @@
     "clientName": "ElastiCache",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5702,6 +11292,7 @@
     "clientName": "EFS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticfilesystem-fips.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5709,6 +11300,7 @@
     "clientName": "ELBv2",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5716,6 +11308,7 @@
     "clientName": "EMR",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5723,6 +11316,7 @@
     "clientName": "OpenSearch",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "es.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5730,6 +11324,7 @@
     "clientName": "CloudWatchEvents",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "events.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5737,6 +11332,7 @@
     "clientName": "Firehose",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "firehose.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5744,6 +11340,7 @@
     "clientName": "Glacier",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glacier.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5751,6 +11348,7 @@
     "clientName": "Health",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "health.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5758,6 +11356,7 @@
     "clientName": "Kinesis",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5765,6 +11364,7 @@
     "clientName": "KMS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kms-fips.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5772,6 +11372,7 @@
     "clientName": "Lambda",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lambda.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5779,6 +11380,7 @@
     "clientName": "LicenseManager",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5786,6 +11388,7 @@
     "clientName": "CloudWatchLogs",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "logs.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5793,6 +11396,7 @@
     "clientName": "MediaLive",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "medialive.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5800,6 +11404,7 @@
     "clientName": "MediaPackage",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "mediapackage.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5807,6 +11412,7 @@
     "clientName": "CloudWatch",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5814,6 +11420,7 @@
     "clientName": "Outposts",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "outposts.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5821,6 +11428,7 @@
     "clientName": "RAM",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ram.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5828,6 +11436,7 @@
     "clientName": "RDS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "rds.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5835,6 +11444,7 @@
     "clientName": "Redshift",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "redshift.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5842,6 +11452,7 @@
     "clientName": "Route53Resolver",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53resolver.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5849,6 +11460,7 @@
     "clientName": "SageMakerRuntime",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "runtime.sagemaker.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5856,6 +11468,7 @@
     "clientName": "S3",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "s3.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5863,6 +11476,7 @@
     "clientName": "SecretsManager",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "secretsmanager.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5870,6 +11484,7 @@
     "clientName": "Snowball",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "snowball.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5877,6 +11492,7 @@
     "clientName": "SNS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sns.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5884,6 +11500,7 @@
     "clientName": "SQS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sqs.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5891,6 +11508,7 @@
     "clientName": "SSM",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ssm.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5898,6 +11516,7 @@
     "clientName": "StepFunctions",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "states.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5905,6 +11524,7 @@
     "clientName": "DynamoDBStreams",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5912,6 +11532,7 @@
     "clientName": "STS",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sts.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5919,6 +11540,7 @@
     "clientName": "SWF",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "swf.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5926,6 +11548,7 @@
     "clientName": "TranscribeService",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "transcribe.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5933,6 +11556,7 @@
     "clientName": "Translate",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "translate.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5940,6 +11564,7 @@
     "clientName": "WorkSpaces",
     "region": "us-iso-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "workspaces.us-iso-east-1.c2s.ic.gov"
   },
   {
@@ -5947,6 +11572,7 @@
     "clientName": "ApplicationAutoScaling",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "application-autoscaling.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5954,6 +11580,7 @@
     "clientName": "AutoScaling",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "autoscaling.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5961,6 +11588,7 @@
     "clientName": "CloudFormation",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudformation.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5968,6 +11596,7 @@
     "clientName": "CloudTrail",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "cloudtrail.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5975,6 +11604,7 @@
     "clientName": "CodeDeploy",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "codedeploy.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5982,6 +11612,7 @@
     "clientName": "ConfigService",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "config.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5989,6 +11620,7 @@
     "clientName": "DirectConnect",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "directconnect.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -5996,6 +11628,7 @@
     "clientName": "DMS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6003,6 +11636,7 @@
     "clientName": "DirectoryService",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ds.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6010,6 +11644,7 @@
     "clientName": "DynamoDB",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "dynamodb.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6017,6 +11652,7 @@
     "clientName": "EBS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ebs.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6024,6 +11660,7 @@
     "clientName": "EC2",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ec2.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6031,6 +11668,7 @@
     "clientName": "ECS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ecs.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6038,6 +11676,7 @@
     "clientName": "ElastiCache",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6045,6 +11684,7 @@
     "clientName": "ELBv2",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticloadbalancing.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6052,6 +11692,7 @@
     "clientName": "EMR",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "elasticmapreduce.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6059,6 +11700,7 @@
     "clientName": "OpenSearch",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "es.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6066,6 +11708,7 @@
     "clientName": "CloudWatchEvents",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "events.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6073,6 +11716,7 @@
     "clientName": "Glacier",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "glacier.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6080,6 +11724,7 @@
     "clientName": "Health",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "health.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6087,6 +11732,7 @@
     "clientName": "Kinesis",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "kinesis.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6094,6 +11740,7 @@
     "clientName": "KMS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "kms-fips.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6101,6 +11748,7 @@
     "clientName": "Lambda",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "lambda.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6108,6 +11756,7 @@
     "clientName": "LicenseManager",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "license-manager.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6115,6 +11764,7 @@
     "clientName": "CloudWatchLogs",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "logs.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6122,6 +11772,7 @@
     "clientName": "CloudWatch",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "monitoring.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6129,6 +11780,7 @@
     "clientName": "RDS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "rds.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6136,6 +11788,7 @@
     "clientName": "Redshift",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "redshift.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6143,6 +11796,7 @@
     "clientName": "S3",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "s3.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6150,6 +11804,7 @@
     "clientName": "Snowball",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "snowball.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6157,6 +11812,7 @@
     "clientName": "SNS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sns.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6164,6 +11820,7 @@
     "clientName": "SQS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sqs.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6171,6 +11828,7 @@
     "clientName": "SSM",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "ssm.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6178,6 +11836,7 @@
     "clientName": "StepFunctions",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "states.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6185,6 +11844,7 @@
     "clientName": "DynamoDBStreams",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "streams.dynamodb.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6192,6 +11852,7 @@
     "clientName": "STS",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "sts.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6199,6 +11860,7 @@
     "clientName": "SWF",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "swf.us-isob-east-1.sc2s.sgov.gov"
   },
   {
@@ -6206,6 +11868,7 @@
     "clientName": "ResourceGroupsTaggingAPI",
     "region": "us-isob-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "tagging.us-isob-east-1.sc2s.sgov.gov"
   }
 ]

--- a/test/endpoint/test_cases_unsupported.json
+++ b/test/endpoint/test_cases_unsupported.json
@@ -4,13 +4,23 @@
     "clientName": "IotData",
     "region": "ap-east-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot.ap-east-1.amazonaws.com"
   },
   {
     "endpointPrefix": "data.iot",
     "clientName": "IotData",
     "region": "ap-east-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "data.iot.ap-east-1.api.aws"
+  },
+  {
+    "endpointPrefix": "data.iot",
+    "clientName": "IotData",
+    "region": "ap-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot-fips.ap-east-1.amazonaws.com"
   },
   {
@@ -18,34 +28,72 @@
     "clientName": "IotData",
     "region": "ca-central-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot-fips.ca-central-1.amazonaws.com"
   },
   {
     "endpointPrefix": "data.iot",
     "clientName": "IotData",
+    "region": "ap-east-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "data.iot-fips.ap-east-1.api.aws"
+  },
+
+  {
+    "endpointPrefix": "data.iot",
+    "clientName": "IotData",
     "region": "cn-north-1",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot.cn-north-1.amazonaws.com.cn"
   },
   {
     "endpointPrefix": "data.iot",
     "clientName": "IotData",
     "region": "cn-north-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "data.iot.cn-north-1.api.amazonwebservices.com.cn"
+  },
+  {
+    "endpointPrefix": "data.iot",
+    "clientName": "IotData",
+    "region": "cn-north-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot-fips.cn-north-1.amazonaws.com.cn"
+  },
+  {
+    "endpointPrefix": "data.iot",
+    "clientName": "IotData",
+    "region": "cn-north-1",
+    "useFipsEndpoint": true,
+    "useDualstackEndpoint": true,
+    "hostname": "data.iot-fips.cn-north-1.api.amazonwebservices.com.cn"
   },
   {
     "endpointPrefix": "data.iot",
     "clientName": "IotData",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "data.iot-fips.us-gov-east-1.amazonaws.com"
+  },
+  {
+    "endpointPrefix": "ec2",
+    "clientName": "EC2",
+    "region": "ap-south-1",
+    "useFipsEndpoint": false,
+    "useDualstackEndpoint": true,
+    "hostname": "api.ec2.ap-south-1.aws"
   },
   {
     "endpointPrefix": "dms",
     "clientName": "DMS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "dms.us-gov-east-1.amazonaws.com"
   },
   {
@@ -53,6 +101,7 @@
     "clientName": "ElastiCache",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.us-gov-east-1.amazonaws.com"
   },
   {
@@ -60,6 +109,7 @@
     "clientName": "ElastiCache",
     "region": "us-gov-west-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "elasticache.us-gov-west-1.amazonaws.com"
   },
   {
@@ -67,6 +117,7 @@
     "clientName": "IAM",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "iam.us-gov.amazonaws.com"
   },
   {
@@ -74,6 +125,7 @@
     "clientName": "IAM",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "iam.us-gov.amazonaws.com"
   },
   {
@@ -81,6 +133,7 @@
     "clientName": "Organizations",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "organizations.us-gov-west-1.amazonaws.com"
   },
   {
@@ -88,6 +141,7 @@
     "clientName": "RDS",
     "region": "us-gov-east-1",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "rds.us-gov-east-1.amazonaws.com"
   },
   {
@@ -95,6 +149,7 @@
     "clientName": "Route53",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": false,
+    "useDualstackEndpoint": false,
     "hostname": "route53.us-gov.amazonaws.com"
   },
   {
@@ -102,6 +157,7 @@
     "clientName": "Route53",
     "region": "aws-us-gov-global",
     "useFipsEndpoint": true,
+    "useDualstackEndpoint": false,
     "hostname": "route53.us-gov.amazonaws.com"
   }
 ]

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -109,34 +109,6 @@ describe('region_config.js', function() {
     expect(service.isGlobalEndpoint).to.equal(false);
     expect(service.endpoint.host).to.equal('sts.us-gov-west-1.amazonaws.com');
   });
-
-  describe('dualstack endpoint', function() {
-    it('uses dualstack endpoint if useDualstack flag configured and available for service', function() {
-      helpers.spyOn(AWS.util, 'isDualstackAvailable').andReturn(true);
-      var service = new MockService({
-        region: 'us-west-2',
-        useDualstack: true
-      });
-      expect(service.config.endpoint).to.equal('mockservice.dualstack.us-west-2.amazonaws.com');
-    });
-
-    it('does not use dualstack endpoint if useDualstack flag not set to true', function() {
-      helpers.spyOn(AWS.util, 'isDualstackAvailable').andReturn(true);
-      var service = new MockService({
-        region: 'us-west-2'
-      });
-      expect(service.config.endpoint).to.equal('mockservice.us-west-2.amazonaws.com');
-    });
-
-    it('does not use dualstack endpoint if not available for service', function() {
-      helpers.spyOn(AWS.util, 'isDualstackAvailable').andReturn(false);
-      var service = new MockService({
-        region: 'us-west-2',
-        useDualstack: true
-      });
-      expect(service.config.endpoint).to.equal('mockservice.us-west-2.amazonaws.com');
-    });
-  });
 });
 
 describe('region_config_data.json', function() {

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -123,6 +123,19 @@
         return delete AWS.config.s3;
       });
 
+      it('sets undefined useDualstackEndpoint to value in useDualstack', function() {
+        [true, false].forEach((useDualstack) => {
+          var s3 = new AWS.S3({ useDualstack });
+          expect(s3.config.useDualstackEndpoint).to.equal(useDualstack);
+        });
+        [true, false].forEach((useDualstack) => {
+          var useDualstackEndpoint = !useDualstack;
+          var s3 = new AWS.S3({ useDualstack, useDualstackEndpoint });
+          expect(s3.config.useDualstackEndpoint).to.equal(useDualstackEndpoint);
+        });
+        return delete AWS.config.s3;
+      });
+
       it('merges credential data into config', function() {
         service = new AWS.Service({
           accessKeyId: 'foo',

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -92,18 +92,6 @@ describe('AWS.S3', function() {
         useDualstack: true
       });
       expect(s3.endpoint.hostname).to.equal('s3.dualstack.cn-north-1.amazonaws.com.cn');
-
-      s3 = new AWS.S3({
-        region: 'us-iso-east-1',
-        useDualstack: true
-      });
-      expect(s3.endpoint.hostname).to.equal('s3.dualstack.us-iso-east-1.c2s.ic.gov');
-
-      s3 = new AWS.S3({
-        region: 'us-isob-east-1',
-        useDualstack: true
-      });
-      expect(s3.endpoint.hostname).to.equal('s3.dualstack.us-isob-east-1.sc2s.sgov.gov');
     });
   });
 


### PR DESCRIPTION
This PR:
* Add useDualStack configuration.
* Reads from env/shared ini if it's not passed in client configuration.
* Enables dualstack, if legacy `useDualstack` is passed for S3/S3Control.
* Adds endpoint tests for useDualStackEndpoint.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed