### PR TITLE
Default empty array for previously flattened lists and maps in query compatible services

### DIFF
--- a/.changes/next-release/bugfix-SQS-6fcf1531.json
+++ b/.changes/next-release/bugfix-SQS-6fcf1531.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SQS",
+  "description": "Default empty array for previously flattened lists and maps in query compatible services"
+}

--- a/lib/xml/node_parser.js
+++ b/lib/xml/node_parser.js
@@ -60,6 +60,8 @@ function parseStructure(xml, shape) {
   var data = {};
   if (xml === null) return data;
 
+  var awsQueryCompatible = shape.api && shape.api.protocol === 'query';
+
   util.each(shape.members, function(memberName, memberShape) {
     var xmlName = memberShape.name;
     if (Object.prototype.hasOwnProperty.call(xml, xmlName) && Array.isArray(xml[xmlName])) {
@@ -70,6 +72,12 @@ function parseStructure(xml, shape) {
     } else if (memberShape.isXmlAttribute &&
                xml.$ && Object.prototype.hasOwnProperty.call(xml.$, xmlName)) {
       data[memberName] = parseScalar(xml.$[xmlName], memberShape);
+    } else if (awsQueryCompatible && memberShape.flattened) {
+      if (memberShape.type === 'list') {
+        data[memberName] = [];
+      } else if (memberShape.type === 'map') {
+        data[memberName] = {};
+      }
     } else if (memberShape.type === 'list' && !shape.api.xmlNoDefaultLists) {
       data[memberName] = memberShape.defaultValue;
     }


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`

