### PR TITLE
fix: adding default value for list members for awsQueryCompatible for…

### DIFF
--- a/.changes/next-release/bugfix-awsQueryCompatible-5c2d41f9.json
+++ b/.changes/next-release/bugfix-awsQueryCompatible-5c2d41f9.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "awsQueryCompatible",
+  "description": "set default list member value for awsQueryCompatible"
+}

--- a/lib/json/parser.js
+++ b/lib/json/parser.js
@@ -23,12 +23,17 @@ function translateStructure(structure, shape) {
 
   var struct = {};
   var shapeMembers = shape.members;
+  var isAwsQueryCompatible = shape.api && shape.api.awsQueryCompatible;
   util.each(shapeMembers, function(name, memberShape) {
     var locationName = memberShape.isLocationName ? memberShape.name : name;
     if (Object.prototype.hasOwnProperty.call(structure, locationName)) {
       var value = structure[locationName];
       var result = translate(value, memberShape);
       if (result !== undefined) struct[name] = result;
+    } else if (isAwsQueryCompatible && memberShape.defaultValue) {
+      if (memberShape.type === 'list') {
+        struct[name] = typeof memberShape.defaultValue === 'function' ? memberShape.defaultValue() : memberShape.defaultValue;
+      }
     }
   });
   return struct;

--- a/test/json/parser.spec.js
+++ b/test/json/parser.spec.js
@@ -52,6 +52,44 @@
             }
           }
         };
+        it('sets the default value for list members if service is awsQueryCompatible', function() {
+          var mockSQSShape = {
+            type: 'structure',
+            members: {
+              Failed: {
+                type: 'list',
+                defaultValue: function() {
+                  return [];
+                },
+                member: { type: 'structure' }
+              },
+              Successful: {
+                type: 'list',
+                defaultValue: function() {
+                  return [];
+                },
+                member: { type: 'structure' }
+              }
+            },
+            api: {
+              awsQueryCompatible: {}
+            }
+          };
+          var mockSQSStructure = {
+            Successful: [
+              {
+                Id: 'msg1',
+                MessageId: '63ba9799-f001-4ec0-b05e-21af5124f96a',
+                MD5OfMessageBody: '5f8c4f7ebd0d2503d620bd34a3229868'
+              }
+            ]
+          };
+          var parsed = parser.parse(JSON.stringify(mockSQSStructure), mockSQSShape);
+          expect(parsed).to.have.property('Failed');
+          expect(parsed.Failed).to.be.an('array').that.is.empty;
+          expect(parsed).to.have.property('Successful');
+          expect(parsed.Successful).to.be.an('array').with.lengthOf(1);
+        });
         it('translates input', function() {
           var params;
           params = '{ "Items": { "A": "a", "B": "b" } }';


### PR DESCRIPTION
- [x] `npm run test` passes
- [x] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [x] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [x] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
