### PR TITLE
fix: update redirect logic to also update path

### DIFF
--- a/.changes/next-release/bugfix-event-listeners-536ce342.json
+++ b/.changes/next-release/bugfix-event-listeners-536ce342.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "event listeners",
+  "description": "Configures the endpoint path for redirect requests, instead of just the hostname, allowing for proper redirects."
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -472,6 +472,7 @@ AWS.EventListeners = {
         this.httpRequest.endpoint =
           new AWS.Endpoint(resp.httpResponse.headers['location']);
         this.httpRequest.headers['Host'] = this.httpRequest.endpoint.host;
+        this.httpRequest.path = this.httpRequest.endpoint.path;
         resp.error.redirect = true;
         resp.error.retryable = true;
       }


### PR DESCRIPTION
When a 307 redirect comes in, it contains the new, full URL for the location change.
The current logic respects this for the `Host` header that gets sent, but it does not
then update the path, leading to possibly invalid redirects. The new logic pulls the
path out of the endpoint and updates the outgoing request.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes

Ref: Ticket ID V544628989