### PR TITLE
Skip NeptuneGraph client test

### DIFF
--- a/test/clients.spec.js
+++ b/test/clients.spec.js
@@ -8,6 +8,9 @@ var customConstructorArgs = {
 
 for (var serviceAbbreviation in metadata) {
   var clientName = metadata[serviceAbbreviation].name;
+  if (clientName === 'NeptuneGraph') {
+    continue; // NeptuneGraph is not present in AWS SDK for JSv2.
+  }
   describe(
     'Instantiating AWS.' + clientName + ' clients',
     (function(clientName, serviceAbbreviation) {


### PR DESCRIPTION
Previous PR to exclude NeptuneGraph: #4548 

**Description:**
skips the client test if client is NeptuneGraph (since this service doesn't exist in AWS SDK for JSv2)
