### PR TITLE
fix(region_config): remove mutation of global signatureVersion

### DIFF
--- a/.changes/next-release/bugfix-region-config-31f590e0.json
+++ b/.changes/next-release/bugfix-region-config-31f590e0.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "region_config",
-  "description": "avoid mutation in global object signatureVersion"
+  "description": "Set signatureVersion to bearer explcitly when defined in service API"
 }

--- a/.changes/next-release/bugfix-region-config-31f590e0.json
+++ b/.changes/next-release/bugfix-region-config-31f590e0.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "region_config",
+  "description": "avoid mutation in global object signatureVersion"
+}

--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -64,11 +64,20 @@ function configureEndpoint(service) {
 
       // signature version
       if (!config.signatureVersion) {
-        config.signatureVersion = (service.api && service.api.signatureVersion) || 'v4';
+        // Note: config is a global object and should not be mutated here.
+        // However, we are retaining this line for backwards compatibility.
+        // The non-v4 signatureVersion will be set in a copied object below.
+        config.signatureVersion = 'v4';
       }
 
+      var useBearer = (service.api && service.api.signatureVersion) === 'bearer';
+
       // merge config
-      applyConfig(service, config);
+      applyConfig(service, Object.assign(
+        {},
+        config,
+        { signatureVersion: useBearer ? 'bearer' : config.signatureVersion }
+      ));
       return;
     }
   }


### PR DESCRIPTION
A fix for https://github.com/aws/aws-sdk-js/issues/4286

##### Checklist
- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
