### PR TITLE
Remove union widening for enum string literals in typescript definitions

### DIFF
--- a/.changes/next-release/feature-Typings-472a5e03.json
+++ b/.changes/next-release/feature-Typings-472a5e03.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Typings",
+  "description": "Removes enum string literal widening with string"
+}

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -342,7 +342,7 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
         if (Array.isArray(shape.enum)) {
             stringType = shape.enum.map(function(s) {
                 return '"' + s + '"';
-            }).join('|') + '|' + stringType;
+            }).join('|');
         }
         code += tabs(tabCount) + 'export type ' + shapeKey + ' = ' + stringType + ';\n';
     } else if (['double', 'long', 'short', 'biginteger', 'bigdecimal', 'integer', 'float'].indexOf(type) >= 0) {


### PR DESCRIPTION
Removes string type from generated enum string literal unions. There's additional discussion and motivation in the noted issue,.

Widening the union like this is aggressively optimized by typescript into a `string` type, which renders the enum largely useless, both in type hinting and also at compile-time. 

 (Fixes #1624)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
