### PR TITLE
Update chime.d.ts

### DIFF
--- a/clients/chime.d.ts
+++ b/clients/chime.d.ts
@@ -216,7 +216,7 @@ declare class Chime extends Service {
    */
   createMeetingWithAttendees(params: Chime.Types.CreateMeetingWithAttendeesRequest, callback?: (err: AWSError, data: Chime.Types.CreateMeetingWithAttendeesResponse) => void): Request<Chime.Types.CreateMeetingWithAttendeesResponse, AWSError>;
   /**
-   *  Creates a new Amazon Chime SDK meeting in the specified media Region, with attendees. For more information about specifying media Regions, see Amazon Chime SDK Media Regions in the Amazon Chime Developer Guide . For more information about the Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon Chime Developer Guide . 
+   *  Creates a new Amazon Chime SDK meeting in the specified media Region, up to 10 attendees. For more information about specifying media Regions, see Amazon Chime SDK Media Regions in the Amazon Chime Developer Guide . For more information about the Amazon Chime SDK, see Using the Amazon Chime SDK in the Amazon Chime Developer Guide . 
    */
   createMeetingWithAttendees(callback?: (err: AWSError, data: Chime.Types.CreateMeetingWithAttendeesResponse) => void): Request<Chime.Types.CreateMeetingWithAttendeesResponse, AWSError>;
   /**


### PR DESCRIPTION
Hello.
I took me a lot of time to figure it out whats wrong with this function and I want to help others.

Validation rules doesn't allow to pass more than 10 attendees to createMeetingWithAttendees function and you need to use batchCreateAttendee instead.

<!--
Thank you for your pull request. Please provide a description below.
-->
createMeetingWithAttendee function throws error if you pass more than 10 attendees.

the error:
ValidationException: 1 validation error detected: Value at 'attendees' failed to satisfy constraint: Member must have length less than or equal to 10
