### PR TITLE
fix(endpoints): fix FIPS endpoints for CloudFormation

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-edafef26.json
+++ b/.changes/next-release/bugfix-Endpoints-edafef26.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Use correct FIPS endpoint for CloudFormation in GovCloud"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -108,6 +108,7 @@
     "us-gov-*/runtime.lex": "fips.runtime.lex",
     "us-gov-*/acm-pca": "fipsWithServiceOnly",
     "us-gov-*/batch": "fipsWithServiceOnly",
+    "us-gov-*/cloudformation": "fipsWithServiceOnly",
     "us-gov-*/config": "fipsWithServiceOnly",
     "us-gov-*/eks": "fipsWithServiceOnly",
     "us-gov-*/elasticmapreduce": "fipsWithServiceOnly",


### PR DESCRIPTION
The SDK currently uses the following FIPS endpoint for CloudFormation in Gov regions:

```
cloudformation-fips.us-gov-west-1.amazonaws.com
```

According to the [FIPS endpoint reference](https://aws.amazon.com/compliance/fips/) it should be:

```
cloudformation.us-gov-west-1.amazonaws.com
```

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
