### PR TITLE
Read identity type from service.api.signatureVersion

### DIFF
--- a/.changes/next-release/bugfix-Signer-57f3328c.json
+++ b/.changes/next-release/bugfix-Signer-57f3328c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Signer",
+  "description": "Read identity type from service.api.signatureVersion"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -73,6 +73,23 @@ function getOperationAuthtype(req) {
   return operation ? operation.authtype : '';
 }
 
+/**
+ * @api private
+ */
+function getIdentityType(req) {
+  var service = req.service;
+
+  if (service.config.signatureVersion) {
+    return service.config.signatureVersion;
+  }
+
+  if (service.api.signatureVersion) {
+    return service.api.signatureVersion;
+  }
+
+  return getOperationAuthtype(req);
+}
+
 AWS.EventListeners = {
   Core: new SequentialExecutor().addNamedListeners(function(add, addAsync) {
     addAsync('VALIDATE_CREDENTIALS', 'validate',
@@ -250,12 +267,10 @@ AWS.EventListeners = {
 
     addAsync('SIGN', 'sign', function SIGN(req, done) {
       var service = req.service;
-      var operations = req.service.api.operations || {};
-      var operation = operations[req.operation];
-      var authtype = operation ? operation.authtype : '';
-      if (!service.api.signatureVersion && !authtype && !service.config.signatureVersion) return done(); // none
+      var identityType = getIdentityType(req);
+      if (!identityType || identityType.length === 0) return done(); // none
 
-      if (authtype === 'bearer' || service.config.signatureVersion === 'bearer') {
+      if (identityType === 'bearer') {
         service.config.getToken(function (err, token) {
           if (err) {
             req.response.error = err;
@@ -281,6 +296,8 @@ AWS.EventListeners = {
           try {
             var date = service.getSkewCorrectedDate();
             var SignerClass = service.getSignerClass(req);
+            var operations = req.service.api.operations || {};
+            var operation = operations[req.operation];
             var signer = new SignerClass(req.httpRequest,
               service.getSigningName(req),
               {


### PR DESCRIPTION
Internal JS-3870

The [event listener for sign](https://github.com/aws/aws-sdk-js/blob/f387f39238bed26d17ed8b562848ff6c7d4f1f4e/lib/event_listeners.js#L258) does not check for `service.api.signatureVersion`.
This PR adds a function `getIdentityType` which performs the required checks, and it's tested in JS-3870.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`