### PR TITLE
Allow httpOptions to be passed to SSO credentials

### DIFF
--- a/.changes/next-release/bugfix-SSO-ad1e88c8.json
+++ b/.changes/next-release/bugfix-SSO-ad1e88c8.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SSO",
+  "description": "sso did not allow httpOptions to be passed through"
+}

--- a/lib/credentials/sso_credentials.d.ts
+++ b/lib/credentials/sso_credentials.d.ts
@@ -1,5 +1,6 @@
 import {Credentials} from '../credentials';
 import SSO = require('../../clients/sso');
+import { HTTPOptions } from '../config-base';
 export class SsoCredentials extends Credentials {
     /**
      * Creates a new SsoCredentials object.
@@ -8,6 +9,7 @@ export class SsoCredentials extends Credentials {
 }
 
 interface SsoCredentialsOptions {
+    httpOptions?: HTTPOptions,
     profile?: string;
     filename?: string;
     ssoClient?: SSO;

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -60,6 +60,7 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
     this.filename = options.filename;
     this.profile = options.profile || process.env.AWS_PROFILE || AWS.util.defaultProfile;
     this.service = options.ssoClient;
+    this.httpOptions = options.httpOptions || null;
     this.get(options.callback || AWS.util.fn.noop);
   },
 
@@ -130,7 +131,10 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
       }
 
       if (!self.service || self.service.config.region !== profile.sso_region) {
-        self.service = new AWS.SSO({ region: profile.sso_region });
+        self.service = new AWS.SSO({
+          region: profile.sso_region,
+          httpOptions: this.httpOptions,
+        });
       }
       var request = {
         accessToken: cacheContent.accessToken,

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -572,6 +572,26 @@ const exp = require('constants');
             done();
           });
         });
+        it('will pass httpOptions through', function(done) {
+          var httpClient, spy;
+          helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
+          creds = new AWS.SsoCredentials({
+            httpOptions: {
+              connectTimeout: 2000,
+              proxy: 'https://foo.bar',
+              timeout: 2000,
+            }
+          });
+          httpClient = AWS.HttpClient.getInstance();
+          spy = helpers.spyOn(httpClient, 'handleRequest').andCallThrough();
+          return creds.refresh(function(err) {
+            expect(spy.calls.length).to.equal(1);
+            expect(spy.calls[0].arguments[1].connectTimeout).to.equal(2000);
+            expect(spy.calls[0].arguments[1].proxy).to.equal('https://foo.bar');
+            expect(spy.calls[0].arguments[1].timeout).to.equal(2000);
+            return done();
+          });
+        });
         it('loads successfully while changing region and endpoint', function(done) {
           expect(creds.service.config.region).to.equal('us-east-1');
           expect(creds.service.config.endpoint).to.equal('portal.sso.us-east-1.amazonaws.com');

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -572,7 +572,7 @@ const exp = require('constants');
             done();
           });
         });
-        it('will pass httpOptions through', function(done) {
+        it('passes httpOptions through', function(done) {
           var httpClient, spy;
           helpers.mockHttpResponse(200, {}, '<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">\n  <AssumeRoleResult>\n    <Credentials>\n      <AccessKeyId>KEY</AccessKeyId>\n      <SecretAccessKey>SECRET</SecretAccessKey>\n      <SessionToken>TOKEN</SessionToken>\n      <Expiration>1970-01-01T00:00:00.000Z</Expiration>\n    </Credentials>\n  </AssumeRoleResult>\n</AssumeRoleResponse>');
           creds = new AWS.SsoCredentials({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
