### PR TITLE
fix: recognize cost explorer global endpoints

### DIFF
--- a/.changes/next-release/bugfix-Global-Services-2456cbf7.json
+++ b/.changes/next-release/bugfix-Global-Services-2456cbf7.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Global Services",
+  "description": "Recognize cost explorer service as service with global endpoints."
+}

--- a/.changes/next-release/bugfix-Global-Services-2456cbf7.json
+++ b/.changes/next-release/bugfix-Global-Services-2456cbf7.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
-  "category": "Global Services",
-  "description": "Recognize cost explorer service as service with global endpoints."
+  "category": "Cost Explorer",
+  "description": "recognize Cost Explorer global endpoints."
 }

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -50,6 +50,18 @@
     },
 
     "us-gov-*/iam": "globalGovCloud",
+
+    "*/ce": {
+      "endpoint": "{service}.us-east-1.amazonaws.com",
+      "globalEndpoint": true,
+      "signingRegion": "us-east-1"
+    },
+    "cn-*/ce": {
+      "endpoint": "{service}.cn-northwest-1.amazonaws.com.cn",
+      "globalEndpoint": true,
+      "signingRegion": "cn-northwest-1"
+    },
+
     "us-gov-*/sts": {
       "endpoint": "{service}.{region}.amazonaws.com"
     },

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -47,6 +47,24 @@ describe('region_config.js', function() {
     expect(service.endpoint.host).to.equal('iam.cn-north-1.amazonaws.com.cn');
   });
 
+  it('uses "global" endpoint for Cost Explorer in us-east-2', function() {
+    var service = new AWS.CostExplorer({
+      region: 'us-east-2'
+    });
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.signingRegion).to.equal('us-east-1');
+    expect(service.endpoint.host).to.equal('ce.us-east-1.amazonaws.com');
+  });
+
+  it('uses "global" endpoint for Cost Explorer in cn-north-1', function() {
+    var service = new AWS.CostExplorer({
+      region: 'cn-north-1'
+    });
+    expect(service.isGlobalEndpoint).to.equal(true);
+    expect(service.signingRegion).to.equal('cn-northwest-1');
+    expect(service.endpoint.host).to.equal('ce.cn-northwest-1.amazonaws.com.cn');
+  });
+
   [
     ['cn-north-1', 'cn-northwest-1', 'route53.amazonaws.com.cn'],
     ['us-gov-west-1', 'us-gov-west-1', 'route53.us-gov.amazonaws.com'],


### PR DESCRIPTION
# Description

Cost explorer seems to be missing from being as recognized as a global endpoint. While a "region" is specified, this service is only available in one region at a single endpoint in both the commercial and cn partitions.

Commercial: https://docs.aws.amazon.com/cost-management/latest/userguide/ce-api.html
China: https://docs.amazonaws.cn/en_us/cost-management/latest/userguide/ce-api.html

# Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`

Root of this change is that I am running into token signature problems when using. Similar to the problems that this PR solved: https://github.com/aws/aws-sdk-js/pull/3274