### PR TITLE
fix: correct reference to profile in sso-token-provider

### DIFF
--- a/lib/token/sso_token_provider.js
+++ b/lib/token/sso_token_provider.js
@@ -122,7 +122,7 @@ AWS.SSOTokenProvider = AWS.util.inherit(AWS.Token, {
       );
     } else if (!profile['sso_session']) {
       throw AWS.util.error(
-        new Error('Profile "' + profileName + '" is missing required property "sso_session".'),
+        new Error('Profile "' + this.profile + '" is missing required property "sso_session".'),
         { code: 'SSOTokenProviderFailure' }
       );
     }
@@ -138,12 +138,12 @@ AWS.SSOTokenProvider = AWS.util.inherit(AWS.Token, {
       );
     } else if (!ssoSession['sso_start_url']) {
       throw AWS.util.error(
-        new Error('Sso session "' + profileName + '" is missing required property "sso_start_url".'),
+        new Error('Sso session "' + this.profile + '" is missing required property "sso_start_url".'),
         { code: 'SSOTokenProviderFailure' }
       );
     } else if (!ssoSession['sso_region']) {
       throw AWS.util.error(
-        new Error('Sso session "' + profileName + '" is missing required property "sso_region".'),
+        new Error('Sso session "' + this.profile + '" is missing required property "sso_region".'),
         { code: 'SSOTokenProviderFailure' }
       );
     }


### PR DESCRIPTION
For Issue #4435 

replaces `profileName` (that is not defined anywhere) with `this.profile`

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
