### PR TITLE
Update maintenance mode message to share upcoming end-of-life

### DIFF
--- a/.changes/next-release/feature-Support-201c0f79.json
+++ b/.changes/next-release/feature-Support-201c0f79.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Support",
+  "description": "Update maintenance mode message to share upcoming end-of-support"
+}

--- a/lib/maintenance_mode_message.js
+++ b/lib/maintenance_mode_message.js
@@ -1,6 +1,6 @@
 var warning = [
-  'The AWS SDK for JavaScript (v2) will enter maintenance mode on',
-  'September 8, 2024 and reach end-of-support on September 8, 2025.\n',
+  'The AWS SDK for JavaScript (v2) will enter maintenance mode',
+  'on September 8, 2024 and reach end-of-support on September 8, 2025.\n',
   'Please migrate your code to use AWS SDK for JavaScript (v3).',
   'For more information, check blog post at https://a.co/cUPnyil'
 ].join('\n');

--- a/lib/maintenance_mode_message.js
+++ b/lib/maintenance_mode_message.js
@@ -1,7 +1,8 @@
 var warning = [
-  'We are formalizing our plans to enter AWS SDK for JavaScript (v2) into maintenance mode in 2023.\n',
+  'The AWS SDK for JavaScript (v2) will enter maintenance mode on',
+  'September 8, 2024 and reach end-of-support on September 8, 2025.\n',
   'Please migrate your code to use AWS SDK for JavaScript (v3).',
-  'For more information, check the migration guide at https://a.co/7PzMCcy'
+  'For more information, check blog post at https://a.co/cUPnyil'
 ].join('\n');
 
 module.exports = {


### PR DESCRIPTION
Similar to https://github.com/aws/aws-sdk-js/pull/4599

#### Testing

```console
$ ./scripts/console 
aws-sdk> Missing repl.history package, history will not be supported.
  Type `npm install repl.history` to enable history.
(node:89393) NOTE: The AWS SDK for JavaScript (v2) will enter maintenance mode
on September 8, 2024 and reach end-of-support on September 8, 2025.

Please migrate your code to use AWS SDK for JavaScript (v3).
For more information, check blog post at https://a.co/cUPnyil
(Use `node --trace-warnings ...` to show where the warning was created)
```

##### Checklist

- [x] non-code related change (markdown/git settings etc)
- [x] changelog is added, `npm run add-change`