### PR TITLE
Bump xml2js to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "0.10.3",
     "util": "^0.12.4",
     "uuid": "8.0.0",
-    "xml2js": "0.4.19"
+    "xml2js": "0.5.0"
   },
   "main": "lib/aws.js",
   "browser": {


### PR DESCRIPTION
This PR bumps `xml2js` to `0.5.0`.

Resolves https://github.com/aws/aws-sdk-js/issues/4387.

##### Checklist

- [X] non-code related change (markdown/git settings etc)