### PR TITLE
Add endpoint override for eu-isoe-* region

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-52ee1372.json
+++ b/.changes/next-release/bugfix-Endpoints-52ee1372.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Add endpoint override for eu-isoe-* region"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -6,6 +6,7 @@
     "cn-*/*": {
       "endpoint": "{service}.{region}.amazonaws.com.cn"
     },
+    "eu-isoe-*/*": "euIsoe",
     "us-iso-*/*": "usIso",
     "us-isob-*/*": "usIsob",
     "*/budgets": "globalSSL",
@@ -242,6 +243,9 @@
     "s3signature": {
       "endpoint": "{service}.{region}.amazonaws.com",
       "signatureVersion": "s3"
+    },
+    "euIsoe": {
+      "endpoint": "{service}.{region}.cloud.adc-e.uk"
     },
     "usIso": {
       "endpoint": "{service}.{region}.c2s.ic.gov"


### PR DESCRIPTION
Internal JS-5117

### Testing

```js
import AWS from "../aws-sdk-js/lib/aws.js";

const client = new AWS.STS({ region: "eu-isoe-west-1" });
console.log(client.endpoint);
```

Verified with three services:
* STS: `sts.eu-isoe-west-1.cloud.adc-e.uk`
* S3: `s3.eu-isoe-west-1.cloud.adc-e.uk`
* DynamoDB: `dynamodb.eu-isoe-west-1.cloud.adc-e.uk`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`