### PR TITLE
fix: source_profile credential_process resolution when used by role_arn

### DIFF
--- a/.changes/next-release/bugfix-Credentials-6b971f33.json
+++ b/.changes/next-release/bugfix-Credentials-6b971f33.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Credentials",
+  "description": "fix credential_process credential resolution failure if it is the only item in source_profile when used by role_arn"
+}

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -123,19 +123,20 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
         var sourceProfileName = profile['source_profile'];
-        var credentialsChain = [
-          [AWS.SharedIniFileCredentials, function () { return false; }],
-          [AWS.ProcessCredentials, function () {
+        var credentialsSetChain = [
+          [AWS.SharedIniFileCredentials, function() { return false; }],
+          [AWS.ProcessCredentials, function() {
             return !profiles[sourceProfileName] ||
                    !profiles[sourceProfileName]['credential_process'];
           }],
         ];
-        var i = credentialsChain.length;
+        var i = credentialsSetChain.length;
         var errs = [];
-        for (var [credentials, skip] of credentialsChain) {
-          if (skip()){
+        for (var index = 0; index < credentialsSetChain.length; index++) {
+          var credentials = credentialsSetChain[index][0], skip = credentialsSetChain[index][1];
+          if (skip()) {
             i--;
-            continue
+            continue;
           }
           this.loadRoleProfile(profiles, profile, credentials, function(err, data) {
             i--;

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -232,53 +232,61 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sourceCredentials = new AWS.SharedIniFileCredentials(
-      AWS.util.merge(this.options || {}, {
-        profile: sourceProfileName,
-        preferStaticCredentials: true
-      })
-    );
-
-    this.roleArn = roleArn;
-    var sts = new STS({
-      credentials: sourceCredentials,
-      region: profileRegion,
-      httpOptions: this.httpOptions
+    var sourceOptions = AWS.util.merge(this.options || {}, {
+      profile: sourceProfileName,
+      preferStaticCredentials: true
     });
+    var chain = new AWS.CredentialProviderChain([
+      function () { return new AWS.SsoCredentials(sourceOptions); },
+      function () { return new AWS.SharedIniFileCredentials(sourceOptions); },
+      function () { return new AWS.ProcessCredentials(sourceOptions); },
+      function () { return new AWS.TokenFileWebIdentityCredentials(sourceOptions); },
+    ]);
+    chain.resolve(function (err, creds) {
+      if (err) throw err;
+      else {
+        this.roleArn = roleArn;
+        var sts = new STS({
+          credentials: creds,
+          region: profileRegion,
+          httpOptions: this.httpOptions
+        });
 
-    var roleParams = {
-      DurationSeconds: durationSeconds,
-      RoleArn: roleArn,
-      RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
-    };
+        var roleParams = {
+          DurationSeconds: durationSeconds,
+          RoleArn: roleArn,
+          RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
+        };
 
-    if (externalId) {
-      roleParams.ExternalId = externalId;
-    }
-
-    if (mfaSerial && self.tokenCodeFn) {
-      roleParams.SerialNumber = mfaSerial;
-      self.tokenCodeFn(mfaSerial, function(err, token) {
-        if (err) {
-          var message;
-          if (err instanceof Error) {
-            message = err.message;
-          } else {
-            message = err;
-          }
-          callback(
-            AWS.util.error(
-              new Error('Error fetching MFA token: ' + message),
-              { code: 'SharedIniFileCredentialsProviderFailure' }
-            ));
-          return;
+        if (externalId) {
+          roleParams.ExternalId = externalId;
         }
 
-        roleParams.TokenCode = token;
+        if (mfaSerial && self.tokenCodeFn) {
+          roleParams.SerialNumber = mfaSerial;
+          self.tokenCodeFn(mfaSerial, function(err, token) {
+            if (err) {
+              var message;
+              if (err instanceof Error) {
+                message = err.message;
+              } else {
+                message = err;
+              }
+              callback(
+                AWS.util.error(
+                  new Error('Error fetching MFA token: ' + message),
+                  { code: 'SharedIniFileCredentialsProviderFailure' }
+                ));
+              return;
+            }
+
+            roleParams.TokenCode = token;
+            sts.assumeRole(roleParams, callback);
+          });
+          return;
+        }
         sts.assumeRole(roleParams, callback);
-      });
-      return;
-    }
-    sts.assumeRole(roleParams, callback);
+      }
+    });
   }
 });

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -122,18 +122,36 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
-        this.loadRoleProfile(profiles, profile, function(err, data) {
-          if (err) {
-            callback(err);
-          } else {
-            self.expired = false;
-            self.accessKeyId = data.Credentials.AccessKeyId;
-            self.secretAccessKey = data.Credentials.SecretAccessKey;
-            self.sessionToken = data.Credentials.SessionToken;
-            self.expireTime = data.Credentials.Expiration;
-            callback(null);
+        var sourceProfileName = profile['source_profile'];
+        var errs = [];
+        for (var [credentials, skip] of [
+          [AWS.SharedIniFileCredentials, function () { return false; }],
+          [AWS.ProcessCredentials, function () {
+            return !profiles[sourceProfileName] ||
+                   !profiles[sourceProfileName]['credential_process'];
+          }],
+        ]) {
+          if (skip()){
+            continue
           }
-        });
+          this.loadRoleProfile(profiles, profile, credentials, function(err, data) {
+            if (err) {
+              errs.push(err);
+            } else {
+              self.expired = false;
+              self.accessKeyId = data.Credentials.AccessKeyId;
+              self.secretAccessKey = data.Credentials.SecretAccessKey;
+              self.sessionToken = data.Credentials.SessionToken;
+              self.expireTime = data.Credentials.Expiration;
+              callback(null);
+              sourceProfileName = '';
+            }
+          });
+          if (!sourceProfileName) {
+            return;
+          }
+        }
+        errs.forEach(function (err) { callback(err); });
         return;
       }
 
@@ -176,7 +194,7 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
   /**
    * @api private
    */
-  loadRoleProfile: function loadRoleProfile(creds, roleProfile, callback) {
+  loadRoleProfile: function loadRoleProfile(creds, roleProfile, credentials, callback) {
     if (this.disableAssumeRole) {
       throw AWS.util.error(
         new Error('Role assumption profiles are disabled. ' +
@@ -232,61 +250,53 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
       );
     }
 
-    var sourceOptions = AWS.util.merge(this.options || {}, {
-      profile: sourceProfileName,
-      preferStaticCredentials: true
+    var sourceCredentials = new credentials(
+      AWS.util.merge(this.options || {}, {
+        profile: sourceProfileName,
+        preferStaticCredentials: true
+      })
+    );
+
+    this.roleArn = roleArn;
+    var sts = new STS({
+      credentials: sourceCredentials,
+      region: profileRegion,
+      httpOptions: this.httpOptions
     });
-    var chain = new AWS.CredentialProviderChain([
-      function () { return new AWS.SsoCredentials(sourceOptions); },
-      function () { return new AWS.SharedIniFileCredentials(sourceOptions); },
-      function () { return new AWS.ProcessCredentials(sourceOptions); },
-      function () { return new AWS.TokenFileWebIdentityCredentials(sourceOptions); },
-    ]);
-    chain.resolve(function (err, creds) {
-      if (err) throw err;
-      else {
-        this.roleArn = roleArn;
-        var sts = new STS({
-          credentials: creds,
-          region: profileRegion,
-          httpOptions: this.httpOptions
-        });
 
-        var roleParams = {
-          DurationSeconds: durationSeconds,
-          RoleArn: roleArn,
-          RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
-        };
+    var roleParams = {
+      DurationSeconds: durationSeconds,
+      RoleArn: roleArn,
+      RoleSessionName: roleSessionName || 'aws-sdk-js-' + Date.now()
+    };
 
-        if (externalId) {
-          roleParams.ExternalId = externalId;
-        }
+    if (externalId) {
+      roleParams.ExternalId = externalId;
+    }
 
-        if (mfaSerial && self.tokenCodeFn) {
-          roleParams.SerialNumber = mfaSerial;
-          self.tokenCodeFn(mfaSerial, function(err, token) {
-            if (err) {
-              var message;
-              if (err instanceof Error) {
-                message = err.message;
-              } else {
-                message = err;
-              }
-              callback(
-                AWS.util.error(
-                  new Error('Error fetching MFA token: ' + message),
-                  { code: 'SharedIniFileCredentialsProviderFailure' }
-                ));
-              return;
-            }
-
-            roleParams.TokenCode = token;
-            sts.assumeRole(roleParams, callback);
-          });
+    if (mfaSerial && self.tokenCodeFn) {
+      roleParams.SerialNumber = mfaSerial;
+      self.tokenCodeFn(mfaSerial, function(err, token) {
+        if (err) {
+          var message;
+          if (err instanceof Error) {
+            message = err.message;
+          } else {
+            message = err;
+          }
+          callback(
+            AWS.util.error(
+              new Error('Error fetching MFA token: ' + message),
+              { code: 'SharedIniFileCredentialsProviderFailure' }
+            ));
           return;
         }
+
+        roleParams.TokenCode = token;
         sts.assumeRole(roleParams, callback);
-      }
-    });
+      });
+      return;
+    }
+    sts.assumeRole(roleParams, callback);
   }
 });

--- a/lib/credentials/shared_ini_file_credentials.js
+++ b/lib/credentials/shared_ini_file_credentials.js
@@ -123,18 +123,22 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
 
       if (profile['role_arn'] && !preferStaticCredentialsToRoleArn) {
         var sourceProfileName = profile['source_profile'];
-        var errs = [];
-        for (var [credentials, skip] of [
+        var credentialsChain = [
           [AWS.SharedIniFileCredentials, function () { return false; }],
           [AWS.ProcessCredentials, function () {
             return !profiles[sourceProfileName] ||
                    !profiles[sourceProfileName]['credential_process'];
           }],
-        ]) {
+        ];
+        var i = credentialsChain.length;
+        var errs = [];
+        for (var [credentials, skip] of credentialsChain) {
           if (skip()){
+            i--;
             continue
           }
           this.loadRoleProfile(profiles, profile, credentials, function(err, data) {
+            i--;
             if (err) {
               errs.push(err);
             } else {
@@ -151,7 +155,14 @@ AWS.SharedIniFileCredentials = AWS.util.inherit(AWS.Credentials, {
             return;
           }
         }
-        errs.forEach(function (err) { callback(err); });
+        (function() {
+          var j = setInterval(function() {
+            if (i <= 0) {
+              errs.forEach(function(err) { callback(err); });
+              clearInterval(j);
+            }
+          }, 0);
+        })();
         return;
       }
 

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -1344,15 +1344,22 @@ const exp = require('constants');
         var STSPrototype = (new STS()).constructor.prototype;
         var spy = helpers.spyOn(STSPrototype, 'assumeRole').andCallFake(
           function(roleParams, callback) {
-            AWS.util.defer(function () {
-              callback(null, {
-                Credentials: {
-                  AccessKeyId: 'KEY',
-                  SecretAccessKey: 'SECRET',
-                  SessionToken: 'TOKEN',
-                  Expiration: expiration
-                }
+            if (this.config.credentials.accessKeyId === 'akid' &&
+                this.config.credentials.secretAccessKey === 'secret' &&
+                this.config.credentials.sessionToken === 'session') {
+              setImmediate(function () {
+                callback(null, {
+                  Credentials: {
+                    AccessKeyId: 'KEY',
+                    SecretAccessKey: 'SECRET',
+                    SessionToken: 'TOKEN',
+                    Expiration: expiration
+                  }
+                });
               });
+            }
+            setImmediate(function () {
+              callback(new Error('INVALID CREDENTIAL'));
             });
           }
         );

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -1364,19 +1364,26 @@ const exp = require('constants');
           }
         );
 
-        var creds = new AWS.SharedIniFileCredentials();
-        expect(creds.roleArn).to.equal('arn');
-        return creds.refresh(function(err) {
-          expect(spy.calls[0].arguments[0].RoleArn).to.equal('arn');
-          expect(spy.calls[0].object.config.credentials.profile).to.equal('base');
-          expect(spy.calls[0].object.config.credentials.accessKeyId).to.equal('akid');
-          expect(spy.calls[0].object.config.credentials.secretAccessKey).to.equal('secret');
-          expect(spy.calls[0].object.config.credentials.sessionToken).to.equal('session');
-          expect(creds.accessKeyId).to.equal('KEY');
-          expect(creds.secretAccessKey).to.equal('SECRET');
-          expect(creds.sessionToken).to.equal('TOKEN');
-          expect(creds.expireTime).to.equal(expiration);
-          return done();
+        var creds = new AWS.SharedIniFileCredentials({
+          callback: function (err) {
+            expect(err).to.be.null;
+            expect(spy.calls.length).to.equal(2);
+            expect(spy.calls[0].arguments[0].RoleArn).to.equal('arn');
+            expect(spy.calls[0].object.config.credentials.profile).to.equal('base');
+            expect(spy.calls[0].object.config.credentials.accessKeyId).to.be.undefined;
+            expect(spy.calls[0].object.config.credentials.secretAccessKey).to.be.undefined;
+            expect(spy.calls[0].object.config.credentials.sessionToken).to.be.undefined;
+            expect(spy.calls[1].arguments[0].RoleArn).to.equal('arn');
+            expect(spy.calls[1].object.config.credentials.profile).to.equal('base');
+            expect(spy.calls[1].object.config.credentials.accessKeyId).to.equal('akid');
+            expect(spy.calls[1].object.config.credentials.secretAccessKey).to.equal('secret');
+            expect(spy.calls[1].object.config.credentials.sessionToken).to.equal('session');
+            expect(creds.accessKeyId).to.equal('KEY');
+            expect(creds.secretAccessKey).to.equal('SECRET');
+            expect(creds.sessionToken).to.equal('TOKEN');
+            expect(creds.expireTime).to.equal(expiration);
+            done();
+          }
         });
       });
 

--- a/test/credentials.spec.js
+++ b/test/credentials.spec.js
@@ -1347,20 +1347,16 @@ const exp = require('constants');
             if (this.config.credentials.accessKeyId === 'akid' &&
                 this.config.credentials.secretAccessKey === 'secret' &&
                 this.config.credentials.sessionToken === 'session') {
-              setImmediate(function () {
-                callback(null, {
-                  Credentials: {
-                    AccessKeyId: 'KEY',
-                    SecretAccessKey: 'SECRET',
-                    SessionToken: 'TOKEN',
-                    Expiration: expiration
-                  }
-                });
+              callback(null, {
+                Credentials: {
+                  AccessKeyId: 'KEY',
+                  SecretAccessKey: 'SECRET',
+                  SessionToken: 'TOKEN',
+                  Expiration: expiration
+                }
               });
             }
-            setImmediate(function () {
-              callback(new Error('INVALID CREDENTIAL'));
-            });
+            callback(new Error('INVALID CREDENTIAL'));
           }
         );
 


### PR DESCRIPTION
Fix `loadRoleProfile` when source profile only has `credential_process`.

```ini
[base]
credential_process = saml2aws ...

[mysaml]
role_arn       = arn
source_profile = base
```

This PR might also fixes #4301.

##### Checklist

- [x] `npm run test` passes
- [x] changelog is added, `npm run add-change`
