### PR TITLE
fix(ResourceExplorer2): add fips dualstack by default

### DIFF
--- a/.changes/next-release/bugfix-ResourceExplorer2-af0b0824.json
+++ b/.changes/next-release/bugfix-ResourceExplorer2-af0b0824.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ResourceExplorer2",
+  "description": "Add dualstack by default for FIPS"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -128,7 +128,8 @@
     "us-gov-west-1/organizations": "fipsWithServiceOnly",
     "us-gov-west-1/route53": {
       "endpoint": "route53.us-gov.amazonaws.com"
-    }
+    },
+    "*/resource-explorer-2": "fipsDualstackByDefault"
   },
 
   "dualstackRules": {
@@ -227,6 +228,9 @@
     },
     "dualstackByDefault": {
       "endpoint": "{service}.{region}.api.aws"
+    },
+    "fipsDualstackByDefault": {
+      "endpoint": "{service}-fips.{region}.api.aws"
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js/issues/4275

```console
$ AWS_REGION=us-west-2 AWS_USE_FIPS_ENDPOINT=true node resourceExplorer.v2.mjs
{ endpoint: 'resource-explorer-2-fips.us-west-2.api.aws' }
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`