### PR TITLE
Ensure regionalEndpoint variable is declared for s3UsEast1RegionalEndpoint

### DIFF
--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -278,7 +278,7 @@ AWS.util.update(AWS.S3.prototype, {
       req.httpRequest.endpoint.hostname.indexOf('s3.amazonaws.com') >= 0
     ) {
       var insertPoint = config.endpoint.indexOf('.amazonaws.com');
-      regionalEndpoint = config.endpoint.substring(0, insertPoint) +
+      var regionalEndpoint = config.endpoint.substring(0, insertPoint) +
         '.us-east-1' + config.endpoint.substring(insertPoint);
       req.httpRequest.updateEndpoint(regionalEndpoint);
     }


### PR DESCRIPTION
If the file is executed in node strict mode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#assigning_to_undeclared_variables the line fails. Typically that should not happen because the file does not declare a "use strict" at the top but with some bundlers it can still happen.

---

Steps to reproduce:

package.json

```
{
  "name": "s3sdktest",
  "version": "1.0.0",
  "dependencies": {
    "aws-sdk": "^2.1501.0"
  },
  "devDependencies": {
    "esbuild": "^0.19.7"
  }
}
```

test.js

```
"use strict";
const AWS = require("aws-sdk");
const s3 = new AWS.S3({ region: "us-east-1",  s3UsEast1RegionalEndpoint: "regional" });
s3.listBuckets().promise();
```

Command to bundle:

```
$ npx esbuild --bundle test.js --outdir=dist --platform=node --target=node18
```

Resulting file includes a `"use strict";` in the first line from the esbuild bundler:

```
$ head dist/test.js 
"use strict";
var __getOwnPropNames = Object.getOwnPropertyNames;
var __commonJS = (cb, mod) => function __require() {
  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
};

// node_modules/aws-sdk/lib/json/builder.js
var require_builder = __commonJS({
  "node_modules/aws-sdk/lib/json/builder.js"(exports, module2) {
    var util = require_util();
```

That means all bundled files have strict mode enabled and not only the test.js file which declared it. It feels like this is a bug in esbuild but still we should solve it in the sdk as well.

Fixes https://github.com/aws/aws-sdk-js/issues/4486

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes - **not needed**
- [ ] `.d.ts` file is updated - **not needed**
- [ ] changelog is added, `npm run add-change` - **not needed?**
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed - **not needed**
- [ ] run `npm run integration` if integration test is changed - **not needed**
- [ ] non-code related change (markdown/git settings etc) - **not really**
