### PR TITLE
chore: add env var for suppressing maintenance mode message

### DIFF
--- a/.changes/next-release/bugfix-maintenance-mode-message-dce36b79.json
+++ b/.changes/next-release/bugfix-maintenance-mode-message-dce36b79.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "maintenance mode message",
+  "description": "add environment var for suppression of maintenance mode message"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+login:
+	ada credentials update --account 812168580665 --role Admin --once
+
+sync:
+	gh repo sync kuhe/aws-sdk-js -b master

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ for updates and announcements regarding the maintenance plans and timelines.
 Please refer to the [AWS SDKs and Tools maintenance policy][aws-sdks-maintenance-policy]
 for further details.
 
+A maintenance mode message may be emitted by this package on startup. 
+To suppress this message, use an environment variable:
+
+```sh
+AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE=1 node my_program.js
+```
+
+or a JavaScript setting as follows:
+```js
+var SDK = require('aws-sdk');
+require('aws-sdk/lib/maintenance_mode_message').suppress = true;
+```
+
 [v2-new-issue]: https://github.com/aws/aws-sdk-js/issues/new/choose
 [v3-recommended-blog]: https://aws.amazon.com/blogs/developer/why-and-how-you-should-use-aws-sdk-for-javascript-v3-on-node-js-18/
 [v3-contributing]: https://github.com/aws/aws-sdk-js-v3#giving-feedback-and-contributing

--- a/lib/maintenance_mode_message.js
+++ b/lib/maintenance_mode_message.js
@@ -26,6 +26,13 @@ function emitWarning() {
     return;
   }
 
+  if (
+    typeof process.env === 'object' &&
+    typeof process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE !== 'undefined'
+  ) {
+    return;
+  }
+
   if (typeof process.emitWarning === 'function') {
     process.emitWarning(warning, {
       type: 'NOTE'


### PR DESCRIPTION
add `AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE=1` option for suppressing maintenance mode message.

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
