### PR TITLE
Fixed CognitoIdentityServiceProvider UserType definition

### DIFF
--- a/.changes/next-release/bugfix-CognitoIdentityServiceProvider-1dbbc277.json
+++ b/.changes/next-release/bugfix-CognitoIdentityServiceProvider-1dbbc277.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "CognitoIdentityServiceProvider",
+  "description": "`Attributes` property defined in `UserType` updated to `UserAttributes` according to SDK documentation."
+}

--- a/clients/cognitoidentityserviceprovider.d.ts
+++ b/clients/cognitoidentityserviceprovider.d.ts
@@ -4575,7 +4575,7 @@ declare namespace CognitoIdentityServiceProvider {
     /**
      * A container with information about the user type attributes.
      */
-    Attributes?: AttributeListType;
+    UserAttributes?: AttributeListType;
     /**
      * The creation date of the user.
      */


### PR DESCRIPTION
Hi everyone!

`CognitoIdentityServiceProvider.UserType` definition has a property wrongly defined as `Attributes` when it is actually `UserAttributes`. That's it!

Source: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CognitoIdentityServiceProvider.html#getUser-property

Thank you!

##### Checklist

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
