### PR TITLE
chore: internal region check before default

### DIFF
--- a/lib/region_config.js
+++ b/lib/region_config.js
@@ -19,6 +19,7 @@ function derivedKeys(service) {
     [region, '*'],
     [regionPrefix, '*'],
     ['*', endpointPrefix],
+    [region, 'internal-*'],
     ['*', '*']
   ].map(function(item) {
     return item[0] && item[1] ? item.join('/') : null;


### PR DESCRIPTION
Add `*/internal-*` region config check before the final `*/*` default.

This has no effect on public clients, and will only be used internally.

##### Checklist

- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- n/a changelog is added, `npm run add-change` 
  -  skipping this since this is internal feature
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- n/a run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
