### PR TITLE
disable validation for non-object values to document members

### DIFF
--- a/.changes/next-release/bugfix-ParamValidator-72a79dfa.json
+++ b/.changes/next-release/bugfix-ParamValidator-72a79dfa.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ParamValidator",
+  "description": "Fix the validation error when assign non-object values to member with document trait"
+}

--- a/lib/param_validator.js
+++ b/lib/param_validator.js
@@ -51,10 +51,9 @@ AWS.ParamValidator = AWS.util.inherit({
   },
 
   validateStructure: function validateStructure(shape, params, context) {
-    this.validateType(params, context, ['object'], 'structure');
-
     if (shape.isDocument) return true;
 
+    this.validateType(params, context, ['object'], 'structure');
     var paramName;
     for (var i = 0; shape.required && i < shape.required.length; i++) {
       paramName = shape.required[i];

--- a/test/param_validator.spec.js
+++ b/test/param_validator.spec.js
@@ -226,6 +226,7 @@
                 },
                 hash3: {
                   type: 'structure',
+                  members: {},
                   document: true
                 }
               }
@@ -275,13 +276,21 @@
           }
         });
       });
-      it('accepts document type members', function () {
-        return expectValid({
-          hash1: {
-            hash3: {foo: 'foo', bar: ['bar']}
-          }
+      for (const documentMember of [
+        'string',
+        1,
+        true,
+        { foo: 'foo', bar: ['bar'] },
+        [1, 'array', false, { baz: 'baz' }]
+      ]) {
+        it('accepts document type member of ' + JSON.stringify(documentMember), function () {
+          return expectValid({
+            hash1: {
+              hash3: documentMember
+            }
+          });
         });
-      });
+      }
       return it('does not check inherited properties on parameters', function() {
         var cls, obj;
         cls = function() {


### PR DESCRIPTION
Follow-up to https://github.com/aws/aws-sdk-js/pull/4011
Fix the validation error when assign non-object values to member with document trait

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
