### PR TITLE
Set Authorization header correctly in Bearer Signer

### DIFF
--- a/.changes/next-release/bugfix-Signer-19c64295.json
+++ b/.changes/next-release/bugfix-Signer-19c64295.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Signer",
+  "description": "Set Authorization header correctly in Bearer Signer"
+}

--- a/lib/signers/bearer.js
+++ b/lib/signers/bearer.js
@@ -9,6 +9,6 @@ AWS.Signers.Bearer = AWS.util.inherit(AWS.Signers.RequestSigner, {
   },
 
   addAuthorization: function addAuthorization(token) {
-    this.request.httpRequest.headers['Authorization'] = 'Bearer ' + token.token;
+    this.request.headers['Authorization'] = 'Bearer ' + token.token;
   }
 });


### PR DESCRIPTION
Internal JS-3870

The `req.httpRequest` is correctly passed in constructor in [lib/event_listeners.js](https://github.com/aws/aws-sdk-js/blob/fe074d5cf424d9da8ac3196210c6420bfe6744a9/lib/event_listeners.js#L284)
However, the BearerSigner tries to read `.httpRequest` which is incorrect in [lib/signers/bearer.js](https://github.com/aws/aws-sdk-js/blob/fe074d5cf424d9da8ac3196210c6420bfe6744a9/lib/signers/bearer.js#L11-L13)

This PR fixes it, and it's tested in JS-3870.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`