### PR TITLE
fix ParamValidator failing on document trait

### DIFF
--- a/.changes/next-release/bugfix-ParamValidator-b021ee76.json
+++ b/.changes/next-release/bugfix-ParamValidator-b021ee76.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ParamValidator",
+  "description": "fix the issue that the ParamValidator always fails on the document trait"
+}

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -53,6 +53,8 @@ AWS.ParamValidator = AWS.util.inherit({
   validateStructure: function validateStructure(shape, params, context) {
     this.validateType(params, context, ['object'], 'structure');
 
+    if (shape.isDocument) return true;
+
     var paramName;
     for (var i = 0; shape.required && i < shape.required.length; i++) {
       paramName = shape.required[i];

--- a/test/param_validator.spec.js
+++ b/test/param_validator.spec.js
@@ -223,6 +223,10 @@
                       type: 'integer'
                     }
                   }
+                },
+                hash3: {
+                  type: 'structure',
+                  document: true
                 }
               }
             }
@@ -268,6 +272,13 @@
         return expectError({
           hash1: {
             oops: 'abc'
+          }
+        });
+      });
+      it('accepts document type members', function () {
+        return expectValid({
+          hash1: {
+            hash3: {foo: 'foo', bar: ['bar']}
           }
         });
       });


### PR DESCRIPTION
Resolves #3991 
Follow-up to #3808 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
