### PR TITLE
Enable Rescue SES InvalidParameterValue test

### DIFF
--- a/features/ses/ses.feature
+++ b/features/ses/ses.feature
@@ -13,8 +13,8 @@ Feature: SES
     When I ask to verify the email address "foo@example.com"
     Then the status code should be 200
 
-  # Scenario: Rescue SES InvalidParameterValue
-  #   When I ask to verify the email address "abc123"
-  #   Then I should get the error:
-  #   | code                  | message                        |
-  #   | InvalidParameterValue | Invalid email address<abc123>. |
+  Scenario: Rescue SES InvalidParameterValue
+    When I ask to verify the email address "abc123"
+    Then I should get the error:
+    | code                  | message                        |
+    | InvalidParameterValue | Invalid email address<abc123>. |


### PR DESCRIPTION
Reverts https://github.com/aws/aws-sdk-js/pull/3956
The error message is corrected in the backend.

<details>
<summary>Integration test run</summary>

```console
$ AWS_REGION=us-east-1 npm run integration -- -t @ses

> aws-sdk@2.1027.0 integration /local/home/trivikr/workspace/aws-sdk-js
> cucumber.js "-t" "@ses"

@ses
Feature: SES

  I want to use Simple Email Service.


  Scenario: Check quota                                     # features/ses/ses.feature:7
    When I check quota                                      # features/ses/ses.feature:8
    Then the result should include number "SentLast24Hours" # features/ses/ses.feature:9
    And the result should include number "MaxSendRate"      # features/ses/ses.feature:10


  Scenario: Verify email                                     # features/ses/ses.feature:12
(node:12155) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.
    When I ask to verify the email address "foo@example.com" # features/ses/ses.feature:13
    Then the status code should be 200                       # features/ses/ses.feature:14


  Scenario: Rescue SES InvalidParameterValue        # features/ses/ses.feature:16
    When I ask to verify the email address "abc123" # features/ses/ses.feature:17
    Then I should get the error:                    # features/ses/ses.feature:18
      | code                  | message                        |
      | InvalidParameterValue | Invalid email address<abc123>. |


3 scenarios (3 passed)
7 steps (7 passed)
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `npm run integration` if integration test is changed