### PR TITLE
fix: exclude locationconstraint from s3 createBucket in us-east-1

### DIFF
--- a/.changes/next-release/bugfix-s3-9367ca5d.json
+++ b/.changes/next-release/bugfix-s3-9367ca5d.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "omit locationConstraint in createBucket to us-east-1"
+}

--- a/lib/services/s3.js
+++ b/lib/services/s3.js
@@ -1263,7 +1263,11 @@ AWS.util.update(AWS.S3.prototype, {
     // mutate params object argument passed in by user
     var copiedParams = AWS.util.copy(params);
 
-    if (hostname !== this.api.globalEndpoint && !params.CreateBucketConfiguration) {
+    if (
+      this.config.region !== 'us-east-1'
+        && hostname !== this.api.globalEndpoint
+        && !params.CreateBucketConfiguration
+    ) {
       copiedParams.CreateBucketConfiguration = { LocationConstraint: this.config.region };
     }
     return this.makeRequest('createBucket', copiedParams, callback);

--- a/scripts/region-checker/allowlist.js
+++ b/scripts/region-checker/allowlist.js
@@ -50,7 +50,8 @@ var allowlist = {
         819,
         820,
         821,
-        826
+        826,
+        1266
     ],
     '/token/sso_token_provider.js': [
         60


### PR DESCRIPTION
Add region check before adding locationConstraint in us-east-1.

Equivalent functionaltiy in JSv3: https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-location-constraint/src/index.ts

##### Checklist

- [x] `npm run test` passes
- [ ] `.d.ts` file is updated
- [x] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [ ] non-code related change (markdown/git settings etc)
