### PR TITLE
fix(ts-generator): generate exception shapes

### DIFF
--- a/.changes/next-release/bugfix-typings-generator-cb6fec18.json
+++ b/.changes/next-release/bugfix-typings-generator-cb6fec18.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "typings-generator",
+  "description": "generate exception shape types"
+}

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -305,7 +305,7 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
             // each member is an individual event type, so each must be optional
             return member + '?:' + shape.members[member].shape;
         });
-        return code += tabs(tabCount) + 'export type ' + shapeKey + ' = EventStream<{' + events.join(',') + '}>;\n'; 
+        return code += tabs(tabCount) + 'export type ' + shapeKey + ' = EventStream<{' + events.join(',') + '}>;\n';
     }
     if (type === 'structure') {
         if (shape.isDocument) {
@@ -614,10 +614,6 @@ TSGenerator.prototype.processServiceModel = function processServiceModel(service
     });
     shapeKeys.forEach(function (shapeKey) {
         var modelShape = modelShapes[shapeKey];
-        // ignore exceptions
-        if (modelShape.exception) {
-            return;
-        }
         code += self.generateTypingsFromShape(model, shapeKey, modelShape, 1, customClassNames);
     });
     //add extra dependencies like 'streaming'

--- a/tasks/apis.rake
+++ b/tasks/apis.rake
@@ -102,7 +102,7 @@ end
 desc 'Builds the API for each service.'
 task :api => 'api:all'
 
-if File.exists?("#{root}/apis/metadata.json")
+if File.exist?("#{root}/apis/metadata.json")
   service_map = JSON.parse(File.read('apis/metadata.json'))
   service_map.each do |service, config|
     add_tasks(service, config)


### PR DESCRIPTION
It's possible for a service to use an Exception shape in its operation output shape instead of the operation errors list if it is a streaming union.

Need confirmation. This only affects an unreleased model.

##### Checklist

- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- n/a run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
