### PR TITLE
fix invalid signature error when consecutive slashes exists in path

### DIFF
--- a/.changes/next-release/feature-SignatureV4-36bf6f50.json
+++ b/.changes/next-release/feature-SignatureV4-36bf6f50.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SignatureV4",
+  "description": "Fix the invalid signature error when signing with request containing dot segment in path or relative path"
+}

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -116,7 +116,10 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
 
   canonicalString: function canonicalString() {
     var parts = [], pathname = this.request.pathname();
-    if (this.serviceName !== 's3' && this.signatureVersion !== 's3v4') pathname = AWS.util.uriEscapePath(pathname);
+    if (this.serviceName !== 's3' && this.signatureVersion !== 's3v4') {
+      pathname = AWS.util.uriNormalizePath(pathname);
+      pathname = AWS.util.uriEscapePath(pathname);
+    }
 
     parts.push(this.request.method);
     parts.push(pathname);

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,6 +56,29 @@ var util = {
     return parts.join('/');
   },
 
+  /**
+   * For non-S3 services. Remove the consecutive slashes from the path and
+   * remove dot segments(Ref: https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4)
+   * S3 doesn't need to normalize the path because they are handled on server-side,
+   * normalizing it will cause the object path to change.
+   */
+  uriNormalizePath: function uriNormalizePath(string) {
+    var parts = [];
+    util.arrayEach(string.split('/'), function (part) {
+      if (!part || part.length === 0 || part === '.') {
+        return;
+      }
+      if (part === '..') {
+        parts.pop();
+      } else {
+        parts.push(part);
+      }
+    });
+    var hasLeadingSlash = string && string[0] === '/';
+    var hasEndingSlash = string && parts.length > 0 && string[string.length - 1] === '/';
+    return (hasLeadingSlash ? '/' : '') + parts.join('/') + (hasEndingSlash ? '/' : '');
+  },
+
   urlParse: function urlParse(url) {
     return util.url.parse(url);
   },

--- a/test/signers/v4.spec.js
+++ b/test/signers/v4.spec.js
@@ -152,6 +152,18 @@
         return expect(signer.canonicalString().split('\n')[1]).to.equal('/identitypools/id/identities/a%253Ab%253Ac/datasets');
       });
 
+      it('normalize paths for non S3 services', function() {
+        var spy = helpers.spyOn(AWS.util, 'uriNormalizePath').andCallThrough();
+        var req = new AWS.CognitoSync().listDatasets({
+          IdentityPoolId: 'id',
+          IdentityId: 'a:b:c'
+        }).build();
+        expect(spy.calls.length).to.equal(1);
+        signer = new AWS.Signers.V4(req.httpRequest, 'cognito-identity');
+        signer.canonicalString();
+        expect(spy.calls.length).to.equal(2);
+      });
+
       it('does not double encode path for S3', function() {
         var req;
         req = new AWS.S3().getObject({

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -68,6 +68,16 @@
     });
   });
 
+  describe('uriNormalizePath', function() {
+    it('should normalize relative path', function () {
+      expect(AWS.util.uriNormalizePath('../a/b/../c')).to.equal('a/c');
+    });
+
+    it('should fix invalid path with consecutive slashes', function () {
+      expect(AWS.util.uriNormalizePath('a//c')).to.equal('a/c');
+    });
+  });
+
   describe('AWS.util.queryParamsToString', function() {
     var qpts;
     qpts = AWS.util.queryParamsToString;


### PR DESCRIPTION
Similar to https://github.com/aws/aws-sdk-js-v3/pull/3408, this change fixes invalid signature error when consecutive slashes exists in the reques path. This change also normalizes the relative pathes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
