### PR TITLE
docs(cognito_identity_credentials): Explain limitation of CognitoIden…

### DIFF
--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -27,7 +27,7 @@ var STS = require('../../clients/sts');
  * implementation calls Cognito's `getId()` and `GetCredentialsForIdentity()`.
  * In this flow there is no way to explicitly set a session policy, resulting in
  * STS attaching the default policy and limiting the permissions of the federated role.
- * To be able to explicitly set a session policy, do not use this convinience method. 
+ * To be able to explicitly set a session policy, do not use this convinience method.
  * Instead, you can use the Cognito client to call `getId()`, `GetOpenIdToken()` and then use
  * that token with your desired session policy to call STS's `AssumeRoleWithWebIdentity()`
  * For further reading refer to: https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -23,6 +23,15 @@ var STS = require('../../clients/sts');
  * identity providers. See {constructor} for an example on creating a credentials
  * object with proper property values.
  *
+ * DISCLAIMER: This convinience method leverages the Enhanced (simplified) Authflow. The underlying
+ * implementation calls Cognito's `getId()` and `GetCredentialsForIdentity()`.
+ * In this flow there is no way to explicitly set a session policy, resulting in
+ * STS attaching the default policy and limiting the permissions of the federated role.
+ * To be able to explicitly set a session policy, do not use this convinience method. 
+ * Instead, you can use the Cognito client to call `getId()`, `GetOpenIdToken()` and then use
+ * that token with your desired session policy to call STS's `AssumeRoleWithWebIdentity()`
+ * For further reading refer to: https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html
+ *
  * ## Refreshing Credentials from Identity Service
  *
  * In addition to AWS credentials expiring after a given amount of time, the

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -27,7 +27,7 @@ var STS = require('../../clients/sts');
  * implementation calls Cognito's `getId()` and `GetCredentialsForIdentity()`.
  * In this flow there is no way to explicitly set a session policy, resulting in
  * STS attaching the default policy and limiting the permissions of the federated role.
- * To be able to explicitly set a session policy, do not use this convinience method.
+ * To be able to explicitly set a session policy, do not use this convenience method.
  * Instead, you can use the Cognito client to call `getId()`, `GetOpenIdToken()` and then use
  * that token with your desired session policy to call STS's `AssumeRoleWithWebIdentity()`
  * For further reading refer to: https://docs.aws.amazon.com/cognito/latest/developerguide/authentication-flow.html

--- a/lib/credentials/cognito_identity_credentials.js
+++ b/lib/credentials/cognito_identity_credentials.js
@@ -23,7 +23,7 @@ var STS = require('../../clients/sts');
  * identity providers. See {constructor} for an example on creating a credentials
  * object with proper property values.
  *
- * DISCLAIMER: This convinience method leverages the Enhanced (simplified) Authflow. The underlying
+ * DISCLAIMER: This convenience method leverages the Enhanced (simplified) Authflow. The underlying
  * implementation calls Cognito's `getId()` and `GetCredentialsForIdentity()`.
  * In this flow there is no way to explicitly set a session policy, resulting in
  * STS attaching the default policy and limiting the permissions of the federated role.


### PR DESCRIPTION
This method uses the simplified authflow, which means users cannot explicitly set a session policy. This results in STS appending the Default Session Policy to the request, which can lead to limiting permissions even if they are explicitly attached to a role.

The doc change highlights the limitation of the connivence method since it uses that Enhanced (simplified) flow "under the hood" which limits permissions on the assumed role because of the intersection of multiple policies resulting in the least permissive one being applied to the credentials returned from STS.

[Related ticket ](https://github.com/aws/aws-sdk-js/issues/4303)