### PR TITLE
feat(sso): fail-fast on networking errors in sso credential retrieval

### DIFF
--- a/.changes/next-release/feature-sso-f3293d3c.json
+++ b/.changes/next-release/feature-sso-f3293d3c.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "sso",
+  "description": "sso TLS errors are now rethrown without going through the load() callabck. This allows a faster failure, and prepends the error message to make it clear which call failed."
+}

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -143,6 +143,12 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
       };
       self.service.getRoleCredentials(request, function(err, data) {
         if (err || !data || !data.roleCredentials) {
+          if (err && err.code === 'NetworkingError') {
+            // throw directly instead of using the callback to ensure a faster failure
+              throw AWS.util.error(new Error('SSO credential retrieval failed with \'' + err.message + '\''), {
+              code: err.code,
+            });
+          }
           callback(AWS.util.error(
             err || new Error('Please log in using "aws sso login"'),
             { code: self.errorCode }

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -703,7 +703,7 @@ const exp = require('constants');
             done();
           });
         });
-        return it('throws error if sso client returns an error', function(done) {
+        it('throws error if sso client returns an error', function(done) {
           var mockErr;
           mockErr = 'foo Error';
           helpers.spyOn(creds.service, 'getRoleCredentials').andCallFake(function(_, cb) {
@@ -711,6 +711,20 @@ const exp = require('constants');
           });
           creds.refresh(function(err) {
             expect(err.message).to.eql(mockErr);
+            expect(creds.accessKeyId).to.be.undefined;
+            done();
+          });
+        });
+        return it('rethrows NetworkingErrors with a modified error message', function(done) {
+          const netError = 'unable to verify the first certificate';
+          helpers.spyOn(creds.service, 'getRoleCredentials').andCallFake(function(_, cb) {
+            const e = new Error(netError);
+            e.code = 'NetworkingError';
+            return cb(e, null);
+          });
+          creds.refresh(function(err) {
+            expect(err.message).to.eql('SSO credential retrieval failed with \'' + netError + '\'');
+            expect(err.code).to.eql('NetworkingError');
             expect(creds.accessKeyId).to.be.undefined;
             done();
           });


### PR DESCRIPTION
If a NetworkingError is received by the SSO service, rethrow the error immediately instead of passing it to the `load()` callback. This will provide a faster failure, and allows the sdk to prepend text to the error message to indicate that the SSO credential retrieval failed. 

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
