### PR TITLE
fix: allow cloudsearchdomain POST search compatibility in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 configuration
 node_modules
 npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@
 .npmignore
 .tesselinclude
 .vscode/
+.idea
 apis/*.normal.json
 appveyor.yml
 bower.json

--- a/lib/services/cloudsearchdomain.js
+++ b/lib/services/cloudsearchdomain.js
@@ -99,6 +99,9 @@ AWS.util.update(AWS.CloudSearchDomain.prototype, {
    */
   convertGetToPost: function(request) {
     var httpRequest = request.httpRequest;
+    if (httpRequest.method === 'POST') {
+      return;
+    }
     // convert queries to POST to avoid length restrictions
     var path = httpRequest.path.split('?');
     httpRequest.method = 'POST';

--- a/test/services/cloudsearchdomain.spec.js
+++ b/test/services/cloudsearchdomain.spec.js
@@ -87,19 +87,8 @@
         params = {
           query: 'foo'
         };
-        req = build('search', params);
+        req = build('suggest', params);
         return expect(req.headers).to.have.property('Authorization');
-      });
-      it('converts the GET request to POST for search operation', function() {
-        var params, req;
-        params = {
-          query: 'foo'
-        };
-        req = build('search', params);
-        expect(req.method).to.equal('POST');
-        expect(req.path.indexOf('?')).to.equal(-1);
-        expect(typeof req.body).to.equal('string');
-        return expect(req.headers['Content-Length']).to.equal(req.body.length);
       });
       return it('keeps the suggest operation as a GET request', function() {
         var params, req;

--- a/test/signers/v4.spec.js
+++ b/test/signers/v4.spec.js
@@ -129,19 +129,6 @@
       });
     });
     describe('canonicalString', function() {
-      it('sorts the search string', function() {
-        var req;
-        req = new AWS.CloudSearchDomain({
-          endpoint: 'host.domain.com'
-        }).search({
-          query: 'foo',
-          cursor: 'initial',
-          queryOptions: '{}'
-        }).removeListener('build', AWS.CloudSearchDomain.prototype.convertGetToPost).build();
-        signer = new AWS.Signers.V4(req.httpRequest, 'cloudsearchdomain');
-        return expect(signer.canonicalString().split('\n')[2]).to.equal('cursor=initial&format=sdk&pretty=true&q=foo&q.options=%7B%7D');
-      });
-
       it('double URI encodes paths for non S3 services', function() {
         var req;
         req = new AWS.CognitoSync().listDatasets({


### PR DESCRIPTION
unit test compatibility with an upcoming change making search POST instead of GET
