### PR TITLE
chore: use ssh private key for git sync

### DIFF
--- a/.github/workflows/git-sync.yml
+++ b/.github/workflows/git-sync.yml
@@ -12,14 +12,13 @@ jobs:
     steps:
       - name: git-sync
         env:
-          git_sync_source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
           git_sync_destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
-        if: env.git_sync_source_repo && env.git_sync_destination_repo
+          git_sync_ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}
+        if: env.git_sync_destination_repo && env.git_sync_ssh_private_key
         uses: wei/git-sync@v3
         with:
-          source_repo: ${{ secrets.GIT_SYNC_SOURCE_REPO }}
+          source_repo: "git@github.com:aws/aws-sdk-js.git"
           source_branch: "master"
-          destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }} 
+          destination_repo: ${{ secrets.GIT_SYNC_DESTINATION_REPO }}
           destination_branch: "master"
-          source_ssh_private_key: ${{ secrets.GIT_SYNC_SOURCE_SSH_PRIVATE_KEY }}
-          destination_ssh_private_key:  ${{ secrets.GIT_SYNC_DESTINATION_SSH_PRIVATE_KEY }}
+          ssh_private_key: ${{ secrets.GIT_SYNC_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
##### Checklist

Internal JS-6078

Referred documentation https://github.com/wei/git-sync
Once this commit is merged, we'll verify that git-sync is successful.

On success, we'll delete the following:
* Secret: `GIT_SYNC_SOURCE_REPO`
* Secret: `GIT_SYNC_SOURCE_SSH_PRIVATE_KEY`
* Secret: `GIT_SYNC_DESTINATION_SSH_PRIVATE_KEY`
* Deploy key on this repo: `git-sync-source-public-key`
* Deploy key on destination repo: `git-sync-destination-public-key`

Similar change in v3 https://github.com/aws/aws-sdk-js-v3/pull/7224

- [ ] `npm run test` passes
- [ ] `.d.ts` file is updated
- [ ] changelog is added, `npm run add-change`
- [ ] run `bundle exec rake docs:api` and inspect `doc/latest/index.html` if documentation is changed
- [ ] run `npm run integration` if integration test is changed
- [x] non-code related change (markdown/git settings etc)
