### PR TITLE
Support FIPS for S3 Outposts

### DIFF
--- a/.changes/next-release/feature-S3Control-8b5d37ea.json
+++ b/.changes/next-release/feature-S3Control-8b5d37ea.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "S3Control",
+  "description": "Support FIPS for S3 Outposts"
+}

--- a/lib/services/s3control.js
+++ b/lib/services/s3control.js
@@ -27,7 +27,7 @@ AWS.util.update(AWS.S3Control.prototype, {
     }
 
     if (isArnInBucket || isArnInName) {
-      request.addListener('validate', s3util.validateArnRegion);
+      request.addListener('validate', this.validateArnRegion);
       request.addListener('validate', this.validateArnAccountWithParams, true);
       request.addListener('validate', s3util.validateArnAccount);
       request.addListener('validate', s3util.validateArnService);
@@ -98,9 +98,10 @@ AWS.util.update(AWS.S3Control.prototype, {
 
     var endpoint = req.httpRequest.endpoint;
     var useArnRegion = req.service.config.s3UseArnRegion;
+    var useFipsEndpoint = req.service.config.useFipsEndpoint;
 
     endpoint.hostname = [
-      's3-outposts',
+      's3-outposts' + (useFipsEndpoint ? '-fips': ''),
       useArnRegion ? parsedArn.region : req.service.config.region,
       'amazonaws.com'
     ].join('.');
@@ -112,8 +113,9 @@ AWS.util.update(AWS.S3Control.prototype, {
    */
   populateEndpointForOutpostId: function populateEndpointForOutpostId(req) {
     var endpoint = req.httpRequest.endpoint;
+    var useFipsEndpoint = req.service.config.useFipsEndpoint;
     endpoint.hostname = [
-      's3-outposts',
+      's3-outposts' + (useFipsEndpoint ? '-fips': ''),
       req.service.config.region,
       'amazonaws.com'
     ].join('.');
@@ -129,6 +131,13 @@ AWS.util.update(AWS.S3Control.prototype, {
     if (response.error) {
       response.error.extendedRequestId = hostId;
     }
+  },
+
+  /**
+   * @api private
+   */
+  validateArnRegion: function validateArnRegion(req) {
+    s3util.validateArnRegion(req, { allowFipsEndpoint: true });
   },
 
   /**

--- a/test/services/s3control.spec.js
+++ b/test/services/s3control.spec.js
@@ -240,7 +240,7 @@ describe('AWS.S3Control', function() {
           error = err;
         });
         expect(error.name).to.equal('InvalidConfiguration');
-          expect(error.message).to.equal('FIPS region not allowed in ARN');
+        expect(error.message).to.equal('FIPS region not allowed in ARN');
       });
 
       it('should use regions from ARN if s3UseArnRegion config is set to false', function(done) {

--- a/test/services/s3control.spec.js
+++ b/test/services/s3control.spec.js
@@ -205,7 +205,7 @@ describe('AWS.S3Control', function() {
         });
       });
 
-      it('should correctly generate access point endpoint for pseudo regions', function() {
+      it('should correctly generate access point endpoint for s3-external-1', function() {
         var client = new AWS.S3Control({region: 'us-east-1'});
         helpers.mockHttpResponse(200, {}, '');
         var request = client.getBucket({
@@ -215,22 +215,32 @@ describe('AWS.S3Control', function() {
         expect(
           built.httpRequest.endpoint.hostname
         ).to.equal('s3-outposts.s3-external-1.amazonaws.com');
+      });
 
-        var testFipsError = (client) => {
-          helpers.mockHttpResponse(200, {}, '');
-          request = client.getBucket({
-            Bucket: 'arn:aws:s3-outposts:s3-external-1:123456789012:outpost/op-01234567890123456/bucket/mybucket'
-          });
-          var error;
-          request.build(function(err) {
-            error = err;
-          });
-          expect(error.name).to.equal('InvalidConfiguration');
-          expect(error.message).to.equal('ARN endpoint is not compatible with FIPS region');
-        };
-        testFipsError(new AWS.S3Control({region: 'fips-us-east-1'}));
-        testFipsError(new AWS.S3Control({region: 'us-east-1-fips'}));
-        testFipsError(new AWS.S3Control({region: 'us-east-1', useFipsEndpoint: true}));
+      it('should correctly generate access point endpoint when useFipsEndpoint=true', function() {
+        var client = new AWS.S3Control({region: 'us-gov-west-1', useFipsEndpoint: true});
+        helpers.mockHttpResponse(200, {}, '');
+        var request = client.getBucket({
+          Bucket: 'arn:aws:s3-outposts:us-gov-west-1:123456789012:outpost/op-01234567890123456/bucket/mybucket'
+        });
+        var built = request.build(function() {});
+        expect(
+          built.httpRequest.endpoint.hostname
+        ).to.equal('s3-outposts-fips.us-gov-west-1.amazonaws.com');
+      });
+
+      it('should throw when fips region is passed in ARN', function() {
+        var client = new AWS.S3Control({region: 'us-gov-west-1', useFipsEndpoint: true});
+        helpers.mockHttpResponse(200, {}, '');
+        var request = client.getBucket({
+          Bucket: 'arn:aws:s3-outposts:fips-us-gov-west-1:123456789012:outpost/op-01234567890123456/bucket/mybucket'
+        });
+        var error;
+        request.build(function(err) {
+          error = err;
+        });
+        expect(error.name).to.equal('InvalidConfiguration');
+          expect(error.message).to.equal('FIPS region not allowed in ARN');
       });
 
       it('should use regions from ARN if s3UseArnRegion config is set to false', function(done) {


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/3961
~~This PR will be made ready once https://github.com/aws/aws-sdk-js/pull/3962 is merged.~~ Ready!

### Testing
* Unit testing.
* Verified that URL is generated for S3 Outposts Control Plane.

<details>
<summary>Code</summary>

```js
import AWS from "../aws-sdk-js/index.js"; // v2.1029.0

const region = "us-gov-west-1";
const useFipsEndpoint = true;
const AccountId = "123456789012";
const Bucket = `arn:aws-us-gov:s3-outposts:${region}:${AccountId}:outpost:outpost-name:bucket:bucket-name`;

const client = new AWS.S3Control({ region, useFipsEndpoint });
const req = client.getBucket({ AccountId, Bucket });
req.on('complete', function () {
  console.log({ hostname: req.httpRequest.endpoint.host });
});
req.send(function () {});
```

</details>

<details>
<summary>Output</summary>

```console
{ hostname: 's3-outposts-fips.us-gov-west-1.amazonaws.com' }
```

</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`