### PR TITLE
fix(event_listeners): do not add content length 0 to bodyless request methods

### DIFF
--- a/.changes/next-release/bugfix-Http-9b51f306.json
+++ b/.changes/next-release/bugfix-Http-9b51f306.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Http",
+  "description": "skip addition of content length 0 header for GET etc. bodyless requests"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -188,7 +188,10 @@ AWS.EventListeners = {
       if (req.httpRequest.headers['Content-Length'] === undefined) {
         try {
           var length = AWS.util.string.byteLength(req.httpRequest.body);
-          req.httpRequest.headers['Content-Length'] = length;
+          var method = req.httpRequest.method;
+          if (['GET', 'DELETE', 'TRACE', 'OPTIONS', 'HEAD'].indexOf(method) === -1 || length > 0) {
+            req.httpRequest.headers['Content-Length'] = length;
+          }
         } catch (err) {
           if (payloadMember && payloadMember.isStreaming) {
             if (payloadMember.requiresLength) {

--- a/test/event_listeners.spec.js
+++ b/test/event_listeners.spec.js
@@ -240,6 +240,18 @@
           return sendRequest(body).httpRequest.headers['Content-Length'];
         };
 
+        describe('when request is GET or other bodyless method', function() {
+          it('should skip adding content-length header', function() {
+            var service = new FooService();
+            var req = service.get({});
+
+            req.runTo('sign', function(err) {
+              expect('Content-Length' in req.httpRequest.headers).to.equal(false);
+              expect(!err).to.equal(true);
+            });
+          });
+        });
+
         describe('when using unsigned authtype', function() {
           it('when payload is a buffer', function() {
             var service = new FooService();

--- a/test/foo-service.fixture.js
+++ b/test/foo-service.fixture.js
@@ -15,6 +15,12 @@ var model = {
     'uid': 'foo-2018-06-13'
   },
   'operations': {
+    'Get': {
+      'http': {
+        'method': 'GET',
+        'requestUri': '/'
+      }
+    },
     'PutStream': {
       'http': {
         'method': 'PUT',


### PR DESCRIPTION
Do not add content length 0 header to GET, DELETE, TRACE, OPTIONS, and HEAD requests.

- [x] add/fix unit tests

##### Checklist
- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- n/a run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
