### PR TITLE
Converting apigateway getExport payload to string for openapi3 export types

### DIFF
--- a/.changes/next-release/bugfix-apigateway-bd1b2f68.json
+++ b/.changes/next-release/bugfix-apigateway-bd1b2f68.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "apigateway",
+  "description": "converting getExport payload to string for openapi3 export types"
+}

--- a/lib/services/apigateway.js
+++ b/lib/services/apigateway.js
@@ -20,7 +20,7 @@ AWS.util.update(AWS.APIGateway.prototype, {
     request.addListener('build', this.setAcceptHeader);
     if (request.operation === 'getExport') {
       var params = request.params || {};
-      if (params.exportType === 'swagger') {
+      if (params.exportType === 'swagger' || params.exportType === 'oas30') {
         request.addListener('extractData', AWS.util.convertPayloadToString);
       }
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
the getExport api accepts `swagger` or `oas30` (openapi3) for the `exportType` param, but only `swagger` is converted to string from a binary array. This results in the getExport api returning a binary array for openapi3 and a json string for swagger.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`

