### PR TITLE
doc: added allowlist docs to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,18 @@ specific service, for example:
 AWS_REGION=[set region] node node_modules/cucumber/bin/cucumber.js --tag @s3
 ```
 
+Hardcoded region strings are not allowed in the SDK. To check the code for
+the presence of hardcoded region strings, run
+
+```
+node ./scripts/region-checker/index.js
+```
+
+from the project root directory. If this command shows any output, the PR will
+not be merged. Any lines that appear here must have the region string removed
+or be added to `scripts/region-checker/allowlist.js`. Lines should only be
+allowlisted if absolutely necessary.
+
 ### Testing the documentation changes:
 
 To test the documentation changes, please ensure you have the following requirements installed (Please make sure you have the latest version of Ruby):


### PR DESCRIPTION
This PR adds a section to CONTRIBUTING.md that informs contributors that the output of the region checker script must be empty for their PR to pass the codebuild check. 

##### Checklist

- [x] non-code related change (markdown/git settings etc)