### PR TITLE
fix(event_listeners): check identity type in VALIDATE_CREDENTIALS

### DIFF
--- a/.changes/next-release/bugfix-event-listeners-44cd040f.json
+++ b/.changes/next-release/bugfix-event-listeners-44cd040f.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "event_listeners",
+  "description": "differentiate identity type in VALIDATE_CREDENTIALS listener"
+}

--- a/lib/event_listeners.js
+++ b/lib/event_listeners.js
@@ -92,16 +92,33 @@ function getIdentityType(req) {
 
 AWS.EventListeners = {
   Core: new SequentialExecutor().addNamedListeners(function(add, addAsync) {
-    addAsync('VALIDATE_CREDENTIALS', 'validate',
-        function VALIDATE_CREDENTIALS(req, done) {
-      if (!req.service.api.signatureVersion && !req.service.config.signatureVersion) return done(); // none
-      req.service.config.getCredentials(function(err) {
-        if (err) {
-          req.response.error = AWS.util.error(err,
-            {code: 'CredentialsError', message: 'Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1'});
+    addAsync(
+      'VALIDATE_CREDENTIALS', 'validate',
+      function VALIDATE_CREDENTIALS(req, done) {
+        if (!req.service.api.signatureVersion && !req.service.config.signatureVersion) return done(); // none
+
+        var identityType = getIdentityType(req);
+        if (identityType === 'bearer') {
+          req.service.config.getToken(function(err) {
+            if (err) {
+              req.response.error = AWS.util.error(err, {code: 'TokenError'});
+            }
+            done();
+          });
+          return;
         }
-        done();
-      });
+
+        req.service.config.getCredentials(function(err) {
+          if (err) {
+            req.response.error = AWS.util.error(err,
+              {
+                code: 'CredentialsError',
+                message: 'Missing credentials in config, if using AWS_CONFIG_FILE, set AWS_SDK_LOAD_CONFIG=1'
+              }
+            );
+          }
+          done();
+        });
     });
 
     add('VALIDATE_REGION', 'validate', function VALIDATE_REGION(req) {


### PR DESCRIPTION
If the identity type is bearer, the validate_credentials listener will only check the token used in bearer auth. 

Internal V776401135

##### Checklist
- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
