### PR TITLE
[fix] [SageMakerRuntime] empty body string when invokeEndpointAsync

### DIFF
--- a/.changes/next-release/bugfix-SageMakerRuntime-407b0118.json
+++ b/.changes/next-release/bugfix-SageMakerRuntime-407b0118.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SageMakerRuntime",
+  "description": "fixed the issue that invokeEndpointAsync is not callable #4203"
+}

--- a/clients/sagemakerruntime.js
+++ b/clients/sagemakerruntime.js
@@ -5,6 +5,7 @@ var apiLoader = AWS.apiLoader;
 
 apiLoader.services['sagemakerruntime'] = {};
 AWS.SageMakerRuntime = Service.defineService('sagemakerruntime', ['2017-05-13']);
+require('../lib/services/sagemakerruntime');
 Object.defineProperty(apiLoader.services['sagemakerruntime'], '2017-05-13', {
   get: function get() {
     var model = require('../apis/runtime.sagemaker-2017-05-13.min.json');

--- a/lib/services/sagemakerruntime.js
+++ b/lib/services/sagemakerruntime.js
@@ -1,0 +1,20 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.SageMakerRuntime.prototype, {
+  /**
+   * @api private
+   */
+  setupRequestListeners: function setupRequestListeners(request) {
+    if (request.operation === 'invokeEndpointAsync') {
+      request.addListener('build', this.emptyBody);
+    }
+  },
+
+  /**
+   * Empty request body for async inference
+   * @api private
+   */
+  emptyBody: function emptyBody(request) {
+    request.httpRequest.body = '';
+  },
+});

--- a/test/services/sagemakerruntime.spec.js
+++ b/test/services/sagemakerruntime.spec.js
@@ -1,0 +1,30 @@
+(function () {
+  const helpers = require('../helpers');
+  const { AWS, spyOn } = helpers;
+
+  return describe('SageMakerRuntime.invokeEndpointAsync', function () {
+    it('should call api with an empty body', async () => {
+      const httpClient = AWS.HttpClient.getInstance();
+      spyOn(httpClient, 'handleRequest').andCallFake(function (
+        httpReq,
+        httpOp,
+        cb,
+        errCb
+      ) {
+        expect(httpReq.body).to.equal('');
+        helpers.mockHttpSuccessfulResponse(
+          200,
+          {},
+          JSON.stringify({ success: true }),
+          cb
+        );
+      });
+      await new AWS.SageMakerRuntime()
+        .invokeEndpointAsync({
+          InputLocation: 's3://mock',
+          EndpointName: 'mock',
+        })
+        .promise();
+    });
+  });
+}.call(this));


### PR DESCRIPTION
# what I did

- replace the request body with an empty string when calling Async Inference. 

# related issue

#4203 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`

