### PR TITLE
fix(service): do not allow api signatureVersion bearer to be overridden

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -70,6 +70,10 @@ AWS.Service = inherit({
 
     this.validateService();
     if (!this.config.endpoint) regionConfig.configureEndpoint(this);
+    if (this.api.signatureVersion === 'bearer') {
+      // bearer from API declaration may not be overridden by config.
+      this.config.signatureVersion = 'bearer';
+    }
 
     this.config.endpoint = this.endpointFromTemplate(this.config.endpoint);
     this.setEndpoint(this.config.endpoint);


### PR DESCRIPTION
internal P76145538

##### Checklist
- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)

alternates:
https://github.com/aws/aws-sdk-js/pull/4283
https://github.com/aws/aws-sdk-js/pull/4284