### PR TITLE
remove all in-line scripts in API reference

### DIFF
--- a/doc-src/templates/default/fulldoc/html/js/app.js
+++ b/doc-src/templates/default/fulldoc/html/js/app.js
@@ -265,6 +265,7 @@
 
   function navExpander() {
     var done = false, timer = setTimeout(postMessage, 500);
+    var pathId = $('#app-script').attr('pathid');
     function postMessage() {
       if (done) return;
       clearTimeout(timer);

--- a/doc-src/templates/default/fulldoc/html/js/custom.js
+++ b/doc-src/templates/default/fulldoc/html/js/custom.js
@@ -1,3 +1,5 @@
+hljs.initHighlightingOnLoad();
+
 $(document).ready(function() {
   var trueValue = 'true';
   var nodeVersionNoticeKey = 'nodeVersionNoticeDismissed';

--- a/doc-src/templates/default/layout/html/headers.erb
+++ b/doc-src/templates/default/layout/html/headers.erb
@@ -1,0 +1,23 @@
+<meta charset="<%= charset %>">
+<title>
+  <%= h @page_title %>
+  <% if options.title && @page_title != options.title %>
+    &mdash; <%= h options.title %>
+  <% end %>
+</title>
+<% stylesheets.each do |stylesheet| %>
+  <link rel="stylesheet" href="<%= url_for(stylesheet) %>" type="text/css" media="screen" charset="utf-8" />
+<% end %>
+<% javascripts.each do |javascript| %>
+  <% if url_for(javascript) == '../js/app.js' %>
+    <script
+      type="text/javascript"
+      charset="utf-8"
+      src="<%= url_for(javascript) %>"
+      id="app-script"
+      pathid=<%= @path ? @path.inspect : 'null' %>
+      relpath='<%= u = url_for(''); u + (u != '' ? '/' : '') %>'></script>
+  <% else %>
+    <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
+  <% end %>
+<% end %>

--- a/doc-src/yard-js/templates/default/layout/html/headers.erb
+++ b/doc-src/yard-js/templates/default/layout/html/headers.erb
@@ -12,6 +12,3 @@
 <% javascripts.each do |javascript| %>
   <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
 <% end %>
-<script type="text/javascript" charset="utf-8">
-  hljs.initHighlightingOnLoad();
-</script>


### PR DESCRIPTION
JS-2977

Confirmed code highlight and navigation bar expanding works.

<details>
  <summary>Snapshot</summary>
  
![Screen Shot 2022-01-20 at 8 57 55 AM](https://user-images.githubusercontent.com/7614947/150478080-9fd266c4-611a-4be5-ae2e-281d98b0d6a7.png)
</details>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] non-code related change (markdown/git settings etc)


