### PR TITLE
Use rules.payload when extracting data for event stream

### DIFF
--- a/.changes/next-release/bugfix-rest-json-7a3f1db2.json
+++ b/.changes/next-release/bugfix-rest-json-7a3f1db2.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "rest-json",
+  "description": "use rules.payload when extracting data for event stream"
+}

--- a/lib/protocol/rest_json.js
+++ b/lib/protocol/rest_json.js
@@ -1,3 +1,4 @@
+var AWS = require('../core');
 var util = require('../util');
 var Rest = require('./rest');
 var Json = require('./json');
@@ -75,7 +76,7 @@ function extractData(resp) {
     var body = resp.httpResponse.body;
     if (payloadMember.isEventStream) {
       parser = new JsonParser();
-      resp.data[payload] = util.createEventStream(
+      resp.data[rules.payload] = util.createEventStream(
         AWS.HttpClient.streamsApiVersion === 2 ? resp.httpResponse.stream : body,
         parser,
         payloadMember


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-js/issues/4580, problem is that there were undefined variables in `lib/protocol/rest_json.js`

File could use more cleanup as well, as there are also unused variables from whoever touched it last.

Without this change, you cannot use the client to get a streamed sagemaker request.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] `npm run test` passes (tests seem flaky, less are failing after this change, and failures change with each run, before and after the change. Your guys' judgement call)
- [x ] run `npm run integration` if integration test is changed (tests are flaky and also just fail, always fail on my machine before and after change, didn't change them)
