### PR TITLE
Fix FIPS endpoints for EC2

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-a25af9c7.json
+++ b/.changes/next-release/bugfix-Endpoints-a25af9c7.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Use correct FIPS endpoint for EC2 in GovCloud"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -128,6 +128,7 @@
     "us-gov-*/batch": "fipsWithServiceOnly",
     "us-gov-*/cloudformation": "fipsWithServiceOnly",
     "us-gov-*/config": "fipsWithServiceOnly",
+    "us-gov-*/ec2": "fipsWithServiceOnly",
     "us-gov-*/eks": "fipsWithServiceOnly",
     "us-gov-*/elasticmapreduce": "fipsWithServiceOnly",
     "us-gov-*/identitystore": "fipsWithServiceOnly",


### PR DESCRIPTION
Internal OSDS-3456

The endpoints mentioned in [FIPS](https://aws.amazon.com/compliance/fips/) are:
* `ec2.us-gov-east-1.amazonaws.com`
* `ec2.us-gov-west-1.amazonaws.com`

### Testing

```js
import AWS from "../aws-sdk-js/index.js";

for (const region of ["us-gov-west-1", "us-gov-east-1"]) {
  const client = new AWS.EC2({ region, useFipsEndpoint: true });
  console.log(`Endpoint for region "${region}" is "${client.config.endpoint}"`);
}
```

#### Before

Endpoints follow AWS standard 
```console
Endpoint for region "us-gov-west-1" is "ec2-fips.us-gov-west-1.amazonaws.com"
Endpoint for region "us-gov-east-1" is "ec2-fips.us-gov-east-1.amazonaws.com"
```

#### After

Endpoints for EC2 customization
```console
Endpoint for region "us-gov-west-1" is "ec2.us-gov-west-1.amazonaws.com"
Endpoint for region "us-gov-east-1" is "ec2.us-gov-east-1.amazonaws.com"
```

### Checklist

- [x] changelog is added, `npm run add-change`
