### PR TITLE
fix(service): customization for dualstack dnsSuffix

### DIFF
--- a/.changes/next-release/bugfix-New-Service-d75d27b3.json
+++ b/.changes/next-release/bugfix-New-Service-d75d27b3.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "New Service",
+  "description": "Dualstack support customization for a new service."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/browser/sample/appinfo.js
 dist/aws-sdk-all.js
 yarn.lock
 package-lock.json
+workspace

--- a/lib/services/resourceexplorer2.js
+++ b/lib/services/resourceexplorer2.js
@@ -1,0 +1,12 @@
+var AWS = require('../core');
+
+AWS.util.update(AWS.ResourceExplorer2.prototype, {
+  validateService: function () {
+    var config = this.config;
+    if (config.useDualstackEndpoint === false || config.useDualStack === false) {
+      throw new Error('Resource Explorer 2 only supports Dualstack');
+    }
+    config.useDualstackEndpoint = true;
+    config.useDualstack = true;
+  }
+});

--- a/lib/services/resourceexplorer2.js
+++ b/lib/services/resourceexplorer2.js
@@ -3,10 +3,10 @@ var AWS = require('../core');
 AWS.util.update(AWS.ResourceExplorer2.prototype, {
   validateService: function () {
     var config = this.config;
-    if (config.useDualStackEndpoint === false || config.useDualStack === false) {
-      throw new Error('Resource Explorer 2 only supports DualStack');
+    if (config.useDualstackEndpoint === false || config.useDualstack === false) {
+      throw new Error('Resource Explorer 2 only supports Dualstack');
     }
-    config.useDualStackEndpoint = true;
-    config.useDualStack = true;
+    config.useDualstackEndpoint = true;
+    config.useDualstack = true;
   }
 });

--- a/lib/services/resourceexplorer2.js
+++ b/lib/services/resourceexplorer2.js
@@ -3,10 +3,10 @@ var AWS = require('../core');
 AWS.util.update(AWS.ResourceExplorer2.prototype, {
   validateService: function () {
     var config = this.config;
-    if (config.useDualstackEndpoint === false || config.useDualStack === false) {
-      throw new Error('Resource Explorer 2 only supports Dualstack');
+    if (config.useDualStackEndpoint === false || config.useDualStack === false) {
+      throw new Error('Resource Explorer 2 only supports DualStack');
     }
-    config.useDualstackEndpoint = true;
-    config.useDualstack = true;
+    config.useDualStackEndpoint = true;
+    config.useDualStack = true;
   }
 });


### PR DESCRIPTION
Dualstack dnsSuffix customization for a service.

Tests confirmed that the customization was generated into the client file. 

##### Checklist
- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
