### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/event-stream/parse-message.js
+++ b/lib/event-stream/parse-message.js
@@ -101,11 +101,11 @@ function parseHeaders(headers) {
                 position += 16;
                 out[name] = {
                     type: UUID_TAG,
-                    value: uuidChars.substr(0, 8) + '-' +
-                        uuidChars.substr(8, 4) + '-' +
-                        uuidChars.substr(12, 4) + '-' +
-                        uuidChars.substr(16, 4) + '-' +
-                        uuidChars.substr(20)
+                    value: uuidChars.slice(0, 8) + '-' +
+                        uuidChars.slice(8, 12) + '-' +
+                        uuidChars.slice(12, 16) + '-' +
+                        uuidChars.slice(16, 20) + '-' +
+                        uuidChars.slice(20)
                 };
                 break;
             default:

--- a/lib/publisher/index.js
+++ b/lib/publisher/index.js
@@ -21,7 +21,7 @@ function Publisher(options) {
     this.address = options.host || '127.0.0.1';
     if (this.clientId.length > 255) {
         // ClientId has a max length of 255
-        this.clientId = this.clientId.substr(0, 255);
+        this.clientId = this.clientId.slice(0, 255);
     }
     this.messagesInFlight = 0;
 }
@@ -53,7 +53,7 @@ Publisher.prototype.trimFields = function(event) {
             var maxLength = this.fieldsToTrim[field];
             var value = event[field];
             if (value && value.length > maxLength) {
-                event[field] = value.substr(0, maxLength);
+                event[field] = value.slice(0, maxLength);
             }
         }
     }

--- a/lib/query/query_param_serializer.js
+++ b/lib/query/query_param_serializer.js
@@ -11,7 +11,7 @@ function ucfirst(shape) {
   if (shape.isQueryName || shape.api.protocol !== 'ec2') {
     return shape.name;
   } else {
-    return shape.name[0].toUpperCase() + shape.name.substr(1);
+    return shape.name[0].toUpperCase() + shape.name.slice(1);
   }
 }
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -152,7 +152,7 @@ AWS.Service = inherit({
       if (keys[i][keys[i].length - 1] !== '*') {
         selectedVersion = keys[i];
       }
-      if (keys[i].substr(0, 10) <= version) {
+      if (keys[i].slice(0, 10) <= version) {
         return selectedVersion;
       }
     }

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -234,9 +234,9 @@ AWS.util.update(AWS.S3.prototype, {
       if (typeof key === 'string' && slashIndex > 0) {
         req.params = AWS.util.copy(req.params);
         // Need to include trailing slash to match sigv2 behavior
-        var prefix = bucket.substr(slashIndex + 1) || '';
+        var prefix = bucket.slice(slashIndex + 1) || '';
         req.params.Key = prefix + '/' + key;
-        req.params.Bucket = bucket.substr(0, slashIndex);
+        req.params.Bucket = bucket.slice(0, slashIndex);
       } else if (signatureVersion === 'v4') {
         var msg = 'Bucket names cannot contain forward slashes. Bucket: ' + bucket;
         throw AWS.util.error(new Error(),
@@ -1124,7 +1124,7 @@ AWS.util.update(AWS.S3.prototype, {
     expiresInSeconds = expiresInSeconds || 3600;
 
     var signingDate = AWS.util.date.iso8601(now).replace(/[:\-]|\.\d{3}/g, '');
-    var shortDate = signingDate.substr(0, 8);
+    var shortDate = signingDate.slice(0, 8);
     var scope = v4Credentials.createScope(shortDate, region, 's3');
     var credential = credentials.accessKeyId + '/' + scope;
 

--- a/lib/signers/presign.js
+++ b/lib/signers/presign.js
@@ -46,7 +46,7 @@ function signedUrlSigner(request) {
   var queryParams = {};
 
   if (parsedUrl.search) {
-    queryParams = AWS.util.queryStringParse(parsedUrl.search.substr(1));
+    queryParams = AWS.util.queryStringParse(parsedUrl.search.slice(1));
   }
 
   var auth = request.httpRequest.headers['Authorization'].split(' ');

--- a/lib/signers/v4.js
+++ b/lib/signers/v4.js
@@ -97,7 +97,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
   signature: function signature(credentials, datetime) {
     var signingKey = v4Credentials.getSigningKey(
       credentials,
-      datetime.substr(0, 8),
+      datetime.slice(0, 8),
       this.request.region,
       this.serviceName,
       this.signatureCache
@@ -167,7 +167,7 @@ AWS.Signers.V4 = inherit(AWS.Signers.RequestSigner, {
 
   credentialString: function credentialString(datetime) {
     return v4Credentials.createScope(
-      datetime.substr(0, 8),
+      datetime.slice(0, 8),
       this.request.region,
       this.serviceName
     );

--- a/lib/signers/v4_credentials.js
+++ b/lib/signers/v4_credentials.js
@@ -34,7 +34,7 @@ module.exports = {
    */
   createScope: function createScope(date, region, serviceName) {
     return [
-      date.substr(0, 8),
+      date.slice(0, 8),
       region,
       serviceName,
       v4Identifier

--- a/lib/util.js
+++ b/lib/util.js
@@ -203,11 +203,11 @@ var util = {
     },
 
     upperFirst: function upperFirst(string) {
-      return string[0].toUpperCase() + string.substr(1);
+      return string[0].toUpperCase() + string.slice(1);
     },
 
     lowerFirst: function lowerFirst(string) {
-      return string[0].toLowerCase() + string.substr(1);
+      return string[0].toLowerCase() + string.slice(1);
     }
   },
 
@@ -490,7 +490,7 @@ var util = {
     toHex: function toHex(data) {
       var out = [];
       for (var i = 0; i < data.length; i++) {
-        out.push(('0' + data.charCodeAt(i).toString(16)).substr(-2, 2));
+        out.push(('0' + data.charCodeAt(i).toString(16)).slice(-2));
       }
       return out.join('');
     },

--- a/scripts/lib/translator.js
+++ b/scripts/lib/translator.js
@@ -7,7 +7,7 @@ function each(obj, iter) {
 }
 
 function nextString(str) {
-  return 'S' + (parseInt(str.substr(1), 36) + 1).toString(36);
+  return 'S' + (parseInt(str.slice(1), 36) + 1).toString(36);
 }
 
 /* End utility methods */

--- a/test/event-stream/scripts/build-test-vectors-fixture.js
+++ b/test/event-stream/scripts/build-test-vectors-fixture.js
@@ -96,7 +96,7 @@ function headerValue(type, vectorRepresentation) {
             return `new Date(${vectorRepresentation})`;
         case 9:
             const hex = Buffer.from(vectorRepresentation, 'base64').toString('hex');
-            return `'${hex.substr(0, 8)}-${hex.substr(8, 4)}-${hex.substr(12, 4)}-${hex.substr(16, 4)}-${hex.substr(20)}'`;
+            return `'${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}'`;
         default:
             return vectorRepresentation;
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
