### PR TITLE
feat(sso_credentials): if new sso session format in config, use sso token provider in sso credentials

### DIFF
--- a/.changes/next-release/feature-sso-7155c7f5.json
+++ b/.changes/next-release/feature-sso-7155c7f5.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "sso",
+  "description": "use sso token provider in sso credentials if sso session is set in config"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/browser/sample/appinfo.js
 dist/aws-sdk-all.js
 yarn.lock
 package-lock.json
+workspace

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -11,10 +11,21 @@ var iniLoader = AWS.util.iniLoader;
  *
  * The credentials file must specify the information below to use sso:
  *
- *     [default]
+ *     [profile sso-profile]
  *     sso_account_id = 012345678901
  *     sso_region = us-east-1
  *     sso_role_name = SampleRole
+ *     sso_start_url = https://d-abc123.awsapps.com/start
+ *
+ * or using the session format:
+ *
+ *     [profile sso-token]
+ *     sso_session = prod
+ *     sso_account_id = 012345678901
+ *     sso_role_name = SampleRole
+ *
+ *     [sso-session prod]
+ *     sso_region = us-east-1
  *     sso_start_url = https://d-abc123.awsapps.com/start
  *
  * This information will be automatically added to your shared credentials file by running
@@ -68,14 +79,8 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
    * @api private
    */
   load: function load(callback) {
-    /**
-     * The time window (15 mins) that SDK will treat the SSO token expires in before the defined expiration date in token.
-     * This is needed because server side may have invalidated the token before the defined expiration date.
-     *
-     * @internal
-     */
-    var EXPIRE_WINDOW_MS = 15 * 60 * 1000;
     var self = this;
+
     try {
       var profiles = AWS.util.getProfilesFromSharedConfig(iniLoader, this.filename);
       var profile = profiles[this.profile] || {};
@@ -87,17 +92,107 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
         );
       }
 
-      if (!profile.sso_start_url || !profile.sso_account_id || !profile.sso_region || !profile.sso_role_name) {
-        throw AWS.util.error(
-          new Error('Profile ' + this.profile + ' does not have valid SSO credentials. Required parameters "sso_account_id", "sso_region", ' +
-          '"sso_role_name", "sso_start_url". Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html'),
-          { code: self.errorCode }
-        );
+      if (profile.sso_session) {
+        if (!profile.sso_account_id || !profile.sso_role_name) {
+          throw AWS.util.error(
+            new Error('Profile ' + this.profile + ' with session ' + profile.sso_session +
+              ' does not have valid SSO credentials. Required parameters "sso_account_id", "sso_session", ' +
+              '"sso_role_name". Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html'),
+            { code: self.errorCode }
+          );
+        }
+      } else {
+        if (!profile.sso_start_url || !profile.sso_account_id || !profile.sso_region || !profile.sso_role_name) {
+          throw AWS.util.error(
+            new Error('Profile ' + this.profile + ' does not have valid SSO credentials. Required parameters "sso_account_id", "sso_region", ' +
+            '"sso_role_name", "sso_start_url". Reference: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html'),
+            { code: self.errorCode }
+          );
+        }
       }
 
+      this.getToken(this.profile, profile, function (err, token) {
+        if (err) {
+          return callback(err);
+        }
+        var request = {
+          accessToken: token,
+          accountId: profile.sso_account_id,
+          roleName: profile.sso_role_name,
+        };
+
+        if (!self.service || self.service.config.region !== profile.sso_region) {
+          self.service = new AWS.SSO({
+            region: profile.sso_region,
+            httpOptions: this.httpOptions,
+          });
+        }
+
+        self.service.getRoleCredentials(request, function(err, data) {
+          if (err || !data || !data.roleCredentials) {
+            callback(AWS.util.error(
+              err || new Error('Please log in using "aws sso login"'),
+              { code: self.errorCode }
+            ), null);
+          } else if (!data.roleCredentials.accessKeyId || !data.roleCredentials.secretAccessKey || !data.roleCredentials.sessionToken || !data.roleCredentials.expiration) {
+            throw AWS.util.error(new Error(
+              'SSO returns an invalid temporary credential.'
+            ));
+          } else {
+            self.expired = false;
+            self.accessKeyId = data.roleCredentials.accessKeyId;
+            self.secretAccessKey = data.roleCredentials.secretAccessKey;
+            self.sessionToken = data.roleCredentials.sessionToken;
+            self.expireTime = new Date(data.roleCredentials.expiration);
+            callback(null);
+          }
+        });
+      });
+    } catch (err) {
+      callback(err);
+    }
+  },
+
+  /**
+   * @private
+   * Uses legacy file system retrieval or if sso-session is set,
+   * use the SSOTokenProvider.
+   *
+   * @param {string} profileName - name of the profile.
+   * @param {object} profile - profile data containing sso_session or sso_start_url etc.
+   * @param {function} callback - called with (err, (string) token).
+   *
+   * @returns {void}
+   */
+  getToken: function getToken(profileName, profile, callback) {
+    var self = this;
+
+    if (profile.sso_session) {
+      var _iniLoader = AWS.util.iniLoader;
+      var ssoSessions = _iniLoader.loadSsoSessionsFrom();
+      var ssoSession = ssoSessions[profile.sso_session];
+      Object.assign(profile, ssoSession);
+
+      var ssoTokenProvider = new AWS.SSOTokenProvider({
+        profile: profileName,
+      });
+      ssoTokenProvider.load(function (err) {
+        if (err) {
+          return callback(err);
+        }
+        return callback(null, ssoTokenProvider.token);
+      });
+      return;
+    }
+
+    try {
+      /**
+       * The time window (15 mins) that SDK will treat the SSO token expires in before the defined expiration date in token.
+       * This is needed because server side may have invalidated the token before the defined expiration date.
+       */
+      var EXPIRE_WINDOW_MS = 15 * 60 * 1000;
       var hasher = crypto.createHash('sha1');
       var fileName = hasher.update(profile.sso_start_url).digest('hex') + '.json';
-
       var cachePath = path.join(
         iniLoader.getHomeDir(),
         '.aws',
@@ -110,7 +205,6 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
       if (cacheFile) {
         cacheContent = JSON.parse(cacheFile);
       }
-
       if (!cacheContent) {
         throw AWS.util.error(
           new Error('Cached credentials not found under ' + this.profile + ' profile. Please make sure you log in with aws sso login first'),
@@ -130,38 +224,9 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
         ));
       }
 
-      if (!self.service || self.service.config.region !== profile.sso_region) {
-        self.service = new AWS.SSO({
-          region: profile.sso_region,
-          httpOptions: this.httpOptions,
-        });
-      }
-      var request = {
-        accessToken: cacheContent.accessToken,
-        accountId: profile.sso_account_id,
-        roleName: profile.sso_role_name,
-      };
-      self.service.getRoleCredentials(request, function(err, data) {
-        if (err || !data || !data.roleCredentials) {
-          callback(AWS.util.error(
-            err || new Error('Please log in using "aws sso login"'),
-            { code: self.errorCode }
-          ), null);
-        } else if (!data.roleCredentials.accessKeyId || !data.roleCredentials.secretAccessKey || !data.roleCredentials.sessionToken || !data.roleCredentials.expiration) {
-          throw AWS.util.error(new Error(
-            'SSO returns an invalid temporary credential.'
-          ));
-        } else {
-          self.expired = false;
-          self.accessKeyId = data.roleCredentials.accessKeyId;
-          self.secretAccessKey = data.roleCredentials.secretAccessKey;
-          self.sessionToken = data.roleCredentials.sessionToken;
-          self.expireTime = new Date(data.roleCredentials.expiration);
-          callback(null);
-        }
-      });
+      return callback(null, cacheContent.accessToken);
     } catch (err) {
-      callback(err);
+      return callback(err, null);
     }
   },
 

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -13,9 +13,9 @@ var iniLoader = AWS.util.iniLoader;
  *
  *     [profile sso-profile]
  *     sso_account_id = 012345678901
- *     sso_region = us-east-1
+ *     sso_region = **-****-*
  *     sso_role_name = SampleRole
- *     sso_start_url = https://d-abc123.awsapps.com/start
+ *     sso_start_url = https://d-******.awsapps.com/start
  *
  * or using the session format:
  *
@@ -25,8 +25,8 @@ var iniLoader = AWS.util.iniLoader;
  *     sso_role_name = SampleRole
  *
  *     [sso-session prod]
- *     sso_region = us-east-1
- *     sso_start_url = https://d-abc123.awsapps.com/start
+ *     sso_region = **-****-*
+ *     sso_start_url = https://d-******.awsapps.com/start
  *
  * This information will be automatically added to your shared credentials file by running
  * `aws configure sso`.

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -124,7 +124,7 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
         if (!self.service || self.service.config.region !== profile.sso_region) {
           self.service = new AWS.SSO({
             region: profile.sso_region,
-            httpOptions: this.httpOptions,
+            httpOptions: self.httpOptions,
           });
         }
 


### PR DESCRIPTION
- in SSO Credentials, use the SSO Token Provider to get the token string if the config format is in the new format with an `sso-session` name.

##### Checklist

- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- n/a run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)

testing:

sso.js
```js
var AWS = require('../../lib/aws');
var S3 = require('../../clients/s3');

Promise.resolve()
  .then(function () {
    return new Promise(function (resolve) {
      var creds = new AWS.SsoCredentials({
        callback: function (err, done) {
          resolve(err || creds);
        }
      });
    });
  })
  .then(function (credentials) {
    console.log('credentials from:', credentials.profile);
    return new S3({credentials: credentials, region: 'us-east-1'}).listBuckets({}).promise();
  })
  .then(function (data) {
    console.log('list buckets OK');
  })
  .catch(function (err) {
    console.error('oh no', err);
  });
```

```Makefile
test:
	make legacy
	make new

legacy:
	AWS_SDK_LOAD_CONFIG=1 AWS_PROFILE=sso-legacy node sso

new:
	AWS_SDK_LOAD_CONFIG=1 AWS_PROFILE=sso-token node sso
```

~/.aws/config

```
[profile sso-legacy]
sso_account_id = ****
sso_region = us-east-1
sso_role_name = ******
sso_start_url = https://d-******.awsapps.com/start

[profile sso-token]
sso_session = dev
sso_account_id = ****
sso_role_name = ******

[sso-session dev]
sso_region = us-east-1
sso_start_url = https://d-******.awsapps.com/start
sso_registration_scopes = sso:account:access
```