### PR TITLE
Fix documentation of DynamoDB.DocumentClient.transactWrite

### DIFF
--- a/lib/dynamodb/document_client.d.ts
+++ b/lib/dynamodb/document_client.d.ts
@@ -61,7 +61,7 @@ export class DocumentClient {
     transactGet(params: DocumentClient.TransactGetItemsInput, callback?: (err: AWSError, data: DocumentClient.TransactGetItemsOutput) => void): Request<DocumentClient.TransactGetItemsOutput, AWSError>;
 
     /**
-     * Synchronous write operation that groups up to 25 action requests.
+     * Synchronous write operation that groups up to 100 action requests.
      */
     transactWrite(params: DocumentClient.TransactWriteItemsInput, callback?: (err: AWSError, data: DocumentClient.TransactWriteItemsOutput) => void): Request<DocumentClient.TransactWriteItemsOutput, AWSError>;
 }

--- a/lib/dynamodb/document_client.js
+++ b/lib/dynamodb/document_client.js
@@ -397,7 +397,7 @@ AWS.DynamoDB.DocumentClient = AWS.util.inherit({
   },
 
   /**
-   * Synchronous write operation that groups up to 25 action requests.
+   * Synchronous write operation that groups up to 100 action requests.
    *
    * Supply the same parameters as {AWS.DynamoDB.transactWriteItems} with
    * `AttributeValue`s substituted by native JavaScript types.


### PR DESCRIPTION
According to [this announcement](https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/), limit increased to 100 actions per transaction. [Documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html#DDB-TransactWriteItems-request-TransactItems) now also mentions "up to 100 `TransactWriteItem` objects"

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] non-code related change (markdown/git settings etc)
