### PR TITLE
fix(sqs): add queryCompatibility to json protocol

### DIFF
--- a/.changes/next-release/bugfix-SQS-e1c1ffea.json
+++ b/.changes/next-release/bugfix-SQS-e1c1ffea.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SQS",
+  "description": "add queryCompatibility fix to JSON protocol"
+}

--- a/lib/protocol/json.js
+++ b/lib/protocol/json.js
@@ -12,6 +12,15 @@ function buildRequest(req) {
   var builder = new JsonBuilder();
 
   if (version === 1) version = '1.0';
+
+  if (api.awsQueryCompatible) {
+    if (!httpRequest.params) {
+      httpRequest.params = {};
+    }
+    // because Query protocol does this.
+    Object.assign(httpRequest.params, req.params);
+  }
+
   httpRequest.body = builder.build(req.params || {}, input);
   httpRequest.headers['Content-Type'] = 'application/x-amz-json-' + version;
   httpRequest.headers['X-Amz-Target'] = target;

--- a/lib/services/sqs.js
+++ b/lib/services/sqs.js
@@ -5,7 +5,7 @@ AWS.util.update(AWS.SQS.prototype, {
    * @api private
    */
   setupRequestListeners: function setupRequestListeners(request) {
-    request.addListener('build', this.buildEndpoint.bind(this));
+    request.addListener('build', this.buildEndpoint);
 
     if (request.service.config.computeChecksums) {
       if (request.operation === 'sendMessage') {
@@ -118,8 +118,7 @@ AWS.util.update(AWS.SQS.prototype, {
    * @api private
    */
   buildEndpoint: function buildEndpoint(request) {
-    var params = request.httpRequest.params || this.config.params;
-    var url = params.QueueUrl;
+    var url = request.httpRequest.params.QueueUrl;
     if (url) {
       request.httpRequest.endpoint = new AWS.Endpoint(url);
 


### PR DESCRIPTION
##### Checklist

- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)

Ran `npx cucmber-js -t @sqs` this time for both current and new model JSON.