### PR TITLE
fix: add global hostnames for additional regions

### DIFF
--- a/lib/region_config_data.json
+++ b/lib/region_config_data.json
@@ -36,6 +36,8 @@
       "globalEndpoint": true,
       "signingRegion": "us-isob-east-1"
     },
+    "us-isof-*/route53": "globalUsIsof",
+    "eu-isoe-*/route53": "globalEuIsoe",
 
     "*/waf": "globalSSL",
 
@@ -240,6 +242,16 @@
       "endpoint": "{service}.us-gov.amazonaws.com",
       "globalEndpoint": true,
       "signingRegion": "us-gov-west-1"
+    },
+    "globalUsIsof": {
+      "endpoint": "{service}.csp.hci.ic.gov",
+      "globalEndpoint": true,
+      "signingRegion": "us-isof-south-1"
+    },
+    "globalEuIsoe": {
+      "endpoint": "{service}.cloud.adc-e.uk",
+      "globalEndpoint": true,
+      "signingRegion": "eu-isoe-west-1"
     },
     "s3signature": {
       "endpoint": "{service}.{region}.amazonaws.com",

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -18,6 +18,19 @@ describe('region_config.js', function() {
     });
   });
 
+  [AWS.Route53].forEach(function(svcClass) {
+    ['us-isof-south-1', 'eu-isoe-west-1'].forEach(function(region) {
+      it('uses a global partition endpoint for ' + svcClass.serviceIdentifier, function() {
+        var service = new svcClass({
+          region: region
+        });
+        expect(service.endpoint.host).to.contain(service.serviceIdentifier + '.');
+        expect(service.endpoint.host).not.to.contain(region);
+        expect(service.isGlobalEndpoint).to.equal(true);
+      });
+    });
+  });
+
   it('always enables SSL for Route53', function() {
     var service = new AWS.Route53;
     expect(service.config.sslEnabled).to.equal(true);

--- a/test/region_config.spec.js
+++ b/test/region_config.spec.js
@@ -19,7 +19,13 @@ describe('region_config.js', function() {
   });
 
   [AWS.Route53].forEach(function(svcClass) {
-    ['us-isof-south-1', 'eu-isoe-west-1'].forEach(function(region) {
+    [
+      'us-isof-south-1',
+      'eu-isoe-west-1',
+      'us-gov-west-1',
+      'cn-northwest-1',
+      'cn-north-1'
+    ].forEach(function(region) {
       it('uses a global partition endpoint for ' + svcClass.serviceIdentifier, function() {
         var service = new svcClass({
           region: region


### PR DESCRIPTION
This configures a partition global endpoint for two partitions of Route53.

- [x] `npm run test` passes

Test code:

```js
var AWS = require("../../lib/aws");

process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = 1;

const regions = [
  "us-east-1",
  "us-west-2",
  "il-central-1",
  "us-isof-south-1",
  "eu-isoe-west-1",
];

for (const region of regions) {
  const r53 = new AWS.Route53({
    region,
  });
  const req = r53.listCidrBlocks({});
  console.log(req.httpRequest.endpoint.href);
}

for (const region of regions) {
  const cf = new AWS.CloudFront({
    region,
  });
  const req = cf.listDistributions({});
  console.log(req.httpRequest.endpoint.href);
}

```

output:

```
https://route53.amazonaws.com/
https://route53.amazonaws.com/
https://route53.amazonaws.com/
https://route53.csp.hci.ic.gov/
https://route53.cloud.adc-e.uk/
https://cloudfront.amazonaws.com/
https://cloudfront.amazonaws.com/
https://cloudfront.amazonaws.com/
https://cloudfront.us-isof-south-1.csp.hci.ic.gov/
https://cloudfront.eu-isoe-west-1.cloud.adc-e.uk/
```