### PR TITLE
Fix invalid regex pattern for ClientRequestId in Chime SDK schema

### DIFF
--- a/apis/chime-sdk-voice-2022-08-03.normal.json
+++ b/apis/chime-sdk-voice-2022-08-03.normal.json
@@ -3909,7 +3909,7 @@
     },
     "ClientRequestId": {
       "type": "string",
-      "pattern": "^[-_a-zA-Z0-9]*${2,64}$"
+      "pattern": "^[-_a-zA-Z0-9]{2,64}$"
     },
     "ConfidenceScore": {
       "type": "float",


### PR DESCRIPTION

### Description

Fixes an invalid regex pattern for `ClientRequestId` in `apis/chime-sdk-voice-2022-08-03.normal.json`.

**Previous (invalid):**
```regex
^[-_a-zA-Z0-9]*${2,64}$
````

**Updated (valid):**

```regex
^[-_a-zA-Z0-9]{2,64}$
```

The original pattern used an invalid quantifier `${2,64}` after a `*`, which is not valid regex syntax. The corrected pattern enforces 2–64 characters that are alphanumeric, underscores, or hyphens — as likely intended.

---

##### Checklist

* [ ] `npm run test` passes
* [ ] `.d.ts` file is updated
* [ ] changelog is added, `npm run add-change`
* [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
* [ ] run `npm run integration` if integration test is changed
* [x] non-code related change (markdown/git settings etc)

