### PR TITLE
chore(s3util): add allowFipsEndpoint option in validateArnRegion

### DIFF
--- a/.changes/next-release/feature-s3util-4a5bd10b.json
+++ b/.changes/next-release/feature-s3util-4a5bd10b.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "s3util",
+  "description": "Add allowFipsEndpoint option in validateArnRegion"
+}

--- a/lib/services/s3util.js
+++ b/lib/services/s3util.js
@@ -132,11 +132,16 @@ var s3util = {
   /**
    * Validate region field in ARN supplied in Bucket parameter is a valid region
    */
-  validateArnRegion: function validateArnRegion(req) {
+  validateArnRegion: function validateArnRegion(req, options) {
+    if (options === undefined) {
+      options = {};
+    }
+
     var useArnRegion = s3util.loadUseArnRegionConfig(req);
     var regionFromArn = req._parsedArn.region;
     var clientRegion = req.service.config.region;
     var useFipsEndpoint = req.service.config.useFipsEndpoint;
+    var allowFipsEndpoint = options.allowFipsEndpoint || false;
 
     if (!regionFromArn) {
       throw AWS.util.error(new Error(), {
@@ -145,13 +150,17 @@ var s3util = {
       });
     }
 
-    if (
-      useFipsEndpoint ||
-      regionFromArn.indexOf('fips') >= 0
-    ) {
+    if (useFipsEndpoint && !allowFipsEndpoint) {
       throw AWS.util.error(new Error(), {
         code: 'InvalidConfiguration',
         message: 'ARN endpoint is not compatible with FIPS region'
+      });
+    }
+
+    if (regionFromArn.indexOf('fips') >= 0) {
+      throw AWS.util.error(new Error(), {
+        code: 'InvalidConfiguration',
+        message: 'FIPS region not allowed in ARN'
       });
     }
 


### PR DESCRIPTION
Refs:
* https://github.com/aws/aws-sdk-js/issues/3959
* https://github.com/aws/aws-sdk-js/issues/3960
* https://github.com/aws/aws-sdk-js/issues/3961

The unit tests will be updated for when s3util is called from each customizations above.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`
