### PR TITLE
Make maxSockets predictable

### DIFF
--- a/lib/http/node.js
+++ b/lib/http/node.js
@@ -162,12 +162,7 @@ AWS.NodeHttpClient = AWS.util.inherit({
         Object.defineProperty(AWS.NodeHttpClient.sslAgent, 'maxSockets', {
           enumerable: true,
           get: function() {
-            var defaultMaxSockets = 50;
-            var globalAgent = http.globalAgent;
-            if (globalAgent && globalAgent.maxSockets !== Infinity && typeof globalAgent.maxSockets === 'number') {
-              return globalAgent.maxSockets;
-            }
-            return defaultMaxSockets;
+            return http.globalAgent.maxSockets;
           }
         });
       }


### PR DESCRIPTION
Not sure why this value is hard-coded to be 50, but it isn't a predictable thing.

I was facing with hidden infrastructure issue because of this, and I didn't be possible to find the root cause of problems until I randomly read a blog post related to that:

https://plaid.com/blog/how-we-parallelized-our-node-service-by-30x

I'll happy to reflect the changes on the testing suite if I have ACK of this will be merge 🙂