### PR TITLE
Expose fetchMetadataToken to AWS.MetadataService

### DIFF
--- a/.changes/next-release/feature-MetadataService-3a550e8f.json
+++ b/.changes/next-release/feature-MetadataService-3a550e8f.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "MetadataService",
+  "description": "Update AWS.MetadataService to expose the fetchMetadataToken function."
+}

--- a/lib/metadata_service.d.ts
+++ b/lib/metadata_service.d.ts
@@ -18,6 +18,10 @@ export class MetadataService {
         callback: (err: AWSError, data: string) => void
     ): void;
     /**
+     * Fetches metadata token used for authenticating against the instance metadata service.
+     */
+    fetchMetadataToken(callback: (err: AWSError, token: string) => void): void;
+    /**
      * 169.254.169.254
      */
     static host: string

--- a/lib/metadata_service.js
+++ b/lib/metadata_service.js
@@ -114,9 +114,8 @@ AWS.MetadataService = inherit({
   loadCredentialsCallbacks: [],
 
   /**
-   * Fetches metadata token used for getting credentials
+   * Fetches metadata token used for authenticating against the instance metadata service.
    *
-   * @api private
    * @callback callback function(err, token)
    *   Called when token is loaded from the resource
    */


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

This PR exposes the fetchMetadataToken to the AWS.MetadataService class. This helps with the usability of the workaround in [3584](https://github.com/aws/aws-sdk-js/issues/3584)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `.d.ts` file is updated
- [ x] changelog is added, `npm run add-change`
- [ x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
