### PR TITLE
fix(waf): remove WAF error handling test scenario

### DIFF
--- a/features/waf/waf.feature
+++ b/features/waf/waf.feature
@@ -11,13 +11,3 @@ Feature: AWS WAF
     """
     Then the request should be successful
     And the value at "Rules" should be a list
-
-  Scenario: Error handling
-    Given I run the "createSqlInjectionMatchSet" operation with params:
-    """
-    {
-      "Name": "fake_name",
-      "ChangeToken": "fake_token"
-    }
-    """
-    Then the error code should be "WAFStaleDataException"


### PR DESCRIPTION
Internal request to remove test scenario.

(do I need to run any of these checklist steps?)

##### Checklist
- [n/a] `npm run test` passes
- [n/a] `.d.ts` file is updated
- [n/a] changelog is added, `npm run add-change`
- [n/a] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [n/a] run `npm run integration` if integration test is changed
- [n/a] non-code related change (markdown/git settings etc)
