### PR TITLE
fix: sso credential resolution when sso-session access token requires a refresh

### DIFF
--- a/.changes/next-release/bugfix-SSO-4dba7ee8.json
+++ b/.changes/next-release/bugfix-SSO-4dba7ee8.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SSO",
+  "description": "fix sso credential resolution failure when sso-session access token requires a refresh"
+}

--- a/lib/credentials/sso_credentials.js
+++ b/lib/credentials/sso_credentials.js
@@ -176,7 +176,7 @@ AWS.SsoCredentials = AWS.util.inherit(AWS.Credentials, {
       var ssoTokenProvider = new AWS.SSOTokenProvider({
         profile: profileName,
       });
-      ssoTokenProvider.load(function (err) {
+      ssoTokenProvider.get(function (err) {
         if (err) {
           return callback(err);
         }


### PR DESCRIPTION
This commit fixes an issue which caused the SSO credentials provider to fail to resolve credentials if a cached access token associated with an sso-session required a refresh.

Reason for the issue is that SSOTokenProvider.load() skips token refresh if another refresh had been kicked off within the last 30 seconds. In this case, SSOTokenProvider.load() was called twice when credentials were being resolved: once from SSOTokenProvider constructor (via .get()) and second time from SsoCredentials.getToken() method.

If the access token on disk had expired, the first call to SSOTokenProvider.load() from SSOTokenProvider constructor kicked off a token refresh. When SsoCredentials.getToken() called SSOTokenProvider.load() again immediately, SSOTokenProvider would skip the token refresh and invoke the SsoCredentials.getToken() callback without having a valid token.

Because of this, SsoCredentials did not get a valid SSO access token from SSOTokenProvider and it could not fetch AWS credential from AWS IAM Identity Center.

Loading the SSO access token with SSOTokenProvider.get() instead of SSOTokenProvider.load() fixes the issue as SSOTokenProvider.get() tracks the calls to .get(), triggers the load just once and invokes all the callbacks when the new token is available.

This way SsoCredentials.getToken() will receive a valid access token once the initial load kicked off by the SSOTokenProvider constructor completes and SsoCredentials can use the refreshed token to fetch AWS credentials from AWS IAM Identity Center.

Fixes #4441

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
