### PR TITLE
Fix rest-json test case, which was not being run

### DIFF
--- a/test/fixtures/protocol/output/rest-json.json
+++ b/test/fixtures/protocol/output/rest-json.json
@@ -742,7 +742,7 @@
           "name": "OperationName"
         },
         "result": {
-          "HeaderField": {"Foo":{}}
+          "HeaderField": {}
         },
         "response": {
           "status_code": 200,

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -197,8 +197,10 @@
 
   mockHttpSuccessfulResponse = function(status, headers, data, cb) {
     var httpResp;
-    if (!Array.isArray(data)) {
-      data = (data === undefined) ? [] : [data];
+    if (data === undefined) {
+      data = [];
+    } else if (!Array.isArray(data)) {
+      data = [data];
     }
     httpResp = new EventEmitter();
     httpResp.pipe = function(destination) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -198,7 +198,7 @@
   mockHttpSuccessfulResponse = function(status, headers, data, cb) {
     var httpResp;
     if (!Array.isArray(data)) {
-      data = [data];
+      data = (data === undefined) ? [] : [data];
     }
     httpResp = new EventEmitter();
     httpResp.pipe = function(destination) {


### PR DESCRIPTION
I have been running the protocol fixtures against a different codebase, and one of the newer fixtures doesn't seem to pass properly there. I determined that protocol fixture cases without a `body` field weren't being fully evaluated in this project. So I first fix the test helper to properly run the bad case, and then fix the case. The first commit "should" be red if CI runs on it.

##### Checklist
- [ ] `npm run test` passes
- [ ] changelog is added, `npm run add-change`
- [ ] run `npm run integration` if integration test is changed
