### PR TITLE
Add endpoint override for us-isof-* region

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-8c993a32.json
+++ b/.changes/next-release/bugfix-Endpoints-8c993a32.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Add endpoint override for us-isof-* region"
+}

--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -9,6 +9,7 @@
     "eu-isoe-*/*": "euIsoe",
     "us-iso-*/*": "usIso",
     "us-isob-*/*": "usIsob",
+    "us-isof-*/*": "usIsof",
     "*/budgets": "globalSSL",
     "*/cloudfront": "globalSSL",
     "*/sts": "globalSSL",
@@ -252,6 +253,9 @@
     },
     "usIsob": {
       "endpoint": "{service}.{region}.sc2s.sgov.gov"
+    },
+    "usIsof": {
+      "endpoint": "{service}.{region}.csp.hci.ic.gov"
     },
     "fipsStandard": {
       "endpoint": "{service}-fips.{region}.amazonaws.com"


### PR DESCRIPTION
Internal JS-5148

### Testing

```js
import AWS from "../aws-sdk-js/lib/aws.js";

const client = new AWS.DynamoDB({ region: "us-isof-east-1" });
console.log(client.endpoint.host);
```

The output is `dynamodb.us-isof-east-1.csp.hci.ic.gov`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] changelog is added, `npm run add-change`