### PR TITLE
fix(service): use service signatureVersion as default

### DIFF
--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -63,7 +63,9 @@ function configureEndpoint(service) {
       }
 
       // signature version
-      if (!config.signatureVersion) config.signatureVersion = 'v4';
+      if (!config.signatureVersion) {
+        config.signatureVersion = (service.api && service.api.signatureVersion) || 'v4';
+      }
 
       // merge config
       applyConfig(service, config);


### PR DESCRIPTION
internal P76145538

##### Checklist
- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)

alternates:
https://github.com/aws/aws-sdk-js/pull/4283
https://github.com/aws/aws-sdk-js/pull/4284