### PR TITLE
docs(document_client): update doc on input service instance

### DIFF
--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -88,7 +88,11 @@ export namespace DocumentClient {
          */
         params?: {[key: string]: any}
         /**
-         * An optional pre-configured instance of the AWS.DynamoDB service object to use for requests. The object may bound parameters used by the document client.
+         * An optional pre-configured instance
+         * of the AWS.DynamoDB service object. This instance's config will be
+         * copied to a new instance used by this client. You should not need to
+         * retain a reference to the input object, and may destroy it or allow it
+         * to be garbage collected.
          */
         service?: DynamoDB
     }

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -46,8 +46,10 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
    * @option options params [map] An optional map of parameters to bind to every
    *   request sent by this service object.
    * @option options service [AWS.DynamoDB] An optional pre-configured instance
-   *  of the AWS.DynamoDB service object to use for requests. The object may
-   *  bound parameters used by the document client.
+   *  of the AWS.DynamoDB service object. This instance's config will be
+   *  copied to a new instance used by this client. You should not need to
+   *  retain a reference to the input object, and may destroy it or allow it
+   *  to be garbage collected.
    * @option options convertEmptyValues [Boolean] set to true if you would like
    *  the document client to convert empty values (0-length strings, binary
    *  buffers, and sets) to be converted to NULL types when persisting to


### PR DESCRIPTION
Clarify what happens with the input field `service: DynamoDB` for `DocumentClientOptions`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- n/a run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
