### PR TITLE
Throw runtime error when unsupported features are invoked

### DIFF
--- a/.changes/next-release/feature-EventBridge-cb87ec0e.json
+++ b/.changes/next-release/feature-EventBridge-cb87ec0e.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "EventBridge",
+  "description": "Throw runtime error when unsupported parameter EndpointId is supplied with PutEvents API"
+}

--- a/.changes/next-release/feature-S3-d46d71d9.json
+++ b/.changes/next-release/feature-S3-d46d71d9.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "S3",
+  "description": "Add error message to try v3 SDK when customer uses multi-regional ARN in s3"
+}

--- a/clients/eventbridge.js
+++ b/clients/eventbridge.js
@@ -5,6 +5,7 @@ var apiLoader = AWS.apiLoader;
 
 apiLoader.services['eventbridge'] = {};
 AWS.EventBridge = Service.defineService('eventbridge', ['2015-10-07']);
+require('../lib/services/eventbridge');
 Object.defineProperty(apiLoader.services['eventbridge'], '2015-10-07', {
   get: function get() {
     var model = require('../apis/eventbridge-2015-10-07.min.json');

--- a/lib/services/eventbridge.js
+++ b/lib/services/eventbridge.js
@@ -1,0 +1,19 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.EventBridge.prototype, {
+  /**
+   * @api private
+   */
+  setupRequestListeners: function setupRequestListeners(request) {
+    if (request.operation === 'putEvents') {
+      var params = request.params || {};
+      if (params.EndpointId !== undefined) {
+        throw new AWS.util.error(new Error(), {
+          code: 'InvalidParameter',
+          message: 'EndpointId is not supported in current SDK.\n' +
+            'You should consider switching to V3(https://github.com/aws/aws-sdk-js-v3).'
+        });
+      }
+    }
+  },
+});

--- a/lib/services/s3util.js
+++ b/lib/services/s3util.js
@@ -144,9 +144,14 @@ var s3util = {
     var allowFipsEndpoint = options.allowFipsEndpoint || false;
 
     if (!regionFromArn) {
+      var message = 'ARN region is empty';
+      if (req._parsedArn.service === 's3') {
+        message = message + '\nYou may want to use multi-regional ARN. The feature is not supported in current SDK. ' +
+        'You should consider switching to V3(https://github.com/aws/aws-sdk-js-v3).';
+      }
       throw AWS.util.error(new Error(), {
         code: 'InvalidARN',
-        message: 'ARN region is empty'
+        message: message
       });
     }
 

--- a/test/services/eventbridge.spec.js
+++ b/test/services/eventbridge.spec.js
@@ -1,0 +1,20 @@
+var helpers = require('../helpers');
+var AWS = helpers.AWS;
+
+describe('AWS.EventBridge', function() {
+  var eventBridge;
+  beforeEach(function() {
+    return eventBridge = new AWS.EventBridge();
+  });
+  describe('putEvents', function() {
+    it('should throw if EndPointId is supplied', function(done) {
+      try {
+        eventBridge.putEvents({Entries: [], EndpointId: 'foo'});
+      } catch (err) {
+        expect(err.name).to.eql('InvalidParameter');
+        expect(err.message).to.contain('EndpointId is not supported in current SDK.');
+        done();
+      }
+    });
+  });
+});

--- a/test/services/s3.spec.js
+++ b/test/services/s3.spec.js
@@ -3477,7 +3477,7 @@ describe('AWS.S3', function() {
         request.send(function(err, data) {
           expect(err).to.exist;
           expect(err.name).to.equal('InvalidARN');
-          expect(err.message).to.equal('ARN region is empty');
+          expect(err.message).to.contain('ARN region is empty');
           done();
         });
       });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
Both S3 mult-regional access point and the EventBridge global endpoint are not supported in V2 SDK but only implemented in V3. This change detect these invocations and throws runtime errors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
