### PR TITLE
chore: add maintenance mode message

### DIFF
--- a/lib/aws.js
+++ b/lib/aws.js
@@ -4,6 +4,7 @@ var AWS = require('./core');
 
 // Load all service classes
 require('../clients/all');
+require('./maintenance_mode_message');
 
 /**
  * @api private

--- a/lib/aws.js
+++ b/lib/aws.js
@@ -4,7 +4,6 @@ var AWS = require('./core');
 
 // Load all service classes
 require('../clients/all');
-require('./maintenance_mode_message');
 
 /**
  * @api private

--- a/lib/core.js
+++ b/lib/core.js
@@ -85,6 +85,7 @@ require('./response');
 require('./resource_waiter');
 require('./signers/request_signer');
 require('./param_validator');
+require('./maintenance_mode_message');
 
 /**
  * @readonly

--- a/lib/maintenance_mode_message.js
+++ b/lib/maintenance_mode_message.js
@@ -1,0 +1,31 @@
+var warning = [
+  'The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.\n',
+  'Please migrate your code to use AWS SDK for JavaScript (v3).',
+  'For more information, check the migration guide at https://a.co/7PzMCcy'
+].join('\n');
+
+module.exports = {
+  suppress: false
+};
+
+/**
+ * To suppress this message:
+ * @example
+ * require('aws-sdk/lib/maintenance_mode_message').suppress = true;
+ */
+function emitWarning() {
+  if (
+    typeof process !== 'undefined' &&
+    typeof process.emitWarning === 'function'
+  ) {
+    process.emitWarning(warning, {
+      type: 'NOTE'
+    });
+  }
+}
+
+setTimeout(function () {
+  if (!module.exports.suppress) {
+    emitWarning();
+  }
+}, 0);


### PR DESCRIPTION
Adds a maintenance mode message for 2023.

I still wanted to add a suppression method, but not in the spec-derived config files or as an ENV variable. This suppression method is specific to JSv2, just like the message itself.

##### Checklist

- [n/a] `npm run test` passes
- [n/a] `.d.ts` file is updated
- [n/a] changelog is added, `npm run add-change`
- [n/a] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [n/a] run `npm run integration` if integration test is changed
- [n/a] non-code related change (markdown/git settings etc)
