### PR TITLE
Update ts-generator.js to stop typescript from collapsing strings with string literalls

### DIFF
--- a/.changes/next-release/bugfix-ts-generator-f547c396.json
+++ b/.changes/next-release/bugfix-ts-generator-f547c396.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ts-generator",
+  "description": "Provides loose auto complete capabilities for enum like inputs."
+}

--- a/scripts/lib/ts-generator.js
+++ b/scripts/lib/ts-generator.js
@@ -338,7 +338,7 @@ TSGenerator.prototype.generateTypingsFromShape = function generateTypingsFromSha
     } else if (type === 'map') {
         code += tabs(tabCount) + 'export type ' + shapeKey + ' = {[key: string]: ' + this.generateSafeShapeName(shape.value.shape, customClassNames) + '};\n';
     } else if (type === 'string' || type === 'character') {
-        var stringType = 'string';
+        var stringType = '(string & {})';
         if (Array.isArray(shape.enum)) {
             stringType = shape.enum.map(function(s) {
                 return '"' + s + '"';


### PR DESCRIPTION
This PR fixes an issue where the current AWS SDK TS generator causes code editors to lose autocomplete definitions.

As of today, when an API has an argument that is an enum like, this enum gets converted to a string literal that's then merged with `string`. ie: `'Foo' | 'Bar' | string`

While this works mostly okay, it comes with a major downside: Typescript loses reference to the original inputs and collapses everything into `string`, since `string` superseeds both `foo` and `bar`. This causes an issue that, if you're then using either of these types to type your function inputs, intellisense cannot provide type-ahead hints to it:

![ScreenShot 2023-11-15 at 08 34 00](https://github.com/aws/aws-sdk-js/assets/5016970/9714e39f-d44f-4206-881f-d547d6586295)

This PR fixes that behaviour by merging in `string & {}` instead of just `string`.
By merging it, we will **keep** the type generation fully **backwards compatible** and we solve the issue described above

![ScreenShot 2023-11-15 at 08 35 29](https://github.com/aws/aws-sdk-js/assets/5016970/ffd93b5e-bd45-4735-9c2e-a48c8e824b97)


--

Try it by yourself:

https://www.typescriptlang.org/play?#code/C4TwDgpgBAkgdmArsKBeKByAZgexxqAH0wCMBDAJwOIwFsIALDAbgChWtE4BjYASxxwoAYUQUKEOMABCjMgDcBYgBSUA5gGcAXLATIiUDcAp84agJQBvAL6tR4yTLmKcKjGQ0ATDObtiJUrIMCkoUyth4PuwcXLwCQgByEADuQSGuYeraukgoxMpGJmZQAGRQNuZWtkmpzqHh5FS+NWkubsAMfBoAtF3dZAA2GjjdOADWZCA+QA

<!--
Thank you for your pull request. Please provide a description below.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] changelog is added, `npm run add-change`
