### PR TITLE
Update maintenance mode message to justify hint

### DIFF
--- a/lib/maintenance_mode_message.js
+++ b/lib/maintenance_mode_message.js
@@ -1,5 +1,5 @@
 var warning = [
-  'The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.\n',
+  'We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.\n',
   'Please migrate your code to use AWS SDK for JavaScript (v3).',
   'For more information, check the migration guide at https://a.co/7PzMCcy'
 ].join('\n');


### PR DESCRIPTION
As per [AWS SDKs and Tools maintenance policy](https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html) Phase 2, a public announcement needs to be made before an SDK version is put into maintenance mode. This announcement gives users at least six months to upgrade, and calls out the date for Phase 3. This is usually done through blog post, documentation and deprecation warnings.

In https://github.com/aws/aws-sdk-js/pull/4345, we added a hint about our plans to put v2 into maintenance mode with the following warning:
```console
The AWS SDK for JavaScript (v2) will be put into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
```

However, users are confusing it with the official announcement which is not made yet.

This PR uses the statement from README instead:
```console
We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check the migration guide at https://a.co/7PzMCcy
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes