### PR TITLE
fix(InternetMonitor): set endpoint to dualstack by default

### DIFF
--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -70,6 +70,7 @@
     },
     "*/resource-explorer-2": "dualstackByDefault",
     "*/kendra-ranking": "dualstackByDefault",
+    "*/internetmonitor": "dualstackByDefault",
     "*/codecatalyst": "globalDualstackByDefault"
   },
 
@@ -134,6 +135,7 @@
     },
     "*/resource-explorer-2": "fipsDualstackByDefault",
     "*/kendra-ranking": "dualstackByDefault",
+    "*/internetmonitor": "dualstackByDefault",
     "*/codecatalyst": "fipsGlobalDualstackByDefault"
   },
 


### PR DESCRIPTION
Internal JS-3997

Similar to https://github.com/aws/aws-sdk-js/pull/4319

##### Checklist

- [x] `npm run test` passes