### PR TITLE
Read awsQueryCompatible trait from  metadata with tests

### DIFF
--- a/.changes/next-release/bugfix-AWSQueryCompatible-f891b653.json
+++ b/.changes/next-release/bugfix-AWSQueryCompatible-f891b653.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "AWSQueryCompatible",
+  "description": "Read trait from metadata"
+}

--- a/lib/model/api.js
+++ b/lib/model/api.js
@@ -80,7 +80,7 @@ function Api(api, options) {
     property(this, 'documentation', api.documentation);
     property(this, 'documentationUrl', api.documentationUrl);
   }
-  property(this, 'awsQueryCompatible', api.awsQueryCompatible);
+  property(this, 'awsQueryCompatible', api.metadata.awsQueryCompatible);
 }
 
 /**

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -18,7 +18,7 @@
     let metadata = {
       endpointPrefix : 'mockservice',
       signatureVersion : 'v4'
-    }
+    };
 
     beforeEach(function(done) {
       AwsQueryService = MockServiceFromApi({
@@ -43,7 +43,7 @@
         expect(err.statusCode).to.equal(500);
         return expect(data).to.equal(null);
       }));
-    })
+    });
 
     it('can receive awsquery compatible error code when header present', function () {
       helpers.mockHttpResponse(500, {

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -15,9 +15,15 @@
   describe('AWSQuery compatible error codes', function () {
     let service;
     let AwsQueryService;
+    let metadata = {
+      endpointPrefix : 'mockservice',
+      signatureVersion : 'v4'
+    }
 
     beforeEach(function(done) {
-      AwsQueryService = MockServiceFromApi({awsQueryCompatible: {}});
+      AwsQueryService = MockServiceFromApi({
+        metadata: {...metadata, awsQueryCompatible: {}}
+      });
       service = new AwsQueryService({maxRetries: 0});
       return done();
     });
@@ -25,6 +31,19 @@
     it('awsQueryCompatible trait is translated to correct property', function() {
       return expect(service.api.awsQueryCompatible).to.eql({});
     });
+
+    it('can receive default error code when trait is not present', function() {
+      AwsQueryService = MockServiceFromApi({ metadata: metadata });
+      service = new AwsQueryService({maxRetries: 0});
+      helpers.mockHttpResponse(500, {
+        'x-amzn-query-error': 'AwsQueryError;Sender'
+      }, ['ServiceError']);
+      return (service.makeRequest('operation', {}, function (err, data) {
+        expect(err.code).to.equal('ServiceError');
+        expect(err.statusCode).to.equal(500);
+        return expect(data).to.equal(null);
+      }));
+    })
 
     it('can receive awsquery compatible error code when header present', function () {
       helpers.mockHttpResponse(500, {


### PR DESCRIPTION
Read awsQueryCompatible trait from metadata with tests

##### Checklist

- [x ] `npm run test` passes
- [ x] changelog is added, `npm run add-change`
