### PR TITLE
feat(errors): add error.body with original JSON error body

### DIFF
--- a/.changes/next-release/feature-errors-02c46955.json
+++ b/.changes/next-release/feature-errors-02c46955.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "errors",
+  "description": "add error.body hidden field with original error body for JSON protocols"
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 dist/*
 test/browser/**/*
 test/configuration.js
+workspace

--- a/lib/protocol/json.js
+++ b/lib/protocol/json.js
@@ -56,14 +56,18 @@ function extractError(resp) {
       // to validate the response shape (members) or
       // check if any are sensitive to logging.
 
-      // For simplicity, assign the error's original body to the
-      // body property, but set it hidden in case anything is sensitive.
-      Object.defineProperty(error, 'body', {
-        value: e,
-        enumerable: false,
-        writable: true
-      });
-      error['[body]'] = 'See this error.body for additional fields.';
+      // Assign the fields as non-enumerable, allowing specific access only.
+      for (var key in e || {}) {
+        if (key === 'code' || key === 'message') {
+          continue;
+        }
+        error['[' + key + ']'] = 'See error.' + key + ' for details.';
+        Object.defineProperty(error, key, {
+          value: e[key],
+          enumerable: false,
+          writable: true
+        });
+      }
     } catch (e) {
       error.statusCode = httpResponse.statusCode;
       error.message = httpResponse.statusMessage;

--- a/lib/protocol/json.js
+++ b/lib/protocol/json.js
@@ -63,6 +63,7 @@ function extractError(resp) {
         enumerable: false,
         writable: true
       });
+      error['[body]'] = 'See this error.body for additional fields.';
     } catch (e) {
       error.statusCode = httpResponse.statusCode;
       error.message = httpResponse.statusMessage;

--- a/lib/protocol/json.js
+++ b/lib/protocol/json.js
@@ -40,6 +40,7 @@ function extractError(resp) {
   if (httpResponse.body.length > 0) {
     try {
       var e = JSON.parse(httpResponse.body.toString());
+
       var code = e.__type || e.code || e.Code;
       if (code) {
         error.code = code.split('#').pop();
@@ -49,6 +50,19 @@ function extractError(resp) {
       } else {
         error.message = (e.message || e.Message || null);
       }
+
+      // The minimized models do not have error shapes, so
+      // without expanding the model size, it's not possible
+      // to validate the response shape (members) or
+      // check if any are sensitive to logging.
+
+      // For simplicity, assign the error's original body to the
+      // body property, but set it hidden in case anything is sensitive.
+      Object.defineProperty(error, 'body', {
+        value: e,
+        enumerable: false,
+        writable: true
+      });
     } catch (e) {
       error.statusCode = httpResponse.statusCode;
       error.message = httpResponse.statusMessage;

--- a/lib/util.js
+++ b/lib/util.js
@@ -610,7 +610,15 @@ var util = {
     err.name = String(options && options.name || err.name || err.code || 'Error');
     err.time = new Date();
 
-    if (originalError) err.originalError = originalError;
+    if (originalError) {
+      err.originalError = originalError;
+    }
+
+    Object.defineProperty(err, 'body', {
+      value: err.body || (options && options.body) || (originalError && originalError.body),
+      enumerable: false,
+      writable: true
+    });
 
     return err;
   },

--- a/lib/util.js
+++ b/lib/util.js
@@ -614,11 +614,21 @@ var util = {
       err.originalError = originalError;
     }
 
-    Object.defineProperty(err, 'body', {
-      value: err.body || (options && options.body) || (originalError && originalError.body),
-      enumerable: false,
-      writable: true
-    });
+
+    for (var key in options || {}) {
+      if (key[0] === '[' && key[key.length - 1] === ']') {
+        key = key.slice(1, -1);
+        if (key === 'code' || key === 'message') {
+          continue;
+        }
+        err['[' + key + ']'] = 'See error.' + key + ' for details.';
+        Object.defineProperty(err, key, {
+          value: err[key] || (options && options[key]) || (originalError && originalError[key]),
+          enumerable: false,
+          writable: true
+        });
+      }
+    }
 
     return err;
   },


### PR DESCRIPTION
Add `error.body` hidden field with the original JSON body of the error response.

##### Checklist
- [x] `npm run test` passes
- n/a `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- n/a run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- n/a non-code related change (markdown/git settings etc)
