### PR TITLE
fix(IAM): endpoint in aws-iso partition

### DIFF
--- a/.changes/next-release/bugfix-IAM-c81b705c.json
+++ b/.changes/next-release/bugfix-IAM-c81b705c.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "IAM",
+  "description": "Fix endpoint for IAM in aws-iso partition"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -46,7 +46,7 @@
     "us-iso-*/iam": {
       "endpoint": "{service}.us-iso-east-1.c2s.ic.gov",
       "globalEndpoint": true,
-      "signingRegion": "us-east-1"
+      "signingRegion": "us-iso-east-1"
     },
 
     "us-gov-*/iam": "globalGovCloud",

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -43,8 +43,13 @@
       "globalEndpoint": true,
       "signingRegion": "cn-north-1"
     },
-    "us-gov-*/iam": "globalGovCloud",
+    "us-iso-*/iam": {
+      "endpoint": "{service}.us-iso-east-1.c2s.ic.gov",
+      "globalEndpoint": true,
+      "signingRegion": "us-east-1"
+    },
 
+    "us-gov-*/iam": "globalGovCloud",
     "us-gov-*/sts": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },


### PR DESCRIPTION
Fix endpoint for IAM for us-iso partition

IAM is partitional service, previously it was being treated as regional.

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes -> tests don't even pass in master branch for me locally
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
