### PR TITLE
chore(console): skip neptunegraph from console repl

### DIFF
--- a/.changes/next-release/bugfix-Neptune-Graph-5bb38964.json
+++ b/.changes/next-release/bugfix-Neptune-Graph-5bb38964.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Neptune Graph",
+  "description": "skips Neptune Graph from console repl"
+}

--- a/scripts/console
+++ b/scripts/console
@@ -107,7 +107,7 @@ repl.context.autoSend = true;
 for (var key in AWS) {
   var id = AWS[key].serviceIdentifier;
   if (id) {
-    if (id === 'cloudsearchdomain' || id === 'iotdata') continue; // this required an explicit endpoint
+    if (id === 'cloudsearchdomain' || id === 'iotdata' || id === 'neptunegraph') continue; // this required an explicit endpoint
 
     var svcClass = AWS[key];
     var svc = new svcClass(defaultOptions);


### PR DESCRIPTION
skips Neptune Graph from the console repl

**Testing**
console works without throwing the service exclusion error for neptune graph 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`

