### PR TITLE
Upgrade buffer dependency to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack": "^1.15.0"
   },
   "dependencies": {
-    "buffer": "4.9.2",
+    "buffer": "6.0.3",
     "events": "1.1.1",
     "ieee754": "1.1.13",
     "jmespath": "0.16.0",


### PR DESCRIPTION
Using 4.9.2 version of the buffer package package causes an error on Lambda

Since it's a console.error, this logs to AWS CloudWatch every time a request is made.  This problem exists only on Lambda, on local, it doesn't show any such errors.

`ERROR    (node:8) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
`

![Screenshot 2023-03-10 at 1 41 43 AM](https://user-images.githubusercontent.com/800668/224145338-1a028721-888d-439c-851f-442a11ddfc70.png)
![Screenshot 2023-03-10 at 1 40 08 AM](https://user-images.githubusercontent.com/800668/224145345-7e803bde-ec25-4dae-ad96-dbc93d4421d1.png)
![Screenshot 2023-03-10 at 1 39 56 AM](https://user-images.githubusercontent.com/800668/224145354-ce32813d-0eb8-4cca-b2fd-0362fbcfcd4d.png)
