### PR TITLE
Update readme message about v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,29 @@ For release notes, see the [CHANGELOG](https://github.com/aws/aws-sdk-js/blob/ma
 We are formalizing our plans to enter **AWS SDK for JavaScript v2** into maintenance mode in 2023.
 
 [**AWS SDK for JavaScript v3**][aws-sdk-js-v3] is the latest and recommended version, 
-which has been GA since December 2020. Please refer to [this blog][v3-recommended-blog]
-on why and how you should use [**AWS SDK for JavaScript v3**][aws-sdk-js-v3] and 
-the experimental codemod scripts you can use to migrate your application from v2 to v3. 
+which has been GA since December 2020. Here is [why and how you should use
+**AWS SDK for JavaScript v3**][v3-recommended-blog]. You can try our experimental
+migration scripts in [aws-sdk-js-codemod][aws-sdk-js-codemod] to migrate
+your application from v2 to v3.
+
 To get help with your migration, please follow our general guidelines to 
-[open an issue](https://github.com/aws/aws-sdk-js/issues/new/choose) 
-and choose [guidance][open-issue-v2-guidance]. To give feedback on and 
-report issues in the v3 repo, please refer to 
-[Giving feedback and contributing](https://github.com/aws/aws-sdk-js-v3#giving-feedback-and-contributing).
-Watch this README and the 
-[AWS Developer Tools Blog][aws-devtools-blog] for updates and announcements
-regarding the maintenance plans and timelines. Please refer to the
-[AWS SDKs and Tools maintenance policy][aws-sdks-maintenance-policy]
+[open an issue][v2-new-issue] and choose [guidance][open-issue-v2-guidance].
+To give feedback on and report issues in the v3 repo, please refer to 
+[Giving feedback and contributing][v3-contributing].
+
+Watch this README and the [AWS Developer Tools Blog][aws-devtools-blog]
+for updates and announcements regarding the maintenance plans and timelines.
+Please refer to the [AWS SDKs and Tools maintenance policy][aws-sdks-maintenance-policy]
 for further details.
 
+[v2-new-issue]: https://github.com/aws/aws-sdk-js/issues/new/choose
 [v3-recommended-blog]: https://aws.amazon.com/blogs/developer/why-and-how-you-should-use-aws-sdk-for-javascript-v3-on-node-js-18/
+[v3-contributing]: https://github.com/aws/aws-sdk-js-v3#giving-feedback-and-contributing
 [aws-sdk-js-v3]: https://github.com/aws/aws-sdk-js-v3
 [aws-devtools-blog]: https://aws.amazon.com/blogs/developer/
 [aws-sdks-maintenance-policy]: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html
 [open-issue-v2-guidance]: https://github.com/aws/aws-sdk-js/issues/new?assignees=&labels=guidance%2C+needs-triage&template=---questions---help.md&title=
+[aws-sdk-js-codemod]: https://www.npmjs.com/package/aws-sdk-js-codemod
 
 ## Table of Contents:
 * [Getting Started](#getting-Started)


### PR DESCRIPTION
Suggests the following changes to the message added in https://github.com/aws/aws-sdk-js/pull/4281
* Breaks the message into three paragraphs for improved readibility:
  * Announcement
  * Get help with migration
  * Subscribe to updates and announcements
* Uses topic for v3-recommended-blog instead of "this blog"
* Adds explicit link to aws-sdk-js-codemod for folks who may not read the blog.
* Uses language with "you" as an actor for the messaging about experimental scripts.

Rendered version can be viewed at https://github.com/trivikr/aws-sdk-js/blob/v3-recommended-blog-topic/README.md

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] non-code related change (markdown/git settings etc)
