### PR TITLE
fix(KendraRanking): set endpoint to dualstack by default

### DIFF
--- a/.changes/next-release/bugfix-KendraRanking-2ca3213c.json
+++ b/.changes/next-release/bugfix-KendraRanking-2ca3213c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "KendraRanking",
+  "description": "Set endpoint to dualstack by default"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -69,6 +69,7 @@
       "signatureVersion": "v2"
     },
     "*/resource-explorer-2": "dualstackByDefault",
+    "*/kendra-ranking": "dualstackByDefault",
     "*/codecatalyst": "globalDualstackByDefault"
   },
 
@@ -131,6 +132,7 @@
       "endpoint": "route53.us-gov.amazonaws.com"
     },
     "*/resource-explorer-2": "fipsDualstackByDefault",
+    "*/kendra-ranking": "dualstackByDefault",
     "*/codecatalyst": "fipsGlobalDualstackByDefault"
   },
 


### PR DESCRIPTION
Similar to https://github.com/aws/aws-sdk-js/pull/4263

### Testing

Code:
```js
import AWS from "./index.js";

(async () => {
  const client1 = new AWS.KendraRanking({ region: "us-west-2" });
  console.log("default endpoint:", client1.config.endpoint);

  const client2 = new AWS.KendraRanking({
    region: "us-west-2",
    useDualstackEndpoint: false,
  });
  console.log(
    "endpoint with useDualstackEndpoint=false:",
    client2.config.endpoint
  );

  const client3 = new AWS.KendraRanking({
    region: "us-west-2",
    useDualstackEndpoint: true,
  });
  console.log(
    "endpoint with useDualstackEndpoint=true:",
    client3.config.endpoint
  );
})();

```

Output:
```console
default endpoint: kendra-ranking.us-west-2.api.aws
endpoint with useDualstackEndpoint=false: kendra-ranking.us-west-2.api.aws
endpoint with useDualstackEndpoint=true: kendra-ranking.us-west-2.api.aws
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`