### PR TITLE
fix: unset content length in rest-json when payload is undefined

### DIFF
--- a/.changes/next-release/bugfix-rest-json-a441c484.json
+++ b/.changes/next-release/bugfix-rest-json-a441c484.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "rest-json",
+  "description": "unset content length in rest-json when payload is undefined"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -678,6 +678,7 @@ AWS.EventListeners = {
     add('BUILD', 'build', svc.buildRequest);
     add('EXTRACT_DATA', 'extractData', svc.extractData);
     add('EXTRACT_ERROR', 'extractError', svc.extractError);
+    add('UNSET_CONTENT_LENGTH', 'afterBuild', svc.unsetContentLength);
   }),
 
   RestXml: new SequentialExecutor().addNamedListeners(function(add) {

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -4,6 +4,16 @@ var Json = require('./json');
 var JsonBuilder = require('../json/builder');
 var JsonParser = require('../json/parser');
 
+function unsetContentLength(req) {
+  var payloadMember = util.getRequestPayloadShape(req);
+  if (
+    payloadMember === undefined &&
+    ['GET', 'HEAD', 'DELETE'].indexOf(req.httpRequest.method) >= 0
+  ) {
+    delete req.httpRequest.headers['Content-Length'];
+  }
+}
+
 function populateBody(req) {
   var builder = new JsonBuilder();
   var input = req.service.api.operations[req.operation].input;
@@ -89,5 +99,6 @@ function extractData(resp) {
 module.exports = {
   buildRequest: buildRequest,
   extractError: extractError,
-  extractData: extractData
+  extractData: extractData,
+  unsetContentLength: unsetContentLength
 };

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -4,11 +4,13 @@ var Json = require('./json');
 var JsonBuilder = require('../json/builder');
 var JsonParser = require('../json/parser');
 
+var METHODS_WITHOUT_BODY = ['GET', 'HEAD', 'DELETE'];
+
 function unsetContentLength(req) {
   var payloadMember = util.getRequestPayloadShape(req);
   if (
     payloadMember === undefined &&
-    ['GET', 'HEAD', 'DELETE'].indexOf(req.httpRequest.method) >= 0
+    METHODS_WITHOUT_BODY.indexOf(req.httpRequest.method) >= 0
   ) {
     delete req.httpRequest.headers['Content-Length'];
   }
@@ -50,7 +52,7 @@ function buildRequest(req) {
   Rest.buildRequest(req);
 
   // never send body payload on GET/HEAD/DELETE
-  if (['GET', 'HEAD', 'DELETE'].indexOf(req.httpRequest.method) < 0) {
+  if (METHODS_WITHOUT_BODY.indexOf(req.httpRequest.method) < 0) {
     populateBody(req);
   }
 }

--- a/test/protocol/protocol.spec.js
+++ b/test/protocol/protocol.spec.js
@@ -101,6 +101,12 @@
           expect(req.httpRequest.headers[key]).to.equal(data.headers[key]);
         });
       }
+      if (data.forbidHeaders) {
+        for (k in data.forbidHeaders) {
+          v = data.forbidHeaders[k];
+          expect(req.httpRequest.headers[v]).to.be.undefined;
+        }
+      }
     } else if (svc.api.protocol.match(/(json|xml)/)) {
       if (req.httpRequest.body === '{}') {
         req.httpRequest.body = '';


### PR DESCRIPTION
Unsets content length in rest-json when payload is undefined

Previous PR: https://github.com/aws/aws-sdk-js/pull/3914
Internal JS-3610

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
- [x] run `npm run integration` if integration test is changed