### PR TITLE
fix(ResourceExplorer2): set endpoint to dualstack by default

### DIFF
--- a/.changes/next-release/bugfix-ResourceExplorer2-176b5724.json
+++ b/.changes/next-release/bugfix-ResourceExplorer2-176b5724.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ResourceExplorer2",
+  "description": "Set endpoint to dualstack by default"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -67,7 +67,8 @@
     "*/sdb": {
       "endpoint": "{service}.{region}.amazonaws.com",
       "signatureVersion": "v2"
-    }
+    },
+    "*/resource-explorer-2": "dualstackByDefault"
   },
 
   "fipsRules": {
@@ -223,6 +224,9 @@
     },
     "dualstackLegacyEc2": {
       "endpoint": "api.ec2.{region}.aws"
+    },
+    "dualstackByDefault": {
+      "endpoint": "{service}.{region}.api.aws"
     }
   }
 }


### PR DESCRIPTION
Internal JS-3686

### Testing

```js
import AWS from "./index";

(async () => {
  const client1 = new AWS.ResourceExplorer2({ region: "us-west-2" });
  console.log("default endpoint:", client1.config.endpoint);

  const client2 = new AWS.ResourceExplorer2({
    region: "us-west-2",
    useDualstackEndpoint: false,
  });
  console.log(
    "endpoint with useDualstackEndpoint=false:",
    client2.config.endpoint
  );

  const client3 = new AWS.ResourceExplorer2({
    region: "us-west-2",
    useDualstackEndpoint: true,
  });
  console.log(
    "endpoint with useDualstackEndpoint=true:",
    client3.config.endpoint
  );
})();
```

```console
default endpoint: resource-explorer-2.us-west-2.api.aws
endpoint with useDualstackEndpoint=false: resource-explorer-2.us-west-2.api.aws
endpoint with useDualstackEndpoint=true: resource-explorer-2.us-west-2.api.aws
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
