### PR TITLE
typing: add loadSsoSessionsFrom and expose private util methods to IniLoader

### DIFF
--- a/lib/shared-ini/ini-loader.d.ts
+++ b/lib/shared-ini/ini-loader.d.ts
@@ -24,7 +24,15 @@ export class IniLoader{
  * Load configurations from config/credentials files and cache them 
  * for later use. If no file is specified it will try to load default
  * files.
- * @returns {object} object of all profile information in the file
+ * @returns {Record<string, string>} object of all profile information in the file
  */
   loadFrom(options: LoadFileOptions): IniFileContent;
+
+  /**
+ * Load sso sessions from config/credentials files and cache them 
+ * for later use. If no file is specified it will try to load default
+ * files.
+ * @returns {Record<string, string>} object of all sso sessions information in the file
+ */
+  loadSsoSessionsFrom(options: LoadFileOptions): IniFileContent;
 }

--- a/lib/shared-ini/ini-loader.d.ts
+++ b/lib/shared-ini/ini-loader.d.ts
@@ -35,4 +35,19 @@ export class IniLoader{
  * @returns {Record<string, string>} object of all sso sessions information in the file
  */
   loadSsoSessionsFrom(options: LoadFileOptions): IniFileContent;
+
+  /**
+   * Get default file path for config/credentials files.
+   * 
+   * @param isConfig whether the file is a config file or a credentials file
+   * @returns {string} default file path
+   */
+  getDefaultFilePath(isConfig: boolean): string;
+
+  /**
+   * Get Home directory of the current user.
+   * 
+   * @returns {string} home directory path
+   * */
+   getHomeDir(): string;
 }

--- a/lib/shared-ini/ini-loader.js
+++ b/lib/shared-ini/ini-loader.js
@@ -103,9 +103,6 @@ AWS.IniLoader = AWS.util.inherit({
     return this.resolvedSsoSessions[filename];
   },
 
-  /**
-   * @api private
-   */
   getDefaultFilePath: function getDefaultFilePath(isConfig) {
     return path.join(
       this.getHomeDir(),
@@ -114,9 +111,6 @@ AWS.IniLoader = AWS.util.inherit({
     );
   },
 
-  /**
-   * @api private
-   */
   getHomeDir: function getHomeDir() {
     var env = process.env;
     var home = env.HOME ||


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
- Add the new `loadSsoSessionsFrom` new method in `IniLoader` exported type.
- Expose `getHomeDir` and `getDefaultFilePath` util methods in  `IniLoader` exported type.

This can be useful to handle properly the new SSO connection with sessions, like in https://github.com/thomasmichaelwallace/serverless-better-credentials. See issue https://github.com/thomasmichaelwallace/serverless-better-credentials/issues/18

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm run test` passes
- [x] `.d.ts` file is updated
