### PR TITLE
doc: updated command in CONTRIBUTING.md to use --cask

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Please be aware of the following notes prior to opening a pull request:
 To run the tests locally, install `phantomjs`. You can do so using [Homebrew][homebrew]:
 
 ```
-brew cask install phantomjs
+brew install --cask phantomjs
 ```
 
 Then, to run all tests:


### PR DESCRIPTION
##### Checklist

- [x] non-code related change (markdown/git settings etc)

Running `brew cask install phantomjs` gives the error:

"Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead."

This PR updates the CONTRIBUTING.md file to reflect this.