### PR TITLE
fix TokenFileWebIdentityCredentials typing

### DIFF
--- a/.changes/next-release/bugfix-Typing-102b0d52.json
+++ b/.changes/next-release/bugfix-Typing-102b0d52.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Typing",
+  "description": "Align the typing for constructor param of TokenFileWebIdentityCredentials with STS client"
+}

--- a/lib/credentials/token_file_web_identity_credentials.d.ts
+++ b/lib/credentials/token_file_web_identity_credentials.d.ts
@@ -1,12 +1,12 @@
 import {Credentials} from '../credentials';
 import {AWSError} from '../error';
-import {ConfigurationOptions} from '../config-base';
+import {ClientConfiguration} from '../../clients/sts';
 export class TokenFileWebIdentityCredentials extends Credentials {
     /**
      * Creates a new credentials object with optional configuraion.
      * @param {Object} clientConfig - a map of configuration options to pass to the underlying STS client.
      */
-    constructor(clientConfig?: ConfigurationOptions);
+    constructor(clientConfig?: ClientConfiguration);
     /**
      * Refreshes credentials using AWS.STS.assumeRoleWithWebIdentity().
      */

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -2106,6 +2106,14 @@ const exp = require('constants');
         });
       });
 
+      it('should forward endpoint param to sts client', function() {
+        var creds = new AWS.TokenFileWebIdentityCredentials({
+          endpoint: 'https://testendpoint'
+        });
+        creds.createClients();
+        expect(creds.service.endpoint.hostname).to.equal('testendpoint');
+      });
+
       return it('fails if params are not available in both environment variables or shared config', function(done) {
         delete process.env.AWS_WEB_IDENTITY_TOKEN_FILE;
         helpers.spyOn(AWS.util, 'getProfilesFromSharedConfig').andReturn({});
@@ -2344,7 +2352,7 @@ const exp = require('constants');
         });
         expect(creds).to.have.property('tokenCodeFn', null);
       });
-      it('should forward enpoint param to sts client', function() {
+      it('should forward endpoint param to sts client', function() {
         var creds = new AWS.ChainableTemporaryCredentials({
           stsConfig: { endpoint: 'https://testendpoint' }
         });


### PR DESCRIPTION
Change the typing of the constructor param for `TokenFileWebIdentityCredentials` to the same as `STS.Types.ClientConfiguration`, since the whole config is passed down to the STS client.

Fix the issue that type error occurs when changing the STS endpoint via the constructor param of `TokenFileWebIdentityCredentials`. For example:

```js
new AWS.TokenFileWebIdentityCredentials({
  endpoint: 'https://testendpoint.com'
})
```

will throw error 
```
Argument of type '{ endpoint: string; }' is not assignable to parameter of type 'ConfigurationOptions'.
  Object literal may only specify known properties, and 'endpoint' does not exist in type 'ConfigurationOptions'.ts(2345)
```

but actually, the code will change the STS client endpoint successfully.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
